### PR TITLE
Suite Localization: Creating a temporary locale redirect in MMOptions

### DIFF
--- a/megamek/src/megamek/MMOptions.java
+++ b/megamek/src/megamek/MMOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021-2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek;
+
+import megamek.common.preference.PreferenceManager;
+
+import java.util.Locale;
+
+public class MMOptions {
+    //region Temporary
+    /**
+     * This is a temporary Locale getter, which sets the stage for suite-wide localization.
+     */
+    public Locale getLocale() {
+        return PreferenceManager.getClientPreferences().getLocale();
+    }
+
+    /**
+     * This is a temporary Locale getter for dates, which sets the stage for suite-wide localization.
+     */
+    public Locale getDateLocale() {
+        return PreferenceManager.getClientPreferences().getLocale();
+    }
+    //endregion Temporary
+}

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -43,6 +43,7 @@ import java.util.Vector;
  */
 public class MegaMek {
     private static MMPreferences preferences = null;
+    private static MMOptions mmOptions = new MMOptions();
 
     public static long TIMESTAMP = new File(PreferenceManager.getClientPreferences().getLogDirectory()
             + File.separator + "timestamp").lastModified();
@@ -135,6 +136,10 @@ public class MegaMek {
         }
 
         return preferences;
+    }
+
+    public static MMOptions getMMOptions() {
+        return mmOptions;
     }
 
     /**

--- a/megamek/src/megamek/SuiteOptions.java
+++ b/megamek/src/megamek/SuiteOptions.java
@@ -18,10 +18,30 @@
  */
 package megamek;
 
