### PR TITLE
Correct Remote Sensor Dispenser BA ammo amount

### DIFF
--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -200,7 +200,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         }
         if ((type instanceof MiscType)
                 && type.hasFlag(MiscType.F_SENSOR_DISPENSER)) {
-            setShotsLeft(30);
+            setShotsLeft(type.hasFlag(MiscType.F_BA_EQUIPMENT) ? 6 : 30);
         }
         if ((type instanceof MiscType)
                 && ((((MiscType) type).isShield() || type


### PR DESCRIPTION
The amount of sensors for a BA type remote dispenser is 6 as per the TechManual p.268 while for the vehicular RD its 30 (TM 236).

