### PR TITLE
3273: Quirk NPE and Code Cleanup

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -450,8 +450,8 @@ public class Client implements IClientCommandHandler {
             case LOUNGE:
                 try {
                     QuirksHandler.initQuirksList();
-                } catch (IOException e) {
-                    MegaMek.getLogger().error(e);
+                } catch (Exception e) {
+                    MegaMek.getLogger().error("Error initializing quirks", e);
                 }
                 UnitRoleHandler.initialize();
                 MechSummaryCache.getInstance().addListener(RandomUnitGenerator::getInstance);

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -929,12 +929,7 @@ public class MegaMekGUI  implements IPreferenceChangeListener, IMegaMekGUI {
             MegaMek.getLogger().error("Error saving custom weapon orders!", e);
         }
 
-        try {
-            QuirksHandler.saveCustomQuirksList();
-        } catch (IOException e) {
-            MegaMek.getLogger().error("Error saving quirks override!", e);
-        }
-
+        QuirksHandler.saveCustomQuirksList();
         System.exit(0);
     }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14801,9 +14801,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public void loadDefaultQuirks() {
-
         // Get a list of quirks for this entity.
-        List<QuirkEntry> quirks = QuirksHandler.getQuirks(this);
+        List<QuirkEntry> quirks;
+        try {
+            quirks = QuirksHandler.getQuirks(this);
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
+            return;
+        }
 
         // If this unit has no quirks, we do not need to proceed further.
         if ((quirks == null) || quirks.isEmpty()) {

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -1,140 +1,121 @@
 /*
  * MegaMek - Copyright (C) 2003, 2004 Ben Mazur (bmazur@sev.org)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
-
 package megamek.common;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.xml.parsers.DocumentBuilder;
-
+import megamek.MegaMek;
 import megamek.common.annotations.Nullable;
-import megamek.common.logging.DefaultMmLogger;
-import megamek.common.logging.MMLogger;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
 import megamek.common.options.Quirks;
 import megamek.common.options.WeaponQuirks;
 import megamek.utils.MegaMekXmlUtil;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class loads the quirks lists from the data/canonUnitQuirks.xml and /mmconf/unitQuirksOverride.xml files.
  *
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
- * @version %I% %G%
  * @since 2012-03-05
  */
 public class QuirksHandler {
-
+    //region Variable Declarations
     private static final String CUSTOM_QUIRKS_FOOTER = "</unitQuirks>";
-    private static final String CUSTOM_QUIRKS_HEADER;
-
-    static {
-        CUSTOM_QUIRKS_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n" +
-                               "<!--\n" +
-                               "NOTE: saving quirks for units within MM will cause this file to get re-written and all changes will be lost!\n\n" +
-                               "This file allows users to customize the default cannon quirks list.  Any quirk assignments in this file will override\n" +
-                               "  the cannon quirk entries entirely.  Changes to this file will not take effect until the next time megamek is launched.\n\n" +
-                               "To assign a unit a quirk, the entry should be in the following format:\n" +
-                               "    <unit>\n" +
-                               "        <chassis>[chassis name]</chassis>\n" +
-                               "        <model>{model}</model>\n" +
-                               "        <quirk>[quirk1 name]</quirk>\n" +
-                               "        <quirk>[quirk2 name]</quirk>\n" +
-                               "        <weaponQuirk>\n" +
-                               "            <weaponQuirkName>[weapon quirk 1 name]</weaponQuirkName>\n" +
-                               "            <location>[location of weapon]</location>\n" +
-                               "            <slot>[critical slot of weapon]</slot>\n" +
-                               "            <weaponName>[name of weapon]</weaponName>\n" +
-                               "        </weaponQuirk>\n" +
-                               "        <weaponQuirk>\n" +
-                               "            <weaponQuirkName>[weapon quirk 2 name]</weaponQuirkName>\n" +
-                               "            <location>[location of weapon]</location>\n" +
-                               "            <slot>[critical slot of weapon]</slot>\n" +
-                               "            <weaponName>[name of weapon]</weaponName>\n" +
-                               "        </weaponQuirk>\n" +
-                               "    </unit>\n\n" +
-                               "The \"model\" field can be left blank if there is no model number for the unit (common for some tank chassis), but the\n" +
-                               "  tags should still be included.  A <model> of \"all\" will cause all units with the same <chassis> to have the defined\n" +
-                               "  quirks.  This can later be overridden with entries for specific models.\n\n" +
-                               "Multiple quirks should be contained within separate \"quirk\" tags.\n\n" +
-                               "Multiple weapon quirks should be contained within separate \"weaponQuirk\" structures, even if multiple quirks apply to\n" +
-                               "  the same weapon.\n\n" +
-                               "The proper names for quirks can be found in the\n" +
-                               "  l10n/megamek/common/options/messages.properties file.  Search for the \"QuirksInfo\" section.\n" +
-                               "  The name you want will fall between \"option\" and \"displayableName\".  For example, if you wish to apply the\n" +
-                               "  \"Anti-Aircraft Targeting\" quirk to a unit, you will find the following entry in the messages.properties file:\n" +
-                               "    QuirksInfo.option.anti_air.displayableName\n" +
-                               "  The name you want to include in this file for the <quirk> entry is \"anti_air\".\n" +
-                               "If you wish to remove all quirks for a unit, you can create an entry in this file with a <quirk> of \"none\".\n\n" +
-                               "Example:  If you wish to declare that all Atlas variants do not have the Command Mech quirk:\n" +
-                               "    <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>all</model>\n" +
-                               "        <quirk>none</quirk>\n" +
-                               "    </unit>\n\n" +
-                               "Example: If you decide only the AS7-D Atlas, but no other variant, should have the Command Mech quirk:\n" +
-                               "        <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>all</model>\n" +
-                               "        <quirk>none</quirk>\n" +
-                               "    </unit>\n" +
-                               "    <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>AS7-D</model>\n" +
-                               "        <quirk>command_mech</quirk>\n" +
-                               "    </unit>\n\n" +
-                               "Example: You can also do this in the opposite direction, so that all Atlases have the Command Mech quirk except the AS7-D:\n" +
-                               "    <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>all</model>\n" +
-                               "        <quirk>command_mech</quirk>\n" +
-                               "    </unit>\n" +
-                               "    <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>AS7-D</model>\n" +
-                               "        <quirk>none</quirk>\n" +
-                               "    </unit>\n\n" +
-                               "Example: You can define quirks that affect all units of a given chassis and then add specific quirks to specific models:\n" +
-                               "    <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>all</model>\n" +
-                               "        <quirk>command_mech</quirk>\n" +
-                               "    </unit>\n" +
-                               "    <unit>\n" +
-                               "        <chassis>Atlas</chassis>\n" +
-                               "        <model>AS7-D</model>\n" +
-                               "        <quirk>anti_air</quirk>\n" +
-                               "    </unit>\n" +
-                               "-->\n\n" +
-                               "<unitQuirks xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"../data/unitQuirksSchema.xsd\">\n";
-    }
+    private static final String CUSTOM_QUIRKS_HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\n" +
+            "<!--\n" +
+            "NOTE: saving quirks for units within MM will cause this file to get re-written and all changes will be lost!\n\n" +
+            "This file allows users to customize the default cannon quirks list. Any quirk assignments in this file will override\n" +
+            " the cannon quirk entries entirely. Changes to this file will not take effect until the next time MegaMek is launched.\n\n" +
+            "To assign a unit a quirk, the entry should be in the following format:\n" +
+            "    <unit>\n" +
+            "        <chassis>[chassis name]</chassis>\n" +
+            "        <model>{model}</model>\n" +
+            "        <quirk>[quirk1 name]</quirk>\n" +
+            "        <quirk>[quirk2 name]</quirk>\n" +
+            "        <weaponQuirk>\n" +
+            "            <weaponQuirkName>[weapon quirk 1 name]</weaponQuirkName>\n" +
+            "            <location>[location of weapon]</location>\n" +
+            "            <slot>[critical slot of weapon]</slot>\n" +
+            "            <weaponName>[name of weapon]</weaponName>\n" +
+            "        </weaponQuirk>\n" +
+            "        <weaponQuirk>\n" +
+            "            <weaponQuirkName>[weapon quirk 2 name]</weaponQuirkName>\n" +
+            "            <location>[location of weapon]</location>\n" +
+            "            <slot>[critical slot of weapon]</slot>\n" +
+            "            <weaponName>[name of weapon]</weaponName>\n" +
+            "        </weaponQuirk>\n" +
+            "    </unit>\n\n" +
+            "The \"model\" field can be left blank if there is no model number for the unit (common for some tank chassis), but the\n" +
+            " tags should still be included. A <model> of \"all\" will cause all units with the same <chassis> to have the defined\n" +
+            " quirks. This can later be overridden with entries for specific models.\n\n" +
+            "Multiple quirks should be contained within separate \"quirk\" tags.\n\n" +
+            "Multiple weapon quirks should be contained within separate \"weaponQuirk\" structures, even if multiple quirks apply to\n" +
+            " the same weapon.\n\n" +
+            "The proper names for quirks can be found in the\n" +
+            " l10n/megamek/common/options/messages.properties file.  Search for the \"QuirksInfo\" section.\n" +
+            " The name you want will fall between \"option\" and \"displayableName\".  For example, if you wish to apply the\n" +
+            " \"Anti-Aircraft Targeting\" quirk to a unit, you will find the following entry in the messages.properties file:\n" +
+            "   QuirksInfo.option.anti_air.displayableName\n" +
+            " The name you want to include in this file for the <quirk> entry is \"anti_air\".\n" +
+            "If you wish to remove all quirks for a unit, you can create an entry in this file with a <quirk> of \"none\".\n\n" +
+            "Example:  If you wish to declare that all Atlas variants do not have the Command Mech quirk:\n" +
+            "    <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>all</model>\n" +
+            "        <quirk>none</quirk>\n" +
+            "    </unit>\n\n" +
+            "Example: If you decide only the AS7-D Atlas, but no other variant, should have the Command Mech quirk:\n" +
+            "        <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>all</model>\n" +
+            "        <quirk>none</quirk>\n" +
+            "    </unit>\n" +
+            "    <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>AS7-D</model>\n" +
+            "        <quirk>command_mech</quirk>\n" +
+            "    </unit>\n\n" +
+            "Example: You can also do this in the opposite direction, so that all Atlases have the Command Mech quirk except the AS7-D:\n" +
+            "    <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>all</model>\n" +
+            "        <quirk>command_mech</quirk>\n" +
+            "    </unit>\n" +
+            "    <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>AS7-D</model>\n" +
+            "        <quirk>none</quirk>\n" +
+            "    </unit>\n\n" +
+            "Example: You can define quirks that affect all units of a given chassis and then add specific quirks to specific models:\n" +
+            "    <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>all</model>\n" +
+            "        <quirk>command_mech</quirk>\n" +
+            "    </unit>\n" +
+            "    <unit>\n" +
+            "        <chassis>Atlas</chassis>\n" +
+            "        <model>AS7-D</model>\n" +
+            "        <quirk>anti_air</quirk>\n" +
+            "    </unit>\n" +
+            "-->\n\n" +
+            "<unitQuirks xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"../data/unitQuirksSchema.xsd\">\n";
 
     private static final String UNIT = "unit";
     private static final String CHASSIS = "chassis";
@@ -155,83 +136,55 @@ public class QuirksHandler {
     private static Map<String, List<QuirkEntry>> customQuirkMap;
     private static AtomicBoolean customQuirksDirty = new AtomicBoolean(false);
     private static AtomicBoolean initialized = new AtomicBoolean(false);
-
-    private static MMLogger logger = null;
+    //endregion Variable Declarations
 
     private QuirksHandler() {
-    }
 
-    // Use to pass in a fake logger for unit tests.
-    static void setLogger(final MMLogger newLogger) {
-        logger = newLogger;
-    }
-
-    private static MMLogger getLogger() {
-        if (null == logger) {
-            logger = DefaultMmLogger.getInstance();
-        }
-        return logger;
     }
 
     /**
      * Generate a Quirk's Unit ID given an Entity.
      *
-     * @param ent Entity to generate UnitId from
+     * @param entity Entity to generate UnitId from
      * @param useModel determines if the model should be used, or be 'all'
      * @return The ID for the unit.
      */
-    private static String getUnitId(Entity ent, boolean useModel) {
-        String typeText = Entity.getEntityMajorTypeName(ent.getEntityType());
-        if (useModel) {
-            return ent.getChassis() + "~" + ent.getModel() + "~" + typeText;
-        } else {
-            return ent.getChassis() + "~~" + typeText;
-        }
+    private static String getUnitId(final Entity entity, final boolean useModel) {
+        final String typeText = Entity.getEntityMajorTypeName(entity.getEntityType());
+        return useModel
+                ? entity.getChassis() + "~" + entity.getModel() + "~" + typeText
+                : entity.getChassis() + "~~" + typeText;
     }
 
-    public static String getUnitId(String chassis, String model, String type) {
+    public static String getUnitId(final String chassis, final String model, final String type) {
         return chassis + "~" + (model.equals(MODEL_ALL) ? "" : model) + "~" + type;
     }
 
-    public static String getChassis(String unitId) {
-        int splitIdx = unitId.indexOf("~");
-        if (splitIdx == -1) {
-            return unitId;
-        } else {
-            return unitId.substring(0, splitIdx);
-        }
+    public static String getChassis(final String unitId) {
+        final int splitIdx = unitId.indexOf("~");
+        return  (splitIdx == -1) ? unitId : unitId.substring(0, splitIdx);
     }
 
-    public static String getModel(String unitId) {
-        int splitIdx = unitId.indexOf("~");
-        int endIdx = unitId.lastIndexOf("~");
-        if (splitIdx == -1) {
-            return null;
-        } else {
-            return unitId.substring(splitIdx + 1, endIdx);
-        }
+    public static @Nullable String getModel(final String unitId) {
+        final int splitIdx = unitId.indexOf("~");
+        return (splitIdx == -1) ? null : unitId.substring(splitIdx + 1, unitId.lastIndexOf("~"));
     }
 
-    public static String getUnitType(String unitId) {
+    public static @Nullable String getUnitType(final String unitId) {
         int splitIdx = unitId.lastIndexOf("~");
-        if (splitIdx == -1) {
-            return null;
-        } else {
-            return unitId.substring(splitIdx + 1, unitId.length());
-        }
+        return (splitIdx == -1) ? null : unitId.substring(splitIdx + 1);
     }
 
-    public static String replaceUnitType(String unitId, String newUnitType) {
-        int splitIdx = unitId.lastIndexOf("~");
-        return unitId.substring(0, splitIdx) + "~" + newUnitType;
+    public static String replaceUnitType(final String unitId, final String newUnitType) {
+        return unitId.substring(0, unitId.lastIndexOf("~")) + "~" + newUnitType;
     }
 
-    private static Map<String, List<QuirkEntry>> loadQuirksFile(String path) throws IOException {
-        Map<String, List<QuirkEntry>> quirkMap = new HashMap<>();
+    private static Map<String, List<QuirkEntry>> loadQuirksFile(final String path) throws Exception {
+        final Map<String, List<QuirkEntry>> quirkMap = new HashMap<>();
 
-        File file = new File(path);
+        final File file = new File(path);
         if (!file.exists() || !file.isFile()) {
-            getLogger().warning("Could not load quirks from " + path);
+            MegaMek.getLogger().warning("Could not load quirks from " + path);
             return quirkMap;
         }
 
@@ -262,14 +215,14 @@ public class QuirksHandler {
 
                 // Get the model.
                 Element modelElement = (Element) unitList.getElementsByTagName(MODEL).item(0);
-                // default to "all" model for entries that don't list a model.. backwards compatibility with older quirks files
+                // default to "all" model for entries that don't list a model... backwards compatibility with older quirks files
                 String model = MODEL_ALL;
                 if (modelElement != null) {
                     model = modelElement.getTextContent().trim();
                 }
 
                 Element typeElement = (Element) unitList.getElementsByTagName(UNIT_TYPE).item(0);
-                // default to "Mech" type for entries that don't list a type.. backwards compatibility with older quirks files
+                // default to "Mech" type for entries that don't list a type... backwards compatibility with older quirks files
                 String unitType = "Mech";
                 if (typeElement != null) {
                     unitType = typeElement.getTextContent().trim();
@@ -338,21 +291,17 @@ public class QuirksHandler {
                     String weaponName = weapElement.getTextContent().trim();
 
                     // Add the weapon quirk to the list.
-                    QuirkEntry weaponQuirk = new QuirkEntry(weaponQuirkName,
-                            location, Integer.parseInt(slot), weaponName,
-                            unitId);
+                    QuirkEntry weaponQuirk = new QuirkEntry(weaponQuirkName, location,
+                            Integer.parseInt(slot), weaponName, unitId);
                     quirkList.add(weaponQuirk);
                 }
 
                 // Add the unit to the default quirks list.
                 if (quirkList.isEmpty()) {
-                    log.append("\n\t\tNo quirks found for ");
-                    if (unitId.length() > 0) {
-                        log.append(unitId);
-                    } else {
-                        log.append("<BlankUnitId>");
-                    }
+                    log.append("\n\t\tNo quirks found for ")
+                            .append((unitId.length() > 0) ? unitId : "<BlankUnitId>");
                 }
+
                 if (quirkMap.containsKey(unitId)) {
                     log.append("\n\t\t").append(unitId).append(": duplicate entry added!");
                 }
@@ -361,38 +310,36 @@ public class QuirksHandler {
             log.append("\n\tTotal number of quirk entries: ").append(quirkMap.size());
             return quirkMap;
         } catch (Exception e) {
-            getLogger().error(e);
-            throw new IOException(e);
+            throw MegaMek.getLogger().error(e);
         } finally {
-            getLogger().info(log.toString());
+            MegaMek.getLogger().info(log.toString());
         }
     }
 
     /**
      * Reads in the values from the canonUnitQuirks.xml file and stores them in memory.
      *
-     * @throws IOException If the file cannot be read.
+     * @throws Exception If the file cannot be read.
      */
-    public static void initQuirksList() throws IOException {
-
+    public static void initQuirksList() throws Exception {
         // Get the path to the canonUnitQuirks.xml file.
-        String userDir = System.getProperty("user.dir");
+        String userDir = System.getProperty("user.dir"); // TODO : Remove inline file path
         if (!userDir.endsWith(File.separator)) {
             userDir += File.separator;
         }
 
         // Load the canon quirks list.
-        String filePath = Configuration.dataDir().getAbsolutePath() + File.separator + "canonUnitQuirks.xml";
+        String filePath = Configuration.dataDir().getAbsolutePath() + File.separator + "canonUnitQuirks.xml"; // TODO : Remove inline file path
         canonQuirkMap = loadQuirksFile(filePath);
 
         // Load the custom quirks list.
-        filePath = userDir + "mmconf" + File.separator + "unitQuirksOverride.xml";
+        filePath = userDir + "mmconf" + File.separator + "unitQuirksOverride.xml"; // TODO : Remove inline file path
         customQuirkMap = loadQuirksFile(filePath);
 
         initialized.set(true);
     }
 
-    public static void saveCustomQuirksList() throws IOException {
+    public static void saveCustomQuirksList() {
         // If customQuirkMap wasn't initialized, no reason to save it
         if (customQuirkMap == null) {
             return;
@@ -404,17 +351,14 @@ public class QuirksHandler {
         }
 
         // Get the path to the unitQuirksOverride.xml file.
-        String userDir = System.getProperty("user.dir");
+        String userDir = System.getProperty("user.dir"); // TODO : Remove inline file path
         if (!userDir.endsWith(File.separator)) {
             userDir += File.separator;
         }
-        String filePath = userDir + "mmconf" + File.separator
-                + "unitQuirksOverride.xml";
+        String filePath = userDir + "mmconf" + File.separator + "unitQuirksOverride.xml"; // TODO : Remove inline file path
 
-        Writer output = null;
-        try {
-            output = new BufferedWriter(new OutputStreamWriter(
-                    new FileOutputStream(filePath)));
+        // TODO : Convert to MegaMekXMLUtil
+        try (Writer output = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(filePath)))) {
             output.write(CUSTOM_QUIRKS_HEADER);
             for (String unitId : customQuirkMap.keySet()) {
                 String chassis = getChassis(unitId);
@@ -480,12 +424,8 @@ public class QuirksHandler {
             }
 
             output.write(CUSTOM_QUIRKS_FOOTER);
-        } catch (IOException e) {
-            getLogger().error("Error writing CustomQuirks file!", e);
-        } finally {
-            if (output != null) {
-                output.close();
-            }
+        } catch (Exception e) {
+            MegaMek.getLogger().error("Error writing CustomQuirks file!", e);
         }
     }
 
@@ -504,8 +444,7 @@ public class QuirksHandler {
      * @return A {@code List} of the quirks ({@code QuirkEntry}) for the given
      *         unit. If the unit is not in the list, a NULL value is returned.
      */
-    @Nullable
-    static List<QuirkEntry> getQuirks(Entity entity) {
+    static @Nullable List<QuirkEntry> getQuirks(final Entity entity) throws Exception {
         if (!initialized.get() || (null == canonQuirkMap)) {
             return null;
         }
@@ -525,7 +464,6 @@ public class QuirksHandler {
 
             // Check for a model-specific entry.
             if (customQuirkMap.containsKey(unitId)) {
-
                 // If this specific model has no quirks, return null.
                 if (NO_QUIRKS.equalsIgnoreCase(customQuirkMap.get(unitId).get(0).getQuirk())) {
                     return null;
@@ -535,8 +473,8 @@ public class QuirksHandler {
                 quirks.addAll(customQuirkMap.get(unitId));
             }
 
-            // If there is only one quirk on the list and it indicates that the custom list has removed all quirks from
-            // this unit, return null.
+            // If there is only one quirk on the list, and it indicates that the custom list has
+            // removed all quirks from this unit, return null.
             if ((quirks.size() == 1) && NO_QUIRKS.equalsIgnoreCase(quirks.get(0).getQuirk())) {
                 return null;
             }
@@ -553,7 +491,6 @@ public class QuirksHandler {
 
             // Check for a model-specific entry.
             if (canonQuirkMap.containsKey(unitId)) {
-
                 // If this specific model, has no quirks, return null.
                 if (NO_QUIRKS.equalsIgnoreCase(canonQuirkMap.get(unitId).get(0).getQuirk())) {
                     return null;
@@ -565,19 +502,17 @@ public class QuirksHandler {
 
             return quirks.isEmpty() ? null : quirks;
         } catch (Exception e) {
-            String msg = "generalId: '" + generalId + "'\nunitId: '" + unitId + "'\n";
-            getLogger().error(msg, e);
-            throw new RuntimeException(msg, e);
+            throw MegaMek.getLogger().error("generalId: '" + generalId + "'\nunitId: '" + unitId + "'\n", e);
         }
     }
 
     public static void addCustomQuirk(Entity entity, boolean useModel) {
-        // Shouldn't happen, but lets be careful
+        // Shouldn't happen, but let's be careful
         if (customQuirkMap == null) {
             try {
                 QuirksHandler.initQuirksList();
-            } catch (IOException e) {
-                getLogger().error(e);
+            } catch (Exception e) {
+                MegaMek.getLogger().error(e);
             }
         }
 
@@ -588,11 +523,7 @@ public class QuirksHandler {
         unitId = getUnitId(entity, useModel);
 
         // Get a quirks list
-        List<QuirkEntry> quirkEntries = customQuirkMap.get(unitId);
-        if (quirkEntries == null) {
-            quirkEntries = new ArrayList<>();
-            customQuirkMap.put(unitId, quirkEntries);
-        }
+        List<QuirkEntry> quirkEntries = customQuirkMap.computeIfAbsent(unitId, k -> new ArrayList<>());
         quirkEntries.clear();
 
         // Add Entity Quirks
@@ -606,8 +537,7 @@ public class QuirksHandler {
                 while (quirkOptions.hasMoreElements()) {
                     IOption option = quirkOptions.nextElement();
                     // Ignore illegal quirks, and ones that aren't set
-                    if (!Quirks.isQuirkLegalFor(option, entity)
-                            || !option.booleanValue()) {
+                    if (!Quirks.isQuirkLegalFor(option, entity) || !option.booleanValue()) {
                         continue;
                     }
                     // Add new QuirkEntry
@@ -626,22 +556,19 @@ public class QuirksHandler {
             for (int slot = 0; slot < numCrits; slot++) {
                 CriticalSlot crit = entity.getCritical(loc, slot);
                 // Ignore systems and null entries
-                if ((crit == null)
-                        || (crit.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                if ((crit == null) || (crit.getType() == CriticalSlot.TYPE_SYSTEM)) {
                     continue;
                 }
+
                 // Add quirk for mount if we haven't already
-                if ((crit.getMount() != null)
-                        && !addedEquipment.contains(crit.getMount())) {
-                    addWeaponQuirk(quirkEntries, crit.getMount(), loc, slot,
-                            unitId, entity);
+                if ((crit.getMount() != null) && !addedEquipment.contains(crit.getMount())) {
+                    addWeaponQuirk(quirkEntries, crit.getMount(), loc, slot, unitId, entity);
                     addedEquipment.add(crit.getMount());
                 }
+
                 // Add quirk for mount2 if we haven't already
-                if ((crit.getMount2() != null)
-                        && !addedEquipment.contains(crit.getMount2())) {
-                    addWeaponQuirk(quirkEntries, crit.getMount2(), loc, slot,
-                            unitId, entity);
+                if ((crit.getMount2() != null) && !addedEquipment.contains(crit.getMount2())) {
+                    addWeaponQuirk(quirkEntries, crit.getMount2(), loc, slot, unitId, entity);
                     addedEquipment.add(crit.getMount2());
                 }
             }
@@ -658,18 +585,19 @@ public class QuirksHandler {
      * @param unitId The identity of the unit.
      * @param entity The entity itself.
      */
-    private static void addWeaponQuirk(List<QuirkEntry> quirkEntries,
-            @Nullable Mounted m, int loc, int slot, String unitId, Entity entity) {
+    private static void addWeaponQuirk(List<QuirkEntry> quirkEntries, @Nullable Mounted m, int loc,
+                                       int slot, String unitId, Entity entity) {
         // If mount is null, nothing to do
         if (m == null) {
             return;
         }
+
         // Ignore if the mount has no quirks
         if (m.countQuirks() > 0) {
             WeaponQuirks weapQuirks = m.getQuirks();
             Enumeration<IOptionGroup> quirksGroup = weapQuirks.getGroups();
             Enumeration<IOption> quirkOptions;
-           while (quirksGroup.hasMoreElements()) {
+            while (quirksGroup.hasMoreElements()) {
                 IOptionGroup group = quirksGroup.nextElement();
                 quirkOptions = group.getSortedOptions();
                 while (quirkOptions.hasMoreElements()) {
@@ -678,10 +606,10 @@ public class QuirksHandler {
                     if (!option.booleanValue()) {
                         continue;
                     }
+
                     // Create new entry and add it
-                    QuirkEntry qe = new QuirkEntry(option.getName(),
-                            entity.getLocationAbbr(loc), slot, m.getType()
-                                    .getInternalName(), unitId);
+                    QuirkEntry qe = new QuirkEntry(option.getName(), entity.getLocationAbbr(loc),
+                            slot, m.getType().getInternalName(), unitId);
                     quirkEntries.add(qe);
                 }
             }
@@ -697,12 +625,12 @@ public class QuirksHandler {
      * munge its eType and write it to customQuirks.
      */
     public static void mungeQuirks(String quirkId, String newId) {
-        // Shouldn't happen, but lets be careful
+        // Shouldn't happen, but let's be careful
         if (customQuirkMap == null) {
             try {
                 QuirksHandler.initQuirksList();
-            } catch (IOException e) {
-                getLogger().error(e);
+            } catch (Exception e) {
+                MegaMek.getLogger().error(e);
             }
         }
 

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -490,7 +490,7 @@ public class QuirksHandler {
             }
 
             // Check for a model-specific entry.
-            if (canonQuirkMap.containsKey(unitId)) {
+            if (canonQuirkMap.containsKey(unitId) && !canonQuirkMap.get(unitId).isEmpty()) {
                 // If this specific model, has no quirks, return null.
                 if (NO_QUIRKS.equalsIgnoreCase(canonQuirkMap.get(unitId).get(0).getQuirk())) {
                     return null;

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -162,7 +162,7 @@ public class QuirksHandler {
 
     public static String getChassis(final String unitId) {
         final int splitIdx = unitId.indexOf("~");
-        return  (splitIdx == -1) ? unitId : unitId.substring(0, splitIdx);
+        return (splitIdx == -1) ? unitId : unitId.substring(0, splitIdx);
     }
 
     public static @Nullable String getModel(final String unitId) {

--- a/megamek/src/megamek/test/QuirkRewriteTool.java
+++ b/megamek/src/megamek/test/QuirkRewriteTool.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import megamek.MegaMek;
 import megamek.common.EquipmentType;
 import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
@@ -54,9 +55,8 @@ public class QuirkRewriteTool implements MechSummaryCache.Listener {
 
         try {
             QuirksHandler.initQuirksList();
-        } catch (IOException e) {
-            System.err.println("Error initializing quirks!");
-            e.printStackTrace();
+        } catch (Exception e) {
+            MegaMek.getLogger().error("Error initializing quirks", e);
             return;
         }
 
@@ -93,11 +93,7 @@ public class QuirkRewriteTool implements MechSummaryCache.Listener {
 
         System.out.println("Writing new custom quirks!");
         // Save the munged quirks in the custom quirks list
-        try {
-            QuirksHandler.saveCustomQuirksList();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        QuirksHandler.saveCustomQuirksList();
         System.out.println("\n");
 
         System.out.println("Comparing Quirks!");

--- a/megamek/src/megamek/test/QuirkTool.java
+++ b/megamek/src/megamek/test/QuirkTool.java
@@ -2,56 +2,41 @@
  * MegaMek - Copyright (C) 2003,2004 Ben Mazur (bmazur@sev.org)
  *  Copyright © 2016 Nicholas Walczak (walczak@cs.umn.edu)
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
  */
 package megamek.test;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import megamek.MegaMek;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
 
-import megamek.common.Aero;
-import megamek.common.Entity;
-import megamek.common.EquipmentType;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.MechFileParser;
-import megamek.common.MechSummary;
-import megamek.common.MechSummaryCache;
-import megamek.common.Protomech;
-import megamek.common.QuirksHandler;
-import megamek.common.Tank;
-import megamek.common.VTOL;
+import java.io.File;
+import java.util.*;
 
 /**
- * This program is a tool to help gather information about quirks.  It goes
- * through each canon quirk entry and will print out 1) if it belongs to 
- * multiple types of units (which is an error), 2) if it belongs to no unit 
- * (which likely means there's an error).  Also, since some errors don't appear
- * until a unit is loaded, it will force any problematic quirks to throw up
- * warnings.
+ * This program is a tool to help gather information about quirks. It goes through each canon quirk
+ * entry and will print out:
+ * 1) if it belongs to multiple types of units (which is an error)
+ * 2) if it belongs to no unit (which likely means there's an error)
+ *
+ * Also, since some errors don't appear until a unit is loaded, it will force any problematic quirks
+ * to throw up warnings.
  * 
  * @author arlith
- * @date January 2016
+ * @since January 2016
  */
 public class QuirkTool implements MechSummaryCache.Listener {
-
     private static MechSummaryCache mechSummaryCache = null;
 
-    public static void main(String[] args) {     
+    public static void main(String... args) {
         EquipmentType.initializeTypes();
         
         QuirkTool qc = new QuirkTool();
@@ -65,9 +50,8 @@ public class QuirkTool implements MechSummaryCache.Listener {
 
         try {
             QuirksHandler.initQuirksList();
-        } catch (IOException e) {
-            System.err.println("Error initializing quirks!");
-            e.printStackTrace();
+        } catch (Exception e) {
+            MegaMek.getLogger().error("Error initializing quirks", e);
             return;
         }
         
@@ -76,46 +60,40 @@ public class QuirkTool implements MechSummaryCache.Listener {
         
         for (String quirkId : quirkIds) {
             for (MechSummary summary : ms) {              
-                String allId = QuirksHandler.getUnitId(summary.getChassis(),
-                        "all", MechSummary.determineETypeName(summary));
-                String specificId = QuirksHandler.getUnitId(
-                        summary.getChassis(), summary.getModel(),
+                String allId = QuirksHandler.getUnitId(summary.getChassis(), "all",
                         MechSummary.determineETypeName(summary));
+                String specificId = QuirksHandler.getUnitId(summary.getChassis(),
+                        summary.getModel(), MechSummary.determineETypeName(summary));
                 List<Entity> entities;
                 if (quirkId.equals(allId) || quirkId.equals(specificId)) {
-                    entities = idEntitiesMap.get(quirkId);
-                    if (entities == null) {
-                        entities = new ArrayList<>();
-                        idEntitiesMap.put(quirkId, entities);
-                    }
-                    entities.add(loadEntity(summary.getSourceFile(),
-                            summary.getEntryName()));
+                    entities = idEntitiesMap.computeIfAbsent(quirkId, k -> new ArrayList<>());
+                    entities.add(loadEntity(summary.getSourceFile(), summary.getEntryName()));
                 }
             }
+
             if (idEntitiesMap.get(quirkId) == null) {
-                System.out.println("Entry: " + quirkId
-                        + " doesn't have any matches!");
+                MegaMek.getLogger().warning("Entry: " + quirkId + "doesn't have any matches!");
             }
         }
         
-        for (String quirkId : idEntitiesMap.keySet()) {
+        for (final String quirkId : idEntitiesMap.keySet()) {
             List<Entity> entities = idEntitiesMap.get(quirkId);
             Set<Integer> types = new HashSet<>();
             boolean containsNonMech = false;
-            for (Entity ent : entities) {
+            for (final Entity ent : entities) {
                 if (!(ent instanceof Mech)) {
-                    System.out.println("Entry: " + quirkId
-                            + " contains non 'mech!");
+                    MegaMek.getLogger().info("Entry " + quirkId + " contains non 'Mek");
                     containsNonMech = true;
                 }
+
                 if (ent instanceof Mech) {
                     types.add(1);
+                } else if (ent instanceof VTOL) {
+                    types.add(4);
                 } else if (ent instanceof Tank) {
                     types.add(2);
                 } else if (ent instanceof Aero) {
                     types.add(3);
-                } else if (ent instanceof VTOL) {
-                    types.add(4);
                 } else if (ent instanceof Infantry) {
                     types.add(5);
                 } else if (ent instanceof Protomech) {
@@ -124,29 +102,27 @@ public class QuirkTool implements MechSummaryCache.Listener {
                     types.add(7);
                 }
             }
+
             if (containsNonMech) {
-                System.out.println("non-mech entry: " + quirkId);
+                MegaMek.getLogger().info("Non-Mek Entry " + quirkId);
             }
+
             if (types.size() > 1) {
-                System.out.println("Entry: " + quirkId
-                        + " contains mixed types!");
+                MegaMek.getLogger().warning("Entry " + quirkId + " contains mixed types");
             }
-            if (types.size() == 0) {
-                System.out.println("Entry: " + quirkId
-                        + " doesn't have any matches!");
+
+            if (types.isEmpty()) {
+                MegaMek.getLogger().warning("Entry " + quirkId + " doesn't have any matches");
             }
         }
-    }
-    
-    public Entity loadEntity(File f, String entityName) {
-        Entity entity = null;
-        try {
-            entity = new MechFileParser(f, entityName).getEntity();
-        } catch (megamek.common.loaders.EntityLoadingException e) {
-            System.out.println("Exception: " + e.toString()); //$NON-NLS-1$
-        }
-        return entity;
     }
 
-    
+    public @Nullable Entity loadEntity(final File file, final String entityName) {
+        try {
+            return new MechFileParser(file, entityName).getEntity();
+        } catch (Exception e) {
+            MegaMek.getLogger().error(e);
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
This fixes an NPE found in the logs in #3273, fixes how VTOLs aren't handled properly in the Quirk Tool, and cleans up the code in the region.

For Review: The first commit is a refactor, the second commit is the bugfix, the third commit are review fixes.