-public class MMOptions extends SuiteOptions {
+import megamek.common.preference.PreferenceManager;
+
+import java.util.Locale;
+
+public class SuiteOptions {
     //region Constructors
-    public MMOptions() {
-        super();
+    protected SuiteOptions() {
+
     }
     //endregion Constructors
+
+    //region Temporary
+    /**
+     * This is a temporary Locale getter, which sets the stage for suite-wide localization.
+     */
+    public Locale getLocale() {
+        return PreferenceManager.getClientPreferences().getLocale();
+    }
+
+    /**
+     * This is a temporary Locale getter for dates, which sets the stage for suite-wide localization.
+     */
+    public Locale getDateLocale() {
+        return PreferenceManager.getClientPreferences().getLocale();
+    }
+    //endregion Temporary
 }

--- a/megamek/src/megamek/client/bot/Messages.java
+++ b/megamek/src/megamek/client/bot/Messages.java
@@ -13,7 +13,7 @@
  */
 package megamek.client.bot;
 
-import megamek.common.preference.PreferenceManager;
+import megamek.MegaMek;
 import megamek.common.util.EncodeControl;
 
 import java.text.MessageFormat;
@@ -23,7 +23,7 @@ import java.util.ResourceBundle;
 public class Messages {
 
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.client.bot.messages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+            MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
     private Messages() {
     }

--- a/megamek/src/megamek/client/generator/enums/SkillGeneratorMethod.java
+++ b/megamek/src/megamek/client/generator/enums/SkillGeneratorMethod.java
@@ -18,8 +18,8 @@
  */
 package megamek.client.generator.enums;
 
+import megamek.MegaMek;
 import megamek.client.generator.skillGenerators.*;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import java.util.ResourceBundle;
@@ -41,7 +41,7 @@ public enum SkillGeneratorMethod {
     //region Constructors
     SkillGeneratorMethod(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("megamek.client.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+                MegaMek.getMMOptions().getLocale(), new EncodeControl());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/megamek/src/megamek/client/generator/enums/SkillGeneratorType.java
+++ b/megamek/src/megamek/client/generator/enums/SkillGeneratorType.java
@@ -18,7 +18,7 @@
  */
 package megamek.client.generator.enums;
 
-import megamek.common.preference.PreferenceManager;
+import megamek.MegaMek;
 import megamek.common.util.EncodeControl;
 
 import java.util.ResourceBundle;
@@ -38,7 +38,7 @@ public enum SkillGeneratorType {
     //region Constructors
     SkillGeneratorType(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("megamek.client.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+                MegaMek.getMMOptions().getLocale(), new EncodeControl());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/megamek/src/megamek/client/ui/Messages.java
+++ b/megamek/src/megamek/client/ui/Messages.java
@@ -14,17 +14,17 @@
  */
 package megamek.client.ui;
 
+import megamek.MegaMek;
+import megamek.common.util.EncodeControl;
+import org.apache.logging.log4j.LogManager;
+
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
-import org.apache.logging.log4j.LogManager;
-
 public class Messages {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.client.messages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+            MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
     // All static class, should never be instantiated
     private Messages() { }

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
@@ -18,8 +18,8 @@
  */
 package megamek.client.ui.baseComponents;
 
+import megamek.MegaMek;
 import megamek.client.ui.enums.DialogResult;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
@@ -64,7 +64,7 @@ public abstract class AbstractButtonDialog extends AbstractDialog {
     protected AbstractButtonDialog(final JFrame frame, final boolean modal, final String name,
                                    final String title) {
         this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", 
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name, title);
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name, title);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
@@ -21,7 +21,6 @@ package megamek.client.ui.baseComponents;
 import megamek.MegaMek;
 import megamek.client.ui.preferences.JWindowPreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 import org.apache.logging.log4j.LogManager;
 
@@ -65,7 +64,7 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
      */
     protected AbstractDialog(final JFrame frame, final boolean modal, final String name, final String title) {
         this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", 
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name, title);
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name, title);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractPanel.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractPanel.java
@@ -20,7 +20,6 @@ package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
@@ -55,7 +54,7 @@ public abstract class AbstractPanel extends JPanel {
      */
     protected AbstractPanel(final JFrame frame, final String name, final boolean isDoubleBuffered) {
         this(frame, ResourceBundle.getBundle("megamek.client.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()),
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()),
                 name, new FlowLayout(), isDoubleBuffered);
     }
 
@@ -74,7 +73,7 @@ public abstract class AbstractPanel extends JPanel {
     protected AbstractPanel(final JFrame frame, final String name,
                             final LayoutManager layoutManager, final boolean isDoubleBuffered) {
         this(frame, ResourceBundle.getBundle("megamek.client.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()),
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()),
                 name, layoutManager, isDoubleBuffered);
     }
 

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractScrollPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractScrollPane.java
@@ -19,9 +19,8 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
 import java.util.ResourceBundle;
@@ -56,8 +55,8 @@ public abstract class AbstractScrollPane extends JScrollPane {
     protected AbstractScrollPane(final JFrame frame, final String name,
                                  final int verticalScrollBarPolicy, final int horizontalScrollBarPolicy) {
         this(frame, ResourceBundle.getBundle("megamek.client.messages", 
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()),
-                name, verticalScrollBarPolicy, horizontalScrollBarPolicy);
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name,
+                verticalScrollBarPolicy, horizontalScrollBarPolicy);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractSplitPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractSplitPane.java
@@ -19,10 +19,9 @@
 package megamek.client.ui.baseComponents;
 
 import megamek.MegaMek;
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
 import megamek.client.ui.preferences.JSplitPanePreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
 import java.awt.*;
@@ -50,7 +49,7 @@ public abstract class AbstractSplitPane extends JSplitPane {
      */
     protected AbstractSplitPane(final JFrame frame, final String name) {
         this(frame, ResourceBundle.getBundle("megamek.client.messages", 
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name);
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractTabbedPane.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractTabbedPane.java
@@ -48,7 +48,7 @@ public abstract class AbstractTabbedPane extends JTabbedPane {
      */
     protected AbstractTabbedPane(final JFrame frame, final String name) {
         this(frame, ResourceBundle.getBundle("megamek.client.messages", 
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name);
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractValidationButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractValidationButtonDialog.java
@@ -18,9 +18,9 @@
  */
 package megamek.client.ui.baseComponents;
 
+import megamek.MegaMek;
 import megamek.client.ui.enums.ValidationState;
 import megamek.common.annotations.Nullable;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 import org.apache.logging.log4j.LogManager;
 
@@ -70,7 +70,7 @@ public abstract class AbstractValidationButtonDialog extends AbstractButtonDialo
     protected AbstractValidationButtonDialog(final JFrame frame, final boolean modal,
                                              final String name, final String title) {
         this(frame, modal, ResourceBundle.getBundle("megamek.client.messages", 
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name, title);
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name, title);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/dialogs/AbstractIconChooserDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/AbstractIconChooserDialog.java
@@ -18,13 +18,13 @@
  */
 package megamek.client.ui.dialogs;
 
+import megamek.MegaMek;
 import megamek.client.ui.baseComponents.AbstractButtonDialog;
 import megamek.client.ui.baseComponents.MMButton;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.panels.AbstractIconChooser;
 import megamek.common.annotations.Nullable;
 import megamek.common.icons.AbstractIcon;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import javax.swing.*;
@@ -52,7 +52,7 @@ public abstract class AbstractIconChooserDialog extends AbstractButtonDialog {
     public AbstractIconChooserDialog(final JFrame frame, final String name, final String title,
                                      final AbstractIconChooser chooser, final boolean doubleClick) {
         this(frame, true, ResourceBundle.getBundle("megamek.client.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl()), name,
+                MegaMek.getMMOptions().getLocale(), new EncodeControl()), name,
                 title, chooser, doubleClick);
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -18,6 +18,7 @@
  */
 package megamek.client.ui.swing.lobby;
 
+import megamek.MegaMek;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
@@ -125,7 +126,7 @@ class LobbyMekCellFormatter {
         if (forceView) {
             result.append(DOT_SPACER);
         }
-        NumberFormat formatter = NumberFormat.getNumberInstance(PreferenceManager.getClientPreferences().getLocale());
+        NumberFormat formatter = NumberFormat.getNumberInstance(MegaMek.getMMOptions().getLocale());
         result.append(formatter.format(entity.getWeight()));
         result.append(Messages.getString("ChatLounge.Tons"));
         result.append("</FONT>");

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
@@ -18,28 +18,27 @@
  */
 package megamek.client.ui.swing.lobby;
 
-import static megamek.client.ui.swing.util.UIUtil.*;
+import megamek.MegaMek;
+import megamek.client.bot.BotClient;
+import megamek.client.ui.Messages;
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.IStartingPositions;
+import megamek.common.Player;
+import megamek.common.options.OptionsConstants;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.GridLayout;
-import java.awt.Image;
-import java.awt.Point;
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
+import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.swing.*;
-import javax.swing.table.*;
-
-import megamek.client.bot.BotClient;
-import megamek.client.ui.Messages;
-import megamek.client.ui.swing.GUIPreferences;
-import megamek.client.ui.swing.util.UIUtil;
-import megamek.common.*;
-import megamek.common.options.OptionsConstants;
-import megamek.common.preference.PreferenceManager;
+import static megamek.client.ui.swing.util.UIUtil.*;
 
 class PlayerTable extends JTable {
     private static final long serialVersionUID = 6252953920509362407L;
@@ -203,7 +202,7 @@ class PlayerTable extends JTable {
             result.append(UIUtil.DOT_SPACER);
             result.append(guiScaledFontHTML());
             result.append("BV: ");
-            NumberFormat formatter = NumberFormat.getIntegerInstance(PreferenceManager.getClientPreferences().getLocale());
+            NumberFormat formatter = NumberFormat.getIntegerInstance(MegaMek.getMMOptions().getLocale());
             result.append((player.getBV() != 0) ? formatter.format(player.getBV()) : "--");
             result.append("</FONT>");
 

--- a/megamek/src/megamek/common/EntityMovementMode.java
+++ b/megamek/src/megamek/common/EntityMovementMode.java
@@ -19,7 +19,7 @@
  */
 package megamek.common;
 
-import megamek.common.preference.PreferenceManager;
+import megamek.MegaMek;
 import megamek.common.util.EncodeControl;
 import org.apache.logging.log4j.LogManager;
 
@@ -62,13 +62,12 @@ public enum EntityMovementMode {
 
     //region Variable Declarations
     private final String name;
-
-    private final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
     //endregion Variable Declarations
 
     //region Constructors
     EntityMovementMode(final String name) {
+        final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
+                MegaMek.getMMOptions().getLocale(), new EncodeControl());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/megamek/src/megamek/common/EquipmentMessages.java
+++ b/megamek/src/megamek/common/EquipmentMessages.java
@@ -13,16 +13,16 @@
  */
 package megamek.common;
 
+import megamek.MegaMek;
+import megamek.common.util.EncodeControl;
+
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import megamek.common.util.EncodeControl;
-import megamek.common.preference.PreferenceManager;
-
 public class EquipmentMessages {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.common.equipmentmessages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+            MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
     private EquipmentMessages() {
 

--- a/megamek/src/megamek/common/Messages.java
+++ b/megamek/src/megamek/common/Messages.java
@@ -13,16 +13,16 @@
  */
 package megamek.common;
 
+import megamek.MegaMek;
+import megamek.common.util.EncodeControl;
+
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
-
 public class Messages {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.common.messages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+            MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
     private Messages() {
 

--- a/megamek/src/megamek/common/ReportMessages.java
+++ b/megamek/src/megamek/common/ReportMessages.java
@@ -13,16 +13,16 @@
  */
 package megamek.common;
 
+import megamek.MegaMek;
+import megamek.common.util.EncodeControl;
+
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
-
 public class ReportMessages {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.common.report-messages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+            MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
     private ReportMessages() {
     }

--- a/megamek/src/megamek/common/enums/GamePhase.java
+++ b/megamek/src/megamek/common/enums/GamePhase.java
@@ -18,9 +18,9 @@
  */
 package megamek.common.enums;
 
+import megamek.MegaMek;
 import megamek.common.*;
 import megamek.common.options.OptionsConstants;
-import megamek.common.preference.PreferenceManager;
 import megamek.common.util.EncodeControl;
 
 import java.util.Objects;
@@ -61,7 +61,7 @@ public enum GamePhase {
     //region Constructors
     GamePhase(final String name) {
         final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+                MegaMek.getMMOptions().getLocale(), new EncodeControl());
         this.name = resources.getString(name);
     }
     //endregion Constructors

--- a/megamek/src/megamek/common/enums/SkillLevel.java
+++ b/megamek/src/megamek/common/enums/SkillLevel.java
@@ -18,7 +18,7 @@
  */
 package megamek.common.enums;
 
-import megamek.common.preference.PreferenceManager;
+import megamek.MegaMek;
 import megamek.common.util.EncodeControl;
 import org.apache.logging.log4j.LogManager;
 
@@ -46,7 +46,7 @@ public enum SkillLevel {
     //region Constructors
     SkillLevel(final String name, final String toolTipText) {
         final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
-                PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+                MegaMek.getMMOptions().getLocale(), new EncodeControl());
         this.name = resources.getString(name);
         this.toolTipText = resources.getString(toolTipText);
     }

--- a/megamek/src/megamek/common/options/Messages.java
+++ b/megamek/src/megamek/common/options/Messages.java
@@ -13,17 +13,17 @@
  */
 package megamek.common.options;
 
+import megamek.MegaMek;
+import megamek.common.util.EncodeControl;
+
 import java.text.MessageFormat;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.EncodeControl;
-
 class Messages {
 
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.common.options.messages",
-            PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+            MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
     private Messages() {
     }

--- a/megamek/src/megamek/server/Messages.java
+++ b/megamek/src/megamek/server/Messages.java
@@ -1,17 +1,19 @@
 package megamek.server;
 
-import java.util.MissingResourceException;
-import java.util.ResourceBundle;
-
-import megamek.common.preference.PreferenceManager;
+import megamek.MegaMek;
 import megamek.common.util.EncodeControl;
 import org.apache.logging.log4j.LogManager;
 
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
 public class Messages {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle("megamek.server.messages",
-        PreferenceManager.getClientPreferences().getLocale(), new EncodeControl());
+        MegaMek.getMMOptions().getLocale(), new EncodeControl());
 
-    private Messages() {}
+    private Messages() {
+        
+    }
 
     public static String getString(String key) {
         try {


### PR DESCRIPTION
This is the first MegaMek step towards suite standardized locales, which changes direct preference manager calls to instead be done through MMOptions, using its inheritance from SuiteOptions.