### PR TITLE
RAT Generator editor fixes

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -79,6 +79,7 @@ public class ModelRecord extends AbstractUnitRecord {
         if (unitType == UnitType.MEK) {
             //TODO: id quads and tripods
             movementMode = EntityMovementMode.BIPED;
+            omni = ms.getUnitSubType().equals("Omni");
         } else {
             movementMode = EntityMovementMode.parseFromString(ms.getUnitSubType().toLowerCase());
         }

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -1160,7 +1160,7 @@ public class RATGenerator {
 
         for (int i = 0; i < ERAS.size(); i++) {
             int era = ERAS.get(i);
-            int nextEra = (i < ERAS.size() - 1) ? ERAS.get(i + 1) : era;
+            int nextEra = (i < ERAS.size() - 1) ? ERAS.get(i + 1) : Integer.MAX_VALUE;
             try {
                 file = new File(dir + "/" + era + ".xml");
                 pw = new PrintWriter(file, StandardCharsets.UTF_8);


### PR DESCRIPTION
1. Currently the only time the omni field gets set in the chassis or model record is when the unit is loaded from the ratgen files. Records added for any new omni unit are treated as non-omni and new configurations are treated as a different chassis. This fixes the issue for mechs, but there is no way to tell whether a fighter or vehicle is omni from the MechSummary alone so this is an improvement that falls short of a complete fix.
2. There is a logic error in the filtering when the data is exported. Any record that falls in a date range before the unit's intro date is skipped, but the final date range is incorrectly being treated as a single year, so any unit that appears in or after that year (currently 3150) is skipped. Changing the beginning of the next era to Integer.MAX_VALUE effectively makes the final date range open-ended.