### PR TITLE
3435: Check if the report vector is empty before adding a new line

### DIFF
--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -544,6 +544,11 @@ public class Report implements Serializable {
      * @param v a Vector of Report objects
      */
     public static void addNewline(Vector<Report> v) {
+        if (v.isEmpty()) {
+            // We can't add a new line to an empty report vector
+            return;
+        }
+
         try {
             v.elementAt(v.size() - 1).newlines++;
         } catch (Exception ex) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -35186,12 +35186,10 @@ public class Server implements Runnable {
                 keptAttacks.add(ah);
             }
         }
+
         // resolve standard to capital one more time
-        handleAttackReports.addAll(checkFatalThresholds(lastAttackerId,
-                lastAttackerId));
-        if (handleAttackReports.size() > 0) {
-            Report.addNewline(handleAttackReports);
-        }
+        handleAttackReports.addAll(checkFatalThresholds(lastAttackerId, lastAttackerId));
+        Report.addNewline(handleAttackReports);
         addReport(handleAttackReports);
         // HACK, but anything else seems to run into weird problems.
         game.setAttacksVector(keptAttacks);


### PR DESCRIPTION
This fixes #3435 