### PR TITLE
Add CalculationReport tools

### DIFF
--- a/megamek/src/megamek/client/ui/swing/calculationReport/CalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/CalculationReport.java
@@ -188,7 +188,7 @@ public interface CalculationReport {
     CalculationReport addResultLine(@Nullable String type, @Nullable String calculation, @Nullable String result);
 
     /**
-     * Returns the CalucaltionReport as a JComponent that can be added to a dialog or other Swing component.
+     * Returns the CalculationReport as a JComponent that can be added to a dialog or other Swing component.
      *
      * @return The CalculationReport wrapped in a JComponent form.
      */

--- a/megamek/src/megamek/client/ui/swing/calculationReport/CalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/CalculationReport.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.calculationReport;
+
+import megamek.common.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Locale;
+/**
+ * This represents a report for any typical MegaMek suite calculation such as BV, cost or AS conversion.
+ * It assumes that each line will have at most three entries, a sort of header text ("Damage:"), a calculation
+ * ("5 + 5 + 7 * 0.2") and a result on the right side ("11.4").
+ *
+ * The result can be given as a String or as a double value with a prefix String. When a double value is
+ * given, it will be rounded to one decimal digit. Since the second entry (the calculation text) can
+ * be more complicated than a single number, it can only be passed as a String and rounding must be
+ * performed by the caller if needed.
+ *
+ * @author Simon (Juliez)
+ */
+public interface CalculationReport {
+
+    /**
+     * Adds a single line to the CalculationReport.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param calculation A calculation or other info, displayed after the type
+     * @param result A result or other info, displayed on the right side
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    CalculationReport addLine(@Nullable String type, @Nullable String calculation, @Nullable String result);
+
+    /**
+     * Adds a single line to the CalculationReport. This method performs rounding to
+     * a single decimal digit on the result and writes resultPrefix in front of it.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param calculation A calculation or other info, displayed after the type
+     * @param resultPrefix A text to be display immediately in front of the result, such as "= "
+     * @param result A numerical result which will be rounded to a single decimal, e.g. 25.1
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addLine(@Nullable String type, @Nullable String calculation,
+                              @Nullable String resultPrefix, double result) {
+        return addLine(type, calculation, getRoundedResultString(resultPrefix, result));
+    }
+
+    /**
+     * Adds a single line to the CalculationReport. This method performs rounding to
+     * a single decimal digit on the result and writes resultPrefix in front of it.
+     * This line has only two elements, the type ("Damage: ") and the result displayed
+     * on the right side.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param resultPrefix A text to be display immediately in front of the result, such as "= "
+     * @param result A numerical result which will be rounded to a single decimal, e.g. 25.1
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addLine(@Nullable String type,
+                                      @Nullable String resultPrefix, double result) {
+        return addLine(type, "", getRoundedResultString(resultPrefix, result));
+    }
+
+    /**
+     * Adds a single line to the CalculationReport in the way addLine() does, except
+     * the result has a line above it that may e.g. indicate a summary of previous values.
+     * This method performs rounding to a single decimal digit on the result and
+     * writes resultPrefix in front of it.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param calculation A calculation or other info, displayed after the type
+     * @param resultPrefix A text to be display immediately in front of the result, such as "= "
+     * @param result A numerical result which will be rounded to a single decimal, e.g. 25.1
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addResultLine(@Nullable String type, @Nullable String calculation,
+                                      @Nullable String resultPrefix, double result) {
+        return addResultLine(type, calculation, getRoundedResultString(resultPrefix, result));
+    }
+
+    /**
+     * Adds a single line to the CalculationReport in the way addLine() does, except
+     * the result has a line above it that may e.g. indicate a summary of previous values.
+     * This line has only two elements, the type ("Damage: ") and the result displayed
+     * on the right side. This method performs rounding to a single decimal digit on the
+     * result and writes resultPrefix in front of it.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param resultPrefix A text to be display immediately in front of the result, such as "= "
+     * @param result A numerical result which will be rounded to a single decimal, e.g. 25.1
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addResultLine(@Nullable String type,
+                                            @Nullable String resultPrefix, double result) {
+        return addResultLine(type, "", getRoundedResultString(resultPrefix, result));
+    }
+
+    /**
+     * Adds a single line to the CalculationReport in the way addLine() does, except
+     * the result has a line above it that may e.g. indicate a summary of previous values.
+     * This line has only one element, the result displayed on the right side. This method
+     * performs rounding to a single decimal digit on the result and writes resultPrefix
+     * in front of it.
+     *
+     * @param resultPrefix A text to be display immediately in front of the result, such as "= "
+     * @param result A numerical result which will be rounded to a single decimal, e.g. 25.1
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addResultLine(@Nullable String resultPrefix, double result) {
+        return addResultLine("", "", getRoundedResultString(resultPrefix, result));
+    }
+
+    /**
+     * Adds an empty line to the CalculationReport.
+     *
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addEmptyLine() {
+        return addLine("", "", "");
+    }
+
+    /**
+     * Adds a single line to the CalculationReport. This line has only two elements, the type
+     * ("Damage: ") and a result displayed on the right side.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param result A result or other info, displayed on the right side
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addLine(@Nullable String type, @Nullable String result) {
+        return addLine(type, "", result);
+    }
+
+    /**
+     * Adds a single line to the CalculationReport. This line only has one element displayed
+     * on the right side.
+     *
+     * @param result A result or other info, displayed on the right side
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    default CalculationReport addLine(@Nullable String result) {
+        return addLine("", "", result);
+    }
+
+    /**
+     * Adds a single line to the CalculationReport containing a sub-header.
+     *
+     * @param text The header text
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    CalculationReport addSubHeader(String text);
+
+    /**
+     * Adds a single line to the CalculationReport containing the header for the CalculationReport.
+     * This would typically be used as the first line but can be used anywhere in the CalculationReport
+     * and multiple times.
+     *
+     * @param text The header text
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    CalculationReport addHeader(String text);
+
+    /**
+     * Adds a single line to the CalculationReport in the way addLine() does, except
+     * the result has a line above it that may e.g. indicate a summary of previous values.
+     *
+     * @param type The first element of this line, such as "Damage: "
+     * @param calculation A calculation or other info, displayed after the type
+     * @param result A result or other info, displayed on the right side
+     * @return The CalculationReport itself. Enables multiple stringed addLine calls
+     */
+    CalculationReport addResultLine(@Nullable String type, @Nullable String calculation, @Nullable String result);
+
+    /**
+     * Returns the CalucaltionReport as a JComponent that can be added to a dialog or other Swing component.
+     *
+     * @return The CalculationReport wrapped in a JComponent form.
+     */
+    JComponent toJComponent();
+
+    /**
+     * Returns the assembled rounded result value with the prefix applied. Uses the fixed Locale.US
+     * as the Java way of converting "" + value seems to use Locale.US by default as well.
+     */
+    private String getRoundedResultString(String resultPrefix, double result) {
+        return (resultPrefix != null) ? resultPrefix : ""
+                + String.format(Locale.US, "%1$,.1f", result);
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/calculationReport/CalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/CalculationReport.java
@@ -199,7 +199,7 @@ public interface CalculationReport {
      * as the Java way of converting "" + value seems to use Locale.US by default as well.
      */
     private String getRoundedResultString(String resultPrefix, double result) {
-        return (resultPrefix != null) ? resultPrefix : ""
+        return ((resultPrefix != null) ? resultPrefix : "")
                 + String.format(Locale.US, "%1$,.1f", result);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/calculationReport/FlexibleCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/FlexibleCalculationReport.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.calculationReport;
+
+import javax.swing.*;
+
+public class FlexibleCalculationReport implements CalculationReport {
+
+    private final HTMLCalculationReport htmlReport = new HTMLCalculationReport();
+    private final SwingCalculationReport swingReport = new SwingCalculationReport();
+    private final TextCalculationReport textReport = new TextCalculationReport();
+
+    public CalculationReport getHtmlReport() {
+        return htmlReport;
+    }
+
+    public CalculationReport getSwingReport() {
+        return swingReport;
+    }
+
+    public CalculationReport getTextReport() {
+        return textReport;
+    }
+
+    @Override
+    public CalculationReport addLine(String type, String calculation, String result) {
+        htmlReport.addLine(type, calculation, result);
+        swingReport.addLine(type, calculation, result);
+        textReport.addLine(type, calculation, result);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addSubHeader(String text) {
+        htmlReport.addSubHeader(text);
+        swingReport.addSubHeader(text);
+        textReport.addSubHeader(text);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addHeader(String text) {
+        htmlReport.addHeader(text);
+        swingReport.addHeader(text);
+        textReport.addHeader(text);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addResultLine(String type, String calculation, String result) {
+        htmlReport.addResultLine(type, calculation, result);
+        swingReport.addResultLine(type, calculation, result);
+        textReport.addResultLine(type, calculation, result);
+        return this;
+    }
+
+    @Override
+    public JComponent toJComponent() {
+        return swingReport.toJComponent();
+    }
+
+    @Override
+    public String toString() {
+        return textReport.toString();
+    }
+
+}

--- a/megamek/src/megamek/client/ui/swing/calculationReport/HTMLCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/HTMLCalculationReport.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.calculationReport;
+
+import javax.swing.*;
+
+public class HTMLCalculationReport implements CalculationReport {
+
+    private final static String HTML_START = "<HTML><BODY>";
+    private final static String HTML_END = "</BODY></HTML>";
+    private final static String TABLE_START = "<TABLE CELLPADDING=0 CELLSPACING=0 BORDER=0>";
+    private final static String TABLE_END = "</TABLE>";
+
+    private final static String ROW_START = "<TR>";
+    private final static String ROW_END = "</TR>";
+    private final static String COL_START = "<TD>";
+    private final static String COL_RESULT_START = "<TD ALIGN=RIGHT>";
+    private final static String COL_HEADER_START = "<TD COLSPAN=6 ALIGN=CENTER>";
+    private final static String COL_END = "</TD>";
+    private final static String COLSPAN_START = "<TD COLSPAN=6>";
+    private final static String COL_SPACER = "<TD>&nbsp;&nbsp;&nbsp;&nbsp;</TD>";
+
+    private final static String HEADER_START = "<H2>";
+    private final static String HEADER_END = "</H2>";
+    private final static String SUBHEADER_START = "<U>";
+    private final static String SUBHEADER_END = "</U>";
+
+    private final StringBuilder report = new StringBuilder();
+
+    public HTMLCalculationReport() {
+        report.append(HTML_START).append(TABLE_START);
+    }
+
+    @Override
+    public JComponent toJComponent() {
+        final JEditorPane editorPane = new JEditorPane("text/html", this.toString());
+        editorPane.setEditable(false);
+        editorPane.setCaretPosition(0);
+        return editorPane;
+    }
+
+    public CalculationReport addResultLine(String type, String calculation, String result) {
+        report.append(ROW_START);
+        report.append(COL_START).append(COL_END);
+        report.append(COL_START).append(COL_END);
+        report.append(COL_START).append(COL_END);
+        report.append(COL_START).append(COL_END);
+        report.append(COL_START).append(COL_END);
+        report.append(COL_RESULT_START).append("<HR>").append(COL_END);
+        report.append(ROW_END);
+        return addLine(type, calculation, result);
+    }
+
+    @Override
+    public CalculationReport addLine(String type, String calculation, String result) {
+        report.append(ROW_START);
+        report.append(COL_START).append("&nbsp;&nbsp;").append(COL_END);
+        report.append(COL_START).append(type).append(COL_END);
+        report.append(COL_SPACER);
+        report.append(COL_START).append(calculation).append(COL_END);
+        report.append(COL_SPACER);
+        report.append(COL_RESULT_START).append(result).append(COL_END);
+        report.append(ROW_END);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addSubHeader(String text) {
+        report.append(ROW_START);
+        report.append(COLSPAN_START).append(SUBHEADER_START).append(text).append(SUBHEADER_END).append(COL_END);
+        report.append(ROW_END);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addHeader(String text) {
+        report.append(ROW_START);
+        report.append(COL_HEADER_START).append(HEADER_START).append(text).append(HEADER_END).append(COL_END);
+        report.append(ROW_END);
+        addEmptyLine();
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return report + TABLE_END + HTML_END;
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/calculationReport/HTMLCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/HTMLCalculationReport.java
@@ -55,6 +55,7 @@ public class HTMLCalculationReport implements CalculationReport {
         return editorPane;
     }
 
+    @Override
     public CalculationReport addResultLine(String type, String calculation, String result) {
         report.append(ROW_START);
         report.append(COL_START).append(COL_END);

--- a/megamek/src/megamek/client/ui/swing/calculationReport/SwingCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/SwingCalculationReport.java
@@ -36,6 +36,7 @@ public class SwingCalculationReport implements CalculationReport {
         return report;
     }
 
+    @Override
     public CalculationReport addResultLine(String type, String calculation, String result) {
         newLine();
         gbc.gridx = 3;

--- a/megamek/src/megamek/client/ui/swing/calculationReport/SwingCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/SwingCalculationReport.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.calculationReport;
+
+import javax.swing.*;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.MatteBorder;
+import java.awt.*;
+
+public class SwingCalculationReport implements CalculationReport {
+
+    private final JPanel report = new JPanel(new GridBagLayout());
+    private final GridBagConstraints gbc = new GridBagConstraints();
+    private final String COL_SPACER = "   ";
+    private final static int PADDING = 15;
+
+    @Override
+    public JComponent toJComponent() {
+        return report;
+    }
+
+    public CalculationReport addResultLine(String type, String calculation, String result) {
+        newLine();
+        gbc.gridx = 3;
+        gbc.anchor = GridBagConstraints.LINE_END;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        JLabel resultLabel = new JLabel();
+        Color color = UIManager.getColor("Label.foreground");
+        resultLabel.setBorder(new CompoundBorder(new EmptyBorder(0, 0, 0, PADDING),
+                new MatteBorder(1, 0, 0, 0, color)));
+        report.add(resultLabel, gbc);
+        return addLine(type, calculation, result);
+    }
+
+    @Override
+    public CalculationReport addLine(String type, String calculation, String result) {
+        newLine();
+        gbc.ipadx = 0;
+        report.add(new JLabel(COL_SPACER), gbc);
+        gbc.gridx++;
+        gbc.ipadx = PADDING;
+        report.add(new JLabel(type), gbc);
+        gbc.gridx++;
+        report.add(new JLabel(calculation), gbc);
+        gbc.gridx++;
+        gbc.anchor = GridBagConstraints.LINE_END;
+        report.add(new JLabel(result), gbc);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addSubHeader(String text) {
+        newLine();
+        gbc.gridwidth = 4;
+        gbc.ipadx = 0;
+        report.add(new JLabel(text), gbc);
+        return this;
+    }
+
+    @Override
+    public CalculationReport addHeader(String text) {
+        newLine();
+        gbc.anchor = GridBagConstraints.CENTER;
+        gbc.gridwidth = 4;
+        JLabel header = new JLabel(text);
+        Font font = header.getFont();
+        int size = font.getSize() + 4;
+        header.setFont(new Font(font.getName(), Font.PLAIN, size));
+        report.add(header, gbc);
+        addEmptyLine();
+        return this;
+    }
+
+    @Override
+    public CalculationReport addEmptyLine() {
+        newLine();
+        gbc.gridwidth = 4;
+        report.add(Box.createVerticalStrut(8), gbc);
+        return this;
+    }
+
+    private void newLine() {
+        gbc.anchor = GridBagConstraints.LINE_START;
+        gbc.gridx = 0;
+        gbc.gridwidth = 1;
+        gbc.ipadx = PADDING;
+        gbc.fill = GridBagConstraints.NONE;
+        gbc.gridy++;
+    }
+
+}

--- a/megamek/src/megamek/client/ui/swing/calculationReport/TextCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/TextCalculationReport.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.calculationReport;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TextCalculationReport implements CalculationReport {
+
+    private final static int COL_SPACER = 3;
+
+    private enum LineType {
+        LINE, HEADER, SUBHEADER, RESULT_LINE
+    }
+
+    private static class ReportLine {
+
+        ReportLine(String c1, String c2, String c3, LineType lt) {
+            lineType = lt;
+            content1 = c1;
+            content2 = c2;
+            content3 = c3;
+        }
+
+        final LineType lineType;
+        final String content1;
+        final String content2;
+        final String content3;
+
+        int getWidth() {
+            if (lineType == LineType.LINE) {
+                return content1.length() + content2.length() + content3.length() + 3 * COL_SPACER;
+            } else if ((lineType == LineType.HEADER) || (lineType == LineType.SUBHEADER)) {
+                return content1.length();
+            } else {
+                return 0;
+            }
+        }
+
+        String getContent(int column) {
+            if (column == 1) {
+                return content1;
+            } else if (column == 2) {
+                return content2;
+            } else {
+                return content3;
+            }
+        }
+    }
+
+    /**
+     * In this report type the lines must be buffered as the text column count can only be found
+     * when all lines are in.
+     */
+    private final List<ReportLine> reportLines = new ArrayList<>();
+
+    @Override
+    public CalculationReport addLine(String type, String calculation, String result) {
+        reportLines.add(new ReportLine(type, calculation, result, LineType.LINE));
+        return this;
+    }
+
+    @Override
+    public CalculationReport addSubHeader(String text) {
+        reportLines.add(new ReportLine(text, "", "", LineType.SUBHEADER));
+        return this;
+    }
+
+    @Override
+    public CalculationReport addHeader(String text) {
+        reportLines.add(new ReportLine(text, "", "", LineType.HEADER));
+        return this;
+    }
+
+    @Override
+    public CalculationReport addResultLine(String type, String calculation, String result) {
+        addLine(type, calculation, result);
+        reportLines.add(new ReportLine("", "", "", LineType.RESULT_LINE));
+        return this;
+    }
+
+    @Override
+    public JComponent toJComponent() {
+        final JEditorPane editorPane = new JEditorPane("text/plain", this.toString());
+        editorPane.setEditable(false);
+        editorPane.setCaretPosition(0);
+        editorPane.setFont(new Font("Monospaced", Font.PLAIN, editorPane.getFont().getSize()));
+        return editorPane;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder result = new StringBuilder();
+        int width = requiredColumns();
+        int resultWidth = maxWidth(3);
+        int calcBegin = calculationBeginColumn();
+        for (ReportLine line : reportLines) {
+            if (line.lineType == LineType.LINE) {
+                result.append(" ".repeat(COL_SPACER)).append(line.content1);
+                result.append(" ".repeat(calcBegin - line.content1.length() - COL_SPACER)).append(line.content2);
+                result.append(" ".repeat(width - line.content3.length() - calcBegin - line.content2.length())).append(line.content3);
+            } else if (line.lineType == LineType.SUBHEADER) {
+                result.append(System.lineSeparator());
+                result.append(line.content1);
+            } else if (line.lineType == LineType.HEADER) {
+                result.append(line.content1).append(System.lineSeparator());
+                result.append("-".repeat(line.content1.length()));
+            } else {
+                result.append(" ".repeat(width - resultWidth)).append("-".repeat(resultWidth));
+            }
+            result.append(System.lineSeparator());
+        }
+        return result.toString();
+    }
+
+    private int maxWidth(int column) {
+        return reportLines.stream()
+                .filter(l -> l.lineType == LineType.LINE)
+                .map(l -> l.getContent(column))
+                .mapToInt(String::length)
+                .max().orElse(1);
+    }
+
+    private int requiredColumns() {
+        int lineMaxWidth = maxWidth(1) + maxWidth(2) + maxWidth(3) + 3 * COL_SPACER;
+        int headerMaxWidth = reportLines.stream()
+                .filter(l -> (l.lineType == LineType.HEADER) || (l.lineType == LineType.SUBHEADER))
+                .mapToInt(ReportLine::getWidth)
+                .max().orElse(1);
+        return Math.max(lineMaxWidth, headerMaxWidth);
+    }
+
+    private int calculationBeginColumn() {
+        return 2 * COL_SPACER + reportLines.stream()
+                .filter(l -> l.lineType == LineType.LINE)
+                .map(l -> l.content1)
+                .mapToInt(String::length)
+                .max().orElse(1);
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/calculationReport/TextCalculationReport.java
+++ b/megamek/src/megamek/client/ui/swing/calculationReport/TextCalculationReport.java
@@ -21,7 +21,6 @@ package megamek.client.ui.swing.calculationReport;
 import javax.swing.*;
 import java.awt.*;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class TextCalculationReport implements CalculationReport {


### PR DESCRIPTION
I noticed that I need to write a conversion report for AlphaStrike conversion. Looking at the BV or cost reports, these are really done per pedes with mountains of stringbuilder.append(ROW_START). I wanted a tool for this, so this is the result and I'd rather add it now than keep it buried in the AS conversion branch.

This consists of an interface "CalculationReport" that writes up ths standard interaction with any of the report classes, such as addLine(String, String, String), addHeader() and so on.
The interface is implemented by four classes. These are:
- HTMLCalculationReport: This creates a report much like it's done now, only without having to use any HTML manually
- SwingCalculationReport: This creates a report using Swing Labels, ready to deploy in a panel or wherever; this is a bit superior to HTML as it knows how wide it wants to be and it is easier to format if any formatting is required. (see screen below)
- TextCalculationReport: This is a pure text report, formatted for display in a monospace font. Good for export (see screen below)
- In addition, there is FlexibleCalculationReport, which internally builds all three of the above and has any of them ready, for example for export to clipboard.

Adding a line to any of the four is the same regardless of which Report type is used (and they can be typed as CalculationReport instead of their class): addLine("Damage:", "2+4+6", " = 12"); Adding any of them to a dialog is simple as they all have a toJComponent() method.

For the examples below, I changed the bv calculation of Mech to the new way (which cuts around 700 lines of code and, I believe, a few bugs along the way). This is not part of the PR as I would need to convert all unit types and thats a lot. Something for later.
The code using it starts with:
bvReport.addHeader("Battle Value Calculations For " + getChassis() + " " + getModel());
bvReport.addSubHeader("Defensive Battle Rating Calculation:");

To switch between these two screenshots I changed only one line:
CalculationReport bvReport = new TextCalculationReport(); <-> CalculationReport bvReport = new SwingCalculationReport();
(and set the font to monospaced for the text)
![image](https://user-images.githubusercontent.com/17069663/155806575-a971df23-74f7-4977-b1ff-67a1ec6d400c.png)
![image](https://user-images.githubusercontent.com/17069663/155808061-baa6ba5d-fa7a-4a09-92c0-96865782fcbd.png)

(There is a bug in the screenshots that has been corrected in the code)
