### PR TITLE
Issue MML/#988 Turret Weight Errata

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -575,19 +575,23 @@ public class MiscType extends EquipmentType {
                 return RoundWeight.nearestTon(entity.getWeight() * (isClan() ? 0.04 : 0.05));
             }
         } else if (hasFlag(F_QUAD_TURRET) || hasFlag(F_SHOULDER_TURRET) || hasFlag(F_HEAD_TURRET)) {
+            // Turrets weight 10% of the weight of equipment in them, not counting Heat Sinks, Ammo and Armor
             int locationToCheck = location;
             if (hasFlag(F_HEAD_TURRET)) {
                 locationToCheck = Mech.LOC_HEAD;
             }
-            // 10% of linked weapons' weight
-            double weaponWeight = 0;
-            for (Mounted m : entity.getWeaponList()) {
-                if ((m.getLocation() == locationToCheck) && m.isMechTurretMounted()) {
-                    weaponWeight += m.getTonnage();
+            double weight = 0;
+            for (Mounted m : entity.getEquipment()) {
+                if ((m.getLocation() == locationToCheck)
+                        && (m.isMechTurretMounted() || m.isSponsonTurretMounted())
+                        && !(m.getType() instanceof AmmoType)
+                        && !((m.getType() instanceof MiscType) && m.getType().hasFlag(MiscType.F_HEAT_SINK))
+                        && (EquipmentType.getArmorType(m.getType()) == EquipmentType.T_ARMOR_UNKNOWN)) {
+                    weight += m.getTonnage();
                 }
             }
             // round to half ton
-            return defaultRounding.round(weaponWeight / 10.0, entity);
+            return defaultRounding.round(weight / 10.0, entity);
         } else if (hasFlag(F_SPONSON_TURRET)) {
             // For omni vehicles, this should be set as part of the base chassis.
             if ((entity.isOmni() && (entity instanceof Tank)

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -580,18 +580,18 @@ public class MiscType extends EquipmentType {
             if (hasFlag(F_HEAD_TURRET)) {
                 locationToCheck = Mech.LOC_HEAD;
             }
-            double weight = 0;
+            double equipmentWeight = 0;
             for (Mounted m : entity.getEquipment()) {
                 if ((m.getLocation() == locationToCheck)
-                        && (m.isMechTurretMounted() || m.isSponsonTurretMounted())
+                        && (m.isMechTurretMounted())
                         && !(m.getType() instanceof AmmoType)
                         && !((m.getType() instanceof MiscType) && m.getType().hasFlag(MiscType.F_HEAT_SINK))
                         && (EquipmentType.getArmorType(m.getType()) == EquipmentType.T_ARMOR_UNKNOWN)) {
-                    weight += m.getTonnage();
+                    equipmentWeight += m.getTonnage();
                 }
             }
             // round to half ton
-            return defaultRounding.round(weight / 10.0, entity);
+            return defaultRounding.round(equipmentWeight / 10.0, entity);
         } else if (hasFlag(F_SPONSON_TURRET)) {
             // For omni vehicles, this should be set as part of the base chassis.
             if ((entity.isOmni() && (entity instanceof Tank)
@@ -600,18 +600,21 @@ public class MiscType extends EquipmentType {
                 return ((Tank) entity).getBaseChassisSponsonPintleWeight() /
                         entity.countWorkingMisc(MiscType.F_SPONSON_TURRET);
             }
-            /* The sponson turret mechanism is equal to 10% of the weight of all mounted weapons, rounded
+            /* The sponson turret mechanism is equal to 10% of the weight of mounted equipment, rounded
              * up to the half ton. Since the turrets come in pairs, splitting the weight between them
              * may result in a quarter-ton result for a single turret, but the overall unit weight will
              * be correct.
              */
-            double weaponWeight = 0;
-            for (Mounted m : entity.getWeaponList()) {
-                if (m.isSponsonTurretMounted()) {
-                    weaponWeight += m.getTonnage();
+            double equipmentWeight = 0;
+            for (Mounted m : entity.getEquipment()) {
+                if (m.isSponsonTurretMounted()
+                        && !(m.getType() instanceof AmmoType)
+                        && !((m.getType() instanceof MiscType) && m.getType().hasFlag(MiscType.F_HEAT_SINK))
+                        && (EquipmentType.getArmorType(m.getType()) == EquipmentType.T_ARMOR_UNKNOWN)) {
+                    equipmentWeight += m.getTonnage();
                 }
             }
-            return defaultRounding.round(weaponWeight / 10.0,
+            return defaultRounding.round(equipmentWeight / 10.0,
                     entity) / entity.countWorkingMisc(MiscType.F_SPONSON_TURRET);
         } else if (hasFlag(F_PINTLE_TURRET)) {
             // For omnivehicles the weight should be set as chassis fixed weight.


### PR DESCRIPTION
BM and sponson turrets now follow Tank turrets in that they count not only weapons but all equipment (sans heat sinks, ammo and armor) to determine their weight. The only affected unit seems to be a RecGuide Grand Crusader that now needs to lose 1t.

Fixes https://github.com/MegaMek/megameklab/issues/985, fixes https://github.com/MegaMek/megameklab/issues/988