### PR TITLE
Transport loading errata

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2796,9 +2796,11 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         // If the current entity has moved, disable "Load" and "Tow" buttons.
         setLoadEnabled(false);
         setTowEnabled(false);
-        if ((cmd.length() == 0) && (cen != Entity.NONE)) {
+        if (cen != Entity.NONE) {
+            Coords currentPathEndpoint = cmd.getFinalCoords();
+            
             // Check the other entities in the current hex for friendly units.
-            for (Entity other : game.getEntitiesVector(ce.getPosition())) {
+            for (Entity other : game.getEntitiesVector(currentPathEndpoint)) {
                 // If the other unit is friendly and not the current entity
                 // and the current entity has at least 1 MP, if it can
                 // transport the other unit, and if the other hasn't moved
@@ -2810,17 +2812,20 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                     break;
                 }
             } // Check the next entity in this position.
-            //Now check all eligible hexes for towable trailers
-            for (Coords c : ce.getHitchLocations()) {
-                for (Entity other : game.getEntitiesVector(c)) {
-                    // If the other unit is friendly and not the current entity
-                    // if it can tow the other unit, and if the other hasn't moved
-                    // then enable the "Tow" button.
-                    if (ce.canTow(other.getId())) {
-                        setTowEnabled(true);
-                        break;
-                    }
-                } // Check the next entity.
+            
+            //Now check all eligible hexes for towable trailers            
+            if (cmd.length() == 0) {
+                for (Coords c : ce.getHitchLocations()) {
+                    for (Entity other : game.getEntitiesVector(c)) {
+                        // If the other unit is friendly and not the current entity
+                        // if it can tow the other unit, and if the other hasn't moved
+                        // then enable the "Tow" button.
+                        if (ce.canTow(other.getId())) {
+                            setTowEnabled(true);
+                            break;
+                        }
+                    } // Check the next entity.
+                }
             }
         } // End ce-hasn't-moved
     } // private void updateLoadButtons

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2933,7 +2933,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         Entity choice = null;
 
         Vector<Entity> choices = new Vector<>();
-        for (Entity other : game.getEntitiesVector(ce().getPosition())) {
+        for (Entity other : game.getEntitiesVector(cmd.getFinalCoords())) {
             if (other.isLoadableThisTurn() && (ce() != null)
                 && ce().canLoad(other, false)) {
                 choices.addElement(other);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2813,7 +2813,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 }
             } // Check the next entity in this position.
             
-            //Now check all eligible hexes for towable trailers            
+            // Now check all eligible hexes for towable trailers            
             if (cmd.length() == 0) {
                 for (Coords c : ce.getHitchLocations()) {
                     for (Entity other : game.getEntitiesVector(c)) {

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -106,8 +106,8 @@ public class MovePath implements Cloneable, Serializable {
     private Set<MoveStepType> containedStepTypes = new HashSet<>();
     
     // whether this movePath take us directly over an enemy unit
-    // useful for aircraft
-    private boolean fliesOverEnemy;
+    // useful for debugging aircraft on ground maps
+    //private boolean fliesOverEnemy;
 
     public static final int DEFAULT_PATHFINDER_TIME_LIMIT = 500;
 
@@ -153,9 +153,9 @@ public class MovePath implements Cloneable, Serializable {
             sb.append("OUT!");
         }
         
-        if (this.getFliesOverEnemy()) {
+        /*if (this.getFliesOverEnemy()) {
             sb.append("E! ");
-        }
+        }*/
         
         return sb.toString();
     }
@@ -351,7 +351,7 @@ public class MovePath implements Cloneable, Serializable {
         // that now exceeds turn mode requirement. We want to show danger on the previous step
         // so the StepSprite will show danger. Hiding the previous step instead would make turning costs
         // show in the turning hex for units tracking turn mode, unlike other units.
-        if (entity.usesTurnMode() && getMpUsed() > 5) {
+        if (entity.usesTurnMode() && (getMpUsed() > 5)) {
             int turnMode = getMpUsed() / 5;
             int nStraight = 0;
             MoveStep prevStep = steps.get(0);
@@ -376,18 +376,21 @@ public class MovePath implements Cloneable, Serializable {
                 s.setDanger(s.isDanger() || Compute.isPilotingSkillNeeded(game, entity.getId(),
                         prevStep.getPosition(), s.getPosition(), lastStep.getMovementType(true),
                         prevStep.isTurning(), prevStep.isPavementStep(), prevStep.getElevation(),
-                                s.getElevation(), s));
+                        s.getElevation(), s));
                 s.setPastDanger(s.isPastDanger() || s.isDanger());
                 prevStep = s;
             }
         }
         
-        if (step.useAeroAtmosphere(game, entity)
-        		&& game.getBoard().onGround()											//we're an aerospace unit on a ground map
-        		&& step.getPosition() != null  											//null
-        		&& game.getFirstEnemyEntity(step.getPosition(), entity) != null) {
+        // if we're an aerospace unit on a ground map and have passed over a hostile unit
+        // record this fact - it is useful for debugging thus we leave the commented out code here
+        // but for performance reasons, we don't actually do it.
+        /*if (step.useAeroAtmosphere(game, entity)
+        		&& game.getBoard().onGround()
+        		&& (step.getPosition() != null)
+        		&& (game.getFirstEnemyEntity(step.getPosition(), entity) != null)) {
         	fliesOverEnemy = true;
-        }
+        }*/
 
         // having checked for illegality and other things, add it to the set of contained step types
         containedStepTypes.add(step.getType());
@@ -781,9 +784,9 @@ public class MovePath implements Cloneable, Serializable {
      * if the target moves.
      * @return Whether or not this flight path takes us over an enemy unit
      */
-    public boolean getFliesOverEnemy() {
+    /*public boolean getFliesOverEnemy() {
     	return fliesOverEnemy;
-    }
+    }*/
     
     /**
      * Method that determines whether a given path goes through a given set of x/y coordinates
@@ -1588,7 +1591,7 @@ public class MovePath implements Cloneable, Serializable {
         copy.steps = new Vector<>(steps);
         copy.careful = careful;
         copy.containedStepTypes = new HashSet<>(containedStepTypes);
-        copy.fliesOverEnemy = fliesOverEnemy;
+        //copy.fliesOverEnemy = fliesOverEnemy;
         copy.cachedEntityState = cachedEntityState; // intentional pointer copy
     }
 

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -356,7 +356,7 @@ public class MovePath implements Cloneable, Serializable {
             int nStraight = 0;
             MoveStep prevStep = steps.get(0);
             for (MoveStep s : steps) {
-                if (s.isTurning() && nStraight < turnMode) {
+                if (s.isTurning() && (nStraight < turnMode)) {
                     prevStep.setDanger(true);
                 }
                 nStraight = s.getNStraight();

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -553,6 +553,7 @@ public class MovePath implements Cloneable, Serializable {
         setEntity(en);
         final Vector<MoveStep> temp = new Vector<>(steps);
         steps.removeAllElements();
+        containedStepTypes.clear();
         for (int i = 0; i < temp.size(); i++) {
             MoveStep step = temp.elementAt(i);
             if ((step.getTargetPosition() != null) && (step.getTarget(getGame()) != null)) {

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3271,12 +3271,6 @@ public class MoveStep implements Serializable {
 
         // The entity is trying to load. Check for a valid move.
         if (type == MoveStepType.LOAD) {
-
-            // Transports can't load after the first step.
-            if (!firstStep) {
-                return false;
-            }
-
             // Find the unit being loaded.
             Entity other = null;
             Iterator<Entity> entities = game.getEntities(src);


### PR DESCRIPTION
This adjust transport loading code so that a transport can load an infantry unit at the end of its movement, rather than at the beginning.

Also makes a minor efficiency improvement - when checking a path for "illegal" situations, the checks are only carried out if the path wasn't already illegal, short-circuiting through many unnecessary if blocks.