### PR TITLE
prevent bot spotting of invalid targets

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2266,8 +2266,8 @@ public class FireControl {
     	    }
     	    
     	    // don't spot sensor returns
-    	    if (target.getTargetType() == Targetable.TYPE_ENTITY &&
-    	            ((Entity) target).isSensorReturn(spotter.getOwner())) {
+    	    if ((target.getTargetType() == Targetable.TYPE_ENTITY) &&
+	            ((Entity) target).isSensorReturn(spotter.getOwner())) {
     	        continue;
     	    }    	        
     	    

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2260,7 +2260,18 @@ public class FireControl {
     	// loop through all enemy targets, pick a random one out of the closest.
     	// future revision: pick one that's the least evasive
     	for (Targetable target : enemyTargets) {
-    		LosEffects effects = LosEffects.calculateLOS(spotter.getGame(), spotter, target);
+    	    // don't spot aerospace units
+    	    if (target.isAirborne()) {
+    	        continue;
+    	    }
+    	    
+    	    // don't spot sensor returns
+    	    if (target.getTargetType() == Targetable.TYPE_ENTITY &&
+    	            ((Entity) target).isSensorReturn(spotter.getOwner())) {
+    	        continue;
+    	    }    	        
+    	    
+    	    LosEffects effects = LosEffects.calculateLOS(spotter.getGame(), spotter, target);
             
             // if we're in LOS
     		if (effects.canSee()) {


### PR DESCRIPTION
Fixes #3312, Fixes #3313 by eliminating airborne targets and sensor contacts from the list of valid objects that can be spotted.