### PR TITLE
MHQ 3072: Preventing the RAT Generator from writing empty parent faction tags

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -599,12 +599,12 @@ public class FactionRecord {
             pw.println("\t\t<ratingLevels>" + StringEscapeUtils.escapeXml10(String.join(",", ratingLevels)) + "</ratingLevels>");
         }
 
-        if (parentFactions != null) {
+        if ((parentFactions != null) && !parentFactions.isEmpty()) {
             pw.println("\t\t<parentFaction>" + StringEscapeUtils.escapeXml10(String.join(",", parentFactions)) + "</parentFaction>");
         }       
         pw.println("\t</faction>");
     }
-    
+
     public void writeToXml(PrintWriter pw, int era) {
         StringBuilder factionRecordBuilder = new StringBuilder();
         if (pctTech.containsKey(TechCategory.OMNI)

--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -457,6 +457,7 @@ public class FactionRecord {
         for (String s : dist.split(",")) {
             list.add(Integer.valueOf(s));
         }
+
         if (!weightDistribution.containsKey(era)) {
             weightDistribution.put(era, new HashMap<>());
         }
@@ -481,16 +482,19 @@ public class FactionRecord {
         } else {
             retVal.minor = false;
         }
+
         if (node.getAttributes().getNamedItem("clan") != null) {
             retVal.clan = Boolean.parseBoolean(node.getAttributes().getNamedItem("clan").getTextContent());
         } else {
             retVal.clan = false;
         }
+
         if (node.getAttributes().getNamedItem("periphery") != null) {
             retVal.periphery = Boolean.parseBoolean(node.getAttributes().getNamedItem("periphery").getTextContent());
         } else {
             retVal.periphery = false;
         }
+
         for (int i = 0; i < node.getChildNodes().getLength(); i++) {
             Node wn = node.getChildNodes().item(i);
             if (wn.getNodeName().equalsIgnoreCase("nameChange")) {
@@ -516,7 +520,7 @@ public class FactionRecord {
             Node wn = node.getChildNodes().item(i);
             switch (wn.getNodeName()) {
                 case "pctOmni":
-                    if (wn.getAttributes().getNamedItem("unitType") != null
+                    if ((wn.getAttributes().getNamedItem("unitType") != null)
                             && wn.getAttributes().getNamedItem("unitType").getTextContent().equalsIgnoreCase("Aero")) {
                         setPctTech(TechCategory.OMNI_AERO, era, wn.getTextContent());
                     } else {
@@ -524,10 +528,10 @@ public class FactionRecord {
                     }
                     break;
                 case "pctClan":
-                    if (wn.getAttributes().getNamedItem("unitType") != null
+                    if ((wn.getAttributes().getNamedItem("unitType") != null)
                             && wn.getAttributes().getNamedItem("unitType").getTextContent().equalsIgnoreCase("Aero")) {
                         setPctTech(TechCategory.CLAN_AERO, era, wn.getTextContent());
-                    } else if (wn.getAttributes().getNamedItem("unitType") != null
+                    } else if ((wn.getAttributes().getNamedItem("unitType") != null)
                                 && wn.getAttributes().getNamedItem("unitType").getTextContent().equalsIgnoreCase("Vehicle")) {
                         setPctTech(TechCategory.CLAN_VEE, era, wn.getTextContent());
                     } else {
@@ -535,10 +539,10 @@ public class FactionRecord {
                     }
                     break;
                 case "pctSL":
-                    if (wn.getAttributes().getNamedItem("unitType") != null
+                    if ((wn.getAttributes().getNamedItem("unitType") != null)
                             && wn.getAttributes().getNamedItem("unitType").getTextContent().equalsIgnoreCase("Aero")) {
                         setPctTech(TechCategory.IS_ADVANCED_AERO, era, wn.getTextContent());
-                    } else if (wn.getAttributes().getNamedItem("unitType") != null
+                    } else if ((wn.getAttributes().getNamedItem("unitType") != null)
                                 && wn.getAttributes().getNamedItem("unitType").getTextContent().equalsIgnoreCase("Vehicle")) {
                         setPctTech(TechCategory.IS_ADVANCED_VEE, era, wn.getTextContent());
                     } else {
@@ -555,12 +559,11 @@ public class FactionRecord {
                     upgradeMargin.put(era, Integer.parseInt(wn.getTextContent()));
                     break;
                 case "salvage":
-                    pctSalvage.put(era,
-                            Integer.parseInt(wn.getAttributes().getNamedItem("pct").getTextContent()));
+                    pctSalvage.put(era, Integer.parseInt(wn.getAttributes().getNamedItem("pct").getTextContent()));
                     salvage.put(era, new HashMap<>());
                     String[] fields = wn.getTextContent().trim().split(",");
                     for (String field : fields) {
-                        if (field.length() > 0) {
+                        if (!field.isBlank()) {
                             String[] subfields = field.split(":");
                             if (subfields.length == 2) {
                                 salvage.get(era).put(subfields[0], Integer.parseInt(subfields[1]));
@@ -573,8 +576,7 @@ public class FactionRecord {
                         int unitType = ModelRecord.parseUnitType(wn.getAttributes().getNamedItem("unitType").getTextContent());
                         setWeightDistribution(era, unitType, wn.getTextContent());
                     } catch (Exception ex) {
-                        LogManager.getLogger().error("RATGenerator: error parsing weight distributions for " + key
-                                + ", " + era);
+                        LogManager.getLogger().error("RATGenerator: error parsing weight distributions for " + key + ", " + era);
                     }
                     break;
             }
@@ -593,61 +595,66 @@ public class FactionRecord {
         pw.print("\t\t<years>");
         pw.print(getYearsAsString());
         pw.println("</years>");
-        if (ratingLevels.size() > 0) {
+        if (!ratingLevels.isEmpty()) {
             pw.println("\t\t<ratingLevels>" + StringEscapeUtils.escapeXml10(String.join(",", ratingLevels)) + "</ratingLevels>");
         }
+
         if (parentFactions != null) {
             pw.println("\t\t<parentFaction>" + StringEscapeUtils.escapeXml10(String.join(",", parentFactions)) + "</parentFaction>");
         }       
         pw.println("\t</faction>");
     }
-
     
     public void writeToXml(PrintWriter pw, int era) {
         StringBuilder factionRecordBuilder = new StringBuilder();
         if (pctTech.containsKey(TechCategory.OMNI)
                 && pctTech.get(TechCategory.OMNI).containsKey(era)
-                && (pctTech.get(TechCategory.OMNI).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.OMNI).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctOmni>%s</pctOmni>\n", 
                             pctTech.get(TechCategory.OMNI).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (pctTech.containsKey(TechCategory.CLAN)
                 && pctTech.get(TechCategory.CLAN).containsKey(era)
-                && (pctTech.get(TechCategory.CLAN).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.CLAN).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctClan>%s</pctClan>\n", 
                             pctTech.get(TechCategory.CLAN).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (pctTech.containsKey(TechCategory.IS_ADVANCED)
                 && pctTech.get(TechCategory.IS_ADVANCED).containsKey(era)
-                && (pctTech.get(TechCategory.IS_ADVANCED).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.IS_ADVANCED).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctSL>%s</pctSL>\n", 
                             pctTech.get(TechCategory.IS_ADVANCED).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (pctTech.containsKey(TechCategory.OMNI_AERO)
                 && pctTech.get(TechCategory.OMNI_AERO).containsKey(era)
-                && (pctTech.get(TechCategory.OMNI_AERO).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.OMNI_AERO).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctOmni unitType='Aero'>%s</pctOmni>\n", 
                             pctTech.get(TechCategory.OMNI_AERO).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (pctTech.containsKey(TechCategory.CLAN_AERO)
                 && pctTech.get(TechCategory.CLAN_AERO).containsKey(era)
-                && (pctTech.get(TechCategory.CLAN_AERO).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.CLAN_AERO).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctClan unitType='Aero'>%s</pctClan>\n", 
                             pctTech.get(TechCategory.CLAN_AERO).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (pctTech.containsKey(TechCategory.IS_ADVANCED_AERO)
                 && pctTech.get(TechCategory.IS_ADVANCED_AERO).containsKey(era)
-                && (pctTech.get(TechCategory.IS_ADVANCED_AERO).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.IS_ADVANCED_AERO).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctSL unitType='Aero'>%s</pctSL>\n", 
                             pctTech.get(TechCategory.IS_ADVANCED_AERO).get(era).stream().map(Object::toString)
@@ -655,20 +662,22 @@ public class FactionRecord {
         }
         if (pctTech.containsKey(TechCategory.CLAN_VEE)
                 && pctTech.get(TechCategory.CLAN_VEE).containsKey(era)
-                && (pctTech.get(TechCategory.CLAN_VEE).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.CLAN_VEE).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctClan unitType='Vehicle'>%s</pctClan>\n", 
                             pctTech.get(TechCategory.CLAN_VEE).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (pctTech.containsKey(TechCategory.IS_ADVANCED_VEE)
                 && pctTech.get(TechCategory.IS_ADVANCED_VEE).containsKey(era)
-                && (pctTech.get(TechCategory.IS_ADVANCED_VEE).get(era).size() > 0)) {
+                && !pctTech.get(TechCategory.IS_ADVANCED_VEE).get(era).isEmpty()) {
             factionRecordBuilder.append(
                     String.format("\t\t<pctSL unitType='Vehicle'>%s</pctSL>\n", 
                             pctTech.get(TechCategory.IS_ADVANCED_VEE).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
+
         if (era > 3067) {
             if (!isClan() && !key.equals("CGB.FRR") && !key.equals("RA.OA")) {
                 factionRecordBuilder.append("\t\t<omniMargin>");
@@ -706,7 +715,7 @@ public class FactionRecord {
         if (weightDistribution.containsKey(era)) {
             for (int unitType : unitWeightKeys) {
                 if (weightDistribution.get(era).containsKey(unitType)
-                        && weightDistribution.get(era).get(unitType).size() > 0) {
+                        && !weightDistribution.get(era).get(unitType).isEmpty()) {
                     factionRecordBuilder.append("\t\t<weightDistribution era='");
                     factionRecordBuilder.append(era);
                     factionRecordBuilder.append("' unitType='");
@@ -743,6 +752,7 @@ public class FactionRecord {
         if (next == null) {
             return false;
         }
+
         for (DateRange dr : yearsActive) {
             if (dr.start != null && dr.start > era && dr.start < next) {
                 return true;

--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -349,7 +349,7 @@ public class FactionRecord {
 
     public void setRatings(String str) {
         ratingLevels.clear();
-        if (str.length() > 0) {
+        if (!str.isBlank()) {
             String[] fields = str.split(",");
             Collections.addAll(ratingLevels, fields);
         }
@@ -367,12 +367,12 @@ public class FactionRecord {
             pctTech.put(category, new HashMap<>());
         }
         ArrayList<Integer> list = new ArrayList<>();
-        if (str != null && str.length() > 0) {
+        if ((str != null) && !str.isBlank()) {
             for (String pct : str.split(",")) {
                 try {
                     list.add(Integer.parseInt(pct));
                 } catch (NumberFormatException ex) {
-                    LogManager.getLogger().error("While loading faction data for " + key);
+                    LogManager.getLogger().error("Failed to parse tech percent while loading faction data for " + key, ex);
                 }
             }
         }

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -835,7 +835,7 @@ public class RATGenerator {
             dispose = false;
         }
     }
-    
+
     /**
      * If the year is equal to one of the era marks, it loads that era. If it is between two, it
      * loads eras on both sides. Otherwise, just load the closest era.
@@ -856,9 +856,9 @@ public class RATGenerator {
             loadEra(getEraSet().ceiling(year));
         }
     }
-    
+
     private void loadFactions(File dir) {
-        File file = new MegaMekFile(dir, "factions.xml").getFile();
+        File file = new MegaMekFile(dir, "factions.xml").getFile(); // TODO : Remove inline file path
         FileInputStream fis;
         try {
             fis = new FileInputStream(file);
@@ -921,8 +921,8 @@ public class RATGenerator {
         while (!MechSummaryCache.getInstance().isInitialized()) {
             try {
                 Thread.sleep(50);
-            } catch (InterruptedException ex) {
-                //do nothing
+            } catch (InterruptedException ignored) {
+
             }
         }
 
@@ -953,8 +953,7 @@ public class RATGenerator {
                             if (rec != null) {
                                 rec.loadEra(wn, era);
                             } else {
-                                LogManager.getLogger().error("Faction " + fKey + " not found in "
-                                        + file.getPath());
+                                LogManager.getLogger().error("Faction " + fKey + " not found in " + file.getPath());
                             }
                         } else {
                             LogManager.getLogger().error("Faction key not found in " + file.getPath());
@@ -1010,7 +1009,7 @@ public class RATGenerator {
         boolean omni = false;
         String chassisName = wn.getAttributes().getNamedItem("name").getTextContent();
         String unitType = wn.getAttributes().getNamedItem("unitType").getTextContent();
-        String chassisKey = chassisName + "[" + unitType + "]";
+        String chassisKey = chassisName + '[' + unitType + ']';
         if (wn.getAttributes().getNamedItem("omni") != null) {
             omni = true;
             if (wn.getAttributes().getNamedItem("omni").getTextContent().equalsIgnoreCase("IS")) {
@@ -1027,11 +1026,11 @@ public class RATGenerator {
             cr.setClan(chassisKey.endsWith("ClanOmni"));
             chassis.put(chassisKey, cr);
         }
+
         for (int j = 0; j < wn.getChildNodes().getLength(); j++) {
             Node wn2 = wn.getChildNodes().item(j);
             if (wn2.getNodeName().equalsIgnoreCase("availability")) {
-                chassisIndex.get(era).put(chassisKey,
-                        new HashMap<>());
+                chassisIndex.get(era).put(chassisKey, new HashMap<>());
                 String[] codes = wn2.getTextContent().trim().split(",");
                 for (String code : codes) {
                     AvailabilityRating ar = new AvailabilityRating(chassisKey, era, code);
@@ -1045,7 +1044,7 @@ public class RATGenerator {
     }
     
     private void parseModelNode(int era, ChassisRecord cr, Node wn) {
-        String modelKey = (cr.getChassis() + " " + wn.getAttributes().getNamedItem("name").getTextContent()).trim();
+        String modelKey = (cr.getChassis() + ' ' + wn.getAttributes().getNamedItem("name").getTextContent()).trim();
         boolean newEntry = false;
         ModelRecord mr = models.get(modelKey);
         if (mr == null) {
@@ -1056,8 +1055,9 @@ public class RATGenerator {
                 mr.setOmni(cr.isOmni());
                 models.put(modelKey, mr);
             }
+
             if (mr == null) {
-                LogManager.getLogger().error(cr.getChassis() + " " 
+                LogManager.getLogger().error(cr.getChassis() + ' '
                         + wn.getAttributes().getNamedItem("name").getTextContent() + " not found.");
                 return;
             }
@@ -1117,31 +1117,28 @@ public class RATGenerator {
     }
     
     public void exportRATGen(File dir) {
-        File file;
         PrintWriter pw;
         
         FactionRecord[] factionRecs = factions.values().toArray(new FactionRecord[0]);
         Arrays.sort(factionRecs, (arg0, arg1) -> {
-            if (arg0.getParentFactions() == null && arg1.getParentFactions() != null) {
+            if ((arg0.getParentFactions() == null) && (arg1.getParentFactions() != null)) {
                 return -1;
-            }
-            if (arg0.getParentFactions() != null && arg1.getParentFactions() == null) {
+            } else if ((arg0.getParentFactions() != null) && (arg1.getParentFactions() == null)) {
                 return 1;
-            }
-            if (arg0.getKey().contains(".") && !arg1.getKey().contains(".")) {
+            } else if (arg0.getKey().contains(".") && !arg1.getKey().contains(".")) {
                 return 1;
-            }
-            if (!arg0.getKey().contains(".") && arg1.getKey().contains(".")) {
+            } else if (!arg0.getKey().contains(".") && arg1.getKey().contains(".")) {
                 return -1;
+            } else {
+                return arg0.getName().compareTo(arg1.getName());
             }
-            return arg0.getName().compareTo(arg1.getName());
         });
 
-        file = new File(dir + "/factions.xml");
+        File file = new File(dir + "/factions.xml"); // TODO : Remove inline file path
         try {
             pw = new PrintWriter(file, StandardCharsets.UTF_8);
-        } catch (Exception e1) {
-            e1.printStackTrace();
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
             return;
         }
         pw.println("<?xml version='1.0' encoding='UTF-8'?>");
@@ -1183,9 +1180,10 @@ public class RATGenerator {
                                 avFields.add(av.toString());
                             }
                         }
-                        if (avFields.size() > 0) {
+
+                        if (!avFields.isEmpty()) {
                             String omni = "";
-                            if (cr.isOmni() && cr.getModels().size() > 0) {
+                            if (cr.isOmni() && !cr.getModels().isEmpty()) {
                                 omni = cr.getModels().iterator().next().isClan()
                                         ? "' omni='Clan" : "' omni='IS";
                             }
@@ -1202,7 +1200,7 @@ public class RATGenerator {
                             pw.println("</availability>");
 
                             for (ModelRecord mr : cr.getSortedModels()) {
-                                if (cr.getIntroYear() < nextEra
+                                if ((cr.getIntroYear() < nextEra)
                                         && modelIndex.get(era).containsKey(mr.getKey())) {
                                     avFields.clear();
                                     for (AvailabilityRating av : modelIndex.get(era).get(mr.getKey()).values()) {
@@ -1210,22 +1208,25 @@ public class RATGenerator {
                                             avFields.add(av.toString());
                                         }
                                     }
+
                                     for (String fKey : mr.getExcludedFactions()) {
                                         avFields.add(fKey + ":0");
                                     }
-                                    if (avFields.size() > 0) {
+
+                                    if (!avFields.isEmpty()) {
                                         pw.print("\t\t<model name='" + mr.getModel().replaceAll("'", "&apos;"));
                                         if (mr.getUnitType() == UnitType.BATTLE_ARMOR) {
                                             pw.print("' mechanized='" + mr.canDoMechanizedBA());
                                         }
                                         pw.println("'>");
-                                        if (mr.getRoles().size() > 0) {
+                                        if (!mr.getRoles().isEmpty()) {
                                             String str = mr.getRoles().stream().map(Object::toString).collect(Collectors.joining(","));
-                                            if (str.length() > 0) {
+                                            if (!str.isEmpty()) {
                                                 pw.println("\t\t\t<roles>" + str + "</roles>");
                                             }
                                         }
-                                        if (mr.getDeployedWith().size() > 0 || mr.getRequiredUnits().size() > 0) {
+
+                                        if (!mr.getDeployedWith().isEmpty() || !mr.getRequiredUnits().isEmpty()) {
                                             pw.print("\t\t\t<deployedWith>");
                                             StringJoiner sj = new StringJoiner(",");
                                             mr.getDeployedWith().forEach(sj::add);
@@ -1252,15 +1253,14 @@ public class RATGenerator {
                 pw.println("</units>");
                 pw.println("</ratgen>");
                 pw.close();
-            } catch (Exception e) {
-                LogManager.getLogger().error("", e);
+            } catch (Exception ex) {
+                LogManager.getLogger().error("", ex);
             }
         }
     }
 
     private boolean shouldExportAv(AvailabilityRating av, int era) {
-        FactionRecord fRec = factions.get(av.getFaction());
-        return fRec == null || fRec.isInEra(era);
+        final FactionRecord fRec = factions.get(av.getFaction());
+        return (fRec == null) || fRec.isInEra(era);
     }
-    
 }

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -1221,7 +1221,7 @@ public class RATGenerator {
                                         pw.println("'>");
                                         if (!mr.getRoles().isEmpty()) {
                                             String str = mr.getRoles().stream().map(Object::toString).collect(Collectors.joining(","));
-                                            if (!str.isEmpty()) {
+                                            if (!str.isBlank()) {
                                                 pw.println("\t\t\t<roles>" + str + "</roles>");
                                             }
                                         }


### PR DESCRIPTION
The second commit prevents https://github.com/MegaMek/mekhq/issues/3072 from occurring, while the first cleans up some of the RAT Generator file I/O code.