### PR TITLE
MML Issue 1045: EquipmentType/MiscType updates, constants, data

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -1502,4 +1502,16 @@ public class EquipmentType implements ITechnology {
     public String getSortingName() {
         return (sortingName != null) ? sortingName : name;
     }
+
+    /**
+     * Returns true if this equipment is any of those identified by the given type Strings.
+     * Best use the constants defined in EquipmentTypeLookup.
+     *
+     * @param eType An equipment type to check
+     * @param eTypes More equipment types to check
+     * @return true if the internalName of this equipment matches any of the given types
+     */
+    public boolean isAnyOf(String eType, String... eTypes) {
+        return internalName.equals(eType) || Arrays.asList(eTypes).contains(internalName);
+    }
 }

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -43,206 +43,139 @@ public class EquipmentTypeLookup {
     @Target(ElementType.FIELD)
     public @interface EquipmentName{}
 
-    @EquipmentName
-    public static final String JUMP_JET = "Jump Jet";
-    @EquipmentName
-    public static final String IMPROVED_JUMP_JET = "Improved Jump Jet";
-    @EquipmentName
-    public static final String PROTOTYPE_JUMP_JET = "ISPrototypeJumpJet";
-    @EquipmentName
-    public static final String PROTOTYPE_IMPROVED_JJ = "ISPrototypeImprovedJumpJet";
-    @EquipmentName
-    public static final String MECH_UMU = "UMU";
-    @EquipmentName
-    public static final String MECH_JUMP_BOOSTER = "MechanicalJumpBooster";
-    @EquipmentName
-    public static final String VEHICLE_JUMP_JET = "VehicleJumpJet";
-    @EquipmentName
-    public static final String PROTOMECH_JUMP_JET = "ProtomechJumpJet";
-    @EquipmentName
-    public static final String EXTENDED_JUMP_JET_SYSTEM = "ExtendedJumpJetSystem";
-    @EquipmentName
-    public static final String PROTOMECH_UMU = "ProtomechUMU";
-    @EquipmentName
-    public static final String PROTOMECH_MYOMER_BOOSTER = "CLMyomerBooster";
-    @EquipmentName
-    public static final String BA_JUMP_JET = "BAJumpJet";
-    @EquipmentName
-    public static final String BA_VTOL = "BAVTOL";
-    @EquipmentName
-    public static final String BA_UMU = "BAUMU";
-    @EquipmentName
-    public static final String BA_MYOMER_BOOSTER = "CLBAMyomerBooster";
-    @EquipmentName
-    public static final String BA_PARTIAL_WING = "BAPartialWing";
-    @EquipmentName
-    public static final String BA_JUMP_BOOSTER = "BAJumpBooster";
-    @EquipmentName
-    public static final String BA_MECHANICAL_JUMP_BOOSTER = "BAMechanicalJumpBooster";
+    @EquipmentName public static final String JUMP_JET = "Jump Jet";
+    @EquipmentName public static final String IMPROVED_JUMP_JET = "Improved Jump Jet";
+    @EquipmentName public static final String PROTOTYPE_JUMP_JET = "ISPrototypeJumpJet";
+    @EquipmentName public static final String PROTOTYPE_IMPROVED_JJ = "ISPrototypeImprovedJumpJet";
+    @EquipmentName public static final String MECH_UMU = "UMU";
+    @EquipmentName public static final String MECH_JUMP_BOOSTER = "MechanicalJumpBooster";
+    @EquipmentName public static final String VEHICLE_JUMP_JET = "VehicleJumpJet";
+    @EquipmentName public static final String PROTOMECH_JUMP_JET = "ProtomechJumpJet";
+    @EquipmentName public static final String EXTENDED_JUMP_JET_SYSTEM = "ExtendedJumpJetSystem";
+    @EquipmentName public static final String PROTOMECH_UMU = "ProtomechUMU";
+    @EquipmentName public static final String PROTOMECH_MYOMER_BOOSTER = "CLMyomerBooster";
+    @EquipmentName public static final String BA_JUMP_JET = "BAJumpJet";
+    @EquipmentName public static final String BA_VTOL = "BAVTOL";
+    @EquipmentName public static final String BA_UMU = "BAUMU";
+    @EquipmentName public static final String BA_MYOMER_BOOSTER = "CLBAMyomerBooster";
+    @EquipmentName public static final String BA_PARTIAL_WING = "BAPartialWing";
+    @EquipmentName public static final String BA_JUMP_BOOSTER = "BAJumpBooster";
+    @EquipmentName public static final String BA_MECHANICAL_JUMP_BOOSTER = "BAMechanicalJumpBooster";
 
-    @EquipmentName
-    public static final String SINGLE_HS = "Heat Sink";
-    @EquipmentName
-    public static final String IS_DOUBLE_HS = "ISDoubleHeatSink";
-    @EquipmentName
-    public static final String CLAN_DOUBLE_HS = "CLDoubleHeatSink";
-    @EquipmentName
-    public static final String LASER_HS = "Laser Heat Sink";
-    @EquipmentName
-    public static final String COMPACT_HS_1 = "1 Compact Heat Sink";
-    @EquipmentName
-    public static final String COMPACT_HS_2 = "2 Compact Heat Sinks";
-    @EquipmentName
-    public static final String IS_DOUBLE_HS_PROTOTYPE = "ISDoubleHeatSinkPrototype";
-    @EquipmentName
-    public static final String IS_DOUBLE_HS_FREEZER = "ISDoubleHeatSinkFreezer";
+    @EquipmentName public static final String SINGLE_HS = "Heat Sink";
+    @EquipmentName public static final String IS_DOUBLE_HS = "ISDoubleHeatSink";
+    @EquipmentName public static final String CLAN_DOUBLE_HS = "CLDoubleHeatSink";
+    @EquipmentName public static final String LASER_HS = "Laser Heat Sink";
+    @EquipmentName public static final String COMPACT_HS_1 = "1 Compact Heat Sink";
+    @EquipmentName public static final String COMPACT_HS_2 = "2 Compact Heat Sinks";
+    @EquipmentName public static final String IS_DOUBLE_HS_PROTOTYPE = "ISDoubleHeatSinkPrototype";
+    @EquipmentName public static final String IS_DOUBLE_HS_FREEZER = "ISDoubleHeatSinkFreezer";
 
-    @EquipmentName
-    public static final String HITCH = "Hitch";
-    @EquipmentName
-    public static final String CLAN_CASE = "CLCASE";
-    @EquipmentName
-    public static final String COOLANT_POD = "Coolant Pod";
-    @EquipmentName
-    public static final String MECH_TRACKS = "Tracks";
-    @EquipmentName
-    public static final String QUADVEE_WHEELS = "QuadVee Wheels";
-    @EquipmentName
-    public static final String IM_EJECTION_SEAT = "Ejection Seat (Industrial Mech)";
-    @EquipmentName
-    public static final String TSM = "Triple Strength Myomer";
-    @EquipmentName
-    public static final String SCM = "ISSuperCooledMyomer";
-    @EquipmentName
-    public static final String ITSM = "Industrial Triple Strength Myomer";
-    @EquipmentName
-    public static final String P_TSM = "Prototype TSM";
-    @EquipmentName
-    public static final String IS_MASC = "ISMASC";
-    @EquipmentName
-    public static final String CLAN_MASC = "CLMASC";
-    @EquipmentName
-    public static final String SPONSON_TURRET = "SponsonTurret";
-    @EquipmentName
-    public static final String PINTLE_TURRET = "PintleTurret";
+    @EquipmentName public static final String HITCH = "Hitch";
+    @EquipmentName public static final String CLAN_CASE = "CLCASE";
+    @EquipmentName public static final String COOLANT_POD = "Coolant Pod";
+    @EquipmentName public static final String MECH_TRACKS = "Tracks";
+    @EquipmentName public static final String QUADVEE_WHEELS = "QuadVee Wheels";
+    @EquipmentName public static final String IM_EJECTION_SEAT = "Ejection Seat (Industrial Mech)";
+    @EquipmentName public static final String TSM = "Triple Strength Myomer";
+    @EquipmentName public static final String SCM = "ISSuperCooledMyomer";
+    @EquipmentName public static final String ITSM = "Industrial Triple Strength Myomer";
+    @EquipmentName public static final String P_TSM = "Prototype TSM";
+    @EquipmentName public static final String IS_MASC = "ISMASC";
+    @EquipmentName public static final String CLAN_MASC = "CLMASC";
+    @EquipmentName public static final String SPONSON_TURRET = "SponsonTurret";
+    @EquipmentName public static final String PINTLE_TURRET = "PintleTurret";
 
-    @EquipmentName
-    public static final String AMPHIBIOUS_CHASSIS_MOD = "AmphibiousChassisMod";
-    @EquipmentName
-    public static final String ARMORED_CHASSIS_MOD = "ArmoredChassisMod";
-    @EquipmentName
-    public static final String BICYCLE_CHASSIS_MOD = "BicycleChassisMod";
-    @EquipmentName
-    public static final String CONVERTIBLE_CHASSIS_MOD = "ConvertibleChassisMod";
-    @EquipmentName
-    public static final String DUNE_BUGGY_CHASSIS_MOD = "DuneBuggyChassisMod";
-    @EquipmentName
-    public static final String SV_ENVIRONMENTAL_SEALING_CHASSIS_MOD = "Environmental Sealing";
-    @EquipmentName
-    public static final String EXTERNAL_POWER_PICKUP_CHASSIS_MOD = "ExternalPowerPickupChassisMod";
-    @EquipmentName
-    public static final String HYDROFOIL_CHASSIS_MOD = "HydrofoilChassisMod";
-    @EquipmentName
-    public static final String MONOCYCLE_CHASSIS_MOD = "MonocycleChassisMod";
-    @EquipmentName
-    public static final String OFFROAD_CHASSIS_MOD = "OffroadChassisMod";
-    @EquipmentName
-    public static final String OMNI_CHASSIS_MOD = "OmniChassisMod";
-    @EquipmentName
-    public static final String PROP_CHASSIS_MOD = "PropChassisMod";
-    @EquipmentName
-    public static final String SNOWMOBILE_CHASSIS_MOD = "SnowmobileChassisMod";
-    @EquipmentName
-    public static final String STOL_CHASSIS_MOD = "STOLChassisMod";
-    @EquipmentName
-    public static final String SUBMERSIBLE_CHASSIS_MOD = "SubmersibleChassisMod";
-    @EquipmentName
-    public static final String TRACTOR_CHASSIS_MOD = "TractorChassisMod";
-    @EquipmentName
-    public static final String TRAILER_CHASSIS_MOD = "TrailerChassisMod";
-    @EquipmentName
-    public static final String ULTRALIGHT_CHASSIS_MOD = "UltraLightChassisMod";
-    @EquipmentName
-    public static final String VSTOL_CHASSIS_MOD = "VSTOLChassisMod";
+    @EquipmentName public static final String AMPHIBIOUS_CHASSIS_MOD = "AmphibiousChassisMod";
+    @EquipmentName public static final String ARMORED_CHASSIS_MOD = "ArmoredChassisMod";
+    @EquipmentName public static final String BICYCLE_CHASSIS_MOD = "BicycleChassisMod";
+    @EquipmentName public static final String CONVERTIBLE_CHASSIS_MOD = "ConvertibleChassisMod";
+    @EquipmentName public static final String DUNE_BUGGY_CHASSIS_MOD = "DuneBuggyChassisMod";
+    @EquipmentName public static final String SV_ENVIRONMENTAL_SEALING_CHASSIS_MOD = "Environmental Sealing";
+    @EquipmentName public static final String EXTERNAL_POWER_PICKUP_CHASSIS_MOD = "ExternalPowerPickupChassisMod";
+    @EquipmentName public static final String HYDROFOIL_CHASSIS_MOD = "HydrofoilChassisMod";
+    @EquipmentName public static final String MONOCYCLE_CHASSIS_MOD = "MonocycleChassisMod";
+    @EquipmentName public static final String OFFROAD_CHASSIS_MOD = "OffroadChassisMod";
+    @EquipmentName public static final String OMNI_CHASSIS_MOD = "OmniChassisMod";
+    @EquipmentName public static final String PROP_CHASSIS_MOD = "PropChassisMod";
+    @EquipmentName public static final String SNOWMOBILE_CHASSIS_MOD = "SnowmobileChassisMod";
+    @EquipmentName public static final String STOL_CHASSIS_MOD = "STOLChassisMod";
+    @EquipmentName public static final String SUBMERSIBLE_CHASSIS_MOD = "SubmersibleChassisMod";
+    @EquipmentName public static final String TRACTOR_CHASSIS_MOD = "TractorChassisMod";
+    @EquipmentName public static final String TRAILER_CHASSIS_MOD = "TrailerChassisMod";
+    @EquipmentName public static final String ULTRALIGHT_CHASSIS_MOD = "UltraLightChassisMod";
+    @EquipmentName public static final String VSTOL_CHASSIS_MOD = "VSTOLChassisMod";
     
-    @EquipmentName
-    public static final String LIMB_CLUB = "Limb Club";
-    @EquipmentName
-    public static final String GIRDER_CLUB = "Girder Club";
-    @EquipmentName
-    public static final String TREE_CLUB = "Tree Club";
+    @EquipmentName public static final String LIMB_CLUB = "Limb Club";
+    @EquipmentName public static final String GIRDER_CLUB = "Girder Club";
+    @EquipmentName public static final String TREE_CLUB = "Tree Club";
 
-    @EquipmentName
-    public static final String INFANTRY_ASSAULT_RIFLE = "InfantryAssaultRifle";
-    @EquipmentName
-    public static final String INFANTRY_TAG = "InfantryTAG";
-    @EquipmentName
-    public static final String VIBRO_SHOVEL = "Vibro-Shovel";
-    @EquipmentName
-    public static final String DEMOLITION_CHARGE = "Demolition Charge";
-    @EquipmentName
-    public static final String INFANTRY_AMMO = "Infantry Ammo";
-    @EquipmentName
-    public static final String INFANTRY_INFERNO_AMMO = "Infantry Inferno Ammo";
+    @EquipmentName public static final String INFANTRY_ASSAULT_RIFLE = "InfantryAssaultRifle";
+    @EquipmentName public static final String INFANTRY_TAG = "InfantryTAG";
+    @EquipmentName public static final String VIBRO_SHOVEL = "Vibro-Shovel";
+    @EquipmentName public static final String DEMOLITION_CHARGE = "Demolition Charge";
+    @EquipmentName public static final String INFANTRY_AMMO = "Infantry Ammo";
+    @EquipmentName public static final String INFANTRY_INFERNO_AMMO = "Infantry Inferno Ammo";
 
-    @EquipmentName
-    public static final String AC_BAY = "AC Bay";
-    @EquipmentName
-    public static final String AMS_BAY = "AMS Bay";
-    @EquipmentName
-    public static final String ARTILLERY_BAY = "Artillery Bay";
-    @EquipmentName
-    public static final String AR10_BAY = "AR10 Bay";
-    @EquipmentName
-    public static final String ATM_BAY = "ATM Bay";
-    @EquipmentName
-    public static final String CAPITAL_AC_BAY = "Capital AC Bay";
-    @EquipmentName
-    public static final String CAPITAL_GAUSS_BAY = "Capital Gauss Bay";
-    @EquipmentName
-    public static final String CAPITAL_LASER_BAY = "Capital Laser Bay";
-    @EquipmentName
-    public static final String CAPITAL_MASS_DRIVER_BAY = "Capital Mass Driver Bay";
-    @EquipmentName
-    public static final String CAPITAL_MISSILE_BAY = "Capital Missile Bay";
-    @EquipmentName
-    public static final String CAPITAL_PPC_BAY = "Capital PPC Bay";
-    @EquipmentName
-    public static final String GAUSS_BAY = "Gauss Bay";
-    @EquipmentName
-    public static final String LASER_BAY = "Laser Bay";
-    @EquipmentName
-    public static final String LBX_AC_BAY = "LBX AC Bay";
-    @EquipmentName
-    public static final String LRM_BAY = "LRM Bay";
-    @EquipmentName
-    public static final String MISC_BAY = "Misc Bay";
-    @EquipmentName
-    public static final String MML_BAY = "MML Bay";
-    @EquipmentName
-    public static final String MRM_BAY = "MRM Bay";
-    @EquipmentName
-    public static final String PLASMA_BAY = "Plasma Bay";
-    @EquipmentName
-    public static final String POINT_DEFENSE_BAY = "Point Defense Bay";
-    @EquipmentName
-    public static final String PPC_BAY = "PPC Bay";
-    @EquipmentName
-    public static final String PULSE_LASER_BAY = "Pulse Laser Bay";
-    @EquipmentName
-    public static final String ROCKET_LAUNCHER_BAY = "Rocket Launcher Bay";
-    @EquipmentName
-    public static final String SCC_BAY = "Sub-Capital Cannon Bay";
-    @EquipmentName
-    public static final String SCL_BAY = "Sub-Capital Laser Bay";
-    @EquipmentName
-    public static final String SC_MISSILE_BAY = "Sub-Capital Missile Bay";
-    @EquipmentName
-    public static final String SCREEN_LAUNCHER_BAY = "Screen Launcher Bay";
-    @EquipmentName
-    public static final String SRM_BAY = "SRM Bay";
-    @EquipmentName
-    public static final String TELE_CAPITAL_MISSILE_BAY = "Tele-Operated Capital Missile Bay";
-    @EquipmentName
-    public static final String THUNDERBOLT_BAY = "Thunderbolt Bay";
+    @EquipmentName public static final String AC_BAY = "AC Bay";
+    @EquipmentName public static final String AMS_BAY = "AMS Bay";
+    @EquipmentName public static final String ARTILLERY_BAY = "Artillery Bay";
+    @EquipmentName public static final String AR10_BAY = "AR10 Bay";
+    @EquipmentName public static final String ATM_BAY = "ATM Bay";
+    @EquipmentName public static final String CAPITAL_AC_BAY = "Capital AC Bay";
+    @EquipmentName public static final String CAPITAL_GAUSS_BAY = "Capital Gauss Bay";
+    @EquipmentName public static final String CAPITAL_LASER_BAY = "Capital Laser Bay";
+    @EquipmentName public static final String CAPITAL_MASS_DRIVER_BAY = "Capital Mass Driver Bay";
+    @EquipmentName public static final String CAPITAL_MISSILE_BAY = "Capital Missile Bay";
+    @EquipmentName public static final String CAPITAL_PPC_BAY = "Capital PPC Bay";
+    @EquipmentName public static final String GAUSS_BAY = "Gauss Bay";
+    @EquipmentName public static final String LASER_BAY = "Laser Bay";
+    @EquipmentName public static final String LBX_AC_BAY = "LBX AC Bay";
+    @EquipmentName public static final String LRM_BAY = "LRM Bay";
+    @EquipmentName public static final String MISC_BAY = "Misc Bay";
+    @EquipmentName public static final String MML_BAY = "MML Bay";
+    @EquipmentName public static final String MRM_BAY = "MRM Bay";
+    @EquipmentName public static final String PLASMA_BAY = "Plasma Bay";
+    @EquipmentName public static final String POINT_DEFENSE_BAY = "Point Defense Bay";
+    @EquipmentName public static final String PPC_BAY = "PPC Bay";
+    @EquipmentName public static final String PULSE_LASER_BAY = "Pulse Laser Bay";
+    @EquipmentName public static final String ROCKET_LAUNCHER_BAY = "Rocket Launcher Bay";
+    @EquipmentName public static final String SCC_BAY = "Sub-Capital Cannon Bay";
+    @EquipmentName public static final String SCL_BAY = "Sub-Capital Laser Bay";
+    @EquipmentName public static final String SC_MISSILE_BAY = "Sub-Capital Missile Bay";
+    @EquipmentName public static final String SCREEN_LAUNCHER_BAY = "Screen Launcher Bay";
+    @EquipmentName public static final String SRM_BAY = "SRM Bay";
+    @EquipmentName public static final String TELE_CAPITAL_MISSILE_BAY = "Tele-Operated Capital Missile Bay";
+    @EquipmentName public static final String THUNDERBOLT_BAY = "Thunderbolt Bay";
+    
+    @EquipmentName public static final String BACKHOE = "Backhoe";
+    @EquipmentName public static final String LIGHT_BRIDGE_LAYER = "LightBridgeLayer";
+    @EquipmentName public static final String MEDIUM_BRIDGE_LAYER = "MediumBridgeLayer";
+    @EquipmentName public static final String HEAVY_BRIDGE_LAYER = "HeavyBridgeLayer";
+    @EquipmentName public static final String BULLDOZER = "Bulldozer";
+    @EquipmentName public static final String CHAINSAW = "Chainsaw";
+    @EquipmentName public static final String COMBINE = "Combine";
+    @EquipmentName public static final String DUAL_SAW = "Dual Saw";
+    @EquipmentName public static final String DUMPER_FRONT = "Dumper (Front)";
+    @EquipmentName public static final String DUMPER_REAR = "Dumper (Rear)";
+    @EquipmentName public static final String DUMPER_RIGHT = "Dumper (Right)";
+    @EquipmentName public static final String DUMPER_LEFT = "Dumper (Left)";
+    @EquipmentName public static final String EXTENDED_FUEL_TANK = "Extended Fuel Tank";
+    @EquipmentName public static final String PILE_DRIVER = "Heavy-Duty Pile Driver";
+    @EquipmentName public static final String LADDER = "Ladder";
+    @EquipmentName public static final String LIFT_HOIST = "Lift Hoist/Arresting Hoist";
+    @EquipmentName public static final String MANIPULATOR_INDUSTRIAL = "Manipulator (Non-Mech/Non-Battle Armor)";
+    @EquipmentName public static final String MINING_DRILL = "MiningDrill";
+    @EquipmentName public static final String NAIL_RIVET_GUN = "Nail/Rivet Gun";
+    @EquipmentName public static final String REFUELING_DROGUE = "RefuelingDrogue";
+    @EquipmentName public static final String FLUID_SUCTION_LIGHT_MEK = "Fluid Suction System (Light - Mech)";
+    @EquipmentName public static final String FLUID_SUCTION_LIGHT_VEE = "Fluid Suction System (Light - Vehicle)";
+    @EquipmentName public static final String FLUID_SUCTION = "Fluid Suction System (Standard)";
+    @EquipmentName public static final String ROCK_CUTTER = "Rock Cutter";
+    @EquipmentName public static final String SALVAGE_ARM = "Salvage Arm";
+    @EquipmentName public static final String SPOT_WELDER = "Spot Welder";
+    @EquipmentName public static final String SPRAYER_MEK = "MechSprayer";
+    @EquipmentName public static final String SPRAYER_VEE = "Tank Sprayer";
+    @EquipmentName public static final String WRECKING_BALL = "IS Wrecking Ball";
+
 }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -6830,7 +6830,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Sprayer (Mech)";
