### PR TITLE
Equipment validation update

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -403,21 +403,11 @@ public class MiscType extends EquipmentType {
     }
 
     public boolean isShield() {
-        if (hasFlag(MiscType.F_CLUB) && (hasSubType(MiscType.S_SHIELD_LARGE) || hasSubType((MiscType.S_SHIELD_MEDIUM))
-                || hasSubType(MiscType.S_SHIELD_SMALL))) {
-            return true;
-        }
-        // else
-        return false;
+        return hasFlag(F_CLUB) && hasSubType(S_SHIELD_LARGE | S_SHIELD_MEDIUM | S_SHIELD_SMALL);
     }
 
     public boolean isVibroblade() {
-        if (hasFlag(MiscType.F_CLUB) && (hasSubType(MiscType.S_VIBRO_LARGE) || hasSubType((MiscType.S_VIBRO_MEDIUM))
-                || hasSubType(MiscType.S_VIBRO_SMALL))) {
-            return true;
-        }
-        // else
-        return false;
+        return hasFlag(F_CLUB) && hasSubType(S_VIBRO_LARGE | S_VIBRO_MEDIUM | S_VIBRO_SMALL);
     }
 
     public boolean isIndustrial() {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1624,19 +1624,11 @@ public class TestMech extends TestEntity {
                 return false;
             }
             if (eq.hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER) || eq.hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
-                    || eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER)) {
-                if (!mech.entityIsQuad()) {
-                    if (buffer != null) {
-                        buffer.append(eq.getName()).append(" can only be used by quadruped Meks.\n");
-                    }
-                    return false;
+                    || eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER) && !mech.locationIsTorso(location)) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be placed in a torso location.\n");
                 }
-                if (!mech.locationIsTorso(location)) {
-                    if (buffer != null) {
-                        buffer.append(eq.getName()).append(" must be placed in a torso location.\n");
-                    }
-                    return false;
-                }
+                return false;
             }
             if (eq.hasFlag(MiscType.F_LIFTHOIST) && ((location == Mech.LOC_HEAD) || mech.locationIsLeg(location))) {
                 if (buffer != null) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1464,27 +1464,7 @@ public class TestMech extends TestEntity {
                 illegal = true;
             }
         }
-        
-        // only one sword/vibroblade per arm
-        for (int loc = Mech.LOC_RARM; loc <= Mech.LOC_LARM; loc++) {
-            int count = 0;
-            for (Mounted m : mech.getMisc()) {
-                if (m.getLocation() == loc) {
-                    if (m.getType().hasFlag(MiscType.F_CLUB)
-                            && (m.getType().hasSubType(MiscType.S_SWORD | MiscType.S_VIBRO_LARGE
-                            | MiscType.S_VIBRO_MEDIUM | MiscType.S_VIBRO_SMALL | MiscType.S_HATCHET
-                            | MiscType.S_CHAIN_WHIP | MiscType.S_CLAW | MiscType.S_FLAIL | MiscType.S_LANCE
-                            | MiscType.S_MACE))) {
-                        count++;
-                    }
-                }
-            }
-            if (count > 1) {
-                buff.append("only one physical attack weapon per arm\n");
-                illegal = true;
-            }
-        }
-        
+
         return illegal;
     }
 
