### PR TITLE
Enum All The Things: 3397: Standardizing the BasementType Enum

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -165,14 +165,6 @@ WeatherConditions.ModerateSnowfall=Moderate Snow
 WeatherConditions.HeavySnowfall=Heavy Snow
 WeatherConditions.Sleet=Sleet
 WeatherConditions.IceStorm=Ice Storm
-Building.BasementUnknown=unknown
-Building.BasementNone=no
-Building.BasementTwoDeepFeet=Double (feet first)
-Building.BasementOneDeepFeet=Single (feet first)
-Building.BasementOneDeepNormal=Single (normal fall)
-Building.BasementOneDeepNormalInfOnly=Small
-Building.BasementOneDeepHead=Single (head first)
-Building.BasementTwoDeepHead=Double (head First)
 
 SkinSpec.defaultElement.Text=Default UI Element
 SkinSpec.defaultElement.Desc=The default UI element, used if no other elements match.
@@ -530,3 +522,13 @@ SkillLevel.ELITE.text=Elite
 SkillLevel.ELITE.toolTipText=The current crew are elite soldiers, the best of the best. This has a default value of 2/3.
 SkillLevel.HEROIC.text=Heroic
 SkillLevel.HEROIC.toolTipText=The current crew are heroes, among the greatest soldiers to see the field of battle. This has a default value of 1/2.
+
+# BasementType Enum
+BasementType.UNKNOWN.text=unknown
+BasementType.NONE.text=no
+BasementType.TWO_DEEP_FEET.text=Double (feet first)
+BasementType.ONE_DEEP_FEET.text=Single (feet first)
+BasementType.ONE_DEEP_NORMAL.text=Single (normal fall)
+BasementType.ONE_DEEP_NORMAL_INFANTRY_ONLY.text=Small
+BasementType.ONE_DEEP_HEAD.text=Single (head first)
+BasementType.TWO_DEEP_HEAD.text=Double (head First)

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -41,10 +41,10 @@ import megamek.client.ui.swing.widget.MegamekBorder;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.common.*;
-import megamek.common.Building.BasementType;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.BasementType;
 import megamek.common.enums.GamePhase;
 import megamek.common.enums.IlluminationLevel;
 import megamek.common.event.*;
@@ -52,7 +52,10 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.BoardClusterTracker;
 import megamek.common.pathfinder.BoardClusterTracker.BoardCluster;