-        misc.setInternalName("MechSprayer");
+        misc.setInternalName(EquipmentTypeLookup.SPRAYER_MEK);
         misc.addLookupName("Sprayer [Mech]");
         misc.tonnage = 0.5;
         misc.criticals = 1;
@@ -6852,7 +6852,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Sprayer (Vehicular)";
-        misc.setInternalName("Tank Sprayer");
+        misc.setInternalName(EquipmentTypeLookup.SPRAYER_VEE);
         misc.addLookupName("Sprayer [Vehicular]");
         misc.shortName = "Sprayer";
         misc.tonnage = 0.015;
@@ -7069,7 +7069,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Backhoe";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.BACKHOE);
         misc.tonnage = 5;
         misc.criticals = 6;
         misc.svslots = 1;
@@ -7096,7 +7096,7 @@ public class MiscType extends EquipmentType {
         misc.svslots = 1;
         misc.bv = 5;
         misc.name = "Bridge Layer (Light)";
-        misc.setInternalName("LightBridgeLayer");
+        misc.setInternalName(EquipmentTypeLookup.LIGHT_BRIDGE_LAYER);
         misc.sortingName = "Bridge B";
         misc.flags = misc.flags.or(F_LIGHT_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
@@ -7119,7 +7119,7 @@ public class MiscType extends EquipmentType {
         misc.svslots = 1;
         misc.bv = 10;
         misc.name = "Bridge Layer (Medium)";
-        misc.setInternalName("MediumBridgeLayer");
+        misc.setInternalName(EquipmentTypeLookup.MEDIUM_BRIDGE_LAYER);
         misc.sortingName = "Bridge C";
         misc.flags = misc.flags.or(F_MEDIUM_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
@@ -7142,7 +7142,7 @@ public class MiscType extends EquipmentType {
         misc.svslots = 1;
         misc.bv = 20;
         misc.name = "Bridge Layer (Heavy)";
-        misc.setInternalName("HeavyBridgeLayer");
+        misc.setInternalName(EquipmentTypeLookup.HEAVY_BRIDGE_LAYER);
         misc.sortingName = "Bridge D";
         misc.flags = misc.flags.or(F_HEAVY_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT);
@@ -7163,7 +7163,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.cost = 50000;
         misc.name = "Bulldozer";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.BULLDOZER);
         misc.bv = 10;
         misc.flags = misc.flags.or(F_BULLDOZER).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT);
         misc.industrial = true;
@@ -7181,7 +7181,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Chainsaw";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.CHAINSAW);
         misc.tonnage = 5;
         misc.criticals = 5;
         misc.svslots = 1;
@@ -7204,7 +7204,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Combine";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.COMBINE);
         misc.tonnage = 2.5f;
         misc.criticals = 4;
         misc.svslots = 1;
@@ -7227,7 +7227,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Dual Saw";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.DUAL_SAW);
         misc.tonnage = 7;
         misc.criticals = 7;
         misc.svslots = 1;
@@ -7275,7 +7275,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Dumper (Front)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.DUMPER_FRONT);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.cost = 5000;
@@ -7295,7 +7295,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Dumper (Rear)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.DUMPER_REAR);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.cost = 5000;
@@ -7315,7 +7315,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Dumper (Right)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.DUMPER_RIGHT);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.cost = 5000;
@@ -7335,7 +7335,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Dumper (Left)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.DUMPER_LEFT);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.cost = 5000;
@@ -7354,7 +7354,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createLightFluidSuctionSystemMech() {
         MiscType misc = new MiscType();
         misc.name = "Fluid Suction System (Light - Mech)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.FLUID_SUCTION_LIGHT_MEK);
         misc.addLookupName("Light Fluid Suction System (Mech)");
         misc.criticals = 1;
         misc.tonnage = .5;
@@ -7374,7 +7374,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createLightFluidSuctionSystem() {
         MiscType misc = new MiscType();
         misc.name = "Fluid Suction System (Light - Vehicle)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.FLUID_SUCTION_LIGHT_VEE);
         misc.addLookupName("Light Fluid Suction System (Vehicle)");
         misc.criticals = 1;
         misc.tankslots = 1;
@@ -7396,7 +7396,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createFluidSuctionSystem() {
         MiscType misc = new MiscType();
         misc.name = "Fluid Suction System (Standard)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.FLUID_SUCTION);
         misc.addLookupName("Fluid Suction System");
         misc.addLookupName("Fluid Suction System[Standard]");
         misc.tonnage = TONNAGE_VARIABLE;
@@ -7421,7 +7421,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Heavy-Duty Pile Driver";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.PILE_DRIVER);
         misc.addLookupName("PileDriver");
         misc.addLookupName("Pile Driver");
         misc.tonnage = 10;
@@ -7445,7 +7445,7 @@ public class MiscType extends EquipmentType {
     public static MiscType createLadder() {
         MiscType misc = new MiscType();
         misc.name = "Ladder";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.LADDER);
         misc.addLookupName("Ladder (20m)");
         misc.addLookupName("Ladder (40m)");
         misc.addLookupName("Ladder (60m)");
@@ -7471,7 +7471,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Lift Hoist/Arresting Hoist";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.LIFT_HOIST);
         misc.addLookupName("Lift Hoist");
         misc.tonnage = 3;
         misc.criticals = 3;
@@ -7494,7 +7494,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Manipulator (Non-Mech/Non-Battle Armor)";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.MANIPULATOR_INDUSTRIAL);
         misc.addLookupName("Manipulator");
         misc.addLookupName("Manipulator [Non-Mech/Non-Battle Armor]");
         misc.shortName = "Manipulator";
@@ -7518,7 +7518,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Mining Drill";
-        misc.setInternalName("MiningDrill");
+        misc.setInternalName(EquipmentTypeLookup.MINING_DRILL);
         misc.cost = 10000;
         misc.tonnage = 3.0;
         misc.criticals = 4;
@@ -7545,7 +7545,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = 1;
         misc.cost = 25000;
         misc.name = "Refueling Drogue/Fluid Suction System (Aero)";
-        misc.setInternalName("RefuelingDrogue");
+        misc.setInternalName(EquipmentTypeLookup.REFUELING_DROGUE);
         misc.flags = misc.flags.or(F_REFUELING_DROGUE).or(F_FIGHTER_EQUIPMENT).or(F_VTOL_EQUIPMENT)
                 .or(F_SUPPORT_TANK_EQUIPMENT).or(F_SC_EQUIPMENT);
         misc.industrial = true;
@@ -7563,7 +7563,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Rock Cutter";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.ROCK_CUTTER);
         misc.tonnage = 5;
         misc.criticals = 5;
         misc.svslots = 1;
@@ -7586,7 +7586,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Salvage Arm";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.SALVAGE_ARM);
         misc.addLookupName("SalvageArm");
         misc.tonnage = 3;
         misc.criticals = 2;
@@ -7608,7 +7608,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Spot Welder";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.SPOT_WELDER);
         misc.tonnage = 2;
         misc.criticals = 1;
         misc.cost = 75000;
@@ -7630,7 +7630,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Wrecking Ball";
-        misc.setInternalName("IS Wrecking Ball");
+        misc.setInternalName(EquipmentTypeLookup.WRECKING_BALL);
         misc.addLookupName("WreckingBall");
         misc.addLookupName("Clan Wrecking Ball");
         misc.addLookupName("CLWrecking Ball");
@@ -8209,7 +8209,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Extended Fuel Tank";
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.EXTENDED_FUEL_TANK);
         misc.addLookupName("Extended Fuel Tank (1 ton)");
         misc.addLookupName("Extended Fuel Tank (0.5 tons)");
         misc.addLookupName("Extended Fuel Tank (1.5 tons)");
@@ -9288,8 +9288,6 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createISCVDuneBuggyChassis() {
         MiscType misc = new MiscType();
-        // TODO this is Combat Vee, and SV combined chassis. Their really needs
-        // to be two different chassis types. 
         misc.name = "Combat Vehicle Chassis Mod [Dune Buggy]";
         misc.setInternalName("ISCVDuneBuggyChassis");
         misc.addLookupName("ISCVDuneBuggy");
@@ -9299,7 +9297,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 0;
         misc.tankslots = 0;
         misc.cost = 0; // Cost accounted as part of unit cost
-        misc.flags = misc.flags.or(F_DUNE_BUGGY).or(F_SUPPORT_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION);
+        misc.flags = misc.flags.or(F_DUNE_BUGGY).or(F_TANK_EQUIPMENT).or(F_CHASSIS_MODIFICATION);
         misc.omniFixedOnly = true;
         misc.bv = 0;
         misc.rulesRefs = "303, TO";
@@ -9431,8 +9429,6 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createISSVDuneBuggyChassis() {
         MiscType misc = new MiscType();
-        // TODO this is Combat Vee, and SV combined chassis. Their really needs
-        // to be two different chassis types. 
         misc.name = "SV Chassis Mod [Dune Buggy]";
         misc.shortName = "Dune Buggy";
         misc.setInternalName("ISSVDuneBuggyChassis");

--- a/megamek/src/megamek/common/weapons/autocannons/ISNailandRivetGun.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISNailandRivetGun.java
@@ -13,6 +13,7 @@
  */
 package megamek.common.weapons.autocannons;
 
+import megamek.common.EquipmentTypeLookup;
 /**
  * @author Sebastian Brocks
  */
@@ -22,7 +23,7 @@ public class ISNailandRivetGun extends NailRivetGunWeapon {
     public ISNailandRivetGun() {
         super();
         name = "Nail/Rivet Gun";
-        setInternalName(name);
+        setInternalName(EquipmentTypeLookup.NAIL_RIVET_GUN);
         addLookupName("ISNailRivet Gun");
         addLookupName("ISNail Gun");
         addLookupName("Nail/Rivet Gun");

--- a/megamek/src/megamek/utils/FilteredUnitListTool.java
+++ b/megamek/src/megamek/utils/FilteredUnitListTool.java
@@ -39,7 +39,7 @@ public class FilteredUnitListTool {
         // SV with amphibious chassis:
         // passesFilter = entity.isSupportVehicle() && entity.hasWorkingMisc(MiscType.F_AMPHIBIOUS);
         // --------------------
-        passesFilter = entity.isSupportVehicle() && entity.hasWorkingMisc(MiscType.F_AMPHIBIOUS);
+        passesFilter = entity.isSupportVehicle() && entity.hasWorkingMisc(MiscType.F_DUNE_BUGGY);
 
         // --------------------
         return passesFilter;


### PR DESCRIPTION
Provides the basis for a fixing a few equipment items not showing up in MML.
- Adds internalName constants in EquipmentTypeLookup for industrial equipment
- By way of exception to the rule, I moved the annotations in EquipmentTypeLookup to the same line as the constant to make this less of a waste of space
- Adds the constants to the MiscType definitions of industrial eqp (the internalNames arent changed, just made a constant) as well as the Nail/Rivet Gun which is also an industrial eqp.
- In MiscType, corrects the ISCVDuneBuggy chassis mod to be TANK_EQUIPMENT instead of SUPPORT_TANK and removes the comment on both the CV Dune buggy and SV dune buggy that there is only one eqp for SV and CV and there should be two, because there are, in fact, two.
- and... I accidentally left in the change to the FilteredUnitListTool but I did use it to find out if there is an SV Dune Buggy and in fact there is, the Dromedary Water Transport.

@HammerGS I'd like to note that the rules say that Dune Buggy is only available to CV. Even though there is an official SV... Has this been errata'd? And, I could not find any mention in the rules of a Buzzsaw, yet we have one that points to TM. 