### PR TITLE
Detachable Pane Mode: Preventing initial exception by adding initial preference

### DIFF
--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -21,6 +21,7 @@ import javax.swing.*;
 import megamek.client.ui.swing.boardview.BoardView;
 import megamek.client.ui.swing.boardview.LabelDisplayStyle;
 import megamek.client.ui.swing.util.PlayerColour;
+import megamek.client.ui.swing.widget.DetachablePane;
 import megamek.common.Entity;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.preference.PreferenceStoreProxy;
@@ -338,6 +339,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(CUSTOM_UNIT_WIDTH, 600);
         store.setDefault(UNIT_DETAIL_SIZE_HEIGHT, 500);
         store.setDefault(UNIT_DETAIL_SIZE_WIDTH, 300);
+        store.setDefault(UNIT_DETAIL_STATE, DetachablePane.Mode.EXPANDED.name());
         store.setDefault(GAME_SUMMARY_BOARD_VIEW, false);
         store.setDefault(GAME_SUMMARY_MINI_MAP, false);
         store.setDefault(ENTITY_OWNER_LABEL_COLOR, true);
@@ -542,8 +544,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getInt(UNIT_DETAIL_SIZE_WIDTH);
     }
 
-    public String getUnitDetailState() {
-        return store.getString(UNIT_DETAIL_STATE);
+    public DetachablePane.Mode getUnitDetailState() {
+        return DetachablePane.Mode.valueOf(store.getString(UNIT_DETAIL_STATE));
     }
 
     public boolean getGameSummaryBoardView() {
@@ -1027,8 +1029,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setValue(UNIT_DETAIL_SIZE_WIDTH, i);
     }
 
-    public void setUnitDetailState(String state) {
-        store.setValue(UNIT_DETAIL_STATE, state);
+    public void setUnitDetailState(DetachablePane.Mode state) {
+        store.setValue(UNIT_DETAIL_STATE, state.name());
     }
 
     public void setGameSummaryBoardView(boolean state) {

--- a/megamek/src/megamek/client/ui/swing/UnitDetailPane.java
+++ b/megamek/src/megamek/client/ui/swing/UnitDetailPane.java
@@ -42,13 +42,11 @@ public class UnitDetailPane extends DetachablePane {
         window.setResizable(true);
         UIUtil.updateWindowBounds(window);
 
-        var state = getState();
         try {
-            state = Mode.valueOf(prefs.getUnitDetailState().toUpperCase());
+            setState(prefs.getUnitDetailState());
         } catch (Exception e) {
             LogManager.getLogger().error("Error setting unit detail state", e);
         }
-        setState(state);
     }
 
     public UnitDisplay getDetail() {
@@ -60,7 +58,7 @@ public class UnitDetailPane extends DetachablePane {
         var existing = getState();
         super.setState(newState);
         if (newState != existing) {
-            GUIPreferences.getInstance().setUnitDetailState(newState.name());
+            GUIPreferences.getInstance().setUnitDetailState(newState);
         }
     }
 }


### PR DESCRIPTION
This fixes an issue with the Detachable Pane Mode and moves the preferences to just save and return the mode itself... to prevent any issues with the preferences.