### PR TITLE
PROOF OF CONCEPT: Roll value input to MegaMek

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -1097,6 +1097,22 @@ public class Aero extends Entity implements IAero, IBomber {
                                    int cover) {
         return rollHitLocation(table, side);
     }
+    
+    /**
+     * Rolls up a hit location
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, int aimedLocation, AimingMode aimingMode, int cover, Entity ae) {
+        return rollHitLocation(table, side);
+    }
+    
+    /**
+     * Rolls up a hit location
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, Entity ae) {
+        return rollHitLocation(table, side);
+    }
 
     @Override
     public HitData rollHitLocation(int table, int side) {

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -1230,6 +1230,14 @@ public class Crew implements Serializable {
 
         return Compute.d6(2);
     }
+    
+    public int rollGunnerySkill(Entity ae) {
+        if (getOptions().booleanOption(OptionsConstants.PILOT_APTITUDE_GUNNERY)) {
+            return Compute.d6(3, 2);
+        }
+
+        return Compute.doRoll(Compute.HIT, ae);
+    }
 
     public int rollPilotingSkill() {
         if (getOptions().booleanOption(OptionsConstants.PILOT_APTITUDE_PILOTING)) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3143,13 +3143,24 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * Rolls the to-hit number
      */
-    public abstract HitData rollHitLocation(int table, int side, int aimedLocation,
-                                            AimingMode aimingMode, int cover);
+    public abstract HitData rollHitLocation(int table, int side,
+                                            int aimedLocation, AimingMode aimingMode, int cover);
+    
+    /**
+     * Rolls the to-hit number
+     */
+    public abstract HitData rollHitLocation(int table, int side,
+                                            int aimedLocation, AimingMode aimingMode, int cover, Entity ae);
 
     /**
      * Rolls up a hit location
      */
     public abstract HitData rollHitLocation(int table, int side);
+    
+    /**
+     * Rolls up a hit location
+     */
+    public abstract HitData rollHitLocation(int table, int side, Entity ae);
 
     /**
      * Gets the location that excess damage transfers to. That is, one location

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -704,6 +704,23 @@ public class Infantry extends Entity {
                                    int cover) {
         return rollHitLocation(table, side);
     }
+    
+    /**
+     * Infantry only have one hit location.
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, int aimedLocation,
+            AimingMode aimingMode, int cover, Entity ae) {
+        return rollHitLocation(table, side);
+    }
+    
+    /**
+     * Infantry only have one hit location.
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, Entity ae) {
+        return new HitData(LOC_INFANTRY);
+    }
 
     @Override
     public HitData rollHitLocation(int table, int side) {

--- a/megamek/src/megamek/common/InitiativeRoll.java
+++ b/megamek/src/megamek/common/InitiativeRoll.java
@@ -41,8 +41,8 @@ public class InitiativeRoll implements Comparable<InitiativeRoll>, Serializable 
         wasRollReplaced.removeAllElements();
     }
 
-    public void addRoll(int bonus) {
-        int roll = Compute.d6(2);
+    public void addRoll(int bonus, ITurnOrdered item) {
+        int roll = Compute.doInitRoll(item);
         rolls.addElement(roll);
         originalRolls.addElement(roll);
         bonuses.addElement(bonus);
@@ -63,8 +63,8 @@ public class InitiativeRoll implements Comparable<InitiativeRoll>, Serializable 
      * Replace the previous init roll with a new one, and make a note that it
      * was replaced. Used for Tactical Genius special pilot ability (lvl 3).
      */
