### PR TITLE
Weapon list sort order

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -1519,7 +1519,7 @@ public class EquipmentType implements ITechnology {
      * order instead of the order AC10/2/20/5 and S/M/L Lasers will be grouped together.
      * @return A String similar to getName() but modified to support a better sorting
      */
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return (sortingName != null) ? sortingName : name;
     }
 }

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -148,6 +148,9 @@ public class EquipmentType implements ITechnology {
 
     protected String internalName = null;
 
+    /** Sorting lists of equipment by this string groups and sorts equipment better. */
+    protected String sortingName;
+
     private Vector<String> namesVector = new Vector<>();
 
     protected double tonnage = 0;
@@ -1508,5 +1511,15 @@ public class EquipmentType implements ITechnology {
      */
     public int getHeat() {
         return 0;
+    }
+
+    /**
+     * Sorting with the String returned by this method results in an improved ordering and grouping
+     * of equipment than by getName(); for example, AC2/5/10/20 will appear in that
+     * order instead of the order AC10/2/20/5 and S/M/L Lasers will be grouped together.
+     * @return A String similar to getName() but modified to support a better sorting
+     */
+    public String getNaturalNameSortingString() {
+        return (sortingName != null) ? sortingName : name;
     }
 }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -4934,6 +4934,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Shield (Small)";
         misc.setInternalName("ISSmallShield");
         misc.addLookupName("Small Shield");
+        misc.sortingName = "Shield B";
         misc.tonnage = 2;
         misc.criticals = 3;
         misc.cost = 50000;
@@ -4962,6 +4963,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Shield (Medium)";
         misc.setInternalName("ISMediumShield");
         misc.addLookupName("Medium Shield");
+        misc.sortingName = "Shield C";
         misc.tonnage = 4;
         misc.criticals = 5;
         misc.cost = 100000;
@@ -4990,6 +4992,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Shield (Large)";
         misc.setInternalName("ISLargeShield");
         misc.addLookupName("Large Shield");
+        misc.sortingName = "Shield D";
         misc.tonnage = 6;
         misc.criticals = 7;
         misc.cost = 300000;
@@ -5076,6 +5079,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Vibroblade (Small)";
         misc.setInternalName("ISSmallVibroblade");
         misc.addLookupName("Small Vibroblade");
+        misc.sortingName = "Vibro B";
         misc.tonnage = 3;
         misc.criticals = 1;
         misc.cost = 150000;
@@ -5100,6 +5104,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Vibroblade (Medium)";
         misc.setInternalName("ISMediumVibroblade");
         misc.addLookupName("Medium Vibroblade");
+        misc.sortingName = "Vibro C";
         misc.tonnage = 5;
         misc.criticals = 2;
         misc.cost = 400000;
@@ -5124,6 +5129,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Vibroblade (Large)";
         misc.setInternalName("ISLargeVibroblade");
         misc.addLookupName("Large Vibroblade");
+        misc.sortingName = "Vibro D";
         misc.tonnage = 7;
         misc.criticals = 4;
         misc.cost = 750000;
@@ -7098,6 +7104,7 @@ public class MiscType extends EquipmentType {
         misc.bv = 5;
         misc.name = "Bridge Layer (Light)";
         misc.setInternalName("LightBridgeLayer");
+        misc.sortingName = "Bridge B";
         misc.flags = misc.flags.or(F_LIGHT_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
         misc.industrial = true;
@@ -7120,6 +7127,7 @@ public class MiscType extends EquipmentType {
         misc.bv = 10;
         misc.name = "Bridge Layer (Medium)";
         misc.setInternalName("MediumBridgeLayer");
+        misc.sortingName = "Bridge C";
         misc.flags = misc.flags.or(F_MEDIUM_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
         misc.industrial = true;
@@ -7142,6 +7150,7 @@ public class MiscType extends EquipmentType {
         misc.bv = 20;
         misc.name = "Bridge Layer (Heavy)";
         misc.setInternalName("HeavyBridgeLayer");
+        misc.sortingName = "Bridge D";
         misc.flags = misc.flags.or(F_HEAVY_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
         misc.industrial = true;

--- a/megamek/src/megamek/common/weapons/CLIATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/CLIATMWeapon.java
@@ -102,7 +102,7 @@ public abstract class CLIATMWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "ATM IMP " + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/CLIATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/CLIATMWeapon.java
@@ -100,4 +100,9 @@ public abstract class CLIATMWeapon extends MissileWeapon {
             removeMode("Indirect");
         }
     }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "ATM IMP " + ((rackSize < 10) ? "0" + rackSize : rackSize);
+    }
 }

--- a/megamek/src/megamek/common/weapons/artillery/ISCruiseMissile50.java
+++ b/megamek/src/megamek/common/weapons/artillery/ISCruiseMissile50.java
@@ -25,21 +25,22 @@ public class ISCruiseMissile50 extends ArtilleryWeapon {
 
     public ISCruiseMissile50() {
         super();
-        this.name = "Cruise Missile/50";
-        this.setInternalName("ISCruiseMissile50");
-        this.heat = 50;
-        this.rackSize = 50;
-        this.ammoType = AmmoType.T_CRUISE_MISSILE;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 50;
-        this.extremeRange = 50; // No extreme range.
-        this.tonnage = 55;
-        this.criticals = 55;
-        this.svslots = 25;
-        this.flags = flags.or(F_CRUISE_MISSILE);
-        this.bv = 601;
-        this.cost = 900000;
+        name = "Cruise Missile/50";
+        setInternalName("ISCruiseMissile50");
+        sortingName = "Cruise Missile/050";
+        heat = 50;
+        rackSize = 50;
+        ammoType = AmmoType.T_CRUISE_MISSILE;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 50;
+        extremeRange = 50; // No extreme range.
+        tonnage = 55;
+        criticals = 55;
+        svslots = 25;
+        flags = flags.or(F_CRUISE_MISSILE);
+        bv = 601;
+        cost = 900000;
         rulesRefs = "284,TO";
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/artillery/ISCruiseMissile70.java
+++ b/megamek/src/megamek/common/weapons/artillery/ISCruiseMissile70.java
@@ -25,21 +25,22 @@ public class ISCruiseMissile70 extends ArtilleryWeapon {
 
     public ISCruiseMissile70() {
         super();
-        this.name = "Cruise Missile/70";
-        this.setInternalName("ISCruiseMissile70");
-        this.heat = 70;
-        this.rackSize = 70;
-        this.ammoType = AmmoType.T_CRUISE_MISSILE;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 90;
-        this.extremeRange = 90; // No extreme range.
-        this.tonnage = 80;
-        this.criticals = 80;
-        this.svslots = 35;
-        this.flags = flags.or(F_CRUISE_MISSILE);
-        this.bv = 1031;
-        this.cost = 1250000;
+        name = "Cruise Missile/70";
+        setInternalName("ISCruiseMissile70");
+        sortingName = "Cruise Missile/070";
+        heat = 70;
+        rackSize = 70;
+        ammoType = AmmoType.T_CRUISE_MISSILE;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 90;
+        extremeRange = 90; // No extreme range.
+        tonnage = 80;
+        criticals = 80;
+        svslots = 35;
+        flags = flags.or(F_CRUISE_MISSILE);
+        bv = 1031;
+        cost = 1250000;
         rulesRefs = "284,TO";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/artillery/ISCruiseMissile90.java
+++ b/megamek/src/megamek/common/weapons/artillery/ISCruiseMissile90.java
@@ -25,21 +25,22 @@ public class ISCruiseMissile90 extends ArtilleryWeapon {
 
     public ISCruiseMissile90() {
         super();
-        this.name = "Cruise Missile/90";
-        this.setInternalName("ISCruiseMissile90");
-        this.heat = 90;
-        this.rackSize = 90;
-        this.ammoType = AmmoType.T_CRUISE_MISSILE;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 120;
-        this.extremeRange = 120; // No extreme range.
-        this.tonnage = 100;
-        this.criticals = 100;
-        this.svslots = 45;
-        this.flags = flags.or(F_CRUISE_MISSILE);
-        this.bv = 1530;
-        this.cost = 1250000;
+        name = "Cruise Missile/90";
+        setInternalName("ISCruiseMissile90");
+        sortingName = "Cruise Missile/090";
+        heat = 90;
+        rackSize = 90;
+        ammoType = AmmoType.T_CRUISE_MISSILE;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 120;
+        extremeRange = 120; // No extreme range.
+        tonnage = 100;
+        criticals = 100;
+        svslots = 45;
+        flags = flags.or(F_CRUISE_MISSILE);
+        bv = 1530;
+        cost = 1250000;
         rulesRefs = "284,TO";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/CLImprovedAC2.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLImprovedAC2.java
@@ -25,10 +25,10 @@ public class CLImprovedAC2 extends ACWeapon {
 
     public CLImprovedAC2() {
         super();
-
         name = "Improved Autocannon/2";
         setInternalName("Improved Autocannon/2");
         addLookupName("CLIMPAC2");
+        sortingName = "Improved Autocannon/02";
         heat = 1;
         damage = 2;
         rackSize = 2;
@@ -47,10 +47,10 @@ public class CLImprovedAC2 extends ACWeapon {
         ammoType = AmmoType.T_AC_IMP;
         rulesRefs = "96, IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_D)
-            .setAvailability(RATING_X, RATING_C, RATING_X, RATING_X)
-            .setClanAdvancement(DATE_NONE, 2815, 2818, 2833, 3080)
-            .setClanApproximate(false, true, false, false, false)
-            .setProductionFactions(F_CLAN).setReintroductionFactions(F_EI)
-            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+                .setAvailability(RATING_X, RATING_C, RATING_X, RATING_X)
+                .setClanAdvancement(DATE_NONE, 2815, 2818, 2833, 3080)
+                .setClanApproximate(false, true, false, false, false)
+                .setProductionFactions(F_CLAN).setReintroductionFactions(F_EI)
+                .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
     }
 }

--- a/megamek/src/megamek/common/weapons/autocannons/CLImprovedAC5.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLImprovedAC5.java
@@ -25,10 +25,10 @@ public class CLImprovedAC5 extends ACWeapon {
 
     public CLImprovedAC5() {
         super();
-
         name = "Improved Autocannon/5";
         setInternalName("Improved Autocannon/5");
         addLookupName("CLIMPAC5");
+        sortingName = "Improved Autocannon/05";
         heat = 1;
         damage = 5;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB2XAC.java
@@ -22,27 +22,27 @@ public class CLLB2XAC extends LBXACWeapon {
 
     public CLLB2XAC() {
         super();
-
-        this.name = "LB 2-X AC";
-        this.setInternalName("CLLBXAC2");
-        this.addLookupName("Clan LB 2-X AC");
-        this.heat = 1;
-        this.damage = 2;
-        this.rackSize = 2;
-        this.minimumRange = 4;
-        this.shortRange = 10;
-        this.mediumRange = 20;
-        this.longRange = 30;
-        this.extremeRange = 40;
-        this.tonnage = 5.0;
-        this.criticals = 3;
-        this.bv = 47;
-        this.cost = 150000;
-        this.shortAV = 2;
-        this.medAV = 2;
-        this.longAV = 2;
-        this.extAV = 2;
-        this.maxRange = RANGE_EXT;
+        name = "LB 2-X AC";
+        setInternalName("CLLBXAC2");
+        addLookupName("Clan LB 2-X AC");
+        sortingName = "LB 02-X AC";
+        heat = 1;
+        damage = 2;
+        rackSize = 2;
+        minimumRange = 4;
+        shortRange = 10;
+        mediumRange = 20;
+        longRange = 30;
+        extremeRange = 40;
+        tonnage = 5.0;
+        criticals = 3;
+        bv = 47;
+        cost = 150000;
+        shortAV = 2;
+        medAV = 2;
+        longAV = 2;
+        extAV = 2;
+        maxRange = RANGE_EXT;
         rulesRefs = "207,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
     	.setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
@@ -1,57 +1,47 @@
+/**
+ * MegaMek - Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
 package megamek.common.weapons.autocannons;
 
 /**
- * MegaMek - Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
- * 
- *  This program is free software; you can redistribute it and/or modify it 
- *  under the terms of the GNU General Public License as published by the Free 
- *  Software Foundation; either version 2 of the License, or (at your option) 
- *  any later version.
- * 
- *  This program is distributed in the hope that it will be useful, but 
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
- *  for more details.
- */
-/*
- * Created on Oct 15, 2004
- *
- */
-
-/**
  * @author Andrew Hunter
+ * @since Oct 15, 2004
  */
 public class CLLB5XAC extends LBXACWeapon {
-    /**
-     * 
-     */
     private static final long serialVersionUID = 722040764690180243L;
 
-    /**
-     * 
-     */
     public CLLB5XAC() {
         super();
-
-        this.name = "LB 5-X AC";
-        this.setInternalName("CLLBXAC5");
-        this.addLookupName("Clan LB 5-X AC");
-        this.heat = 1;
-        this.damage = 5;
-        this.rackSize = 5;
-        this.minimumRange = 3;
-        this.shortRange = 8;
-        this.mediumRange = 15;
-        this.longRange = 24;
-        this.extremeRange = 30;
-        this.tonnage = 7.0;
-        this.criticals = 4;
-        this.bv = 93;
-        this.cost = 250000;
-        this.shortAV = 5;
-        this.medAV = 5;
-        this.longAV = 5;
-        this.maxRange = RANGE_LONG;
+        name = "LB 5-X AC";
+        setInternalName("CLLBXAC5");
+        addLookupName("Clan LB 5-X AC");
+        sortingName = "LB 05-X AC";
+        heat = 1;
+        damage = 5;
+        rackSize = 5;
+        minimumRange = 3;
+        shortRange = 8;
+        mediumRange = 15;
+        longRange = 24;
+        extremeRange = 30;
+        tonnage = 7.0;
+        criticals = 4;
+        bv = 93;
+        cost = 250000;
+        shortAV = 5;
+        medAV = 5;
+        longAV = 5;
+        maxRange = RANGE_LONG;
         rulesRefs = "207,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/CLUAC2.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLUAC2.java
@@ -22,28 +22,28 @@ public class CLUAC2 extends UACWeapon {
 
     public CLUAC2() {
         super();
-
-        this.name = "Ultra AC/2";
-        this.setInternalName("CLUltraAC2");
-        this.addLookupName("Clan Ultra AC/2");
-        this.heat = 1;
-        this.damage = 2;
-        this.rackSize = 2;
-        this.minimumRange = 2;
-        this.shortRange = 9;
-        this.mediumRange = 18;
-        this.longRange = 27;
-        this.extremeRange = 36;
-        this.tonnage = 5.0;
-        this.criticals = 2;
-        this.bv = 62;
-        this.cost = 120000;
-        this.shortAV = 3;
-        this.medAV = 3;
-        this.longAV = 3;
-        this.extAV = 3;
-        this.maxRange = RANGE_EXT;
-        this.explosionDamage = damage;
+        name = "Ultra AC/2";
+        setInternalName("CLUltraAC2");
+        addLookupName("Clan Ultra AC/2");
+        sortingName = "Ultra AC/02";
+        heat = 1;
+        damage = 2;
+        rackSize = 2;
+        minimumRange = 2;
+        shortRange = 9;
+        mediumRange = 18;
+        longRange = 27;
+        extremeRange = 36;
+        tonnage = 5.0;
+        criticals = 2;
+        bv = 62;
+        cost = 120000;
+        shortAV = 3;
+        medAV = 3;
+        longAV = 3;
+        extAV = 3;
+        maxRange = RANGE_EXT;
+        explosionDamage = damage;
         rulesRefs = "208,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/CLUAC5.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLUAC5.java
@@ -22,27 +22,27 @@ public class CLUAC5 extends UACWeapon {
 
     public CLUAC5() {
         super();
-
-        this.name = "Ultra AC/5";
-        this.setInternalName("CLUltraAC5");
-        this.addLookupName("Clan Ultra AC/5");
-        this.heat = 1;
-        this.damage = 5;
-        this.rackSize = 5;
-        this.minimumRange = 0;
-        this.shortRange = 7;
-        this.mediumRange = 14;
-        this.longRange = 21;
-        this.extremeRange = 28;
-        this.tonnage = 7.0;
-        this.criticals = 3;
-        this.bv = 122;
-        this.cost = 200000;
-        this.shortAV = 7;
-        this.medAV = 7;
-        this.longAV = 7;
-        this.maxRange = RANGE_LONG;
-        this.explosionDamage = damage;
+        name = "Ultra AC/5";
+        setInternalName("CLUltraAC5");
+        addLookupName("Clan Ultra AC/5");
+        sortingName = "Ultra AC/05";
+        heat = 1;
+        damage = 5;
+        rackSize = 5;
+        minimumRange = 0;
+        shortRange = 7;
+        mediumRange = 14;
+        longRange = 21;
+        extremeRange = 28;
+        tonnage = 7.0;
+        criticals = 3;
+        bv = 122;
+        cost = 200000;
+        shortAV = 7;
+        medAV = 7;
+        longAV = 7;
+        maxRange = RANGE_LONG;
+        explosionDamage = damage;
         rulesRefs = "208,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/ISAC2.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISAC2.java
@@ -30,6 +30,7 @@ public class ISAC2 extends ACWeapon {
         addLookupName("AC/2");
         addLookupName("ISAC2");
         addLookupName("IS Autocannon/2");
+        sortingName = "AC/02";
         heat = 1;
         damage = 2;
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/autocannons/ISAC5.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISAC5.java
@@ -30,6 +30,7 @@ public class ISAC5 extends ACWeapon {
 		addLookupName("AutoCannon/5");
 		addLookupName("ISAC5");
 		addLookupName("IS Autocannon/5");
+		sortingName = "AC/05";
 		heat = 1;
 		damage = 5;
 		rackSize = 5;

--- a/megamek/src/megamek/common/weapons/autocannons/ISHVAC2.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISHVAC2.java
@@ -29,6 +29,7 @@ public class ISHVAC2 extends HVACWeapon {
         addLookupName("IS Hyper Velocity Auto Cannon/2");
         addLookupName("ISHVAC2");
         addLookupName("IS Hyper Velocity Autocannon/2");
+        sortingName = "HVAC/02";
         heat = 1;
         damage = 2;
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/autocannons/ISHVAC5.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISHVAC5.java
@@ -29,6 +29,7 @@ public class ISHVAC5 extends HVACWeapon {
         addLookupName("IS Hyper Velocity Auto Cannon/5");
         addLookupName("ISHVAC5");
         addLookupName("IS Hyper Velocity Autocannon/5");
+        sortingName = "HVAC/05";
         heat = 3;
         damage = 5;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB2XAC.java
@@ -22,26 +22,27 @@ public class ISLB2XAC extends LBXACWeapon {
 
     public ISLB2XAC() {
         super();
-        this.name = "LB 2-X AC";
-        this.setInternalName("ISLBXAC2");
-        this.addLookupName("IS LB 2-X AC");
-        this.heat = 1;
-        this.damage = 2;
-        this.rackSize = 2;
-        this.minimumRange = 4;
-        this.shortRange = 9;
-        this.mediumRange = 18;
-        this.longRange = 27;
-        this.extremeRange = 36;
-        this.tonnage = 6.0;
-        this.criticals = 4;
-        this.bv = 42;
-        this.cost = 150000;
-        this.shortAV = 2;
-        this.medAV = 2;
-        this.longAV = 2;
-        this.extAV = 2;
-        this.maxRange = RANGE_EXT;
+        name = "LB 2-X AC";
+        setInternalName("ISLBXAC2");
+        addLookupName("IS LB 2-X AC");
+        sortingName = "LB 02-X AC";
+        heat = 1;
+        damage = 2;
+        rackSize = 2;
+        minimumRange = 4;
+        shortRange = 9;
+        mediumRange = 18;
+        longRange = 27;
+        extremeRange = 36;
+        tonnage = 6.0;
+        criticals = 4;
+        bv = 42;
+        cost = 150000;
+        shortAV = 2;
+        medAV = 2;
+        longAV = 2;
+        extAV = 2;
+        maxRange = RANGE_EXT;
         rulesRefs = "207,TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
@@ -22,25 +22,26 @@ public class ISLB5XAC extends LBXACWeapon {
 
     public ISLB5XAC() {
         super();
-        this.name = "LB 5-X AC";
-        this.setInternalName("ISLBXAC5");
-        this.addLookupName("IS LB 5-X AC");
-        this.heat = 1;
-        this.damage = 5;
-        this.rackSize = 5;
-        this.minimumRange = 3;
-        this.shortRange = 7;
-        this.mediumRange = 14;
-        this.longRange = 21;
-        this.extremeRange = 28;
-        this.tonnage = 8.0;
-        this.criticals = 5;
-        this.bv = 83;
-        this.cost = 250000;
-        this.shortAV = 5;
-        this.medAV = 5;
-        this.longAV = 5;
-        this.maxRange = RANGE_LONG;
+        name = "LB 5-X AC";
+        setInternalName("ISLBXAC5");
+        addLookupName("IS LB 5-X AC");
+        sortingName = "LB 05-X AC";
+        heat = 1;
+        damage = 5;
+        rackSize = 5;
+        minimumRange = 3;
+        shortRange = 7;
+        mediumRange = 14;
+        longRange = 21;
+        extremeRange = 28;
+        tonnage = 8.0;
+        criticals = 5;
+        bv = 83;
+        cost = 250000;
+        shortAV = 5;
+        medAV = 5;
+        longAV = 5;
+        maxRange = RANGE_LONG;
         rulesRefs = "207,TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/ISRifleHeavy.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISRifleHeavy.java
@@ -29,6 +29,7 @@ public class ISRifleHeavy extends RifleWeapon {
         shortName = "Heavy Rifle";
         addLookupName("IS Heavy Rifle");
         addLookupName("ISHeavyRifle");
+        sortingName = "Rifle Cannon D";
         heat = 4;
         damage = 9;
         rackSize = 9;

--- a/megamek/src/megamek/common/weapons/autocannons/ISRifleLight.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISRifleLight.java
@@ -29,6 +29,7 @@ public class ISRifleLight extends RifleWeapon {
         shortName = "Light Rifle";
         addLookupName("IS Light Rifle");
         addLookupName("ISLightRifle");
+        sortingName = "Rifle Cannon B";
         heat = 1;
         damage = 3;
         rackSize = 3;

--- a/megamek/src/megamek/common/weapons/autocannons/ISRifleMedium.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISRifleMedium.java
@@ -29,6 +29,7 @@ public class ISRifleMedium extends RifleWeapon {
         shortName = "Medium Rifle";
         addLookupName("IS Medium Rifle");
         addLookupName("ISMediumRifle");
+        sortingName = "Rifle Cannon C";
         heat = 2;
         damage = 6;
         rackSize = 6;

--- a/megamek/src/megamek/common/weapons/autocannons/ISUAC2.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISUAC2.java
@@ -22,27 +22,28 @@ public class ISUAC2 extends UACWeapon {
 
     public ISUAC2() {
         super();
-        this.name = "Ultra AC/2";
-        this.setInternalName("ISUltraAC2");
-        this.addLookupName("IS Ultra AC/2");
-        this.heat = 1;
-        this.damage = 2;
-        this.rackSize = 2;
-        this.minimumRange = 3;
-        this.shortRange = 8;
-        this.mediumRange = 17;
-        this.longRange = 25;
-        this.extremeRange = 34;
-        this.tonnage = 7.0;
-        this.criticals = 3;
-        this.bv = 56;
-        this.cost = 120000;
-        this.shortAV = 3;
-        this.medAV = 3;
-        this.longAV = 3;
-        this.extAV = 3;
-        this.maxRange = RANGE_EXT;
-        this.explosionDamage = damage;
+        name = "Ultra AC/2";
+        setInternalName("ISUltraAC2");
+        addLookupName("IS Ultra AC/2");
+        sortingName = "Ultra AC/02";
+        heat = 1;
+        damage = 2;
+        rackSize = 2;
+        minimumRange = 3;
+        shortRange = 8;
+        mediumRange = 17;
+        longRange = 25;
+        extremeRange = 34;
+        tonnage = 7.0;
+        criticals = 3;
+        bv = 56;
+        cost = 120000;
+        shortAV = 3;
+        medAV = 3;
+        longAV = 3;
+        extAV = 3;
+        maxRange = RANGE_EXT;
+        explosionDamage = damage;
         rulesRefs = "208, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/autocannons/ISUAC5.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISUAC5.java
@@ -25,6 +25,7 @@ public class ISUAC5 extends UACWeapon {
         name = "Ultra AC/5";
         setInternalName("ISUltraAC5");
         addLookupName("IS Ultra AC/5");
+        sortingName = "Ultra AC/05";
         heat = 1;
         damage = 5;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/battlearmor/AdvancedSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/AdvancedSRMWeapon.java
@@ -76,7 +76,7 @@ public abstract class AdvancedSRMWeapon extends SRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         if (sortingName != null) {
             return sortingName;
         } else {

--- a/megamek/src/megamek/common/weapons/battlearmor/AdvancedSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/AdvancedSRMWeapon.java
@@ -29,28 +29,14 @@ import megamek.server.Server;
  */
 public abstract class AdvancedSRMWeapon extends SRMWeapon {
 
-    /**
-     * 
-     */
     private static final long serialVersionUID = 8098857067349950771L;
 
-    /**
-     * 
-     */
     public AdvancedSRMWeapon() {
         super();
         this.ammoType = AmmoType.T_SRM_ADVANCED;
         flags = flags.andNot(F_ARTEMIS_COMPATIBLE);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -87,5 +73,18 @@ public abstract class AdvancedSRMWeapon extends SRMWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        if (sortingName != null) {
+            return sortingName;
+        } else {
+            String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+            if (name.contains("I-OS")) {
+                oneShotTag = "OSI ";
+            }
+            return "SRM Z Advanced " + oneShotTag + rackSize;
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/battlearmor/CLAdvancedSRM1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLAdvancedSRM1.java
@@ -18,14 +18,8 @@ package megamek.common.weapons.battlearmor;
  */
 public class CLAdvancedSRM1 extends AdvancedSRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6709245485008575199L;
 
-    /**
-     *
-     */
     public CLAdvancedSRM1() {
         super();
         name = "Advanced SRM 1";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserMedium.java
@@ -30,6 +30,7 @@ public class CLBAERPulseLaserMedium extends PulseLaserWeapon {
         addLookupName("CLBAERMediumPulseLaser");
         addLookupName("BA Clan ER Pulse Med Laser");
         addLookupName("BA Clan ER Medium Pulse Laser");
+        sortingName = "Laser Pulse ER C";
         heat = 6;
         damage = 7;
         toHitModifier = -1;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserSmall.java
@@ -31,6 +31,7 @@ public class CLBAERPulseLaserSmall extends PulseLaserWeapon {
         addLookupName("Clan BA ER Pulse Small Laser");
         addLookupName("Clan BA ER Small Pulse Laser");
         addLookupName("Clan BA ERSmallPulseLaser");
+        sortingName = "Laser Pulse ER B";
         heat = 3;
         damage = 5;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAFlamer.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAFlamer.java
@@ -29,6 +29,7 @@ public class CLBAFlamer extends BAFlamerWeapon {
         setInternalName("CLBAFlamer");
         addLookupName("Clan BA Flamer");
         addLookupName("ISBAFlamer");
+        sortingName = "Flamer C";
         heat = 3;
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_3D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAFlamerHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAFlamerHeavy.java
@@ -28,6 +28,7 @@ public class CLBAFlamerHeavy extends BAFlamerWeapon {
         setInternalName("CLBAHeavyFlamer");
         addLookupName("ISBAHeavyFlamer");
         addLookupName("IS BA Heavy Flamer");
+        sortingName = "Flamer D";
         heat = 5;
         damage = 4;
         infDamageClass = WeaponType.WEAPON_BURST_6D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAGrenadeLauncherHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAGrenadeLauncherHeavy.java
@@ -37,6 +37,7 @@ public class CLBAGrenadeLauncherHeavy extends Weapon {
         //Per TM Errata the original Grenade Launcher becomes the Heavy. Lookups below to keep unit files consistent.
         addLookupName("ISBAGrenadeLauncher");
       	addLookupName("IS BA Grenade Launcher");
+        sortingName = "Grenade Launcher D";
         heat = 0;
         damage = 1;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMedium.java
@@ -27,6 +27,7 @@ public class CLBALaserERMedium extends LaserWeapon {
         name = "ER Medium Laser";
         setInternalName("CLBAERMediumLaser");
         addLookupName("Clan BA ER Medium Laser");
+        sortingName = "Laser ER C";
         heat = 5;
         damage = 7;
         shortRange = 5;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMicro.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMicro.java
@@ -27,6 +27,7 @@ public class CLBALaserERMicro extends LaserWeapon {
         name = "ER Micro Laser";
         setInternalName("CLBAERMicroLaser");
         addLookupName("Clan BA ER Micro Laser");
+        sortingName = "Laser ER A";
         heat = 1;
         damage = 2;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERSmall.java
@@ -27,6 +27,7 @@ public class CLBALaserERSmall extends LaserWeapon {
         name = "ER Small Laser";
         setInternalName("CLBAERSmallLaser");
         addLookupName("Clan BA ER Small Laser");
+        sortingName = "Laser ER B";
         heat = 2;
         damage = 5;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavyMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavyMedium.java
@@ -24,26 +24,27 @@ public class CLBALaserHeavyMedium extends LaserWeapon {
 
     public CLBALaserHeavyMedium() {
         super();
-        this.name = "Heavy Medium Laser";
-        this.setInternalName("CLBAHeavyMediumLaser");
-        this.addLookupName("Clan BA Medium Heavy Laser");
-        this.heat = 7;
-        this.damage = 10;
-        this.toHitModifier = 1;
-        this.shortRange = 3;
-        this.mediumRange = 6;
-        this.longRange = 9;
-        this.extremeRange = 12;
-        this.waterShortRange = 2;
-        this.waterMediumRange = 4;
-        this.waterLongRange = 6;
-        this.waterExtremeRange = 8;
-        this.tonnage = 1.0;
-        this.criticals = 4;
-        this.bv = 76;
-        this.cost = 100000;
-        this.shortAV = 10;
-        this.maxRange = RANGE_SHORT;
+        name = "Heavy Medium Laser";
+        setInternalName("CLBAHeavyMediumLaser");
+        addLookupName("Clan BA Medium Heavy Laser");
+        sortingName = "Laser Heavy C";
+        heat = 7;
+        damage = 10;
+        toHitModifier = 1;
+        shortRange = 3;
+        mediumRange = 6;
+        longRange = 9;
+        extremeRange = 12;
+        waterShortRange = 2;
+        waterMediumRange = 4;
+        waterLongRange = 6;
+        waterExtremeRange = 8;
+        tonnage = 1.0;
+        criticals = 4;
+        bv = 76;
+        cost = 100000;
+        shortAV = 10;
+        maxRange = RANGE_SHORT;
         flags = flags.or(F_NO_FIRES).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         rulesRefs = "258,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavySmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavySmall.java
@@ -24,26 +24,27 @@ public class CLBALaserHeavySmall extends LaserWeapon {
 
     public CLBALaserHeavySmall() {
         super();
-        this.name = "Heavy Small Laser";
-        this.setInternalName("CLBAHeavySmallLaser");
-        this.addLookupName("Clan BA Small Heavy Laser");
-        this.heat = 3;
-        this.damage = 6;
-        this.toHitModifier = 1;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 3;
-        this.extremeRange = 4;
-        this.waterShortRange = 1;
-        this.waterMediumRange = 2;
-        this.waterLongRange = 2;
-        this.waterExtremeRange = 4;
-        this.tonnage = 0.5;
-        this.criticals = 3;
-        this.bv = 15;
-        this.cost = 20000;
-        this.shortAV = 6;
-        this.maxRange = RANGE_SHORT;
+        name = "Heavy Small Laser";
+        setInternalName("CLBAHeavySmallLaser");
+        addLookupName("Clan BA Small Heavy Laser");
+        sortingName = "Laser Heavy B";
+        heat = 3;
+        damage = 6;
+        toHitModifier = 1;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 3;
+        extremeRange = 4;
+        waterShortRange = 1;
+        waterMediumRange = 2;
+        waterLongRange = 2;
+        waterExtremeRange = 4;
+        tonnage = 0.5;
+        criticals = 3;
+        bv = 15;
+        cost = 20000;
+        shortAV = 6;
+        maxRange = RANGE_SHORT;
         flags = flags.or(F_NO_FIRES).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         rulesRefs = "258,TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserSmall.java
@@ -28,6 +28,7 @@ public class CLBALaserSmall extends LaserWeapon {
         setInternalName("CLBASmall Laser");
         addLookupName("CL BA Small Laser");
         addLookupName("CLBASmallLaser");
+        sortingName = "Laser B";
         heat = 1;
         damage = 3;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMG.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMG.java
@@ -31,6 +31,7 @@ public class CLBAMG extends BAMGWeapon {
         addLookupName("IS BA Machine Gun");
         addLookupName("ISBAMachine Gun");
         addLookupName("ISBAMachineGun");
+        sortingName = "MG C";
         heat = 0;
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMGHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMGHeavy.java
@@ -30,6 +30,7 @@ public class CLBAMGHeavy extends BAMGWeapon {
         addLookupName("ISBAHeavyMachineGun");
         addLookupName("IS BA Heavy Machine Gun");
         addLookupName("ISBAHeavyMG");
+        sortingName = "MG D";
         heat = 0;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMGLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMGLight.java
@@ -30,6 +30,7 @@ public class CLBAMGLight extends BAMGWeapon {
         addLookupName("ISBALightMachineGun");
         addLookupName("IS BA Light Machine Gun");
         addLookupName("ISBALightMG");
+        sortingName = "MG B";
         heat = 0;
         damage = 1;
         infDamageClass = WeaponType.WEAPON_BURST_HALFD6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarHeavy.java
@@ -33,6 +33,7 @@ public class CLBAMortarHeavy extends Weapon {
         addLookupName("CL BA Heavy Mortar");
         addLookupName("ISBAHeavyMortar");
         addLookupName("IS BA Heavy Mortar");
+        sortingName = "Mortar D";
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
         ammoType = AmmoType.T_NA;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarLight.java
@@ -34,6 +34,7 @@ public class CLBAMortarLight extends Weapon {
         addLookupName("CL BA Light Mortar");
         addLookupName("ISBALightMortar");
         addLookupName("IS BA Light Mortar");
+        sortingName = "Mortar B";
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
         ammoType = AmmoType.T_NA;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMedium.java
@@ -24,29 +24,30 @@ public class CLBAPulseLaserMedium extends PulseLaserWeapon {
 
     public CLBAPulseLaserMedium() {
         super();
-        this.name = "Medium Pulse Laser";
-        this.setInternalName("CLBAMediumPulseLaser");
-        this.addLookupName("Clan BA Pulse Med Laser");
-        this.addLookupName("Clan BA Medium Pulse Laser");
-        this.heat = 4;
-        this.damage = 7;
-        this.toHitModifier = -2;
-        this.shortRange = 4;
-        this.mediumRange = 8;
-        this.longRange = 12;
-        this.extremeRange = 16;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 5;
-        this.waterLongRange = 8;
-        this.waterExtremeRange = 10;
-        this.tonnage = .8;
-        this.criticals = 3;
-        this.bv = 111;
-        this.cost = 60000;
-        this.shortAV = 7;
-        this.medAV = 7;
-        this.maxRange = RANGE_MED;
-        this.flags = flags.or(F_BURST_FIRE).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
+        name = "Medium Pulse Laser";
+        setInternalName("CLBAMediumPulseLaser");
+        addLookupName("Clan BA Pulse Med Laser");
+        addLookupName("Clan BA Medium Pulse Laser");
+        sortingName = "Laser Pulse C";
+        heat = 4;
+        damage = 7;
+        toHitModifier = -2;
+        shortRange = 4;
+        mediumRange = 8;
+        longRange = 12;
+        extremeRange = 16;
+        waterShortRange = 3;
+        waterMediumRange = 5;
+        waterLongRange = 8;
+        waterExtremeRange = 10;
+        tonnage = .8;
+        criticals = 3;
+        bv = 111;
+        cost = 60000;
+        shortAV = 7;
+        medAV = 7;
+        maxRange = RANGE_MED;
+        flags = flags.or(F_BURST_FIRE).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         rulesRefs = "258, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMicro.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMicro.java
@@ -28,6 +28,7 @@ public class CLBAPulseLaserMicro extends PulseLaserWeapon {
         name = "Micro Pulse Laser";
         setInternalName("CLBAMicroPulseLaser");
         addLookupName("Clan BA Micro Pulse Laser");
+        sortingName = "Laser Pulse A";
         heat = 1;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserSmall.java
@@ -25,29 +25,30 @@ public class CLBAPulseLaserSmall extends PulseLaserWeapon {
 
     public CLBAPulseLaserSmall() {
         super();
-        this.name = "Small Pulse Laser";
-        this.setInternalName("CLBASmallPulseLaser");
-        this.addLookupName("Clan BA Pulse Small Laser");
-        this.addLookupName("Clan BA Small Pulse Laser");
-        this.heat = 2;
-        this.damage = 3;
-        this.infDamageClass = WeaponType.WEAPON_BURST_2D6;
-        this.toHitModifier = -2;
-        this.shortRange = 2;
-        this.mediumRange = 4;
-        this.longRange = 6;
-        this.extremeRange = 8;
-        this.waterShortRange = 1;
-        this.waterMediumRange = 2;
-        this.waterLongRange = 4;
-        this.waterExtremeRange = 4;
-        this.tonnage = .4;
-        this.criticals = 1;
-        this.bv = 24;
-        this.cost = 16000;
-        this.shortAV = 3;
-        this.maxRange = RANGE_SHORT;
-        this.flags = flags.or(F_BURST_FIRE).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
+        name = "Small Pulse Laser";
+        setInternalName("CLBASmallPulseLaser");
+        addLookupName("Clan BA Pulse Small Laser");
+        addLookupName("Clan BA Small Pulse Laser");
+        sortingName = "Laser Pulse B";
+        heat = 2;
+        damage = 3;
+        infDamageClass = WeaponType.WEAPON_BURST_2D6;
+        toHitModifier = -2;
+        shortRange = 2;
+        mediumRange = 4;
+        longRange = 6;
+        extremeRange = 8;
+        waterShortRange = 1;
+        waterMediumRange = 2;
+        waterLongRange = 4;
+        waterExtremeRange = 4;
+        tonnage = .4;
+        criticals = 1;
+        bv = 24;
+        cost = 16000;
+        shortAV = 3;
+        maxRange = RANGE_SHORT;
+        flags = flags.or(F_BURST_FIRE).or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         rulesRefs = "258, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBARecoillessRifleHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBARecoillessRifleHeavy.java
@@ -33,6 +33,7 @@ public class CLBARecoillessRifleHeavy extends Weapon {
         addLookupName("ISBAHeavyRecoillessRifle");
         addLookupName("ISHeavy Recoilless Rifle");
         addLookupName("ISBAHeavy Recoilless Rifle");
+        sortingName = "Recoilless Rifle D";
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;
         ammoType = AmmoType.T_NA;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBARecoillessRifleLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBARecoillessRifleLight.java
@@ -33,6 +33,7 @@ public class CLBARecoillessRifleLight extends Weapon {
         addLookupName("ISBALightRecoillessRifle");
         addLookupName("ISLight Recoilless Rifle");
         addLookupName("ISBALight Recoilless Rifle");
+        sortingName = "Recoilless Rifle B";
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
         ammoType = AmmoType.T_NA;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBARecoillessRifleMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBARecoillessRifleMedium.java
@@ -34,6 +34,7 @@ public class CLBARecoillessRifleMedium extends Weapon {
         addLookupName("IS BA Medium Recoilless Rifle");
         addLookupName("ISBAMedium Recoilless Rifle");
         addLookupName("ISBAMediumRecoillessRifle");
+        sortingName = "Recoilless Rifle C";
         heat = 0;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAGrenadeLauncherHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAGrenadeLauncherHeavy.java
@@ -37,6 +37,7 @@ public class ISBAGrenadeLauncherHeavy extends Weapon {
         //Per TM Errata the original Grenade Launcher becomes the Heavy. Lookups below to keep unit files consistent.
         addLookupName("ISBAGrenadeLauncher");
       	addLookupName("IS BA Grenade Launcher");
+        sortingName = "Grenade Launcher D";
         heat = 0;
         damage = 1;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAGrenadeLauncherMicro.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAGrenadeLauncherMicro.java
@@ -30,6 +30,7 @@ public class ISBAGrenadeLauncherMicro extends Weapon {
         addLookupName("IS BA Micro Grenade Launcher");
         addLookupName("CL BA Micro Grenade Launcher");
         addLookupName("CLBAMicroGrenadeLauncher");
+        sortingName = "Grenade Launcher A";
         heat = 0;
         damage = 1;
         infDamageClass = WeaponType.WEAPON_BURST_HALFD6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAHeavyFlamer.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAHeavyFlamer.java
@@ -30,6 +30,7 @@ public class ISBAHeavyFlamer extends BAFlamerWeapon {
         name = "Heavy Flamer [BA]";
         setInternalName("ISBAHeavyFlamer");
         addLookupName("IS BA Heavy Flamer");
+        sortingName = "Flamer D";
         heat = 5;
         damage = 4;
         infDamageClass = WeaponType.WEAPON_BURST_6D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERMedium.java
@@ -27,6 +27,7 @@ public class ISBALaserERMedium extends LaserWeapon {
         name = "ER Medium Laser";
         setInternalName("ISBAERMediumLaser");
         addLookupName("IS BA ER Medium Laser");
+        sortingName = "Laser ER C";
         heat = 5;
         damage = 5;
         shortRange = 4;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERSmall.java
@@ -27,6 +27,7 @@ public class ISBALaserERSmall extends LaserWeapon {
          name = "ER Small Laser";
         setInternalName("ISBAERSmallLaser");
         addLookupName("IS BA ER Small Laser");
+        sortingName = "Laser ER B";
         damage = 3;
         shortRange = 2;
         mediumRange = 4;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserMedium.java
@@ -27,6 +27,7 @@ public class ISBALaserMedium extends LaserWeapon {
         name = "Medium Laser";
         setInternalName("ISBAMediumLaser");
         addLookupName("IS BA Medium Laser");
+        sortingName = "Laser C";
         damage = 5;
         shortRange = 3;
         mediumRange = 6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseMedium.java
@@ -28,6 +28,7 @@ public class ISBALaserPulseMedium extends PulseLaserWeapon {
         setInternalName("ISBAMediumPulseLaser");
         addLookupName("IS BA Pulse Med Laser");
         addLookupName("IS BA Medium Pulse Laser");
+        sortingName = "Laser Pulse C";
         damage = 6;
         toHitModifier = -2;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseSmall.java
@@ -29,6 +29,7 @@ public class ISBALaserPulseSmall extends PulseLaserWeapon {
         setInternalName("ISBASmallPulseLaser");
         addLookupName("IS BA Small Pulse Laser");
         addLookupName("ISBASmall Pulse Laser");
+        sortingName = "Laser Pulse B";
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;
         toHitModifier = -2;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserSmall.java
@@ -27,6 +27,7 @@ public class ISBALaserSmall extends LaserWeapon {
         name = "Small Laser";
         setInternalName("ISBASmallLaser");
         addLookupName("ISBASmall Laser");
+        sortingName = "Laser B";
         heat = 1;
         damage = 3;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPMedium.java
@@ -29,6 +29,7 @@ public class ISBALaserVSPMedium extends VariableSpeedPulseLaserWeapon {
         addLookupName("ISBAMVSPL");
         addLookupName("ISBAMediumVariableSpeedLaser");
         addLookupName("ISBAMediumVSP");
+        sortingName = "Laser VSP C";
         heat = 7;
         damage = DAMAGE_VARIABLE;
         toHitModifier = -4;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPSmall.java
@@ -30,6 +30,7 @@ public class ISBALaserVSPSmall extends VariableSpeedPulseLaserWeapon {
         addLookupName("ISBASVSPL");
         addLookupName("ISBASmallVariableSpeedLaser");
         addLookupName("ISBASmallVSP");
+        sortingName = "Laser VSP B";
         heat = 3;
         damage = WeaponType.DAMAGE_VARIABLE;
         toHitModifier = -4;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMG.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMG.java
@@ -31,6 +31,7 @@ public class ISBAMG extends BAMGWeapon {
         addLookupName("IS BA Machine Gun");
         addLookupName("ISBAMachine Gun");
         addLookupName("ISBAMachineGun");
+        sortingName = "MG C";
         heat = 0;
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMGHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMGHeavy.java
@@ -31,6 +31,7 @@ public class ISBAMGHeavy extends BAMGWeapon {
         setInternalName("ISBAHeavyMachineGun");
         addLookupName("IS BA Heavy Machine Gun");
         addLookupName("ISBAHeavyMG");
+        sortingName = "MG D";
         heat = 0;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMGLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMGLight.java
@@ -32,6 +32,7 @@ public class ISBAMGLight extends BAMGWeapon {
         setInternalName("ISBALightMachineGun");
         addLookupName("IS BA Light Machine Gun");
         addLookupName("ISBALightMG");
+        sortingName = "MG B";
         ammoType = AmmoType.T_NA;
         heat = 0;
         damage = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarHeavy.java
@@ -32,6 +32,7 @@ public class ISBAMortarHeavy extends Weapon {
         name = "Heavy Mortar";
         setInternalName("ISBAHeavyMortar");
         addLookupName("IS BA Heavy Mortar");
+        sortingName = "Mortar D";
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
         ammoType = AmmoType.T_NA;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarLight.java
@@ -32,6 +32,7 @@ public class ISBAMortarLight extends Weapon {
         name = "Light Mortar";
         setInternalName("ISBALightMortar");
         addLookupName("IS BA Light Mortar");
+        sortingName = "Mortar B";
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
         ammoType = AmmoType.T_NA;

--- a/megamek/src/megamek/common/weapons/capitalweapons/NGaussWeaponHeavy.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/NGaussWeaponHeavy.java
@@ -24,27 +24,28 @@ public class NGaussWeaponHeavy extends NGaussWeapon {
 
     public NGaussWeaponHeavy() {
         super();
-        this.name = "Naval Gauss (Heavy)";
-        this.setInternalName(this.name);
-        this.addLookupName("HeavyNGauss");
-        this.addLookupName("CLHeavyNGauss");
-        this.addLookupName("Heavy N-Gauss (Clan)");
-        this.shortName = "Heavy NGauss";
-        this.heat = 18;
-        this.damage = 30;
-        this.ammoType = AmmoType.T_HEAVY_NGAUSS;
-        this.shortRange = 12;
-        this.mediumRange = 24;
-        this.longRange = 36;
-        this.extremeRange = 48;
-        this.tonnage = 7000;
-        this.bv = 6048;
-        this.cost = 50050000;
-        this.shortAV = 30;
-        this.medAV = 30;
-        this.longAV = 30;
-        this.extAV = 30;
-        this.maxRange = RANGE_EXT;
+        name = "Naval Gauss (Heavy)";
+        setInternalName(this.name);
+        addLookupName("HeavyNGauss");
+        addLookupName("CLHeavyNGauss");
+        addLookupName("Heavy N-Gauss (Clan)");
+        sortingName = "Gauss Naval D";
+        shortName = "Heavy NGauss";
+        heat = 18;
+        damage = 30;
+        ammoType = AmmoType.T_HEAVY_NGAUSS;
+        shortRange = 12;
+        mediumRange = 24;
+        longRange = 36;
+        extremeRange = 48;
+        tonnage = 7000;
+        bv = 6048;
+        cost = 50050000;
+        shortAV = 30;
+        medAV = 30;
+        longAV = 30;
+        extAV = 30;
+        maxRange = RANGE_EXT;
         rulesRefs = "333, TO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/capitalweapons/NGaussWeaponLight.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/NGaussWeaponLight.java
@@ -24,27 +24,28 @@ public class NGaussWeaponLight extends NGaussWeapon {
 
     public NGaussWeaponLight() {
         super();
-        this.name = "Naval Gauss (Light)";
-        this.setInternalName(this.name);
-        this.addLookupName("LightNGauss");
-        this.addLookupName("CLLightNGauss");
-        this.addLookupName("Light N-Gauss (Clan)");
-        this.shortName = "Light NGauss";
-        this.heat = 9;
-        this.damage = 15;
-        this.ammoType = AmmoType.T_LIGHT_NGAUSS;
-        this.shortRange = 14;
-        this.mediumRange = 28;
-        this.longRange = 40;
-        this.extremeRange = 56;
-        this.tonnage = 4500;
-        this.bv = 3024;
-        this.cost = 20300000;
-        this.shortAV = 15;
-        this.medAV = 15;
-        this.longAV = 15;
-        this.extAV = 15;
-        this.maxRange = RANGE_EXT;
+        name = "Naval Gauss (Light)";
+        setInternalName(this.name);
+        addLookupName("LightNGauss");
+        addLookupName("CLLightNGauss");
+        addLookupName("Light N-Gauss (Clan)");
+        sortingName = "Gauss Naval B";
+        shortName = "Light NGauss";
+        heat = 9;
+        damage = 15;
+        ammoType = AmmoType.T_LIGHT_NGAUSS;
+        shortRange = 14;
+        mediumRange = 28;
+        longRange = 40;
+        extremeRange = 56;
+        tonnage = 4500;
+        bv = 3024;
+        cost = 20300000;
+        shortAV = 15;
+        medAV = 15;
+        longAV = 15;
+        extAV = 15;
+        maxRange = RANGE_EXT;
         rulesRefs = "333, TO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/capitalweapons/NGaussWeaponMedium.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/NGaussWeaponMedium.java
@@ -24,27 +24,28 @@ public class NGaussWeaponMedium extends NGaussWeapon {
 
     public NGaussWeaponMedium() {
         super();
-        this.name = "Naval Gauss (Medium)";
-        this.setInternalName(this.name);
-        this.addLookupName("MediumNGauss");
-        this.addLookupName("CLMediumNGauss");
-        this.addLookupName("Medium N-Gauss (Clan)");
-        this.shortName = "Medium NGauss";
-        this.heat = 15;
-        this.damage = 25;
-        this.ammoType = AmmoType.T_MED_NGAUSS;
-        this.shortRange = 13;
-        this.mediumRange = 26;
-        this.longRange = 39;
-        this.extremeRange = 52;
-        this.tonnage = 5500;
-        this.bv = 5040;
-        this.cost = 30350000;
-        this.shortAV = 25;
-        this.medAV = 25;
-        this.longAV = 25;
-        this.extAV = 25;
-        this.maxRange = RANGE_EXT;
+        name = "Naval Gauss (Medium)";
+        setInternalName(this.name);
+        addLookupName("MediumNGauss");
+        addLookupName("CLMediumNGauss");
+        addLookupName("Medium N-Gauss (Clan)");
+        shortName = "Medium NGauss";
+        sortingName = "Gauss Naval C";
+        heat = 15;
+        damage = 25;
+        ammoType = AmmoType.T_MED_NGAUSS;
+        shortRange = 13;
+        mediumRange = 26;
+        longRange = 39;
+        extremeRange = 52;
+        tonnage = 5500;
+        bv = 5040;
+        cost = 30350000;
+        shortAV = 25;
+        medAV = 25;
+        longAV = 25;
+        extAV = 25;
+        maxRange = RANGE_EXT;
         rulesRefs = "333, TO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/capitalweapons/NPPCWeaponHeavy.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/NPPCWeaponHeavy.java
@@ -22,25 +22,26 @@ public class NPPCWeaponHeavy extends NPPCWeapon {
 
     public NPPCWeaponHeavy() {
         super();
-        this.name = "Naval PPC (Heavy)";
-        this.setInternalName(this.name);
-        this.addLookupName("HeavyNPPC");
-        this.addLookupName("Heavy NPPC (Clan)");
-        this.shortName = "Heavy NPPC";
-        this.heat = 225;
-        this.damage = 15;
-        this.shortRange = 13;
-        this.mediumRange = 26;
-        this.longRange = 39;
-        this.extremeRange = 52;
-        this.tonnage = 3000.0;
-        this.bv = 3780;
-        this.cost = 9050000;
-        this.shortAV = 15;
-        this.medAV = 15;
-        this.longAV = 15;
-        this.extAV = 15;
-        this.maxRange = RANGE_EXT;
+        name = "Naval PPC (Heavy)";
+        setInternalName(this.name);
+        addLookupName("HeavyNPPC");
+        addLookupName("Heavy NPPC (Clan)");
+        shortName = "Heavy NPPC";
+        sortingName = "PPC Naval D";
+        heat = 225;
+        damage = 15;
+        shortRange = 13;
+        mediumRange = 26;
+        longRange = 39;
+        extremeRange = 52;
+        tonnage = 3000.0;
+        bv = 3780;
+        cost = 9050000;
+        shortAV = 15;
+        medAV = 15;
+        longAV = 15;
+        extAV = 15;
+        maxRange = RANGE_EXT;
         rulesRefs = "333, TO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/capitalweapons/NPPCWeaponLight.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/NPPCWeaponLight.java
@@ -22,24 +22,25 @@ public class NPPCWeaponLight extends NPPCWeapon {
 
     public NPPCWeaponLight() {
         super();
-        this.name = "Naval PPC (Light)";
-        this.setInternalName(this.name);
-        this.addLookupName("LightNPPC");
-        this.addLookupName("Light NPPC (Clan)");
-        this.shortName = "Light NPPC";
-        this.heat = 105;
-        this.damage = 7;
-        this.shortRange = 11;
-        this.mediumRange = 22;
-        this.longRange = 33;
-        this.extremeRange = 44;
-        this.tonnage = 1400.0;
-        this.bv = 1659;
-        this.cost = 2000000;
-        this.shortAV = 7;
-        this.medAV = 7;
-        this.longAV = 7;
-        this.maxRange = RANGE_LONG;
+        name = "Naval PPC (Light)";
+        setInternalName(this.name);
+        addLookupName("LightNPPC");
+        addLookupName("Light NPPC (Clan)");
+        shortName = "Light NPPC";
+        sortingName = "PPC Naval B";
+        heat = 105;
+        damage = 7;
+        shortRange = 11;
+        mediumRange = 22;
+        longRange = 33;
+        extremeRange = 44;
+        tonnage = 1400.0;
+        bv = 1659;
+        cost = 2000000;
+        shortAV = 7;
+        medAV = 7;
+        longAV = 7;
+        maxRange = RANGE_LONG;
         rulesRefs = "333, TO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/capitalweapons/NPPCWeaponMedium.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/NPPCWeaponMedium.java
@@ -22,25 +22,26 @@ public class NPPCWeaponMedium extends NPPCWeapon {
 
     public NPPCWeaponMedium() {
         super();
-        this.name = "Naval PPC (Medium)";
-        this.setInternalName(this.name);
-        this.addLookupName("MediumNPPC");
-        this.addLookupName("Medium NPPC (Clan)");
-        this.shortName = "Medium NPPC";
-        this.heat = 135;
-        this.damage = 9;
-        this.shortRange = 12;
-        this.mediumRange = 24;
-        this.longRange = 36;
-        this.extremeRange = 48;
-        this.tonnage = 1800.0;
-        this.bv = 2268;
-        this.cost = 3250000;
-        this.shortAV = 9;
-        this.medAV = 9;
-        this.longAV = 9;
-        this.extAV = 9;
-        this.maxRange = RANGE_EXT;
+        name = "Naval PPC (Medium)";
+        setInternalName(this.name);
+        addLookupName("MediumNPPC");
+        addLookupName("Medium NPPC (Clan)");
+        shortName = "Medium NPPC";
+        sortingName = "PPC Naval C";
+        heat = 135;
+        damage = 9;
+        shortRange = 12;
+        mediumRange = 24;
+        longRange = 36;
+        extremeRange = 48;
+        tonnage = 1800.0;
+        bv = 2268;
+        cost = 3250000;
+        shortAV = 9;
+        medAV = 9;
+        longAV = 9;
+        extAV = 9;
+        maxRange = RANGE_EXT;
         rulesRefs = "333, TO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapCannonWeaponHeavy.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapCannonWeaponHeavy.java
@@ -24,24 +24,25 @@ public class SubCapCannonWeaponHeavy extends SubCapCannonWeapon {
 
     public SubCapCannonWeaponHeavy() {
         super();
-        this.name = "Sub-Capital Cannon (Heavy)";
-        this.setInternalName(this.name);
-        this.addLookupName("HeavySCC");
-        this.addLookupName("Heavy Sub-Capital Cannon");
-        this.shortName = "Heavy SCC";
-        this.heat = 42;
-        this.damage = 7;
-        this.rackSize = 7;
-        this.shortRange = 11;
-        this.mediumRange = 22;
-        this.longRange = 33;
-        this.extremeRange = 44;
-        this.tonnage = 700.0;
-        this.bv = 1901;
-        this.cost = 1300000;
-        this.shortAV = 7;
-        this.medAV = 7;
-        this.maxRange = RANGE_MED;
+        name = "Sub-Capital Cannon (Heavy)";
+        setInternalName(this.name);
+        addLookupName("HeavySCC");
+        addLookupName("Heavy Sub-Capital Cannon");
+        shortName = "Heavy SCC";
+        sortingName = "Sub-Capital Cannon D";
+        heat = 42;
+        damage = 7;
+        rackSize = 7;
+        shortRange = 11;
+        mediumRange = 22;
+        longRange = 33;
+        extremeRange = 44;
+        tonnage = 700.0;
+        bv = 1901;
+        cost = 1300000;
+        shortAV = 7;
+        medAV = 7;
+        maxRange = RANGE_MED;
         rulesRefs = "343, TO";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         techAdvancement.setTechBase(TECH_BASE_ALL)

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapCannonWeaponLight.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapCannonWeaponLight.java
@@ -24,25 +24,26 @@ public class SubCapCannonWeaponLight extends SubCapCannonWeapon {
 
     public SubCapCannonWeaponLight() {
         super();
-        this.name = "Sub-Capital Cannon (Light)";
-        this.setInternalName(this.name);
-        this.addLookupName("LightSCC");
-        this.addLookupName("Light Sub-Capital Cannon");
-        this.shortName = "Light SCC";
-        this.heat = 12;
-        this.damage = 2;
-        this.rackSize = 2;
-        this.shortRange = 11;
-        this.mediumRange = 22;
-        this.longRange = 33;
-        this.extremeRange = 44;
-        this.tonnage = 200.0;
-        this.bv = 379;
-        this.cost = 330000;
-        this.shortAV = 2;
-        this.medAV = 2;
-        this.longAV = 2;
-        this.maxRange = RANGE_LONG;
+        name = "Sub-Capital Cannon (Light)";
+        setInternalName(this.name);
+        addLookupName("LightSCC");
+        addLookupName("Light Sub-Capital Cannon");
+        shortName = "Light SCC";
+        sortingName = "Sub-Capital Cannon B";
+        heat = 12;
+        damage = 2;
+        rackSize = 2;
+        shortRange = 11;
+        mediumRange = 22;
+        longRange = 33;
+        extremeRange = 44;
+        tonnage = 200.0;
+        bv = 379;
+        cost = 330000;
+        shortAV = 2;
+        medAV = 2;
+        longAV = 2;
+        maxRange = RANGE_LONG;
         rulesRefs = "343, TO";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         techAdvancement.setTechBase(TECH_BASE_ALL)

--- a/megamek/src/megamek/common/weapons/capitalweapons/SubCapCannonWeaponMedium.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/SubCapCannonWeaponMedium.java
@@ -27,8 +27,9 @@ public class SubCapCannonWeaponMedium extends SubCapCannonWeapon {
         name = "Sub-Capital Cannon (Medium)";
         setInternalName(name);
         addLookupName("MediumSCC");
-        this.addLookupName("Medium Sub-Capital Cannon");
-        this.shortName = "Medium SCC";
+        addLookupName("Medium Sub-Capital Cannon");
+        shortName = "Medium SCC";
+        sortingName = "Sub-Capital Cannon C";
         heat = 30;
         damage = 5;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/flamers/CLERFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/CLERFlamer.java
@@ -28,6 +28,7 @@ public class CLERFlamer extends FlamerWeapon {
         name = "ER Flamer";
         setInternalName("CLERFlamer");
         addLookupName("CL ER Flamer");
+        sortingName = "Flamer ER";
         flags = flags.or(WeaponType.F_ER_FLAMER);
         heat = 4;
         damage = 2;

--- a/megamek/src/megamek/common/weapons/flamers/CLHeavyFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/CLHeavyFlamer.java
@@ -32,6 +32,7 @@ public class CLHeavyFlamer extends VehicleFlamerWeapon {
         addLookupName("Clan Heavy Flamer");
         addLookupName("CL Heavy Flamer");
         addLookupName("CLHeavyFlamer");
+        sortingName = "Flamer D";
         heat = 5;
         damage = 4;
         infDamageClass = WeaponType.WEAPON_BURST_6D6;

--- a/megamek/src/megamek/common/weapons/flamers/ISERFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/ISERFlamer.java
@@ -29,6 +29,7 @@ public class ISERFlamer extends FlamerWeapon {
         setInternalName(name);
         addLookupName("IS ER Flamer");
         addLookupName("ISERFlamer");
+        sortingName = "Flamer X ER";
         flags = flags.or(WeaponType.F_ER_FLAMER);
         heat = 4;
         damage = 2;

--- a/megamek/src/megamek/common/weapons/flamers/ISFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/ISFlamer.java
@@ -24,24 +24,25 @@ public class ISFlamer extends FlamerWeapon {
 
     public ISFlamer() {
         super();
-        this.name = "Flamer";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Flamer");
-        this.addLookupName("ISFlamer");
-        this.heat = 3;
-        this.damage = 2;
-        this.infDamageClass = WeaponType.WEAPON_BURST_4D6;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 3;
-        this.extremeRange = 4;
-        this.tonnage = 1;
-        this.criticals = 1;
-        this.bv = 6;
-        this.cost = 7500;
-        this.shortAV = 2;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_POINT_DEFENSE;
+        name = "Flamer";
+        setInternalName(this.name);
+        addLookupName("IS Flamer");
+        addLookupName("ISFlamer");
+        sortingName = "Flamer C";
+        heat = 3;
+        damage = 2;
+        infDamageClass = WeaponType.WEAPON_BURST_4D6;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 3;
+        extremeRange = 4;
+        tonnage = 1;
+        criticals = 1;
+        bv = 6;
+        cost = 7500;
+        shortAV = 2;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_POINT_DEFENSE;
         rulesRefs = "218, TM";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(true)

--- a/megamek/src/megamek/common/weapons/flamers/ISHeavyFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/ISHeavyFlamer.java
@@ -31,6 +31,7 @@ public class ISHeavyFlamer extends VehicleFlamerWeapon {
         setInternalName(name);
         addLookupName("IS Heavy Flamer");
         addLookupName("ISHeavyFlamer");
+        sortingName = "Flamer D";
         heat = 5;
         damage = 4;
         infDamageClass = WeaponType.WEAPON_BURST_6D6;

--- a/megamek/src/megamek/common/weapons/gaussrifles/CLImprovedGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/CLImprovedGaussRifle.java
@@ -31,27 +31,27 @@ public class CLImprovedGaussRifle extends GaussWeapon {
 
     public CLImprovedGaussRifle() {
         super();
-
-        this.name = "Improved Gauss Rifle";
-        this.setInternalName("Improved Gauss Rifle");
-        this.addLookupName("CLIMPGaussRifle");
-        this.heat = 1;
-        this.damage = 15;
-        this.ammoType = AmmoType.T_GAUSS_IMP;
-        this.minimumRange = 2;
-        this.shortRange = 7;
-        this.mediumRange = 15;
-        this.longRange = 22;
-        this.extremeRange = 30;
-        this.tonnage = 13.0;
-        this.criticals = 6;
-        this.bv = 320;
-        this.cost = 300000;
-        this.shortAV = 15;
-        this.medAV = 15;
-        this.longAV = 15;
-        this.maxRange = RANGE_LONG;
-        this.explosionDamage = 20;
+        name = "Improved Gauss Rifle";
+        setInternalName("Improved Gauss Rifle");
+        addLookupName("CLIMPGaussRifle");
+        sortingName = "Gauss Imp";
+        heat = 1;
+        damage = 15;
+        ammoType = AmmoType.T_GAUSS_IMP;
+        minimumRange = 2;
+        shortRange = 7;
+        mediumRange = 15;
+        longRange = 22;
+        extremeRange = 30;
+        tonnage = 13.0;
+        criticals = 6;
+        bv = 320;
+        cost = 300000;
+        shortAV = 15;
+        medAV = 15;
+        longAV = 15;
+        maxRange = RANGE_LONG;
+        explosionDamage = 20;
         rulesRefs = "96, IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_E)
                 .setAvailability(RATING_X, RATING_E, RATING_X, RATING_E)
@@ -63,14 +63,6 @@ public class CLImprovedGaussRifle extends GaussWeapon {
                 .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISGaussRifle.java
@@ -31,26 +31,27 @@ public class ISGaussRifle extends GaussWeapon {
     public ISGaussRifle() {
         super();
 
-        this.name = "Gauss Rifle";
-        this.setInternalName("ISGaussRifle");
-        this.addLookupName("IS Gauss Rifle");
-        this.heat = 1;
-        this.damage = 15;
-        this.ammoType = AmmoType.T_GAUSS;
-        this.minimumRange = 2;
-        this.shortRange = 7;
-        this.mediumRange = 15;
-        this.longRange = 22;
-        this.extremeRange = 30;
-        this.tonnage = 15.0;
-        this.criticals = 7;
-        this.bv = 320;
-        this.cost = 300000;
-        this.shortAV = 15;
-        this.medAV = 15;
-        this.longAV = 15;
-        this.maxRange = RANGE_LONG;
-        this.explosionDamage = 20;
+        name = "Gauss Rifle";
+        setInternalName("ISGaussRifle");
+        addLookupName("IS Gauss Rifle");
+        sortingName = "Gauss C";
+        heat = 1;
+        damage = 15;
+        ammoType = AmmoType.T_GAUSS;
+        minimumRange = 2;
+        shortRange = 7;
+        mediumRange = 15;
+        longRange = 22;
+        extremeRange = 30;
+        tonnage = 15.0;
+        criticals = 7;
+        bv = 320;
+        cost = 300000;
+        shortAV = 15;
+        medAV = 15;
+        longAV = 15;
+        maxRange = RANGE_LONG;
+        explosionDamage = 20;
         rulesRefs = "219,TM";
         flags = flags.andNot(F_PROTO_WEAPON);
         techAdvancement.setTechBase(TECH_BASE_IS)
@@ -65,14 +66,6 @@ public class ISGaussRifle extends GaussWeapon {
                 .setReintroductionFactions(F_FC, F_FW, F_DC);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISHGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISHGaussRifle.java
@@ -34,6 +34,7 @@ public class ISHGaussRifle extends GaussWeapon {
         name = "Heavy Gauss Rifle";
         setInternalName("ISHeavyGaussRifle");
         addLookupName("IS Heavy Gauss Rifle");
+        sortingName = "Gauss D";
         heat = 2;
         damage = DAMAGE_VARIABLE;
         ammoType = AmmoType.T_GAUSS_HEAVY;
@@ -79,14 +80,6 @@ public class ISHGaussRifle extends GaussWeapon {
         return damageLong;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISImpHGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISImpHGaussRifle.java
@@ -36,6 +36,7 @@ public class ISImpHGaussRifle extends GaussWeapon {
         shortName = "Imp. Heavy Gauss Rifle";
         setInternalName("ISImprovedHeavyGaussRifle");
         addLookupName("IS Improved Heavy Gauss Rifle");
+        sortingName = "Gauss IMP D";
         heat = 2;
         damage = 22;
         ammoType = AmmoType.T_IGAUSS_HEAVY;
@@ -62,14 +63,6 @@ public class ISImpHGaussRifle extends GaussWeapon {
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISLGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISLGaussRifle.java
@@ -30,28 +30,28 @@ public class ISLGaussRifle extends GaussWeapon {
 
     public ISLGaussRifle() {
         super();
-
-        this.name = "Light Gauss Rifle";
-        this.setInternalName("ISLightGaussRifle");
-        this.addLookupName("IS Light Gauss Rifle");
-        this.heat = 1;
-        this.damage = 8;
-        this.ammoType = AmmoType.T_GAUSS_LIGHT;
-        this.minimumRange = 3;
-        this.shortRange = 8;
-        this.mediumRange = 17;
-        this.longRange = 25;
-        this.extremeRange = 34;
-        this.tonnage = 12.0;
-        this.criticals = 5;
-        this.bv = 159;
-        this.cost = 275000;
-        this.shortAV = 8;
-        this.medAV = 8;
-        this.longAV = 8;
-        this.extAV = 8;
-        this.maxRange = RANGE_EXT;
-        this.explosionDamage = 16;
+        name = "Light Gauss Rifle";
+        setInternalName("ISLightGaussRifle");
+        addLookupName("IS Light Gauss Rifle");
+        sortingName = "Gauss B";
+        heat = 1;
+        damage = 8;
+        ammoType = AmmoType.T_GAUSS_LIGHT;
+        minimumRange = 3;
+        shortRange = 8;
+        mediumRange = 17;
+        longRange = 25;
+        extremeRange = 34;
+        tonnage = 12.0;
+        criticals = 5;
+        bv = 159;
+        cost = 275000;
+        shortAV = 8;
+        medAV = 8;
+        longAV = 8;
+        extAV = 8;
+        maxRange = RANGE_EXT;
+        explosionDamage = 16;
         rulesRefs = "219, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISMagshotGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISMagshotGaussRifle.java
@@ -28,6 +28,7 @@ public class ISMagshotGaussRifle extends GaussWeapon {
 
         name = "MagShot";
         setInternalName("ISMagshotGR");
+        sortingName = "Gauss Z";
         heat = 1;
         damage = 2;
         ammoType = AmmoType.T_MAGSHOT;

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
@@ -37,6 +37,7 @@ public class ISSilverBulletGauss extends GaussWeapon {
         setInternalName("ISSBGR");
         addLookupName("IS Silver Bullet Gauss Rifle");
         addLookupName("ISSBGaussRifle");
+        sortingName = "Gauss X";
         heat = 1;
         damage = 15;
         rackSize = 15;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMHeavyInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMHeavyInfernoWeapon.java
@@ -29,6 +29,7 @@ public class InfantrySupportSRMHeavyInfernoWeapon extends InfantryWeapon {
 		setInternalName("InfantryHeavySRMInferno");
 		addLookupName(name);
 		addLookupName("Infantry Heavy SRM Launcher (Inferno)");
+		sortingName = "SRM Launcher DI";
 		ammoType = AmmoType.T_INFANTRY;
 		cost = 3000;
 		bv = 1.74;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMHeavyWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMHeavyWeapon.java
@@ -36,6 +36,7 @@ public class InfantrySupportSRMHeavyWeapon extends InfantryWeapon {
 		setInternalName("InfantryHeavySRM");
 		addLookupName(name);
 		addLookupName("Infantry Heavy SRM Launcher");
+		sortingName = "SRM Launcher D";
 		ammoType = AmmoType.T_INFANTRY;
 		cost = 3000;
 		bv = 2.91;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMLightInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMLightInfernoWeapon.java
@@ -36,6 +36,7 @@ public class InfantrySupportSRMLightInfernoWeapon extends InfantryWeapon {
 		setInternalName("InfantrySRMLightInferno");
 		addLookupName(name);
 		addLookupName("Light SRM (Inferno)");
+		sortingName = "SRM Launcher BI";
 		ammoType = AmmoType.T_INFANTRY;
 		cost = 1500;
 		bv = 1.74;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMLightWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMLightWeapon.java
@@ -37,6 +37,7 @@ public class InfantrySupportSRMLightWeapon extends InfantryWeapon {
 		addLookupName(name);
 		addLookupName("InfantrySRM");
 		addLookupName("Light SRM Launcher");
+		sortingName = "SRM Launcher B";
 		ammoType = AmmoType.T_INFANTRY;
 		cost = 1500;
 		bv = 2.91;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMStandardInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMStandardInfernoWeapon.java
@@ -37,6 +37,7 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
 		addLookupName(name);
 		addLookupName("Infantry2ShotSRMInferno");
 		addLookupName("Infantry Two-Shot SRM Launcher (Inferno)");
+		sortingName = "SRM Launcher CI";
 		ammoType = AmmoType.T_INFANTRY;
 		cost = 1500;
 		bv = 3.48;

--- a/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMStandardWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantrySupportSRMStandardWeapon.java
@@ -37,6 +37,7 @@ public class InfantrySupportSRMStandardWeapon extends InfantryWeapon {
 		addLookupName(name);
 		addLookupName("Infantry2ShotSRM");
 		addLookupName("Infantry Two-Shot SRM Launcher");
+		sortingName = "SRM Launcher C";
 		ammoType = AmmoType.T_INFANTRY;
 		cost = 1500;
 		bv = 5.83;

--- a/megamek/src/megamek/common/weapons/lasers/CLChemicalLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLChemicalLaserLarge.java
@@ -27,6 +27,7 @@ public class CLChemicalLaserLarge extends CLChemicalLaserWeapon {
         setInternalName("CLLargeChemicalLaser");
         addLookupName("CLLargeChemLaser");
         addLookupName("Large Chem Laser");
+        sortingName = "Chem Laser D";
         heat = 6;
         damage = 8;
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/lasers/CLChemicalLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLChemicalLaserMedium.java
@@ -27,6 +27,7 @@ public class CLChemicalLaserMedium extends CLChemicalLaserWeapon {
         setInternalName("CLMediumChemicalLaser");
         addLookupName("CLMediumChemLaser");
         addLookupName("Medium Chem Laser");
+        sortingName = "Chem Laser C";
         heat = 2;
         damage = 5;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/lasers/CLChemicalLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLChemicalLaserSmall.java
@@ -27,6 +27,7 @@ public class CLChemicalLaserSmall extends CLChemicalLaserWeapon {
         setInternalName("CLSmallChemicalLaser");
         addLookupName("CLSmallChemLaser");
         addLookupName("Small Chem Laser");
+        sortingName = "Chem Laser B";
         heat = 1;
         rackSize = 3;
         damage = 3;

--- a/megamek/src/megamek/common/weapons/lasers/CLERLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERLaserLarge.java
@@ -22,28 +22,29 @@ public class CLERLaserLarge extends LaserWeapon {
 
     public CLERLaserLarge() {
         super();
-        this.name = "ER Large Laser";
-        this.setInternalName("CLERLargeLaser");
-        this.addLookupName("Clan ER Large Laser");
-        this.heat = 12;
-        this.damage = 10;
-        this.shortRange = 8;
-        this.mediumRange = 15;
-        this.longRange = 25;
-        this.extremeRange = 30;
-        this.waterShortRange = 5;
-        this.waterMediumRange = 10;
-        this.waterLongRange = 16;
-        this.waterExtremeRange = 20;
-        this.tonnage = 4.0;
-        this.criticals = 1;
-        this.bv = 248;
-        this.cost = 200000;
-        this.shortAV = 10;
-        this.medAV = 10;
-        this.longAV = 10;
-        this.extAV = 10;
-        this.maxRange = RANGE_EXT;
+        name = "ER Large Laser";
+        setInternalName("CLERLargeLaser");
+        addLookupName("Clan ER Large Laser");
+        sortingName = "Laser ER D";
+        heat = 12;
+        damage = 10;
+        shortRange = 8;
+        mediumRange = 15;
+        longRange = 25;
+        extremeRange = 30;
+        waterShortRange = 5;
+        waterMediumRange = 10;
+        waterLongRange = 16;
+        waterExtremeRange = 20;
+        tonnage = 4.0;
+        criticals = 1;
+        bv = 248;
+        cost = 200000;
+        shortAV = 10;
+        medAV = 10;
+        longAV = 10;
+        extAV = 10;
+        maxRange = RANGE_EXT;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/CLERLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERLaserMedium.java
@@ -25,6 +25,7 @@ public class CLERLaserMedium extends LaserWeapon {
         name = "ER Medium Laser";
         setInternalName("CLERMediumLaser");
         addLookupName("Clan ER Medium Laser");
+        sortingName = "Laser ER C";
         heat = 5;
         damage = 7;
         shortRange = 5;

--- a/megamek/src/megamek/common/weapons/lasers/CLERLaserMicro.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERLaserMicro.java
@@ -25,6 +25,7 @@ public class CLERLaserMicro extends LaserWeapon {
         name = "ER Micro Laser";
         setInternalName("CLERMicroLaser");
         addLookupName("Clan ER Micro Laser");
+        sortingName = "Laser ER A";
         heat = 1;
         damage = 2;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/lasers/CLERLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERLaserSmall.java
@@ -25,6 +25,7 @@ public class CLERLaserSmall extends LaserWeapon {
         name = "ER Small Laser";
         setInternalName("CLERSmallLaser");
         addLookupName("Clan ER Small Laser");
+        sortingName = "Laser ER B";
         heat = 2;
         damage = 5;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/lasers/CLERPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERPulseLaserLarge.java
@@ -28,6 +28,7 @@ public class CLERPulseLaserLarge extends PulseLaserWeapon {
         setInternalName("CLERLargePulseLaser");
         addLookupName("Clan ER Pulse Large Laser");
         addLookupName("Clan ER Large Pulse Laser");
+        sortingName = "Laser Pulse ER D";
         heat = 13;
         damage = 10;
         toHitModifier = -1;

--- a/megamek/src/megamek/common/weapons/lasers/CLERPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERPulseLaserMedium.java
@@ -28,6 +28,7 @@ public class CLERPulseLaserMedium extends PulseLaserWeapon {
         setInternalName("CLERMediumPulseLaser");
         addLookupName("Clan ER Pulse Med Laser");
         addLookupName("Clan ER Medium Pulse Laser");
+        sortingName = "Laser Pulse ER C";
         heat = 6;
         damage = 7;
         toHitModifier = -1;

--- a/megamek/src/megamek/common/weapons/lasers/CLERPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLERPulseLaserSmall.java
@@ -30,6 +30,7 @@ public class CLERPulseLaserSmall extends PulseLaserWeapon {
         addLookupName("Clan ER Pulse Small Laser");
         addLookupName("Clan ER Small Pulse Laser");
         addLookupName("ClanERSmallPulseLaser");
+        sortingName = "Laser Pulse ER B";
         heat = 3;
         damage = 5;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;

--- a/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserLarge.java
@@ -22,27 +22,28 @@ public class CLHeavyLaserLarge extends LaserWeapon {
 
     public CLHeavyLaserLarge() {
         super();
-        this.name = "Heavy Large Laser";
-        this.setInternalName("CLHeavyLargeLaser");
-        this.addLookupName("Clan Large Heavy Laser");
-        this.heat = 18;
-        this.damage = 16;
-        this.toHitModifier = 1;
-        this.shortRange = 5;
-        this.mediumRange = 10;
-        this.longRange = 15;
-        this.extremeRange = 20;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 6;
-        this.waterLongRange = 9;
-        this.waterExtremeRange = 12;
-        this.tonnage = 4.0;
-        this.criticals = 3;
-        this.bv = 244;
-        this.cost = 250000;
-        this.shortAV = 16;
-        this.medAV = 16;
-        this.maxRange = RANGE_MED;
+        name = "Heavy Large Laser";
+        setInternalName("CLHeavyLargeLaser");
+        addLookupName("Clan Large Heavy Laser");
+        sortingName = "Laser Heavy D";
+        heat = 18;
+        damage = 16;
+        toHitModifier = 1;
+        shortRange = 5;
+        mediumRange = 10;
+        longRange = 15;
+        extremeRange = 20;
+        waterShortRange = 3;
+        waterMediumRange = 6;
+        waterLongRange = 9;
+        waterExtremeRange = 12;
+        tonnage = 4.0;
+        criticals = 3;
+        bv = 244;
+        cost = 250000;
+        shortAV = 16;
+        medAV = 16;
+        maxRange = RANGE_MED;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserMedium.java
@@ -22,26 +22,27 @@ public class CLHeavyLaserMedium extends LaserWeapon {
 
     public CLHeavyLaserMedium() {
         super();
-        this.name = "Heavy Medium Laser";
-        this.setInternalName("CLHeavyMediumLaser");
-        this.addLookupName("Clan Medium Heavy Laser");
-        this.heat = 7;
-        this.damage = 10;
-        this.toHitModifier = 1;
-        this.shortRange = 3;
-        this.mediumRange = 6;
-        this.longRange = 9;
-        this.extremeRange = 12;
-        this.waterShortRange = 2;
-        this.waterMediumRange = 4;
-        this.waterLongRange = 6;
-        this.waterExtremeRange = 8;
-        this.tonnage = 1.0;
-        this.criticals = 2;
-        this.bv = 76;
-        this.cost = 100000;
-        this.shortAV = 10;
-        this.maxRange = RANGE_SHORT;
+        name = "Heavy Medium Laser";
+        setInternalName("CLHeavyMediumLaser");
+        addLookupName("Clan Medium Heavy Laser");
+        sortingName = "Laser Heavy C";
+        heat = 7;
+        damage = 10;
+        toHitModifier = 1;
+        shortRange = 3;
+        mediumRange = 6;
+        longRange = 9;
+        extremeRange = 12;
+        waterShortRange = 2;
+        waterMediumRange = 4;
+        waterLongRange = 6;
+        waterExtremeRange = 8;
+        tonnage = 1.0;
+        criticals = 2;
+        bv = 76;
+        cost = 100000;
+        shortAV = 10;
+        maxRange = RANGE_SHORT;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserSmall.java
@@ -22,26 +22,27 @@ public class CLHeavyLaserSmall extends LaserWeapon {
 
     public CLHeavyLaserSmall() {
         super();
-        this.name = "Heavy Small Laser";
-        this.setInternalName("CLHeavySmallLaser");
-        this.addLookupName("Clan Small Heavy Laser");
-        this.heat = 3;
-        this.damage = 6;
-        this.toHitModifier = 1;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 3;
-        this.extremeRange = 4;
-        this.waterShortRange = 1;
-        this.waterMediumRange = 2;
-        this.waterLongRange = 2;
-        this.waterExtremeRange = 4;
-        this.tonnage = 0.5;
-        this.criticals = 1;
-        this.bv = 15;
-        this.cost = 20000;
-        this.shortAV = 6;
-        this.maxRange = RANGE_SHORT;
+        name = "Heavy Small Laser";
+        setInternalName("CLHeavySmallLaser");
+        addLookupName("Clan Small Heavy Laser");
+        sortingName = "Laser Heavy B";
+        heat = 3;
+        damage = 6;
+        toHitModifier = 1;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 3;
+        extremeRange = 4;
+        waterShortRange = 1;
+        waterMediumRange = 2;
+        waterLongRange = 2;
+        waterExtremeRange = 4;
+        tonnage = 0.5;
+        criticals = 1;
+        bv = 15;
+        cost = 20000;
+        shortAV = 6;
+        maxRange = RANGE_SHORT;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/CLImprovedHeavyLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLImprovedHeavyLaserLarge.java
@@ -28,6 +28,7 @@ public class CLImprovedHeavyLaserLarge extends LaserWeapon {
         shortName = "Imp. Heavy Large Laser";
         setInternalName("CLImprovedHeavyLargeLaser");
         addLookupName("Clan Improved Large Heavy Laser");
+        sortingName = "Laser Heavy Imp D";
         heat = 18;
         damage = 16;
         shortRange = 5;

--- a/megamek/src/megamek/common/weapons/lasers/CLImprovedHeavyLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLImprovedHeavyLaserMedium.java
@@ -29,6 +29,7 @@ public class CLImprovedHeavyLaserMedium extends LaserWeapon {
         setInternalName("CLImprovedMediumHeavyLaser");
         addLookupName("Clan Improved Heavy Medium Laser");
         addLookupName("CLImprovedHeavyMediumLaser");
+        sortingName = "Laser Heavy Imp C";
         heat = 7;
         damage = 10;
         shortRange = 3;

--- a/megamek/src/megamek/common/weapons/lasers/CLImprovedHeavyLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLImprovedHeavyLaserSmall.java
@@ -29,6 +29,7 @@ public class CLImprovedHeavyLaserSmall extends LaserWeapon {
         setInternalName("CLImprovedSmallHeavyLaser");
         addLookupName("CLImprovedHeavySmallLaser");
         addLookupName("Clan Improved Small Heavy Laser");
+        sortingName = "Laser Heavy Imp B";
         heat = 3;
         damage = 6;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/lasers/CLPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLPulseLaserLarge.java
@@ -22,29 +22,30 @@ public class CLPulseLaserLarge extends PulseLaserWeapon {
 
     public CLPulseLaserLarge() {
         super();
-        this.name = "Large Pulse Laser";
-        this.setInternalName("CLLargePulseLaser");
-        this.addLookupName("Clan Pulse Large Laser");
-        this.addLookupName("Clan Large Pulse Laser");
-        this.heat = 10;
-        this.damage = 10;
-        this.toHitModifier = -2;
-        this.shortRange = 6;
-        this.mediumRange = 14;
-        this.longRange = 20;
-        this.extremeRange = 28;
-        this.waterShortRange = 4;
-        this.waterMediumRange = 10;
-        this.waterLongRange = 14;
-        this.waterExtremeRange = 20;
-        this.tonnage = 6.0;
-        this.criticals = 2;
-        this.bv = 265;
-        this.cost = 175000;
-        this.shortAV = 10;
-        this.medAV = 10;
-        this.longAV = 10;
-        this.maxRange = RANGE_LONG;
+        name = "Large Pulse Laser";
+        setInternalName("CLLargePulseLaser");
+        addLookupName("Clan Pulse Large Laser");
+        addLookupName("Clan Large Pulse Laser");
+        sortingName = "Laser Pulse D";
+        heat = 10;
+        damage = 10;
+        toHitModifier = -2;
+        shortRange = 6;
+        mediumRange = 14;
+        longRange = 20;
+        extremeRange = 28;
+        waterShortRange = 4;
+        waterMediumRange = 10;
+        waterLongRange = 14;
+        waterExtremeRange = 20;
+        tonnage = 6.0;
+        criticals = 2;
+        bv = 265;
+        cost = 175000;
+        shortAV = 10;
+        medAV = 10;
+        longAV = 10;
+        maxRange = RANGE_LONG;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/CLPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLPulseLaserMedium.java
@@ -22,28 +22,29 @@ public class CLPulseLaserMedium extends PulseLaserWeapon {
 
     public CLPulseLaserMedium() {
         super();
-        this.name = "Medium Pulse Laser";
-        this.setInternalName("CLMediumPulseLaser");
-        this.addLookupName("Clan Pulse Med Laser");
-        this.addLookupName("Clan Medium Pulse Laser");
-        this.heat = 4;
-        this.damage = 7;
-        this.toHitModifier = -2;
-        this.shortRange = 4;
-        this.mediumRange = 8;
-        this.longRange = 12;
-        this.extremeRange = 16;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 5;
-        this.waterLongRange = 8;
-        this.waterExtremeRange = 10;
-        this.tonnage = 2.0;
-        this.criticals = 1;
-        this.bv = 111;
-        this.cost = 60000;
-        this.shortAV = 7;
-        this.medAV = 7;
-        this.maxRange = RANGE_MED;
+        name = "Medium Pulse Laser";
+        setInternalName("CLMediumPulseLaser");
+        addLookupName("Clan Pulse Med Laser");
+        addLookupName("Clan Medium Pulse Laser");
+        sortingName = "Laser Pulse C";
+        heat = 4;
+        damage = 7;
+        toHitModifier = -2;
+        shortRange = 4;
+        mediumRange = 8;
+        longRange = 12;
+        extremeRange = 16;
+        waterShortRange = 3;
+        waterMediumRange = 5;
+        waterLongRange = 8;
+        waterExtremeRange = 10;
+        tonnage = 2.0;
+        criticals = 1;
+        bv = 111;
+        cost = 60000;
+        shortAV = 7;
+        medAV = 7;
+        maxRange = RANGE_MED;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/CLPulseLaserMicro.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLPulseLaserMicro.java
@@ -27,6 +27,7 @@ public class CLPulseLaserMicro extends PulseLaserWeapon {
         name = "Micro Pulse Laser";
         setInternalName("CLMicroPulseLaser");
         addLookupName("Clan Micro Pulse Laser");
+        sortingName = "Laser Pulse A";
         heat = 1;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/lasers/CLPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLPulseLaserSmall.java
@@ -24,29 +24,30 @@ public class CLPulseLaserSmall extends PulseLaserWeapon {
 
     public CLPulseLaserSmall() {
         super();
-        this.name = "Small Pulse Laser";
-        this.setInternalName("CLSmallPulseLaser");
-        this.addLookupName("Clan Pulse Small Laser");
-        this.addLookupName("Clan Small Pulse Laser");
-        this.heat = 2;
-        this.damage = 3;
-        this.infDamageClass = WeaponType.WEAPON_BURST_2D6;
-        this.toHitModifier = -2;
-        this.shortRange = 2;
-        this.mediumRange = 4;
-        this.longRange = 6;
-        this.extremeRange = 8;
-        this.waterShortRange = 1;
-        this.waterMediumRange = 2;
-        this.waterLongRange = 4;
-        this.waterExtremeRange = 4;
-        this.tonnage = 1.0;
-        this.criticals = 1;
-        this.bv = 24;
-        this.cost = 16000;
-        this.shortAV = 3;
-        this.maxRange = RANGE_SHORT;
-        this.flags = flags.or(F_BURST_FIRE);
+        name = "Small Pulse Laser";
+        setInternalName("CLSmallPulseLaser");
+        addLookupName("Clan Pulse Small Laser");
+        addLookupName("Clan Small Pulse Laser");
+        sortingName = "Laser Pulse B";
+        heat = 2;
+        damage = 3;
+        infDamageClass = WeaponType.WEAPON_BURST_2D6;
+        toHitModifier = -2;
+        shortRange = 2;
+        mediumRange = 4;
+        longRange = 6;
+        extremeRange = 8;
+        waterShortRange = 1;
+        waterMediumRange = 2;
+        waterLongRange = 4;
+        waterExtremeRange = 4;
+        tonnage = 1.0;
+        criticals = 1;
+        bv = 24;
+        cost = 16000;
+        shortAV = 3;
+        maxRange = RANGE_SHORT;
+        flags = flags.or(F_BURST_FIRE);
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserLarge.java
@@ -25,27 +25,28 @@ public class ISERLaserLarge extends LaserWeapon {
 
     public ISERLaserLarge() {
         super();
-        this.name = "ER Large Laser";
-        this.setInternalName("ISERLargeLaser");
-        this.addLookupName("IS ER Large Laser");
-        this.heat = 12;
-        this.damage = 8;
-        this.shortRange = 7;
-        this.mediumRange = 14;
-        this.longRange = 19;
-        this.extremeRange = 28;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 9;
-        this.waterLongRange = 12;
-        this.waterExtremeRange = 18;
-        this.tonnage = 5.0;
-        this.criticals = 2;
-        this.bv = 163;
-        this.cost = 200000;
-        this.shortAV = 8;
-        this.medAV = 8;
-        this.longAV = 8;
-        this.maxRange = RANGE_LONG;
+        name = "ER Large Laser";
+        setInternalName("ISERLargeLaser");
+        addLookupName("IS ER Large Laser");
+        sortingName = "ER Laser D";
+        heat = 12;
+        damage = 8;
+        shortRange = 7;
+        mediumRange = 14;
+        longRange = 19;
+        extremeRange = 28;
+        waterShortRange = 3;
+        waterMediumRange = 9;
+        waterLongRange = 12;
+        waterExtremeRange = 18;
+        tonnage = 5.0;
+        criticals = 2;
+        bv = 163;
+        cost = 200000;
+        shortAV = 8;
+        medAV = 8;
+        longAV = 8;
+        maxRange = RANGE_LONG;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserMedium.java
@@ -22,26 +22,27 @@ public class ISERLaserMedium extends LaserWeapon {
 
     public ISERLaserMedium() {
         super();
-        this.name = "ER Medium Laser";
-        this.setInternalName("ISERMediumLaser");
-        this.addLookupName("IS ER Medium Laser");
-        this.heat = 5;
-        this.damage = 5;
-        this.shortRange = 4;
-        this.mediumRange = 8;
-        this.longRange = 12;
-        this.extremeRange = 16;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 5;
-        this.waterLongRange = 8;
-        this.waterExtremeRange = 10;
-        this.tonnage = 1.0;
-        this.criticals = 1;
-        this.bv = 62;
-        this.cost = 80000;
-        this.shortAV = 5;
-        this.medAV = 5;
-        this.maxRange = RANGE_MED;
+        name = "ER Medium Laser";
+        setInternalName("ISERMediumLaser");
+        addLookupName("IS ER Medium Laser");
+        sortingName = "ER Laser C";
+        heat = 5;
+        damage = 5;
+        shortRange = 4;
+        mediumRange = 8;
+        longRange = 12;
+        extremeRange = 16;
+        waterShortRange = 3;
+        waterMediumRange = 5;
+        waterLongRange = 8;
+        waterExtremeRange = 10;
+        tonnage = 1.0;
+        criticals = 1;
+        bv = 62;
+        cost = 80000;
+        shortAV = 5;
+        medAV = 5;
+        maxRange = RANGE_MED;
         rulesRefs = "226, TM";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         // December 2021 - Errata request to change common date

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserSmall.java
@@ -25,6 +25,7 @@ public class ISERLaserSmall extends LaserWeapon {
         name = "ER Small Laser";
         setInternalName("ISERSmallLaser");
         addLookupName("IS ER Small Laser");
+        sortingName = "ER Laser B";
         heat = 2;
         damage = 3;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/lasers/ISLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISLaserLarge.java
@@ -22,27 +22,28 @@ public class ISLaserLarge extends LaserWeapon {
 
     public ISLaserLarge() {
         super();
-        this.name = "Large Laser";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Large Laser");
-        this.addLookupName("ISLargeLaser");
-        this.heat = 8;
-        this.damage = 8;
-        this.shortRange = 5;
-        this.mediumRange = 10;
-        this.longRange = 15;
-        this.extremeRange = 20;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 6;
-        this.waterLongRange = 9;
-        this.waterExtremeRange = 12;
-        this.tonnage = 5.0;
-        this.criticals = 2;
-        this.bv = 123;
-        this.cost = 100000;
-        this.shortAV = 8;
-        this.medAV = 8;
-        this.maxRange = RANGE_MED;
+        name = "Large Laser";
+        setInternalName(this.name);
+        addLookupName("IS Large Laser");
+        addLookupName("ISLargeLaser");
+        sortingName = "Laser D";
+        heat = 8;
+        damage = 8;
+        shortRange = 5;
+        mediumRange = 10;
+        longRange = 15;
+        extremeRange = 20;
+        waterShortRange = 3;
+        waterMediumRange = 6;
+        waterLongRange = 9;
+        waterExtremeRange = 12;
+        tonnage = 5.0;
+        criticals = 2;
+        bv = 123;
+        cost = 100000;
+        shortAV = 8;
+        medAV = 8;
+        maxRange = RANGE_MED;
         rulesRefs = "227, TM";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(true)

--- a/megamek/src/megamek/common/weapons/lasers/ISLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISLaserMedium.java
@@ -22,26 +22,27 @@ public class ISLaserMedium extends LaserWeapon {
 
     public ISLaserMedium() {
         super();
-        this.name = "Medium Laser";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Medium Laser");
-        this.addLookupName("ISMediumLaser");
-        this.heat = 3;
-        this.damage = 5;
-        this.shortRange = 3;
-        this.mediumRange = 6;
-        this.longRange = 9;
-        this.extremeRange = 12;
-        this.waterShortRange = 2;
-        this.waterMediumRange = 4;
-        this.waterLongRange = 6;
-        this.waterExtremeRange = 8;
-        this.tonnage = 1.0;
-        this.criticals = 1;
-        this.bv = 46;
-        this.cost = 40000;
-        this.shortAV = 5;
-        this.maxRange = RANGE_SHORT;
+        name = "Medium Laser";
+        setInternalName(this.name);
+        addLookupName("IS Medium Laser");
+        addLookupName("ISMediumLaser");
+        sortingName = "Laser C";
+        heat = 3;
+        damage = 5;
+        shortRange = 3;
+        mediumRange = 6;
+        longRange = 9;
+        extremeRange = 12;
+        waterShortRange = 2;
+        waterMediumRange = 4;
+        waterLongRange = 6;
+        waterExtremeRange = 8;
+        tonnage = 1.0;
+        criticals = 1;
+        bv = 46;
+        cost = 40000;
+        shortAV = 5;
+        maxRange = RANGE_SHORT;
         rulesRefs = "227, TM";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(true)

--- a/megamek/src/megamek/common/weapons/lasers/ISLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISLaserSmall.java
@@ -29,6 +29,7 @@ public class ISLaserSmall extends LaserWeapon {
         addLookupName("ClSmall Laser");
         addLookupName("CL Small Laser");
         addLookupName("CLSmallLaser");
+        sortingName = "Laser B";
         heat = 1;
         damage = 3;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/lasers/ISPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISPulseLaserLarge.java
@@ -26,6 +26,7 @@ public class ISPulseLaserLarge extends PulseLaserWeapon {
         setInternalName("ISLargePulseLaser");
         addLookupName("IS Pulse Large Laser");
         addLookupName("IS Large Pulse Laser");
+        sortingName = "Laser Pulse D";
         heat = 10;
         damage = 9;
         toHitModifier = -2;

--- a/megamek/src/megamek/common/weapons/lasers/ISPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISPulseLaserMedium.java
@@ -23,27 +23,28 @@ public class ISPulseLaserMedium extends PulseLaserWeapon {
 
     public ISPulseLaserMedium() {
         super();
-        this.name = "Medium Pulse Laser";
-        this.setInternalName("ISMediumPulseLaser");
-        this.addLookupName("IS Pulse Med Laser");
-        this.addLookupName("IS Medium Pulse Laser");
-        this.heat = 4;
-        this.damage = 6;
-        this.toHitModifier = -2;
-        this.shortRange = 2;
-        this.mediumRange = 4;
-        this.longRange = 6;
-        this.extremeRange = 8;
-        this.waterShortRange = 2;
-        this.waterMediumRange = 3;
-        this.waterLongRange = 4;
-        this.waterExtremeRange = 6;
-        this.tonnage = 2.0;
-        this.criticals = 1;
-        this.bv = 48;
-        this.cost = 60000;
-        this.shortAV = 6;
-        this.maxRange = RANGE_SHORT;
+        name = "Medium Pulse Laser";
+        setInternalName("ISMediumPulseLaser");
+        addLookupName("IS Pulse Med Laser");
+        addLookupName("IS Medium Pulse Laser");
+        sortingName = "Laser Pulse C";
+        heat = 4;
+        damage = 6;
+        toHitModifier = -2;
+        shortRange = 2;
+        mediumRange = 4;
+        longRange = 6;
+        extremeRange = 8;
+        waterShortRange = 2;
+        waterMediumRange = 3;
+        waterLongRange = 4;
+        waterExtremeRange = 6;
+        tonnage = 2.0;
+        criticals = 1;
+        bv = 48;
+        cost = 60000;
+        shortAV = 6;
+        maxRange = RANGE_SHORT;
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/ISPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISPulseLaserSmall.java
@@ -24,30 +24,31 @@ public class ISPulseLaserSmall extends PulseLaserWeapon {
 
     public ISPulseLaserSmall() {
         super();
-        this.name = "Small Pulse Laser";
-        this.setInternalName("ISSmallPulseLaser");
-        this.addLookupName("IS Small Pulse Laser");
-        this.addLookupName("ISSmall Pulse Laser");
-        this.heat = 2;
-        this.damage = 3;
-        this.infDamageClass = WeaponType.WEAPON_BURST_2D6;
-        this.toHitModifier = -2;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 3;
-        this.extremeRange = 4;
-        this.waterShortRange = 1;
-        this.waterMediumRange = 2;
-        this.waterLongRange = 2;
-        this.waterExtremeRange = 4;
-        this.tonnage = 1.0;
-        this.criticals = 1;
-        this.bv = 12;
-        this.cost = 16000;
-        this.shortAV = 3;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_POINT_DEFENSE;
-        this.flags = flags.or(F_BURST_FIRE);
+        name = "Small Pulse Laser";
+        setInternalName("ISSmallPulseLaser");
+        addLookupName("IS Small Pulse Laser");
+        addLookupName("ISSmall Pulse Laser");
+        sortingName = "Laser Pulse B";
+        heat = 2;
+        damage = 3;
+        infDamageClass = WeaponType.WEAPON_BURST_2D6;
+        toHitModifier = -2;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 3;
+        extremeRange = 4;
+        waterShortRange = 1;
+        waterMediumRange = 2;
+        waterLongRange = 2;
+        waterExtremeRange = 4;
+        tonnage = 1.0;
+        criticals = 1;
+        bv = 12;
+        cost = 16000;
+        shortAV = 3;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_POINT_DEFENSE;
+        flags = flags.or(F_BURST_FIRE);
         rulesRefs = "226, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lasers/ISReengineeredLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISReengineeredLaserLarge.java
@@ -28,6 +28,7 @@ public class ISReengineeredLaserLarge extends ReengineeredLaserWeapon {
         setInternalName(name);
         addLookupName("ISLargeReengineeredLaser");
         addLookupName("ISLargeRELaser");
+        sortingName = "Laser REENG D";
         toHitModifier = -1;
         heat = 9;
         damage = 9;

--- a/megamek/src/megamek/common/weapons/lasers/ISReengineeredLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISReengineeredLaserMedium.java
@@ -28,6 +28,7 @@ public class ISReengineeredLaserMedium extends ReengineeredLaserWeapon {
         setInternalName(name);
         addLookupName("ISMediumReengineeredLaser");
         addLookupName("ISMediumRELaser");
+        sortingName = "Laser REENG C";
         toHitModifier = -1;
         heat = 6;
         damage = 6;

--- a/megamek/src/megamek/common/weapons/lasers/ISReengineeredLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISReengineeredLaserSmall.java
@@ -25,6 +25,7 @@ public class ISReengineeredLaserSmall extends ReengineeredLaserWeapon {
         setInternalName(name);
         addLookupName("ISSmallReengineeredLaser");
         addLookupName("ISSmallRELaser");
+        sortingName = "Laser REENG B";
         toHitModifier = -1;
         heat = 4;
         damage = 4;

--- a/megamek/src/megamek/common/weapons/lasers/ISVariableSpeedPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISVariableSpeedPulseLaserLarge.java
@@ -30,6 +30,7 @@ public class ISVariableSpeedPulseLaserLarge extends VariableSpeedPulseLaserWeapo
         addLookupName("ISLVSPL");
         addLookupName("ISLargeVariableSpeedLaser");
         addLookupName("ISLargeVSP");
+        sortingName = "Laser VSP D";
         heat = 10;
         damage = WeaponType.DAMAGE_VARIABLE;
         toHitModifier = -4;

--- a/megamek/src/megamek/common/weapons/lasers/ISVariableSpeedPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISVariableSpeedPulseLaserMedium.java
@@ -29,6 +29,7 @@ public class ISVariableSpeedPulseLaserMedium extends VariableSpeedPulseLaserWeap
         addLookupName("ISMVSPL");
         addLookupName("ISMediumVariableSpeedLaser");
         addLookupName("ISMediumVSP");
+        sortingName = "Laser VSP C";
         heat = 7;
         damage = DAMAGE_VARIABLE;
         toHitModifier = -4;

--- a/megamek/src/megamek/common/weapons/lasers/ISVariableSpeedPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISVariableSpeedPulseLaserSmall.java
@@ -30,6 +30,7 @@ public class ISVariableSpeedPulseLaserSmall extends VariableSpeedPulseLaserWeapo
         addLookupName("ISSVSPL");
         addLookupName("ISSmallVariableSpeedLaser");
         addLookupName("ISSmallVSP");
+        sortingName = "Laser VSP B";
         heat = 3;
         damage = WeaponType.DAMAGE_VARIABLE;
         toHitModifier = -4;

--- a/megamek/src/megamek/common/weapons/lasers/ISXPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISXPulseLaserLarge.java
@@ -1,7 +1,3 @@
-package megamek.common.weapons.lasers;
-
-import megamek.common.SimpleTechLevel;
-
 /**
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
@@ -15,29 +11,24 @@ import megamek.common.SimpleTechLevel;
  *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
  */
-/*
- * Created on Sep 8, 20045
- *
- */
+package megamek.common.weapons.lasers;
+
+import megamek.common.SimpleTechLevel;
 
 /**
  * @author Sebastian Brocks
+ * @since Sep 8, 2005
  */
 public class ISXPulseLaserLarge extends PulseLaserWeapon {
-    /**
-     *
-     */
     private static final long serialVersionUID = -8159582350685114767L;
 
-    /**
-     *
-     */
     public ISXPulseLaserLarge() {
         super();
         name = "Large X-Pulse Laser";
         setInternalName("ISLargeXPulseLaser");
         addLookupName("IS X-Pulse Large Laser");
         addLookupName("IS Large X-Pulse Laser");
+        sortingName = "Laser XPULSE D";
         heat = 14;
         damage = 9;
         toHitModifier = -2;

--- a/megamek/src/megamek/common/weapons/lasers/ISXPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISXPulseLaserMedium.java
@@ -1,7 +1,3 @@
-package megamek.common.weapons.lasers;
-
-import megamek.common.SimpleTechLevel;
-
 /**
  * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
  *
@@ -15,29 +11,24 @@ import megamek.common.SimpleTechLevel;
  *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
  */
-/*
- * Created on Sep 8, 2005
- *
- */
+package megamek.common.weapons.lasers;
+
+import megamek.common.SimpleTechLevel;
 
 /**
  * @author Sebastian Brocks
+ * @since Sep 8, 2005
  */
 public class ISXPulseLaserMedium extends PulseLaserWeapon {
-    /**
-     *
-     */
     private static final long serialVersionUID = -6576828912486084151L;
 
-    /**
-     *
-     */
     public ISXPulseLaserMedium() {
         super();
         name = "Medium X-Pulse Laser";
         setInternalName("ISMediumXPulseLaser");
         addLookupName("IS X-Pulse Med Laser");
         addLookupName("IS Medium X-Pulse Laser");
+        sortingName = "Laser XPULSE C";
         heat = 6;
         damage = 6;
         toHitModifier = -2;

--- a/megamek/src/megamek/common/weapons/lasers/ISXPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISXPulseLaserSmall.java
@@ -11,10 +11,6 @@
  *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
  */
-/*
- * Created on Sep 8, 2005
- *
- */
 package megamek.common.weapons.lasers;
 
 import megamek.common.SimpleTechLevel;
@@ -22,22 +18,18 @@ import megamek.common.WeaponType;
 
 /**
  * @author Sebastian Brocks
+ * @since Sep 8, 2005
  */
 public class ISXPulseLaserSmall extends PulseLaserWeapon {
-    /**
-     *
-     */
     private static final long serialVersionUID = 5322977585378755226L;
 
-    /**
-     *
-     */
     public ISXPulseLaserSmall() {
         super();
         name = "Small X-Pulse Laser";
         setInternalName("ISSmallXPulseLaser");
         addLookupName("IS X-Pulse Small Laser");
         addLookupName("IS Small X-Pulse Laser");
+        sortingName = "Laser XPULSE B";
         heat = 3;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM10.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM10.java
@@ -51,7 +51,7 @@ public class CLImprovedLRM10 extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         // revert LRMWeapon's override here as the name is not just "LRM xx"
         return name;
     }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM10.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM10.java
@@ -21,17 +21,10 @@ import megamek.common.SimpleTechLevel;
  */
 public class CLImprovedLRM10 extends LRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 4015441487276641235L;
 
-    /**
-     *
-     */
     public CLImprovedLRM10() {
         super();
-
         name = "Improved LRM 10";
         setInternalName(name);
         addLookupName("CLImprovedLRM10");
@@ -55,5 +48,11 @@ public class CLImprovedLRM10 extends LRMWeapon {
             .setClanAdvancement(2815, 2818, 2820, 2831, 3080)
             .setPrototypeFactions(F_CCY).setProductionFactions(F_CCY)
             .setReintroductionFactions(F_EI).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        // revert LRMWeapon's override here as the name is not just "LRM xx"
+        return name;
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM15.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM15.java
@@ -51,7 +51,7 @@ public class CLImprovedLRM15 extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         // revert LRMWeapon's override here as the name is not just "LRM xx"
         return name;
     }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM15.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM15.java
@@ -21,17 +21,10 @@ import megamek.common.SimpleTechLevel;
  */
 public class CLImprovedLRM15 extends LRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 603060073432118270L;
 
-    /**
-     *
-     */
     public CLImprovedLRM15() {
         super();
-
         name = "Improved LRM 15";
         setInternalName(name);
         addLookupName("CLImprovedLRM15");
@@ -55,5 +48,11 @@ public class CLImprovedLRM15 extends LRMWeapon {
             .setClanAdvancement(2815, 2818, 2820, 2831, 3080)
             .setPrototypeFactions(F_CCY).setProductionFactions(F_CCY)
             .setReintroductionFactions(F_EI).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        // revert LRMWeapon's override here as the name is not just "LRM xx"
+        return name;
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM20.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM20.java
@@ -21,17 +21,10 @@ import megamek.common.SimpleTechLevel;
  */
 public class CLImprovedLRM20 extends LRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 3287950524687857609L;
 
-    /**
-     *
-     */
     public CLImprovedLRM20() {
         super();
-
         name = "Improved LRM 20";
         setInternalName(name);
         addLookupName("CLImprovedLRM20");
@@ -55,5 +48,11 @@ public class CLImprovedLRM20 extends LRMWeapon {
             .setClanAdvancement(2815, 2818, 2820, 2831, 3080)
             .setPrototypeFactions(F_CCY).setProductionFactions(F_CCY)
             .setReintroductionFactions(F_EI).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        // revert LRMWeapon's override here as the name is not just "LRM xx"
+        return name;
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM20.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM20.java
@@ -51,7 +51,7 @@ public class CLImprovedLRM20 extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         // revert LRMWeapon's override here as the name is not just "LRM xx"
         return name;
     }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM5.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM5.java
@@ -52,7 +52,7 @@ public class CLImprovedLRM5 extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         // revert LRMWeapon's override here as the name is not just "LRM xx"
         return "Improved LRM 05";
     }

--- a/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM5.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLImprovedLRM5.java
@@ -21,14 +21,8 @@ import megamek.common.SimpleTechLevel;
  */
 public class CLImprovedLRM5 extends LRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 1922843634155860893L;
 
-    /**
-     *
-     */
     public CLImprovedLRM5() {
         super();
 
@@ -55,5 +49,11 @@ public class CLImprovedLRM5 extends LRMWeapon {
             .setClanAdvancement(2815, 2818, 2820, 2831, 3080)
             .setPrototypeFactions(F_CCY).setProductionFactions(F_CCY)
             .setReintroductionFactions(F_EI).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        // revert LRMWeapon's override here as the name is not just "LRM xx"
+        return "Improved LRM 05";
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/CLStreakLRM10IOS.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLStreakLRM10IOS.java
@@ -20,14 +20,8 @@ import megamek.common.SimpleTechLevel;
  */
 public class CLStreakLRM10IOS extends StreakLRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 2692279526867532848L;
 
-    /**
-     *
-     */
     public CLStreakLRM10IOS() {
         super();
         name = "Streak LRM 10 (I-OS)";

--- a/megamek/src/megamek/common/weapons/lrms/CLStreakLRM5IOS.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLStreakLRM5IOS.java
@@ -20,14 +20,8 @@ import megamek.common.SimpleTechLevel;
  */
 public class CLStreakLRM5IOS extends StreakLRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 540083231235504476L;
 
-    /**
-     *
-     */
     public CLStreakLRM5IOS() {
         super();
         name = "Streak LRM 5 (I-OS)";
@@ -44,14 +38,13 @@ public class CLStreakLRM5IOS extends StreakLRMWeapon {
         tonnage = 1.5;
         criticals = 1;
         bv = 17;
-        flags = flags.or(F_ONESHOT);
+        flags = flags.or(F_ONESHOT).andNot(F_PROTO_WEAPON);
         cost = 60000;
         shortAV = 5;
         medAV = 5;
         longAV = 5;
         maxRange = RANGE_LONG;
         rulesRefs = "327,TO";
-        flags = flags.andNot(F_PROTO_WEAPON);
         techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_B)
             .setAvailability(RATING_X, RATING_X, RATING_F, RATING_E)
             .setClanAdvancement(3058, 3081, 3088).setClanApproximate(false, true, false)

--- a/megamek/src/megamek/common/weapons/lrms/EnhancedLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/EnhancedLRMWeapon.java
@@ -29,4 +29,9 @@ public abstract class EnhancedLRMWeapon extends LRMWeapon {
         super();
         ammoType = AmmoType.T_NLRM;
     }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "Enhanced LRM " + ((rackSize < 10) ? "0" + rackSize : rackSize);
+    }
 }

--- a/megamek/src/megamek/common/weapons/lrms/EnhancedLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/EnhancedLRMWeapon.java
@@ -31,7 +31,7 @@ public abstract class EnhancedLRMWeapon extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "Enhanced LRM " + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/ExtendedLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/ExtendedLRMWeapon.java
@@ -40,7 +40,7 @@ public abstract class ExtendedLRMWeapon extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "Extended LRM " + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/ExtendedLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/ExtendedLRMWeapon.java
@@ -20,14 +20,8 @@ import megamek.common.AmmoType;
  */
 public abstract class ExtendedLRMWeapon extends LRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -1266251778897684302L;
 
-    /**
-     *
-     */
     public ExtendedLRMWeapon() {
         super();
         ammoType = AmmoType.T_EXLRM;
@@ -43,5 +37,10 @@ public abstract class ExtendedLRMWeapon extends LRMWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "Extended LRM " + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/ISEnhancedLRM5.java
+++ b/megamek/src/megamek/common/weapons/lrms/ISEnhancedLRM5.java
@@ -20,14 +20,8 @@ import megamek.common.SimpleTechLevel;
  */
 public class ISEnhancedLRM5 extends EnhancedLRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 3287950524687857609L;
 
-    /**
-     *
-     */
     public ISEnhancedLRM5() {
         super();
         name = "Enhanced LRM 5";

--- a/megamek/src/megamek/common/weapons/lrms/ISExtendedLRM5.java
+++ b/megamek/src/megamek/common/weapons/lrms/ISExtendedLRM5.java
@@ -20,14 +20,8 @@ import megamek.common.SimpleTechLevel;
  */
 public class ISExtendedLRM5 extends ExtendedLRMWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -6153832907941260136L;
 
-    /**
-     *
-     */
     public ISExtendedLRM5() {
         super();
         name = "Extended LRM 5";

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -39,9 +39,6 @@ import megamek.server.Server;
  */
 public abstract class LRMWeapon extends MissileWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 8755275511561446251L;
 
     public LRMWeapon() {
@@ -64,14 +61,7 @@ public abstract class LRMWeapon extends MissileWeapon {
             return super.getTonnage(entity, location, size);
         }
     }
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
+
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -132,6 +122,19 @@ public abstract class LRMWeapon extends MissileWeapon {
         } else {
             removeMode("");
             removeMode("Indirect");
+        }
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        if (sortingName != null) {
+            return sortingName;
+        } else {
+            String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+            if (name.contains("I-OS")) {
+                oneShotTag = "XIOS ";
+            }
+            return "LRM " + oneShotTag + ((rackSize < 10) ? "0" + rackSize : rackSize);
         }
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -126,7 +126,7 @@ public abstract class LRMWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         if (sortingName != null) {
             return sortingName;
         } else {

--- a/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
@@ -74,7 +74,7 @@ public abstract class LRTWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
         if (name.contains("I-OS")) {
             oneShotTag = "XIOS ";

--- a/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRTWeapon.java
@@ -30,9 +30,6 @@ import megamek.server.Server;
  */
 public abstract class LRTWeapon extends MissileWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = -7350712286691532142L;
 
     public LRTWeapon() {
@@ -50,14 +47,7 @@ public abstract class LRTWeapon extends MissileWeapon {
             return super.getTonnage(entity, location, size);
         }
     }
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
+
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -81,5 +71,14 @@ public abstract class LRTWeapon extends MissileWeapon {
             removeMode("");
             removeMode("Indirect");
         }
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+        if (name.contains("I-OS")) {
+            oneShotTag = "XIOS ";
+        }
+        return "LRT " + oneShotTag + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
@@ -27,12 +27,8 @@ import megamek.server.Server;
 /**
  * @author Sebastian Brocks
  */
-
 public abstract class StreakLRMWeapon extends LRMWeapon {
 
-    /**
-     * 
-     */
     private static final long serialVersionUID = -2552069184709782928L;
 
     public StreakLRMWeapon() {
@@ -57,14 +53,7 @@ public abstract class StreakLRMWeapon extends LRMWeapon {
             return super.getTonnage(entity, location, size);
         }
     }
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
+
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -86,5 +75,14 @@ public abstract class StreakLRMWeapon extends LRMWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+        if (name.contains("I-OS")) {
+            oneShotTag = "OSI ";
+        }
+        return "LRM STREAK " + oneShotTag + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
@@ -78,7 +78,7 @@ public abstract class StreakLRMWeapon extends LRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
         if (name.contains("I-OS")) {
             oneShotTag = "OSI ";

--- a/megamek/src/megamek/common/weapons/mgs/CLHeavyMG.java
+++ b/megamek/src/megamek/common/weapons/mgs/CLHeavyMG.java
@@ -25,26 +25,26 @@ public class CLHeavyMG extends MGWeapon {
 
     public CLHeavyMG() {
         super();
-
-        this.name = "Heavy Machine Gun";
-        this.setInternalName("CLHeavyMG");
-        this.addLookupName("Clan Heavy Machine Gun");
-        this.heat = 0;
-        this.damage = 3;
-        this.infDamageClass = WeaponType.WEAPON_BURST_3D6;
-        this.rackSize = 3;
-        this.ammoType = AmmoType.T_MG_HEAVY;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 2;
-        this.extremeRange = 2;
-        this.tonnage = 0.5;
-        this.criticals = 1;
-        this.bv = 6;
-        this.cost = 7500;
-        this.shortAV = 3;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_POINT_DEFENSE;
+        name = "Heavy Machine Gun";
+        setInternalName("CLHeavyMG");
+        addLookupName("Clan Heavy Machine Gun");
+        sortingName = "MG D";
+        heat = 0;
+        damage = 3;
+        infDamageClass = WeaponType.WEAPON_BURST_3D6;
+        rackSize = 3;
+        ammoType = AmmoType.T_MG_HEAVY;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 2;
+        extremeRange = 2;
+        tonnage = 0.5;
+        criticals = 1;
+        bv = 6;
+        cost = 7500;
+        shortAV = 3;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_POINT_DEFENSE;
         rulesRefs = "228, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/mgs/CLHeavyMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/CLHeavyMGA.java
@@ -35,6 +35,7 @@ public class CLHeavyMGA extends AmmoWeapon {
         name = "Heavy Machine Gun Array";
         setInternalName("CLHMGA");
         setInternalName("Clan Heavy Machine Gun Array");
+        sortingName = "MGA D";
         heat = 0;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_3D6;

--- a/megamek/src/megamek/common/weapons/mgs/CLLightMG.java
+++ b/megamek/src/megamek/common/weapons/mgs/CLLightMG.java
@@ -25,26 +25,26 @@ public class CLLightMG extends MGWeapon {
 
     public CLLightMG() {
         super();
-
-        this.name = "Light Machine Gun";
-        this.setInternalName("CLLightMG");
-        this.addLookupName("Clan Light Machine Gun");
-        this.heat = 0;
-        this.damage = 1;
-        this.infDamageClass = WeaponType.WEAPON_BURST_1D6;
-        this.rackSize = 1;
-        this.ammoType = AmmoType.T_MG_LIGHT;
-        this.shortRange = 2;
-        this.mediumRange = 4;
-        this.longRange = 6;
-        this.extremeRange = 8;
-        this.tonnage = 0.25;
-        this.criticals = 1;
-        this.bv = 5;
-        this.cost = 5000;
-        this.shortAV = 1;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_AC;
+        name = "Light Machine Gun";
+        setInternalName("CLLightMG");
+        addLookupName("Clan Light Machine Gun");
+        sortingName = "MG B";
+        heat = 0;
+        damage = 1;
+        infDamageClass = WeaponType.WEAPON_BURST_1D6;
+        rackSize = 1;
+        ammoType = AmmoType.T_MG_LIGHT;
+        shortRange = 2;
+        mediumRange = 4;
+        longRange = 6;
+        extremeRange = 8;
+        tonnage = 0.25;
+        criticals = 1;
+        bv = 5;
+        cost = 5000;
+        shortAV = 1;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_AC;
         rulesRefs = "228, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/mgs/CLLightMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/CLLightMGA.java
@@ -31,10 +31,10 @@ public class CLLightMGA extends AmmoWeapon {
 
     public CLLightMGA() {
         super();
-
         name = "Light Machine Gun Array";
         addLookupName("Clan Light Machine Gun Array");
         setInternalName("CLLMGA");
+        sortingName = "MGA B";
         heat = 0;
         damage = 1;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
@@ -48,8 +48,7 @@ public class CLLightMGA extends AmmoWeapon {
         tonnage = 0.25;
         criticals = 1;
         bv = 0; // we'll have to calculate this in calculateBV(),
-        // because it depends on the number of MGs linked to
-        // the MGA
+        // because it depends on the number of MGs linked to the MGA
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON)
                 .or(F_PROTO_WEAPON).or(F_BALLISTIC).or(F_BURST_FIRE).or(F_MGA);
         cost = 1250;
@@ -66,14 +65,6 @@ public class CLLightMGA extends AmmoWeapon {
                 .setClanApproximate(false, false, false, false, false);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/mgs/CLMG.java
+++ b/megamek/src/megamek/common/weapons/mgs/CLMG.java
@@ -24,25 +24,25 @@ public class CLMG extends MGWeapon {
 
     public CLMG() {
         super();
-
-        this.name = "Machine Gun";
-        this.setInternalName("CLMG");
-        this.addLookupName("Clan Machine Gun");
-        this.heat = 0;
-        this.damage = 2;
-        this.infDamageClass = WeaponType.WEAPON_BURST_2D6;
-        this.rackSize = 2;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 3;
-        this.extremeRange = 4;
-        this.tonnage = 0.25;
-        this.criticals = 1;
-        this.bv = 5;
-        this.cost = 5000;
-        this.shortAV = 2;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_POINT_DEFENSE;
+        name = "Machine Gun";
+        setInternalName("CLMG");
+        addLookupName("Clan Machine Gun");
+        sortingName = "MG C";
+        heat = 0;
+        damage = 2;
+        infDamageClass = WeaponType.WEAPON_BURST_2D6;
+        rackSize = 2;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 3;
+        extremeRange = 4;
+        tonnage = 0.25;
+        criticals = 1;
+        bv = 5;
+        cost = 5000;
+        shortAV = 2;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_POINT_DEFENSE;
         rulesRefs = "228, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/mgs/CLMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/CLMGA.java
@@ -30,10 +30,10 @@ public class CLMGA extends AmmoWeapon {
 
     public CLMGA() {
         super();
-
         name = "Machine Gun Array";
         addLookupName("Clan Machine Gun Array");
         setInternalName("CLMGA");
+        sortingName = "MGA C";
         heat = 0;
         damage = 2;
         rackSize = 2;
@@ -46,8 +46,7 @@ public class CLMGA extends AmmoWeapon {
         tonnage = 0.25;
         criticals = 1;
         bv = 0; // we'll have to calculate this in calculateBV(),
-        // because it depends on the number of MGs linked to
-        // the MGA
+        // because it depends on the number of MGs linked to the MGA
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON)
                 .or(F_PROTO_WEAPON).or(F_BALLISTIC).or(F_BURST_FIRE).or(F_MGA);
         cost = 1250;
@@ -65,14 +64,6 @@ public class CLMGA extends AmmoWeapon {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/mgs/ISHeavyMG.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISHeavyMG.java
@@ -26,26 +26,27 @@ public class ISHeavyMG extends MGWeapon {
     public ISHeavyMG() {
         super();
 
-        this.name = "Heavy Machine Gun";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Heavy Machine Gun");
-        this.addLookupName("ISHeavyMG");
-        this.ammoType = AmmoType.T_MG_HEAVY;
-        this.heat = 0;
-        this.damage = 3;
-        this.infDamageClass = WeaponType.WEAPON_BURST_3D6;
-        this.rackSize = 3;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 2;
-        this.extremeRange = 2;
-        this.tonnage = 1.0;
-        this.criticals = 1;
-        this.bv = 6;
-        this.cost = 7500;
-        this.shortAV = 3;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_POINT_DEFENSE;
+        name = "Heavy Machine Gun";
+        setInternalName(name);
+        addLookupName("IS Heavy Machine Gun");
+        addLookupName("ISHeavyMG");
+        sortingName = "MG D";
+        ammoType = AmmoType.T_MG_HEAVY;
+        heat = 0;
+        damage = 3;
+        infDamageClass = WeaponType.WEAPON_BURST_3D6;
+        rackSize = 3;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 2;
+        extremeRange = 2;
+        tonnage = 1.0;
+        criticals = 1;
+        bv = 6;
+        cost = 7500;
+        shortAV = 3;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_POINT_DEFENSE;
         rulesRefs = "228, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/mgs/ISHeavyMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISHeavyMGA.java
@@ -83,8 +83,4 @@ public class ISHeavyMGA extends AmmoWeapon {
         return new MGAWeaponHandler(toHit, waa, game, server);
     }
 
-    @Override
-    public String getNaturalNameSortingString() {
-        return "MG X Array D";
-    }
 }

--- a/megamek/src/megamek/common/weapons/mgs/ISHeavyMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISHeavyMGA.java
@@ -35,6 +35,7 @@ public class ISHeavyMGA extends AmmoWeapon {
         name = "Heavy Machine Gun Array";
         setInternalName("ISHMGA");
         addLookupName("IS Heavy Machine Gun Array");
+        sortingName = "MGA D";
         heat = 0;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_3D6;
@@ -80,5 +81,10 @@ public class ISHeavyMGA extends AmmoWeapon {
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {
         return new MGAWeaponHandler(toHit, waa, game, server);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "MG X Array D";
     }
 }

--- a/megamek/src/megamek/common/weapons/mgs/ISLightMG.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISLightMG.java
@@ -25,26 +25,26 @@ public class ISLightMG extends MGWeapon {
 
     public ISLightMG() {
         super();
-
-        this.name = "Light Machine Gun";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Light Machine Gun");
-        this.addLookupName("ISLightMG");
-        this.ammoType = AmmoType.T_MG_LIGHT;
-        this.heat = 0;
-        this.damage = 1;
-        this.infDamageClass = WeaponType.WEAPON_BURST_1D6;
-        this.rackSize = 1;
-        this.shortRange = 2;
-        this.mediumRange = 4;
-        this.longRange = 6;
-        this.extremeRange = 8;
-        this.tonnage = 0.5;
-        this.criticals = 1;
-        this.bv = 5;
-        this.cost = 5000;
-        this.shortAV = 1;
-        this.maxRange = RANGE_SHORT;
+        name = "Light Machine Gun";
+        setInternalName(this.name);
+        addLookupName("IS Light Machine Gun");
+        addLookupName("ISLightMG");
+        sortingName = "MG B";
+        ammoType = AmmoType.T_MG_LIGHT;
+        heat = 0;
+        damage = 1;
+        infDamageClass = WeaponType.WEAPON_BURST_1D6;
+        rackSize = 1;
+        shortRange = 2;
+        mediumRange = 4;
+        longRange = 6;
+        extremeRange = 8;
+        tonnage = 0.5;
+        criticals = 1;
+        bv = 5;
+        cost = 5000;
+        shortAV = 1;
+        maxRange = RANGE_SHORT;
         rulesRefs = "228, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/mgs/ISLightMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISLightMGA.java
@@ -31,10 +31,10 @@ public class ISLightMGA extends AmmoWeapon {
 
     public ISLightMGA() {
         super();
-
         name = "Light Machine Gun Array";
         addLookupName("IS Light Machine Gun Array");
         setInternalName("ISLMGA");
+        sortingName = "MGA B";
         heat = 0;
         damage = 1;
         infDamageClass = WeaponType.WEAPON_BURST_1D6;
@@ -68,14 +68,6 @@ public class ISLightMGA extends AmmoWeapon {
                 .setProductionFactions(F_TC);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {

--- a/megamek/src/megamek/common/weapons/mgs/ISMG.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISMG.java
@@ -24,26 +24,27 @@ public class ISMG extends MGWeapon {
     public ISMG() {
         super();
 
-        this.name = "Machine Gun";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Machine Gun");
-        this.addLookupName("ISMachine Gun");
-        this.addLookupName("ISMG");
-        this.heat = 0;
-        this.damage = 2;
-        this.infDamageClass = WeaponType.WEAPON_BURST_2D6;
-        this.rackSize = 2;
-        this.shortRange = 1;
-        this.mediumRange = 2;
-        this.longRange = 3;
-        this.extremeRange = 4;
-        this.tonnage = 0.5;
-        this.criticals = 1;
-        this.bv = 5;
-        this.cost = 5000;
-        this.shortAV = 2;
-        this.maxRange = RANGE_SHORT;
-        this.atClass = CLASS_POINT_DEFENSE;
+        name = "Machine Gun";
+        setInternalName(this.name);
+        addLookupName("IS Machine Gun");
+        addLookupName("ISMachine Gun");
+        addLookupName("ISMG");
+        sortingName = "MG C";
+        heat = 0;
+        damage = 2;
+        infDamageClass = WeaponType.WEAPON_BURST_2D6;
+        rackSize = 2;
+        shortRange = 1;
+        mediumRange = 2;
+        longRange = 3;
+        extremeRange = 4;
+        tonnage = 0.5;
+        criticals = 1;
+        bv = 5;
+        cost = 5000;
+        shortAV = 2;
+        maxRange = RANGE_SHORT;
+        atClass = CLASS_POINT_DEFENSE;
         rulesRefs = "228, TM";
         techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setIntroLevel(true)

--- a/megamek/src/megamek/common/weapons/mgs/ISMGA.java
+++ b/megamek/src/megamek/common/weapons/mgs/ISMGA.java
@@ -35,6 +35,7 @@ public class ISMGA extends AmmoWeapon {
         name = "Machine Gun Array";
         addLookupName("IS Machine Gun Array");
         setInternalName("ISMGA");
+        sortingName = "MGA C";
         heat = 0;
         damage = 2;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;
@@ -68,17 +69,10 @@ public class ISMGA extends AmmoWeapon {
                 .setProductionFactions(F_TC);
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
                                               Server server) {
         return new MGAWeaponHandler(toHit, waa, game, server);
     }
+
 }

--- a/megamek/src/megamek/common/weapons/missiles/ATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/ATMWeapon.java
@@ -62,4 +62,9 @@ public abstract class ATMWeapon extends MissileWeapon {
         }
         return damage;
     }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "ATM " + ((rackSize < 10) ? "0" + rackSize : rackSize);
+    }
 }

--- a/megamek/src/megamek/common/weapons/missiles/ATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/ATMWeapon.java
@@ -64,7 +64,7 @@ public abstract class ATMWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "ATM " + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
 }

--- a/megamek/src/megamek/common/weapons/missiles/ISThunderBolt5.java
+++ b/megamek/src/megamek/common/weapons/missiles/ISThunderBolt5.java
@@ -21,14 +21,8 @@ import megamek.common.SimpleTechLevel;
  */
 public class ISThunderBolt5 extends ThunderBoltWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 5295837076559643763L;
 
-    /**
-     *
-     */
     public ISThunderBolt5() {
         super();
         name = "Thunderbolt 5";
@@ -36,6 +30,7 @@ public class ISThunderBolt5 extends ThunderBoltWeapon {
         addLookupName("IS Thunderbolt-5");
         addLookupName("ISThunderbolt5");
         addLookupName("IS Thunderbolt 5");
+        sortingName = "Thunderbolt 05";
         ammoType = AmmoType.T_TBOLT_5;
         heat = 3;
         minimumRange = 5;

--- a/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
@@ -64,7 +64,7 @@ public abstract class MRMWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
         if (name.contains("I-OS")) {
             oneShotTag = "XIOS ";

--- a/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
@@ -31,9 +31,6 @@ public abstract class MRMWeapon extends MissileWeapon {
 
     private static final long serialVersionUID = 274817921444431878L;
 
-    /**
-     *
-     */
     public MRMWeapon() {
         super();
         ammoType = AmmoType.T_MRM;
@@ -41,14 +38,6 @@ public abstract class MRMWeapon extends MissileWeapon {
         atClass = CLASS_MRM;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -72,5 +61,14 @@ public abstract class MRMWeapon extends MissileWeapon {
             damage = adjustBattleForceDamageForMinRange(damage);
         }
         return damage / 10.0;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+        if (name.contains("I-OS")) {
+            oneShotTag = "XIOS ";
+        }
+        return "MRM " + oneShotTag + rackSize;
     }
 }

--- a/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
+++ b/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
@@ -37,9 +37,6 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
 
     private static final long serialVersionUID = -4887277242270179970L;
 
-    /**
-     *
-     */
     public MekMortarWeapon() {
         super();
         ammoType = AmmoType.T_MEK_MORTAR;
@@ -50,14 +47,6 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
         infDamageClass = WEAPON_CLUSTER_MISSILE;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -109,5 +98,10 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
             removeMode("");
             removeMode("Indirect");
         }
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "Mek Mortar " + rackSize;
     }
 }

--- a/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
+++ b/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
@@ -101,7 +101,7 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "Mek Mortar " + rackSize;
     }
 }

--- a/megamek/src/megamek/common/weapons/other/CLLaserAMS.java
+++ b/megamek/src/megamek/common/weapons/other/CLLaserAMS.java
@@ -30,6 +30,7 @@ public class CLLaserAMS extends LaserWeapon {
         setInternalName("CLLaserAntiMissileSystem");
         addLookupName("Clan Laser Anti-Missile Sys");
         addLookupName("Clan Laser AMS");
+        sortingName = "Anti-Missile System Laser";
         heat = 5;
         rackSize = 2;
         damage = 3; // for manual operation
@@ -45,8 +46,7 @@ public class CLLaserAMS extends LaserWeapon {
         criticals = 1;
         bv = 45;
         atClass = CLASS_AMS;
-        // we need to remove the direct fire flag again, so TC weight is not
-        // affected
+        // we need to remove the direct fire flag again, so TC weight is not affected
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON)
                 .andNot(F_PROTO_WEAPON).or(F_AUTO_TARGET).or(F_AMS).or(F_ENERGY)
                 .and(F_DIRECT_FIRE.not());

--- a/megamek/src/megamek/common/weapons/other/ISImprovedNarc.java
+++ b/megamek/src/megamek/common/weapons/other/ISImprovedNarc.java
@@ -23,22 +23,22 @@ public class ISImprovedNarc extends NarcWeapon {
 
     public ISImprovedNarc() {
         super();
-
-        this.name = "iNarc";
-        this.setInternalName("ISImprovedNarc");
-        this.addLookupName("IS iNarc Beacon");
-        this.addLookupName("IS iNarc Missile Beacon");
-        this.ammoType = AmmoType.T_INARC;
-        this.heat = 0;
-        this.rackSize = 1;
-        this.shortRange = 4;
-        this.mediumRange = 9;
-        this.longRange = 15;
-        this.extremeRange = 18;
-        this.tonnage = 5.0;
-        this.criticals = 3;
-        this.bv = 75;
-        this.cost = 250000;
+        name = "iNarc";
+        setInternalName("ISImprovedNarc");
+        addLookupName("IS iNarc Beacon");
+        addLookupName("IS iNarc Missile Beacon");
+        sortingName = "Narc X";
+        ammoType = AmmoType.T_INARC;
+        heat = 0;
+        rackSize = 1;
+        shortRange = 4;
+        mediumRange = 9;
+        longRange = 15;
+        extremeRange = 18;
+        tonnage = 5.0;
+        criticals = 3;
+        bv = 75;
+        cost = 250000;
         rulesRefs = "232,TM";
         techAdvancement.setTechBase(TECH_BASE_IS)
         	.setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/other/ISImprovedNarcOS.java
+++ b/megamek/src/megamek/common/weapons/other/ISImprovedNarcOS.java
@@ -23,11 +23,11 @@ public class ISImprovedNarcOS extends NarcWeapon {
 
     public ISImprovedNarcOS() {
         super();
-
         name = "iNarc (OS)";
         setInternalName("ISImprovedNarc (OS)");
         addLookupName("IS OS iNarc Beacon");
         addLookupName("IS iNarc Missile Beacon (OS)");
+        sortingName = "Narc X OS";
         ammoType = AmmoType.T_INARC;
         heat = 0;
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/other/ISLaserAMS.java
+++ b/megamek/src/megamek/common/weapons/other/ISLaserAMS.java
@@ -31,6 +31,7 @@ public class ISLaserAMS extends LaserWeapon {
         addLookupName("IS Laser Anti-Missile System");
         addLookupName("IS Laser AMS");
         addLookupName("ISLaserAMS");
+        sortingName = "Anti-Missile System Laser";
         heat = 7;
         rackSize = 2;
         damage = 3; // for manual operation

--- a/megamek/src/megamek/common/weapons/ppc/CLEnhancedPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/CLEnhancedPPC.java
@@ -31,6 +31,7 @@ public class CLEnhancedPPC extends PPCWeapon {
         this.addLookupName("Wolverine ER PPC");
         this.addLookupName("ISEHERPPC");
         this.addLookupName("IS EH ER PPC");
+        sortingName = "PPC Enhanced";
         this.heat = 15;
         this.damage = 12;
         this.shortRange = 7;

--- a/megamek/src/megamek/common/weapons/ppc/CLImprovedPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/CLImprovedPPC.java
@@ -28,6 +28,7 @@ public class CLImprovedPPC extends PPCWeapon {
         setInternalName(name);
         addLookupName("Improved Particle Cannon");
         addLookupName("CLIMPPPC");
+        sortingName = "PPC IMP";
         heat = 10;
         damage = 10;
         minimumRange = 3;

--- a/megamek/src/megamek/common/weapons/ppc/ISERPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISERPPC.java
@@ -25,6 +25,7 @@ public class ISERPPC extends PPCWeapon {
         name = "ER PPC";
         setInternalName("ISERPPC");
         addLookupName("IS ER PPC");
+        sortingName = "PPC Y";
         heat = 15;
         damage = 10;
         shortRange = 7;

--- a/megamek/src/megamek/common/weapons/ppc/ISHeavyPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISHeavyPPC.java
@@ -26,6 +26,7 @@ public class ISHeavyPPC extends PPCWeapon {
         setInternalName(name);
         addLookupName("ISHeavyPPC");
         addLookupName("ISHPPC");
+        sortingName = "PPC D";
         heat = 15;
         damage = 15;
         minimumRange = 3;

--- a/megamek/src/megamek/common/weapons/ppc/ISLightPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISLightPPC.java
@@ -26,6 +26,7 @@ public class ISLightPPC extends PPCWeapon {
         setInternalName(name);
         addLookupName("ISLightPPC");
         addLookupName("ISLPPC");
+        sortingName = "PPC B";
         heat = 5;
         damage = 5;
         minimumRange = 3;

--- a/megamek/src/megamek/common/weapons/ppc/ISPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISPPC.java
@@ -27,6 +27,7 @@ public class ISPPC extends PPCWeapon {
         addLookupName("Particle Cannon");
         addLookupName("IS PPC");
         addLookupName("ISPPC");
+        sortingName = "PPC C";
         heat = 10;
         damage = 10;
         minimumRange = 3;

--- a/megamek/src/megamek/common/weapons/ppc/ISSnubNosePPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISSnubNosePPC.java
@@ -26,6 +26,7 @@ public class ISSnubNosePPC extends PPCWeapon {
         name = "Snub-Nose PPC";
         setInternalName("ISSNPPC");
         addLookupName("ISSnubNosedPPC");
+        sortingName = "PPC X";
         heat = 10;
         damage = DAMAGE_VARIABLE;
         minimumRange = 0;

--- a/megamek/src/megamek/common/weapons/primitive/ISAC2Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISAC2Primitive.java
@@ -41,7 +41,8 @@ public class ISAC2Primitive extends ACWeapon {
         addLookupName("AC/2p");
         addLookupName("ISAC2p");
         addLookupName("IS Autocannon/2 Primitive");
-        this.shortName = "AC/2p";
+        sortingName = "Primitive Prototype Autocannon/02";
+        shortName = "AC/2p";
         ammoType = AmmoType.T_AC_PRIMITIVE;
         heat = 1;
         damage = 2;

--- a/megamek/src/megamek/common/weapons/primitive/ISAC5Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISAC5Primitive.java
@@ -41,7 +41,8 @@ public class ISAC5Primitive extends ACWeapon {
         addLookupName("AutoCannon/5 Primitive");
         addLookupName("ISAC5p");
         addLookupName("IS Autocannon/5 Primitive");
-        this.shortName = "AC/5p";
+        shortName = "AC/5p";
+        sortingName = "Primitive Prototype Autocannon/05";
         ammoType = AmmoType.T_AC_PRIMITIVE;
         heat = 1;
         damage = 5;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM10Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM10Primitive.java
@@ -38,7 +38,8 @@ public class ISLRM10Primitive extends LRMWeapon {
         addLookupName("IS LRM-10 Primitive");
         addLookupName("ISLRM10p");
         addLookupName("IS LRM 10 Primitive");
-        this.shortName = "LRM/10 p";
+        shortName = "LRM/10 p";
+        sortingName = name;
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
         heat = 4;
         rackSize = 10;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM15Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM15Primitive.java
@@ -38,7 +38,8 @@ public class ISLRM15Primitive extends LRMWeapon {
         addLookupName("IS LRM-15 Primitive");
         addLookupName("ISLRM15p");
         addLookupName("IS LRM 15 Primitive");
-        this.shortName = "LRM/15 p";
+        shortName = "LRM/15 p";
+        sortingName = name;
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
         heat = 5;
         rackSize = 15;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM20Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM20Primitive.java
@@ -38,7 +38,8 @@ public class ISLRM20Primitive extends LRMWeapon {
         addLookupName("IS LRM-20 Primitive");
         addLookupName("ISLRM20p");
         addLookupName("IS LRM 20 Primitive");
-        this.shortName = "LRM/20 p";
+        shortName = "LRM/20 p";
+        sortingName = name;
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
         heat = 6;
         rackSize = 20;

--- a/megamek/src/megamek/common/weapons/primitive/ISLRM5Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLRM5Primitive.java
@@ -38,7 +38,8 @@ public class ISLRM5Primitive extends LRMWeapon {
         addLookupName("IS LRM-5 Primitive");
         addLookupName("ISLRM5p");
         addLookupName("IS LRM 5 Primitive");
-        this.shortName = "LRM/5 p";
+        shortName = "LRM/5 p";
+        sortingName = "Primitive Prototype LRM 05";
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
         heat = 2;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/primitive/ISLaserPrimitiveLarge.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLaserPrimitiveLarge.java
@@ -26,28 +26,29 @@ public class ISLaserPrimitiveLarge extends LaserWeapon {
     public ISLaserPrimitiveLarge() {
         super();
 
-        this.name = "Primitive Prototype Large Laser";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Large Laser Prototype");
-        this.addLookupName("ISLargeLaserPrototype");
-        this.shortName = "Large Laser p";
-        this.heat = 12;
-        this.damage = 8;
-        this.shortRange = 5;
-        this.mediumRange = 10;
-        this.longRange = 15;
-        this.extremeRange = 20;
-        this.waterShortRange = 3;
-        this.waterMediumRange = 6;
-        this.waterLongRange = 9;
-        this.waterExtremeRange = 12;
-        this.tonnage = 5.0;
-        this.criticals = 2;
-        this.bv = 123;
-        this.cost = 100000;
-        this.shortAV = 8;
-        this.medAV = 8;
-        this.maxRange = RANGE_MED;
+        name = "Primitive Prototype Large Laser";
+        setInternalName(this.name);
+        addLookupName("IS Large Laser Prototype");
+        addLookupName("ISLargeLaserPrototype");
+        shortName = "Large Laser p";
+        sortingName = "Laser Proto D";
+        heat = 12;
+        damage = 8;
+        shortRange = 5;
+        mediumRange = 10;
+        longRange = 15;
+        extremeRange = 20;
+        waterShortRange = 3;
+        waterMediumRange = 6;
+        waterLongRange = 9;
+        waterExtremeRange = 12;
+        tonnage = 5.0;
+        criticals = 2;
+        bv = 123;
+        cost = 100000;
+        shortAV = 8;
+        medAV = 8;
+        maxRange = RANGE_MED;
         // IO Doesn't strictly define when these weapons stop production. Checked with Herb, and
         // they would always be around. This is to cover some of the back worlds in the Periphery.
         flags = flags.or(F_PROTOTYPE);

--- a/megamek/src/megamek/common/weapons/primitive/ISLaserPrimitiveMedium.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLaserPrimitiveMedium.java
@@ -26,27 +26,28 @@ public class ISLaserPrimitiveMedium extends LaserWeapon {
     public ISLaserPrimitiveMedium() {
         super();
 
-        this.name = "Primitive Prototype Medium Laser";
-        this.setInternalName(this.name);
-        this.addLookupName("IS Medium Laser Prototype");
-        this.addLookupName("ISMediumLaserPrototype");
-        this.shortName = "Medium Laser p";
-        this.heat = 5;
-        this.damage = 5;
-        this.shortRange = 3;
-        this.mediumRange = 6;
-        this.longRange = 9;
-        this.extremeRange = 12;
-        this.waterShortRange = 2;
-        this.waterMediumRange = 4;
-        this.waterLongRange = 6;
-        this.waterExtremeRange = 8;
-        this.tonnage = 1.0;
-        this.criticals = 1;
-        this.bv = 46;
-        this.cost = 40000;
-        this.shortAV = 5;
-        this.maxRange = RANGE_SHORT;
+        name = "Primitive Prototype Medium Laser";
+        setInternalName(this.name);
+        addLookupName("IS Medium Laser Prototype");
+        addLookupName("ISMediumLaserPrototype");
+        shortName = "Medium Laser p";
+        sortingName = "Laser Proto C";
+        heat = 5;
+        damage = 5;
+        shortRange = 3;
+        mediumRange = 6;
+        longRange = 9;
+        extremeRange = 12;
+        waterShortRange = 2;
+        waterMediumRange = 4;
+        waterLongRange = 6;
+        waterExtremeRange = 8;
+        tonnage = 1.0;
+        criticals = 1;
+        bv = 46;
+        cost = 40000;
+        shortAV = 5;
+        maxRange = RANGE_SHORT;
         // IO Doesn't strictly define when these weapons stop production. Checked with Herb, and
         // they would always be around. This is to cover some of the back worlds in the Periphery.
         flags = flags.or(F_PROTOTYPE);

--- a/megamek/src/megamek/common/weapons/primitive/ISLaserPrimitiveSmall.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISLaserPrimitiveSmall.java
@@ -29,7 +29,8 @@ public class ISLaserPrimitiveSmall extends LaserWeapon {
         setInternalName(name);
         addLookupName("ISSmall Laser Primitive");
         addLookupName("ISSmallLaserPrimitive");
-        this.shortName = "Small Laser p";
+        shortName = "Small Laser p";
+        sortingName = "Laser Proto B";
         heat = 2;
         damage = 3;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/primitive/ISPPCPrimitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISPPCPrimitive.java
@@ -31,7 +31,8 @@ public class ISPPCPrimitive extends PPCWeapon {
         addLookupName("Particle Cannon Primitive");
         addLookupName("IS PPCp");
         addLookupName("ISPPCp");
-        this.shortName = "PPCp";
+        shortName = "PPCp";
+        sortingName = "PPC Proto C";
         heat = 15;
         damage = 10;
         minimumRange = 3;

--- a/megamek/src/megamek/common/weapons/primitive/ISSRM2Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISSRM2Primitive.java
@@ -38,7 +38,8 @@ public class ISSRM2Primitive extends SRMWeapon {
         addLookupName("IS SRM-2 Primitive");
         addLookupName("ISSRM2p");
         addLookupName("IS SRM 2 Primitive");
-        this.shortName = "SRM/2p";
+        shortName = "SRM/2p";
+        sortingName = "SRM Proto 2";
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
         heat = 2;
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/primitive/ISSRM4Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISSRM4Primitive.java
@@ -32,26 +32,26 @@ public class ISSRM4Primitive extends SRMWeapon {
 
     public ISSRM4Primitive() {
         super();
-
-        this.name = "Primitive Prototype SRM 4";
-        this.setInternalName(this.name);
-        this.addLookupName("IS SRM-4 Primitive");
-        this.addLookupName("ISSRM4p");
-        this.addLookupName("IS SRM 4 Primitive");
-        this.shortName = "SRM/4p";
+        name = "Primitive Prototype SRM 4";
+        setInternalName(this.name);
+        addLookupName("IS SRM-4 Primitive");
+        addLookupName("ISSRM4p");
+        addLookupName("IS SRM 4 Primitive");
+        shortName = "SRM/4p";
+        sortingName = "SRM Proto 4";
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
-        this.heat = 3;
-        this.rackSize = 4;
-        this.shortRange = 3;
-        this.mediumRange = 6;
-        this.longRange = 9;
-        this.extremeRange = 12;
-        this.tonnage = 2.0;
-        this.criticals = 1;
-        this.bv = 39;
-        this.cost = 60000;
-        this.shortAV = 4;
-        this.maxRange = RANGE_SHORT;
+        heat = 3;
+        rackSize = 4;
+        shortRange = 3;
+        mediumRange = 6;
+        longRange = 9;
+        extremeRange = 12;
+        tonnage = 2.0;
+        criticals = 1;
+        bv = 39;
+        cost = 60000;
+        shortAV = 4;
+        maxRange = RANGE_SHORT;
         ammoType = AmmoType.T_SRM_PRIMITIVE;
         // IO Doesn't strictly define when these weapons stop production. Checked with Herb, and
         // they would always be around. This to cover some of the back worlds in the Periphery.

--- a/megamek/src/megamek/common/weapons/primitive/ISSRM6Primitive.java
+++ b/megamek/src/megamek/common/weapons/primitive/ISSRM6Primitive.java
@@ -33,25 +33,26 @@ public class ISSRM6Primitive extends SRMWeapon {
     public ISSRM6Primitive() {
         super();
 
-        this.name = "Primitive Prototype SRM 6";
-        this.setInternalName(this.name);
-        this.addLookupName("IS SRM-6 Primitive");
-        this.addLookupName("ISSRM6p");
-        this.addLookupName("IS SRM 6 Primitive");
-        this.shortName = "SRM/6p";
+        name = "Primitive Prototype SRM 6";
+        setInternalName(this.name);
+        addLookupName("IS SRM-6 Primitive");
+        addLookupName("ISSRM6p");
+        addLookupName("IS SRM 6 Primitive");
+        shortName = "SRM/6p";
+        sortingName = "SRM Proto 6";
         flags = flags.or(F_PROTOTYPE).andNot(F_ARTEMIS_COMPATIBLE);
-        this.heat = 4;
-        this.rackSize = 6;
-        this.shortRange = 3;
-        this.mediumRange = 6;
-        this.longRange = 9;
-        this.extremeRange = 12;
-        this.tonnage = 3.0;
-        this.criticals = 2;
-        this.bv = 59;
-        this.cost = 80000;
-        this.shortAV = 8;
-        this.maxRange = RANGE_SHORT;
+        heat = 4;
+        rackSize = 6;
+        shortRange = 3;
+        mediumRange = 6;
+        longRange = 9;
+        extremeRange = 12;
+        tonnage = 3.0;
+        criticals = 2;
+        bv = 59;
+        cost = 80000;
+        shortAV = 8;
+        maxRange = RANGE_SHORT;
         ammoType = AmmoType.T_SRM_PRIMITIVE;
         // IO Doesn't strictly define when these weapons stop production. Checked with Herb, and
         // they would always be around. This to cover some of the back worlds in the Periphery.

--- a/megamek/src/megamek/common/weapons/prototypes/CLLB2XACPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/CLLB2XACPrototype.java
@@ -27,6 +27,7 @@ public class CLLB2XACPrototype extends CLLBXACPrototypeWeapon {
         name = "Prototype LB 2-X Autocannon";
         setInternalName("CLLBXAC2Prototype");
         shortName = "LB 2-X (P)";
+        sortingName = "Prototype LB 02-X Autocannon";
         heat = 1;
         damage = 2;
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/prototypes/CLLB5XACPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/CLLB5XACPrototype.java
@@ -27,6 +27,7 @@ public class CLLB5XACPrototype extends CLLBXACPrototypeWeapon {
         name = "Prototype LB 5-X Autocannon";
         setInternalName("CLLBXAC5Prototype");
         shortName = "LB 5-X (P)";
+        sortingName = "Prototype LB 05-X Autocannon";
         heat = 1;
         damage = 5;
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/prototypes/ISGaussRiflePrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/ISGaussRiflePrototype.java
@@ -11,10 +11,6 @@
  *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
  */
-/*
- * Created on Oct 19, 2004
- *
- */
 package megamek.common.weapons.prototypes;
 
 import megamek.common.AmmoType;
@@ -29,22 +25,18 @@ import megamek.server.Server;
 
 /**
  * @author Sebastian Brocks
+ * @since Oct 19, 2004
  */
 public class ISGaussRiflePrototype extends GaussWeapon {
-    /**
-     *
-     */
     private static final long serialVersionUID = 317770140657000258L;
 
-    /**
-     *
-     */
     public ISGaussRiflePrototype() {
         super();
         name = "Prototype Gauss Rifle";
         setInternalName("ISGaussRiflePrototype");
         addLookupName("IS Gauss Rifle Prototype");
         shortName = "Gauss Rifle (P)";
+        sortingName = "Gauss PROTO";
         heat = 1;
         damage = 15;
         ammoType = AmmoType.T_GAUSS;
@@ -75,14 +67,6 @@ public class ISGaussRiflePrototype extends GaussWeapon {
 
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {

--- a/megamek/src/megamek/common/weapons/prototypes/ISLB10XACPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/ISLB10XACPrototype.java
@@ -37,6 +37,7 @@ public class ISLB10XACPrototype extends LBXACWeapon {
         setInternalName("ISLBXAC10Prototype");
         addLookupName("IS LB 10-X AC Prototype");
         shortName = "LB 10-X (P)";
+        sortingName = "LB Proto 10-X AC";
         flags = flags.or(F_PROTOTYPE);
         criticals = 7;
         heat = 2;

--- a/megamek/src/megamek/common/weapons/srms/CLImprovedSRM2.java
+++ b/megamek/src/megamek/common/weapons/srms/CLImprovedSRM2.java
@@ -53,7 +53,7 @@ public class CLImprovedSRM2 extends SRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "SRM IMP 2";
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/CLImprovedSRM2.java
+++ b/megamek/src/megamek/common/weapons/srms/CLImprovedSRM2.java
@@ -24,7 +24,6 @@ public class CLImprovedSRM2 extends SRMWeapon {
 
     public CLImprovedSRM2() {
         super();
- 
         name = "Improved SRM 2";
         setInternalName(name);
         addLookupName("CLImprovedSRM2");
@@ -51,5 +50,10 @@ public class CLImprovedSRM2 extends SRMWeapon {
                 .setClanApproximate(true, false, false, true, false)
                 .setPrototypeFactions(F_CCC).setProductionFactions(F_CCC)
                 .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "SRM IMP 2";
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/CLImprovedSRM4.java
+++ b/megamek/src/megamek/common/weapons/srms/CLImprovedSRM4.java
@@ -52,7 +52,7 @@ public class CLImprovedSRM4 extends SRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "SRM IMP 4";
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/CLImprovedSRM4.java
+++ b/megamek/src/megamek/common/weapons/srms/CLImprovedSRM4.java
@@ -24,23 +24,22 @@ public class CLImprovedSRM4 extends SRMWeapon {
 
     public CLImprovedSRM4() {
         super();
-
-        this.name = "Improved SRM 4";
-        this.setInternalName(this.name);
-        this.addLookupName("CLImprovedSRM4");
-        this.heat = 3;
-        this.rackSize = 4;
+        name = "Improved SRM 4";
+        setInternalName(this.name);
+        addLookupName("CLImprovedSRM4");
+        heat = 3;
+        rackSize = 4;
         shortRange = 4;
         mediumRange = 8;
         longRange = 12;
         extremeRange = 16;
-        this.tonnage = 2.0;
-        this.criticals = 1;
-        this.bv = 39;
-        this.cost = 60000;
-        this.shortAV = 6;
-        this.medAV = 6;
-        this.maxRange = RANGE_MED;
+        tonnage = 2.0;
+        criticals = 1;
+        bv = 39;
+        cost = 60000;
+        shortAV = 6;
+        medAV = 6;
+        maxRange = RANGE_MED;
         ammoType = AmmoType.T_SRM_IMP;
         rulesRefs = "96, IO";
         flags = flags.andNot(F_PROTO_WEAPON);
@@ -50,5 +49,10 @@ public class CLImprovedSRM4 extends SRMWeapon {
                 .setClanApproximate(true, false, false, true, false)
                 .setPrototypeFactions(F_CCC).setProductionFactions(F_CCC)
                 .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "SRM IMP 4";
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/CLImprovedSRM6.java
+++ b/megamek/src/megamek/common/weapons/srms/CLImprovedSRM6.java
@@ -52,7 +52,7 @@ public class CLImprovedSRM6 extends SRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         return "SRM IMP 6";
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/CLImprovedSRM6.java
+++ b/megamek/src/megamek/common/weapons/srms/CLImprovedSRM6.java
@@ -24,23 +24,22 @@ public class CLImprovedSRM6 extends SRMWeapon {
 
     public CLImprovedSRM6() {
         super();
-
-        this.name = "Improved SRM 6";
-        this.setInternalName("Improved SRM 6");
-        this.addLookupName("CLImprovedSRM6");
-        this.heat = 4;
-        this.rackSize = 6;
+        name = "Improved SRM 6";
+        setInternalName("Improved SRM 6");
+        addLookupName("CLImprovedSRM6");
+        heat = 4;
+        rackSize = 6;
         shortRange = 4;
         mediumRange = 8;
         longRange = 12;
         extremeRange = 16;
-        this.tonnage = 3.0;
-        this.criticals = 2;
-        this.bv = 79;
-        this.cost = 80000;
-        this.shortAV = 9;
-        this.medAV = 9;
-        this.maxRange = RANGE_MED;
+        tonnage = 3.0;
+        criticals = 2;
+        bv = 79;
+        cost = 80000;
+        shortAV = 9;
+        medAV = 9;
+        maxRange = RANGE_MED;
         ammoType = AmmoType.T_SRM_IMP;
         rulesRefs = "96, IO";
         flags = flags.andNot(F_PROTO_WEAPON);
@@ -50,5 +49,10 @@ public class CLImprovedSRM6 extends SRMWeapon {
                 .setClanApproximate(true, false, false, true, false)
                 .setPrototypeFactions(F_CCC).setProductionFactions(F_CCC)
                 .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        return "SRM IMP 6";
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
@@ -104,7 +104,7 @@ public abstract class SRMWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         if (sortingName != null) {
             return sortingName;
         } else {

--- a/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
@@ -37,14 +37,8 @@ import megamek.server.Server;
  */
 public abstract class SRMWeapon extends MissileWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 3636219178276978444L;
 
-    /**
-     *
-     */
     public SRMWeapon() {
         super();
         ammoType = AmmoType.T_SRM;
@@ -52,7 +46,6 @@ public abstract class SRMWeapon extends MissileWeapon {
         flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
     }
 
-    
     @Override
     public double getTonnage(Entity entity, int location, double size) {
         if ((null != entity) && entity.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
@@ -62,14 +55,6 @@ public abstract class SRMWeapon extends MissileWeapon {
         }
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -116,5 +101,18 @@ public abstract class SRMWeapon extends MissileWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_SRM;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        if (sortingName != null) {
+            return sortingName;
+        } else {
+            String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+            if (name.contains("I-OS")) {
+                oneShotTag = "OSI ";
+            }
+            return "SRM " + oneShotTag + rackSize;
+        }
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
@@ -67,7 +67,7 @@ public abstract class SRTWeapon extends MissileWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
         if (name.contains("I-OS")) {
             oneShotTag = "XIOS ";

--- a/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRTWeapon.java
@@ -28,14 +28,8 @@ import megamek.server.Server;
  */
 public abstract class SRTWeapon extends MissileWeapon {
 
-    /**
-     *
-     */
     private static final long serialVersionUID = 2209880229033489588L;
 
-    /**
-     *
-     */
     public SRTWeapon() {
         super();
         ammoType = AmmoType.T_SRM_TORPEDO;
@@ -50,14 +44,7 @@ public abstract class SRTWeapon extends MissileWeapon {
             return super.getTonnage(entity, location, size);
         }
     }
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
+
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -77,5 +64,14 @@ public abstract class SRTWeapon extends MissileWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_TORP;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+        if (name.contains("I-OS")) {
+            oneShotTag = "XIOS ";
+        }
+        return "SRT " + oneShotTag + rackSize;
     }
 }

--- a/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
@@ -66,7 +66,7 @@ public abstract class StreakSRMWeapon extends SRMWeapon {
     }
 
     @Override
-    public String getNaturalNameSortingString() {
+    public String getSortingName() {
         String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
         if (name.contains("I-OS")) {
             oneShotTag = "XIOS ";

--- a/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/StreakSRMWeapon.java
@@ -28,9 +28,6 @@ import megamek.server.Server;
 
 public abstract class StreakSRMWeapon extends SRMWeapon {
 
-    /**
-     * 
-     */
     private static final long serialVersionUID = 9157660680598071296L;
 
     public StreakSRMWeapon() {
@@ -47,14 +44,7 @@ public abstract class StreakSRMWeapon extends SRMWeapon {
             return super.getTonnage(entity, location, size);
         }
     }
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
+
     @Override
     protected AttackHandler getCorrectHandler(ToHitData toHit,
             WeaponAttackAction waa, Game game, Server server) {
@@ -73,5 +63,14 @@ public abstract class StreakSRMWeapon extends SRMWeapon {
     @Override
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;
+    }
+
+    @Override
+    public String getNaturalNameSortingString() {
+        String oneShotTag = hasFlag(F_ONESHOT) ? "OS " : "";
+        if (name.contains("I-OS")) {
+            oneShotTag = "XIOS ";
+        }
+        return "SRM Streak " + oneShotTag + rackSize;
     }
 }


### PR DESCRIPTION
Adds the method getSortingName() to EquipmentType (and therefore also WeaponType, AmmoType, MiscType) that returns a string similar to the name but optimized for sorting equipment. Using it will sort ACs in the order AC2 / 5 / 10 / 20 instead of alphabetic AC 10 / 2 / 20 / 5 and Lasers in the order Small Medium Large instead of having them all over the place by their first letter. Other equipment like the Gauss variations are grouped together somewhat. Std, OS and IOS versions of missiles are listed apart. I worked over all equipment (CL/IS up to experimental) except Infantry weapons.

Internally it adds a string class field sortingName for this. When it is left at null, getSortingName() returns the name of the equipment, otherwise that sortingName. Some intermediate classes like LRMWeapon override getSortingName() to provide the sorting name for all the multitudes of LRMs and SRMs programmatically.

For review: this is really repetitive, EquipmentType has the only interesting changes. Other than the sortingName addition or sometimes the getSortingName override, I removed many useless "this." and some useless "non-javadoc" and empty comments and sometimes moved a package or import line from over the copyright to below. If you've seen LRMWeapon and AdvancedSRMWeapon, you've seen it all.

Before: 
![image](https://user-images.githubusercontent.com/17069663/150213728-17b32ee8-7e0e-453f-989a-098b0f99de81.png)

After:
![image](https://user-images.githubusercontent.com/17069663/150212970-08a52aa3-cb62-4ed5-834c-9a09c8b5cb7b.png)

This doesn't depend on anything but I'll have a small update for MML that requires this PR.