@@ -1566,10 +1546,16 @@ public class TestMech extends TestEntity {
                 }
             }
             if (eq.hasFlag(MiscType.F_CLUB) && (eq.hasSubType(MiscType.S_HATCHET | MiscType.S_SWORD
-                    | MiscType.S_CHAIN_WHIP | MiscType.S_CLAW | MiscType.S_FLAIL | MiscType.S_LANCE
-                    | MiscType.S_MACE | MiscType.S_VIBRO_LARGE | MiscType.S_VIBRO_MEDIUM | MiscType.S_VIBRO_SMALL
-                    | MiscType.S_WRECKING_BALL)) && (mech.entityIsQuad()
-                    || ((location != Mech.LOC_LARM) && (location != Mech.LOC_RARM)))) {
+                    | MiscType.S_CHAIN_WHIP | MiscType.S_FLAIL | MiscType.S_LANCE | MiscType.S_WRECKING_BALL
+                    | MiscType.S_MACE) || ((MiscType) eq).isShield() || ((MiscType) eq).isVibroblade())
+                    && (mech.entityIsQuad() || ((location != Mech.LOC_LARM) && (location != Mech.LOC_RARM)))) {
+                if (buffer != null) {
+                    buffer.append(eq.getName()).append(" must be mounted in an arm.\n");
+                }
+                return false;
+            }
+            if (eq.hasFlag(MiscType.F_HAND_WEAPON) && eq.hasSubType(MiscType.S_CLAW)
+                    && (mech.entityIsQuad() || ((location != Mech.LOC_LARM) && (location != Mech.LOC_RARM)))) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be mounted in an arm.\n");
                 }

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1547,7 +1547,8 @@ public class TestMech extends TestEntity {
             }
             if (eq.hasFlag(MiscType.F_CLUB) && (eq.hasSubType(MiscType.S_HATCHET | MiscType.S_SWORD
                     | MiscType.S_CHAIN_WHIP | MiscType.S_FLAIL | MiscType.S_LANCE | MiscType.S_WRECKING_BALL
-                    | MiscType.S_MACE) || ((MiscType) eq).isShield() || ((MiscType) eq).isVibroblade())
+                    | MiscType.S_MACE | MiscType.S_RETRACTABLE_BLADE)
+                    || ((MiscType) eq).isShield() || ((MiscType) eq).isVibroblade())
                     && (mech.entityIsQuad() || ((location != Mech.LOC_LARM) && (location != Mech.LOC_RARM)))) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be mounted in an arm.\n");

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1562,12 +1562,6 @@ public class TestMech extends TestEntity {
                 }
                 return false;
             }
-            if (requiresHandActuator(eq) && !mech.hasSystem(Mech.ACTUATOR_HAND, location)) {
-                if (buffer != null) {
-                    buffer.append(eq.getName()).append(" requires a hand actuator.\n");
-                }
-                return false;
-            }
             if (eq.hasFlag(MiscType.F_SALVAGE_ARM) && (mech.entityIsQuad()
                     || ((location != Mech.LOC_LARM) && (location != Mech.LOC_RARM)))) {
                 if (buffer != null) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1611,14 +1611,9 @@ public class TestMech extends TestEntity {
                 return false;
             }
             if ((eq.hasFlag(MiscType.F_FUEL) || (eq.hasFlag(MiscType.F_CASE) && !eq.isClan())
-                    || eq.hasFlag(MiscType.F_LADDER)) && !mech.locationIsTorso(location)) {
-                if (buffer != null) {
-                    buffer.append(eq.getName()).append(" must be placed in a torso location.\n");
-                }
-                return false;
-            }
-            if (eq.hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER) || eq.hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER)
-                    || eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER) && !mech.locationIsTorso(location)) {
+                    || eq.hasFlag(MiscType.F_LADDER) || eq.hasFlag(MiscType.F_LIGHT_BRIDGE_LAYER)
+                    || eq.hasFlag(MiscType.F_MEDIUM_BRIDGE_LAYER) || eq.hasFlag(MiscType.F_HEAVY_BRIDGE_LAYER))
+                    && !mech.locationIsTorso(location)) {
                 if (buffer != null) {
                     buffer.append(eq.getName()).append(" must be placed in a torso location.\n");
                 }


### PR DESCRIPTION
This updates a few checks on equipment validity for meks. One check (sword/vibroblade) is removed as physical weapons stacking is already checked elsewhere (TestEntity). Physical weapons location restrictions are updated.
Nevermind the change in Testmech l.1614/1615 where I added things but then reverted it ending up with a different check ordering.