-    public void replaceRoll(int bonus) {
-        int roll = Compute.d6(2);
+    public void replaceRoll(int bonus, ITurnOrdered item) {
+        int roll = Compute.doInitRoll(item);
         rolls.setElementAt(roll, size() - 1);
         bonuses.setElementAt(bonus, size() - 1);
         wasRollReplaced.setElementAt(Boolean.TRUE, size() - 1);

--- a/megamek/src/megamek/common/MMRoll.java
+++ b/megamek/src/megamek/common/MMRoll.java
@@ -133,6 +133,17 @@ public class MMRoll extends Roll {
     public int getIntValue() {
         return this.total;
     }
+    
+    /**
+     * Set the value of the roll. This is the total of each of the rolls of each
+     * virtual die.
+     * 
+     * @param value the <code>int</code> value of the roll.
+     */
+    @Override
+    public void setIntValue(int value) {
+        this.total = value;
+    }
 
     /**
      * Get a <code>String</code> containing the roll for each of the virtual

--- a/megamek/src/megamek/common/MMShuffle.java
+++ b/megamek/src/megamek/common/MMShuffle.java
@@ -75,6 +75,18 @@ public class MMShuffle extends Roll {
     public int getIntValue() {
         return this.one + this.two;
     }
+    
+    /**
+     * Set the value of the roll. This is the total of each of the rolls of each
+     * virtual die.
+     * 
+     * @param value the <code>int</code> value of the roll.
+     */
+    @Override
+    public void setIntValue(int value) {
+        this.one = value;
+        this.two = 0;
+    }
 
     /**
      * Get a <code>String</code> containing the roll for each of the virtual

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -2134,19 +2134,43 @@ public abstract class Mech extends Entity {
     public HitData rollHitLocation(int table, int side) {
         return rollHitLocation(table, side, LOC_NONE, AimingMode.NONE, LosEffects.COVER_NONE);
     }
+    
+    /*
+     * (non-Javadoc)
+     *
+     * @see megamek.common.Entity#rollHitLocation(int, int)
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, Entity ae) {
+        return rollHitLocation(table, side, LOC_NONE,
+                AimingMode.NONE, LosEffects.COVER_NONE, ae);
+    }
 
     /*
      * (non-Javadoc)
      *
-     * @see megamek.common.Entity#rollHitLocation(int, int, int, int)
+     * @see megamek.common.Entity#rollHitLocation(int, int, int, int, int)
      */
     @Override
-    public HitData rollHitLocation(int table, int side, int aimedLocation, AimingMode aimingMode,
-                                   int cover) {
+    public HitData rollHitLocation(int table, int side, int aimedLocation,
+            AimingMode aimingMode, int cover) {
+        return rollHitLocation(table, side, LOC_NONE,
+                AimingMode.NONE, LosEffects.COVER_NONE, null);
+    }
+    
+    /*
+     * (non-Javadoc)
+     *
+     * @see megamek.common.Entity#rollHitLocation(int, int, int, int, int, int, int)
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, int aimedLocation,
+            AimingMode aimingMode, int cover, Entity ae) {
         int roll = -1;
 
         if ((aimedLocation != LOC_NONE) && !aimingMode.isNone()) {
-            roll = Compute.d6(2);
+
+            roll = Compute.doRoll(Compute.HIT_LOCATION, ae, this);
 
             if ((5 < roll) && (roll < 9)) {
                 return new HitData(aimedLocation, side == ToHitData.SIDE_REAR, true);
@@ -2154,7 +2178,7 @@ public abstract class Mech extends Entity {
         }
 
         if ((table == ToHitData.HIT_NORMAL) || (table == ToHitData.HIT_PARTIAL_COVER)) {
-            roll = Compute.d6(2);
+            roll = Compute.doRoll(Compute.HIT_LOCATION, ae, this);
             try {
                 PrintWriter pw = PreferenceManager.getClientPreferences().getMekHitLocLog();
                 if (pw != null) {
@@ -2412,7 +2436,7 @@ public abstract class Mech extends Entity {
             }
         }
         if (table == ToHitData.HIT_PUNCH) {
-            roll = Compute.d6(1);
+            roll = Compute.doRoll(Compute.PUNCH_LOCATION, ae, this);
             try {
                 PrintWriter pw = PreferenceManager.getClientPreferences()
                         .getMekHitLocLog();
@@ -2529,7 +2553,7 @@ public abstract class Mech extends Entity {
             }
         }
         if (table == ToHitData.HIT_KICK) {
-            roll = Compute.d6(1);
+            roll = Compute.doRoll(Compute.KICK_LOCATION, ae, this);
             try {
                 PrintWriter pw = PreferenceManager.getClientPreferences()
                         .getMekHitLocLog();

--- a/megamek/src/megamek/common/Protomech.java
+++ b/megamek/src/megamek/common/Protomech.java
@@ -672,6 +672,19 @@ public class Protomech extends Entity {
     public HitData rollHitLocation(int table, int side) {
         return rollHitLocation(table, side, LOC_NONE, AimingMode.NONE, LosEffects.COVER_NONE);
     }
+    
+    @Override
+    public HitData rollHitLocation(int table, int side, Entity ae) {
+        return rollHitLocation(table, side, LOC_NONE,
+                AimingMode.NONE, LosEffects.COVER_NONE);
+    }
+    
+    @Override
+    public HitData rollHitLocation(int table, int side, int aimedLocation,
+            AimingMode aimingMode, int cover, Entity ae) {
+        return rollHitLocation(table, side, aimedLocation,
+                aimingMode, cover);
+    }
 
     @Override
     public HitData rollHitLocation(int table, int side, int aimedLocation, AimingMode aimingMode,

--- a/megamek/src/megamek/common/Roll.java
+++ b/megamek/src/megamek/common/Roll.java
@@ -83,6 +83,14 @@ public abstract class Roll {
     public abstract int getIntValue();
 
     /**
+     * Set the value of the roll. This is the total of each of the rolls of each
+     * virtual die.
+     * 
+     * @param value the <code>int</code> value of the roll.
+     */
+    public abstract void setIntValue(int value);
+    
+    /**
      * Get a <code>String</code> containing the roll for each of the virtual
      * dice.
      * 

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -917,6 +917,16 @@ public class Tank extends Entity {
         }
         return false;
     }
+    
+    /**
+     * Rolls up a hit location
+     */
+    @Override
+    public HitData rollHitLocation(int table, int side, int aimedLocation,
+            AimingMode aimingMode, int cover, Entity ae) {
+        return rollHitLocation(table, side, aimedLocation,
+                aimingMode, cover);
+    }
 
     /**
      * Rolls up a hit location
@@ -1197,6 +1207,12 @@ public class Tank extends Entity {
     @Override
     public HitData rollHitLocation(int table, int side) {
         return rollHitLocation(table, side, LOC_NONE, AimingMode.NONE, LosEffects.COVER_NONE);
+    }
+    
+    @Override
+    public HitData rollHitLocation(int table, int side, Entity ae) {
+        return rollHitLocation(table, side, LOC_NONE,
+                AimingMode.NONE, LosEffects.COVER_NONE);
     }
 
     /**

--- a/megamek/src/megamek/common/TurnOrdered.java
+++ b/megamek/src/megamek/common/TurnOrdered.java
@@ -372,12 +372,12 @@ public abstract class TurnOrdered implements ITurnOrdered {
 
             if (rerollRequests == null) { // normal init roll
                 // add a roll for all teams
-                item.getInitiative().addRoll(bonus);
+                item.getInitiative().addRoll(bonus, item);
             } else {
                 // Resolve Tactical Genius (lvl 3) pilot ability
                 for (ITurnOrdered rerollItem : rerollRequests) {
                     if (item == rerollItem) { // this is the team re-rolling
-                        item.getInitiative().replaceRoll(bonus);
+                        item.getInitiative().replaceRoll(bonus, item);
                         break; // each team only needs one reroll
                     }
                 }

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -283,7 +283,7 @@ public class LRMHandler extends MissileWeaponHandler {
             // treat as a Streak launcher (cluster roll 11) to make this happen
             missilesHit = Compute.missilesHit(rackSize,
                     nMissilesModifier, weapon.isHotLoaded(), true,
-                    isAdvancedAMS());
+                    isAdvancedAMS(), ae);
         } else {
             if (ae instanceof BattleArmor) {
                 missilesHit = Compute.missilesHit(rackSize
@@ -293,7 +293,7 @@ public class LRMHandler extends MissileWeaponHandler {
             } else {
                 missilesHit = Compute.missilesHit(rackSize,
                         nMissilesModifier, weapon.isHotLoaded(), false,
-                        isAdvancedAMS());
+                        isAdvancedAMS(), ae);
             }
         }
 

--- a/megamek/src/megamek/common/weapons/LegAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/LegAttackHandler.java
@@ -107,6 +107,6 @@ public class LegAttackHandler extends WeaponHandler {
         if (ae.hasAbility(OptionsConstants.MISC_HUMAN_TRO,Crew.HUMANTRO_MECH)) {
             critMod += 1;
         }
-        vPhaseReport.addAll(server.criticalEntity(entityTarget, hit.getLocation(), hit.isRear(), critMod, damage));
+        vPhaseReport.addAll(server.criticalEntity(entityTarget, hit.getLocation(), hit.isRear(), critMod, damage, ae));
     }
 }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -250,7 +250,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             // treat as a Streak launcher (cluster roll 11) to make this happen
             missilesHit = Compute.missilesHit(wtype.getRackSize(),
                     nMissilesModifier, weapon.isHotLoaded(), true,
-                    isAdvancedAMS());
+                    isAdvancedAMS(), ae);
         } else {
             if (ae instanceof BattleArmor) {
                 int shootingStrength = 1;
@@ -265,7 +265,7 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             } else {
                 missilesHit = Compute.missilesHit(wtype.getRackSize(),
                         nMissilesModifier, weapon.isHotLoaded(), false,
-                        isAdvancedAMS());
+                        isAdvancedAMS(), ae);
             }
         }
 

--- a/megamek/src/megamek/common/weapons/PopUpMineLauncherHandler.java
+++ b/megamek/src/megamek/common/weapons/PopUpMineLauncherHandler.java
@@ -105,7 +105,7 @@ public class PopUpMineLauncherHandler extends AmmoWeaponHandler {
                         entityTarget,
                         hit.getLocation(), hit.isRear(),
                         entityTarget.getArmorType(hit.getLocation()) == EquipmentType.T_ARMOR_HARDENED ? -2
-                                : 0, 4);
+                                : 0, 4, entityTarget);
 
         // Replace "no effect" results with 4 points of damage.
         if ((specialDamageReport.lastElement()).messageId == 6005) {

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1787,9 +1787,9 @@ public class WeaponHandler implements AttackHandler, Serializable {
         // is this an underwater attack on a surface naval vessel?
         underWater = toHit.getHitTable() == ToHitData.HIT_UNDERWATER;
         if (null != ae.getCrew()) {
-            roll = ae.getCrew().rollGunnerySkill();
+            roll = ae.getCrew().rollGunnerySkill(ae);
         } else {
-            roll = Compute.d6(2);
+            roll = Compute.doRoll(Compute.HIT, ae);
         }
         
         nweapons = getNumberWeapons();
@@ -1814,7 +1814,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
     protected void initHit(Entity entityTarget) {
         hit = entityTarget.rollHitLocation(toHit.getHitTable(),
                 toHit.getSideTable(), waa.getAimedLocation(),
-                waa.getAimingMode(), toHit.getCover());
+                waa.getAimingMode(), toHit.getCover(), ae);
         hit.setGeneralDamageType(generalDamageType);
         hit.setCapital(wtype.isCapital());
         hit.setBoxCars(roll == 12);

--- a/megamek/src/megamek/server/commands/RCommand.java
+++ b/megamek/src/megamek/server/commands/RCommand.java
@@ -1,0 +1,269 @@
+/**
+ * 
+ */
+package megamek.server.commands;
+
+import megamek.common.Entity;
+import megamek.common.Player;
+import megamek.common.Compute;
+import megamek.server.Server;
+
+import java.lang.StringBuffer;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * @author Developer
+ */
+
+public class RCommand extends ServerCommand {
+
+    public static final String[] rollCommands =
+    {
+        "init",
+        "psr",
+        "hit",
+        "cluster",
+        "location",
+        "criticals",
+        "critlocation",
+        "physical",
+        "punch",
+        "kick",
+        "consciousness",
+        "wakeup",
+        "heatshutdown",
+        "heatrestart",
+        "heatexplosion",
+        "facing",
+        "spotlight",
+        "unjam"
+    };
+    
+    public static final String[] rollGroupCommands =
+    {
+        "all",
+        "agoac"
+    };
+    
+    public static final String[] rollGroupDescriptions =
+    {
+        "All",
+        "A Game of Armored Combat"
+    };
+    
+    public static final int NO_GROUP = -1;
+    public static final int ALL_ROLL_GROUPS = 0;
+    public static final int AGOAC_ROLL_GROUP = 1;
+    public static final int NUMBER_OF_ROLL_GROUPS = 2;
+    
+    public static final ArrayList<Integer>[] rollGroups = new ArrayList[]
+    {
+        new ArrayList<Integer>() {{             // ALL_ROLL_GROUPS
+            add(Compute.INITIATIVE); 
+            add(Compute.PILOTING);
+            add(Compute.HIT);
+            add(Compute.CLUSTER);
+            add(Compute.HIT_LOCATION); 
+            add(Compute.DETERMINE_CRITICALS);
+            add(Compute.CRITICAL_LOCATION);
+            add(Compute.PHYSICAL_ATTACK);
+            add(Compute.PUNCH_LOCATION); 
+            add(Compute.KICK_LOCATION);
+            add(Compute.LOSE_CONSCIOUSNESS);
+            add(Compute.REGAIN_CONSCIOUSNESS);
+            add(Compute.HEAT_SHUTDOWN); 
+            add(Compute.HEAT_RESTART);
+            add(Compute.HEAT_AMMO_EXPLOSION);
+            add(Compute.FACING_DIRECTION);
+            add(Compute.SPOTLIGHT_HIT);
+            add(Compute.UNJAM);
+            }},
+        
+        new ArrayList<Integer>() {{             // AGOAC_ROLL_GROUP
+            add(Compute.INITIATIVE); 
+            add(Compute.PILOTING);
+            add(Compute.HIT);
+            add(Compute.CLUSTER);
+            add(Compute.HIT_LOCATION); 
+            add(Compute.DETERMINE_CRITICALS);
+            add(Compute.CRITICAL_LOCATION);
+            add(Compute.PHYSICAL_ATTACK);
+            add(Compute.PUNCH_LOCATION); 
+            add(Compute.KICK_LOCATION);
+            add(Compute.LOSE_CONSCIOUSNESS);
+            add(Compute.REGAIN_CONSCIOUSNESS);
+            add(Compute.HEAT_SHUTDOWN); 
+            add(Compute.HEAT_RESTART);
+            add(Compute.HEAT_AMMO_EXPLOSION);
+            add(Compute.FACING_DIRECTION);
+            }}
+    };
+    
+    public RCommand(Server server) {
+        super(
+                server,
+                "r",
+                "Roll input command. Input n amount of rolls to buffer of last requested manual roll. " +
+                "Usage: /r <roll sum> <roll sum> ... <n times roll sum separated with space>");      
+    }
+
+    /**
+     * Run this command with the arguments supplied
+     * 
+     * @see megamek.server.commands.ServerCommand#run(int, java.lang.String[])
+     */
+    @Override
+    public void run(int connId, String[] args) {
+        Player p = server.getGame().getPlayer(connId);
+        if(null == p) {
+            return;
+        }
+        if (args.length == 1) {
+            // no args
+            server.sendServerChat(connId, "/r [args]: no args given");
+        } else {
+            try {   /* NumberFormatException */
+                
+                int type = Compute.NO_ROLL_TYPE;            
+                for (int i = 0; i < Compute.NUMBER_OF_ROLL_TYPES; i++) {
+                    if (args[1].equalsIgnoreCase(rollCommands[i])) {
+                        type = i;
+                    }
+                }
+                
+                if (type != Compute.NO_ROLL_TYPE)
+                {                
+                    /* Roll toggle getter */
+                    if (args.length == 3) {
+                        if (Compute.GetRollToggle(type, Integer.parseInt(args[2]))) {
+                            server.sendServerChat(connId, "/r id " + Integer.parseInt(args[2]) + ": " + Compute.rollDescriptions[type] + " roll: on");
+                        }
+                        else {
+                            server.sendServerChat(connId, "/r id " + Integer.parseInt(args[2]) + ": " + Compute.rollDescriptions[type] + " roll: off");
+                        }
+                    }
+    
+                    /* Roll toggle setter */
+                    if (args.length == 4) {
+                        if (args[2].equalsIgnoreCase("on")) {
+                            server.sendServerChat(connId, "/r id " + Integer.parseInt(args[3]) + ": " + Compute.rollDescriptions[type] + " roll set on");
+                            Compute.SetRollToggle(type, Integer.parseInt(args[3]), true);
+                        } else if (args[2].equalsIgnoreCase("off")) {
+                            server.sendServerChat(connId, "/r id " + Integer.parseInt(args[3]) + ": " + Compute.rollDescriptions[type] + " roll set off");
+                            Compute.SetRollToggle(type, Integer.parseInt(args[3]), false);
+                        }
+                    }
+                    
+                    return;
+                }
+                
+                int group = NO_GROUP;
+                for (int i = 0; i < NUMBER_OF_ROLL_GROUPS; i++) {
+                    if (args[1].equalsIgnoreCase(rollGroupCommands[i])) {
+                        group = i;
+                    }
+                }
+                
+                if (group != NO_GROUP)
+                {
+                    /* Roll group setter */
+                    if (args.length == 5) {
+                        if (args[2].equalsIgnoreCase("on")) {
+                            server.sendServerChat(connId, "/r player " + Integer.parseInt(args[3]) + ", unit " + Integer.parseInt(args[4]) + ": " + rollGroupDescriptions[group] + " rolls set on");
+
+                            for (int i = 0; i < rollGroups[group].size(); i++) {
+                                if (rollGroups[group].get(i) == Compute.INITIATIVE) {
+                                    Compute.SetRollToggle(rollGroups[group].get(i), Integer.parseInt(args[3]), true);
+                                }
+                                else {
+                                    Compute.SetRollToggle(rollGroups[group].get(i), Integer.parseInt(args[4]), true);
+                                }
+                            }
+                            
+                        } else if (args[2].equalsIgnoreCase("off")) {
+                            server.sendServerChat(connId, "/r player " + Integer.parseInt(args[3]) + " unit " + Integer.parseInt(args[4]) + ": " + rollGroupDescriptions[group] + " rolls set off");
+
+                            for (int i = 0; i < rollGroups[group].size(); i++) {
+                                if (rollGroups[group].get(i) == Compute.INITIATIVE) {
+                                    Compute.SetRollToggle(rollGroups[group].get(i), Integer.parseInt(args[3]), false);
+                                }
+                                else {
+                                    Compute.SetRollToggle(rollGroups[group].get(i), Integer.parseInt(args[4]), false);
+                                }
+                            }
+                        }
+                    }
+                    
+                    return;
+                }
+                
+                if (args[1].equalsIgnoreCase("buffer"))
+                {
+                    /* Roll buffer getter */
+                    if (args.length == 4) {
+                        CopyOnWriteArrayList<Integer> rollBuffer = server.GetRollBuffer(Integer.parseInt(args[2]), Integer.parseInt(args[3]));
+                        if (rollBuffer != null) {
+                            server.sendServerChat(connId, "/r player " + Integer.parseInt(args[2]) + " " + Compute.rollDescriptions[Integer.parseInt(args[3])] + " roll buffer: " + rollBuffer);
+                        }
+                        else {
+                            server.sendServerChat(connId, "/r player " + Integer.parseInt(args[2]) + " " + Compute.rollDescriptions[Integer.parseInt(args[3])] + " roll buffer empty");
+                        }
+                    }
+                }
+                if (args[1].equalsIgnoreCase("verbose"))
+                {
+                    /* Roll verbose mode setter */
+                    if (args.length == 3) {
+                        if (args[2].equalsIgnoreCase("on")) {
+                            Compute.SetVerboseMode(true);
+                            server.sendServerChat(connId, "/r verbose rolls on");
+                        }
+                        else if (args[2].equalsIgnoreCase("off")) {
+                            Compute.SetVerboseMode(false);
+                            server.sendServerChat(connId, "/r verbose rolls off");
+                        }
+                    }
+                }
+                if (args[1].equalsIgnoreCase("input"))
+                {
+                    /* Roll input player id setter */
+                    if (args.length == 3) {
+                        Compute.SetRollInputPlayer(Integer.parseInt(args[2]));
+                        server.sendServerChat(connId, "/r roll input player set to " + Integer.parseInt(args[2]));
+                    }
+                }
+                else if (args[1].equalsIgnoreCase("help") || args[1].equalsIgnoreCase("rolls") || args[1].equalsIgnoreCase("groups"))
+                {
+                    /* Print all roll commands and roll group commands */
+                    
+                    StringBuffer rollsSB = new StringBuffer();
+                    String delimiter = "";
+                    for(int i = 0; i < rollCommands.length; i++) {
+                        rollsSB.append(delimiter);
+                        rollsSB.append(rollCommands[i]);
+                        delimiter = ", ";
+                    }
+                    
+                    StringBuffer rollGroupsSB = new StringBuffer();
+                    delimiter = "";
+                    for(int i = 0; i < rollGroupCommands.length; i++) {
+                        rollGroupsSB.append(delimiter);
+                        rollGroupsSB.append(rollGroupCommands[i]);
+                        delimiter = ", ";
+                    }
+                    
+                    server.sendServerChat(connId, "/r roll commands: " + rollsSB.toString() + ". Roll groups: " + rollGroupsSB.toString());
+                }
+                else
+                {
+                    /* Roll buffer input */
+                    for (int i = 1; i < args.length; i++) {
+                        server.SetRollBufferInt(Compute.GetActiveRollType(), Compute.GetActiveRollPlayer(), Integer.parseInt(args[i]));
+                    }
+                }
+            } catch(NumberFormatException e) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request is here simply for giving feedback and to make the feature available for tinkering. The functionality works, but code quality and testing lacks - there might be bugs.

This Proof of Concept is for a feature that allows selecting rolls that require manual input from player, instead of using computer RNG. The feature can be toggled on separately for each different roll type and for each player/unit. During the game the server will pause and inform player what rolls must be manually entered. Command '/r' is used to enter the roll values. Command '/r' was chosen to be as short as possible, to make entering values from command line as fast as possible.
    
Currently supports all roll types from A Game Of Armored Combat. Initiative roll, Hit roll, Location roll, Cluster roll and so on. In future I would like to expand this list to include Total Warfare ground vehicles and infantry, and Aerospace from TW and Strategic Operations.

Forum thread:
https://bg.battletech.com/forums/megamek-games/my-megamek-proof-of-concept-features-thread/