-import megamek.common.preference.*;
+import megamek.common.preference.ClientPreferences;
+import megamek.common.preference.IPreferenceChangeListener;
+import megamek.common.preference.PreferenceChangeEvent;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.FiringSolution;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
@@ -5552,7 +5555,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     txt.append(Messages.getString("BoardView1.Tooltip.Building",
                             mhex.terrainLevel(Terrains.BLDG_ELEV), bldg.toString(),
                             bldg.getCurrentCF(mcoords), bldg.getArmor(mcoords),
-                            bldg.getBasement(mcoords).getDesc()));
+                            bldg.getBasement(mcoords).toString()));
 
                     if (bldg.getBasementCollapsed(mcoords)) {
                         txt.append(Messages.getString("BoardView1.Tooltip.BldgBasementCollapsed"));

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -14,8 +14,8 @@
  */
 package megamek.common;
 
-import megamek.common.Building.BasementType;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.BasementType;
 import megamek.common.event.BoardEvent;
 import megamek.common.event.BoardListener;
 import megamek.common.util.fileUtils.MegaMekFile;
@@ -1569,7 +1569,7 @@ public class Board implements Serializable {
         for (Building b : buildings) {
             for (Enumeration<Coords> coords = b.getCoords(); coords.hasMoreElements();) {
                 Coords c = coords.nextElement();
-                if (b.getBasement(c) == BasementType.UNKNOWN) {
+                if (b.getBasement(c).isUnknown()) {
                     b.setBasement(c, BasementType.NONE);
                 }
             }

--- a/megamek/src/megamek/common/Building.java
+++ b/megamek/src/megamek/common/Building.java
@@ -15,6 +15,7 @@
 */
 package megamek.common;
 
+import megamek.common.enums.BasementType;
 import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
@@ -71,7 +72,7 @@ public class Building implements Serializable {
     /**
      * The Basement type of the building.
      */
-    private Map<Coords,BasementType> basement = new HashMap<>();
+    private Map<Coords, BasementType> basement = new HashMap<>();
 
     private int collapsedHexes = 0;
 
@@ -218,52 +219,6 @@ public class Building implements Serializable {
 
         }
 
-    } // End void protected include( Coords, Board )
-
-
-    /**
-     * Basement handlers
-     */
-    public enum BasementType {
-        UNKNOWN(0, 0, "Building.BasementUnknown"),
-        NONE(1, 0, "Building.BasementNone"),
-        TWO_DEEP_FEET(2, 2, "Building.BasementTwoDeepFeet"),
-        ONE_DEEP_FEET(3, 1, "Building.BasementOneDeepFeet"),
-        ONE_DEEP_NORMAL(4, 1, "Building.BasementOneDeepNormal"),
-        ONE_DEEP_NORMALINFONLY(5, 1, "Building.BasementOneDeepNormalInfOnly"),
-        ONE_DEEP_HEAD(6, 1, "Building.BasementOneDeepHead"),
-        TWO_DEEP_HEAD(7, 2, "Building.BasementTwoDeepHead");
-
-        private int value;
-        private int depth;
-        private String desc;
-
-        BasementType(int type, int depth, String desc) {
-            value = type;
-            this.depth = depth;
-            this.desc = desc;
-        }
-
-        public int getValue() {
-            return value;
-        }
-
-        public int getDepth() {
-            return depth;
-        }
-
-        public String getDesc() {
-            return Messages.getString(desc);
-        }
-
-        public static BasementType getType(int value) {
-            for (BasementType type : BasementType.values()) {
-                if (type.getValue() == value) {
-                    return type;
-                }
-            }
-            return UNKNOWN;
-        }
     }
 
     /**
@@ -441,13 +396,11 @@ public class Building implements Serializable {
         return basementCollapsed.get(coords);
     }
 
-    public void collapseBasement(Coords coords, Board board,
-            Vector<Report> vPhaseReport) {
-        if ((basement.get(coords) == BasementType.NONE) || (basement.get(coords) == BasementType.ONE_DEEP_NORMALINFONLY)) {
+    public void collapseBasement(Coords coords, Board board, Vector<Report> vPhaseReport) {
+        if (basement.get(coords).isNone() || basement.get(coords).isOneDeepNormalInfantryOnly()) {
             LogManager.getLogger().error("Hex has no basement to collapse");
             return;
-        }
-        if (basementCollapsed.get(coords)) {
+        } else if (basementCollapsed.get(coords)) {
             LogManager.getLogger().error("Hex has basement that already collapsed");
             return;
         }
@@ -463,12 +416,12 @@ public class Building implements Serializable {
 
     /**
      * Roll what kind of basement this building has
-     * @param coords the <code>Coords</code> of theb building to roll for
+     * @param coords the <code>Coords</code> of the building to roll for
      * @param vPhaseReport the <code>Vector<Report></code> containing the phasereport
-     * @return a <code>boolean</code> indicating wether the hex and building was changed or not
+     * @return a <code>boolean</code> indicating weather the hex and building was changed or not
      */
     public boolean rollBasement(Coords coords, Board board, Vector<Report> vPhaseReport) {
-        if (basement.get(coords) == BasementType.UNKNOWN) {
+        if (basement.get(coords).isUnknown()) {
             Hex hex = board.getHex(coords);
             Report r = new Report(2111, Report.PUBLIC);
             r.add(getName());
@@ -477,31 +430,32 @@ public class Building implements Serializable {
             r.add(basementRoll);
             if (basementRoll == 2) {
                 basement.put(coords, BasementType.TWO_DEEP_FEET);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             } else if (basementRoll == 3) {
                 basement.put(coords, BasementType.ONE_DEEP_FEET);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             } else if (basementRoll == 4) {
                 basement.put(coords, BasementType.ONE_DEEP_NORMAL);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             } else if (basementRoll == 10) {
                 basement.put(coords, BasementType.ONE_DEEP_NORMAL);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             } else if (basementRoll == 11) {
                 basement.put(coords, BasementType.ONE_DEEP_HEAD);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             } else if (basementRoll == 12) {
                 basement.put(coords, BasementType.TWO_DEEP_HEAD);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             } else {
                 basement.put(coords, BasementType.NONE);
-                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).getValue()));
+                hex.addTerrain(new Terrain(Terrains.BLDG_BASEMENT_TYPE, basement.get(coords).ordinal()));
             }
 
-            r.add(BasementType.getType(hex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).getDesc());
+            r.add(BasementType.getType(hex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).toString());
             vPhaseReport.add(r);
             return true;
         }
+
         return false;
     }
 
@@ -630,7 +584,7 @@ public class Building implements Serializable {
      * @return <code>true</code> if the other object is the same as this
      *         <code>Building</code>. The value <code>false</code> will be
      *         returned if the other object is <code>null</code>, is not a
-     *         <code>Buildig</code>, or if it is not the same as this
+     *         <code>Building</code>, or if it is not the same as this
      *         <code>Building</code>.
      */
     @Override

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -15,11 +15,11 @@
 */
 package megamek.common;
 
-import megamek.common.Building.BasementType;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.AimingMode;
+import megamek.common.enums.BasementType;
 import megamek.common.enums.IlluminationLevel;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.InfantryAttack;
@@ -5976,9 +5976,7 @@ public class Compute {
         int bldgHeight = curHex.terrainLevel(Terrains.BLDG_ELEV);
         int basement = 0;
         if (curHex.containsTerrain(Terrains.BLDG_BASEMENT_TYPE)) {
-            basement = BasementType.getType(
-                    curHex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE))
-                                   .getDepth();
+            basement = BasementType.getType(curHex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).getDepth();
         }
 
         // Return true if the entity is in the range of building elevations.

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -17,11 +17,11 @@ package megamek.common;
 
 import megamek.client.bot.princess.FireControl;
 import megamek.client.ui.swing.GUIPreferences;
-import megamek.common.Building.BasementType;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.AimingMode;
+import megamek.common.enums.BasementType;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GameEntityChangeEvent;
 import megamek.common.force.Force;
@@ -2048,27 +2048,25 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                         || (retVal > bldnex)) {
                     retVal = bldnex;
                 } else if ((bldnex + next.getLevel()) > (bldcur + current.getLevel())) {
-                    int nextBasement = next.terrainLevel(Terrains.BLDG_BASEMENT_TYPE);
+                    BasementType nextBasement = BasementType.getType(next.terrainLevel(Terrains.BLDG_BASEMENT_TYPE));
                     int collapsedBasement = next.terrainLevel(Terrains.BLDG_BASE_COLLAPSED);
                     if (climb || isJumpingNow) {
                         retVal = bldnex + next.getLevel();
                     // If the basement is collapsed, there is no level 0
                     } else if ((assumedElevation == 0)
-                            && (nextBasement > BasementType.NONE.getValue())
+                            && !nextBasement.isUnknownOrNone()
                             && (collapsedBasement > 0)) {
-                        retVal -= BasementType.getType(
-                                next.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).getDepth();
+                        retVal -= nextBasement.getDepth();
                     } else {
                         retVal += current.getLevel();
                         retVal -= next.getLevel();
                     }
                 } else if (elevation == -(current.depth(true))) {
+                    BasementType currentBasement = BasementType.getType(current.terrainLevel(Terrains.BLDG_BASEMENT_TYPE));
                     if (climb || isJumpingNow) {
                         retVal = bldnex + next.getLevel();
-                    } else if ((current.terrainLevel(Terrains.BLDG_BASEMENT_TYPE) > BasementType.NONE.getValue())
-                               && (assumedElevation == -BasementType
-                            .getType(current.terrainLevel(Terrains.BLDG_BASEMENT_TYPE))
-                            .getDepth())) {
+                    } else if (!currentBasement.isUnknownOrNone()
+                               && (assumedElevation == -currentBasement.getDepth())) {
                         retVal = -BasementType.getType(next.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).getDepth();
                     } else {
                         retVal += current.getLevel();
@@ -2076,6 +2074,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     }
                 }
             }
+
             if ((getMovementMode() != EntityMovementMode.NAVAL)
                     && (getMovementMode() != EntityMovementMode.HYDROFOIL)
                     && (next.containsTerrain(Terrains.BRIDGE) || current
@@ -2147,11 +2146,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             case INF_JUMP:
             case INF_LEG:
             case INF_MOTORIZED:
-                minAlt -= Math.max(
-                        0,
-                        BasementType.getType(
-                                hex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE))
-                                    .getDepth());
+                minAlt -= Math.max(0, BasementType.getType(hex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).getDepth());
                 break;
             case WIGE:
                 // Per errata, WiGEs have flotation hull, which makes no sense unless it changes the rule
@@ -2215,12 +2210,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             case BIPED:
             case QUAD:
                 if (this instanceof Protomech) {
-                    minAlt -= Math
-                            .max(0,
-                                 BasementType
-                                         .getType(
-                                                 hex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE))
-                                         .getDepth());
+                    minAlt -= Math.max(0, BasementType.getType(hex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).getDepth());
                 } else {
                     return false;
                 }

--- a/megamek/src/megamek/common/FuelTank.java
+++ b/megamek/src/megamek/common/FuelTank.java
@@ -13,6 +13,8 @@
  */
 package megamek.common;
 
+import megamek.common.enums.BasementType;
+
 /**
  * This class represents a single, possibly multi-hex fuel tank on the board.
  *

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -13,13 +13,13 @@
  */
 package megamek.common;
 
+import megamek.common.annotations.Nullable;
+import megamek.common.enums.BasementType;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
-
-import megamek.common.Building.BasementType;
-import megamek.common.annotations.Nullable;
 
 /**
  * Hex represents a single hex on the board.
@@ -185,7 +185,7 @@ public class Hex implements Serializable {
             // (hex == null) should usually look like ocean and 
             // therefore always gets connection to outside the board 
             if ((cTerr.getType() == Terrains.WATER) && (other == null)) {
-            	cTerr.setExit(direction, true);
+                cTerr.setExit(direction, true);
             }
 
             // Roads exit into pavement, too.

--- a/megamek/src/megamek/common/enums/BasementType.java
+++ b/megamek/src/megamek/common/enums/BasementType.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.enums;
+
+import megamek.MegaMek;
+import megamek.common.util.EncodeControl;
+
+import java.util.Arrays;
+import java.util.ResourceBundle;
+
+public enum BasementType {
+    //region Enum Declarations
+    UNKNOWN("BasementType.UNKNOWN.text", 0),
+    NONE("BasementType.NONE.text", 0),
+    TWO_DEEP_FEET("BasementType.TWO_DEEP_FEET.text", 2),
+    ONE_DEEP_FEET("BasementType.ONE_DEEP_FEET.text", 1),
+    ONE_DEEP_NORMAL("BasementType.ONE_DEEP_NORMAL.text", 1),
+    ONE_DEEP_NORMAL_INFANTRY_ONLY("BasementType.ONE_DEEP_NORMAL_INFANTRY_ONLY.text", 1),
+    ONE_DEEP_HEAD("BasementType.ONE_DEEP_HEAD.text", 1),
+    TWO_DEEP_HEAD("BasementType.TWO_DEEP_HEAD.text", 2);
+    //endregion Enum Declarations
+
+    //region Variable Declarations
+    private final String name;
+    private final int depth;
+    //endregion Variable Declarations
+
+    //region Constructors
+    BasementType(final String name, final int depth) {
+        final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
+                MegaMek.getMMOptions().getLocale(), new EncodeControl());
+        this.name = resources.getString(name);
+        this.depth = depth;
+    }
+    //endregion Constructors
+
+    //region Getters
+    public int getDepth() {
+        return depth;
+    }
+    //endregion Getters
+
+    //region Boolean Comparison Methods
+    public boolean isUnknown() {
+        return this == UNKNOWN;
+    }
+
+    public boolean isNone() {
+        return this == NONE;
+    }
+
+    public boolean isTwoDeepFeet() {
+        return this == TWO_DEEP_FEET;
+    }
+
+    public boolean isOneDeepFeet() {
+        return this == ONE_DEEP_FEET;
+    }
+
+    public boolean isOneDeepNormal() {
+        return this == ONE_DEEP_NORMAL;
+    }
+
+    public boolean isOneDeepNormalInfantryOnly() {
+        return this == ONE_DEEP_NORMAL_INFANTRY_ONLY;
+    }
+
+    public boolean isOneDeepHead() {
+        return this == ONE_DEEP_HEAD;
+    }
+
+    public boolean isTwoDeepHead() {
+        return this == TWO_DEEP_HEAD;
+    }
+
+    public boolean isUnknownOrNone() {
+        return isUnknown() || isNone();
+    }
+    //endregion Boolean Comparison Methods
+
+    public static BasementType getType(final int ordinal) {
+        return Arrays.stream(BasementType.values()).filter(type -> type.ordinal() == ordinal).findFirst().orElse(UNKNOWN);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}


### PR DESCRIPTION
This isolates the BasementType Enum and updates it to the Enum All The Things design. This swapover fixes #3397 and another toString call on an enum without a toString override.