### PR TITLE
3371: Fixing TurnOrdered NPEs for null Entity game and null Player team

### DIFF
--- a/megamek/src/megamek/common/TurnOrdered.java
+++ b/megamek/src/megamek/common/TurnOrdered.java
@@ -361,9 +361,13 @@ public abstract class TurnOrdered implements ITurnOrdered {
             }
 
             if (item instanceof Entity) {
-                Entity e = (Entity) item;
-                bonus = e.getGame().getTeamForPlayer(e.getOwner()).getTotalInitBonus(false)
-                        + e.getCrew().getInitBonus();
+                final Entity entity = (Entity) item;
+                if (entity.getGame() != null) {
+                    final Team team = entity.getGame().getTeamForPlayer(entity.getOwner());
+                    if (team != null) {
+                        bonus = team.getTotalInitBonus(false) + entity.getCrew().getInitBonus();
+                    }
+                }
             }
 
             if (rerollRequests == null) { // normal init roll


### PR DESCRIPTION
This fixes #3371 