### PR TITLE
Hiddenunits

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -3883,6 +3883,11 @@ ReplacePlayersDialog.config=Bot Settings...
 #Point Blank Shot Dialog
 StatusBarPhaseDisplay.pointblankShot=Pointblank shot from a hidden unit!
 
+#Unhide Hidden Dialog
+StatusBarPhaseDisplay.AllPlayersUnhideHidden=Players are revealing hidden units
+StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.title=Reveal Hidden Units
+StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.message=The following units are currently hidden\nSelect any units you wish to reveal this phase
+
 #Force Generator Dialog
 ForceGeneratorDialog.title=Force Generator
 ForceGeneratorDialog.year=Year:

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -44,6 +44,7 @@ import megamek.common.util.SerializationHelper;
 import megamek.common.util.StringUtil;
 import megamek.server.Server;
 import megamek.server.SmokeCloud;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 
 import javax.imageio.ImageIO;
@@ -512,6 +513,25 @@ public class Client implements IClientCommandHandler {
         Object[] data = new Object[1];
         data[0] = entityIds;
         send(new Packet(Packet.COMMAND_UNLOAD_STRANDED, data));
+    }
+
+
+    /**
+     * Can I unhide entities?
+     */
+    public boolean canUnhideHidden() {
+        return (game.getTurn() instanceof GameTurn.UnhideHiddenTurn)
+                && game.getTurn().isValid(localPlayerNumber, game);
+    }
+
+    /**
+     * Send command to unload stranded entities to the server
+     */
+    public void sendUnhideHidden(int[] entityIds) {
+        Object[] data = new Object[1];
+        data[0] = entityIds;
+//        throw new NotImplementedException("sendUnhideHidden");
+        send(new Packet(Packet.COMMAND_UNHIDE_HIDDEN, data));
     }
 
     /**

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -530,7 +530,6 @@ public class Client implements IClientCommandHandler {
     public void sendUnhideHidden(int[] entityIds) {
         Object[] data = new Object[1];
         data[0] = entityIds;
-//        throw new NotImplementedException("sendUnhideHidden");
         send(new Packet(Packet.COMMAND_UNHIDE_HIDDEN, data));
     }
 

--- a/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
+++ b/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
@@ -1033,7 +1033,8 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
 
         @Override
         public Class<?> getColumnClass(int c) {
-            return getValueAt(0, c).getClass();
+            Object obj = getValueAt(0, c);
+            return obj == null ? null : obj.getClass();
         }
 
         @Override

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -2144,19 +2144,37 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements ItemListener
 
         if (clientgui.getClient().getGame().getPhase() == GamePhase.FIRING) {
             if (clientgui.getClient().isMyTurn()) {
-                if (cen == Entity.NONE) {
+                if (clientgui.getClient().canUnhideHidden()) {
+                    unhideHidden();
+                } else if (cen == Entity.NONE) {
                     beginMyTurn();
                 }
                 setStatusBarText(Messages.getString("FiringDisplay.its_your_turn"));
             } else {
                 endMyTurn();
-                String playerName;
-                if (e.getPlayer() != null) {
-                    playerName = e.getPlayer().getName();
+                if ((e.getPlayer() == null)
+                        && ((clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnloadStrandedTurn)
+                        || (clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnhideHiddenTurn))) {
+                    setStatusBarText(Messages
+                            .getString("FiringDisplay.waitForAnother"));
                 } else {
-                    playerName = "Unknown";
+                    String playerName;
+                    if (e.getPlayer() != null) {
+                        playerName = e.getPlayer().getName();
+                    } else {
+                        playerName = "Unknown";
+                    }
+                    setStatusBarText(Messages.getString(
+                            "FiringDisplay.its_others_turn",
+                            new Object[] { playerName }));
                 }
-                setStatusBarText(Messages.getString("FiringDisplay.its_others_turn", playerName));
+//                String playerName;
+//                if (e.getPlayer() != null) {
+//                    playerName = e.getPlayer().getName();
+//                } else {
+//                    playerName = "Unknown";
+//                }
+//                setStatusBarText(Messages.getString("FiringDisplay.its_others_turn", playerName));
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -2145,7 +2145,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements ItemListener
         if (clientgui.getClient().getGame().getPhase() == GamePhase.FIRING) {
             if (clientgui.getClient().isMyTurn()) {
                 if (clientgui.getClient().canUnhideHidden()) {
-                    unhideHidden();
+                    unhideHidden(GamePhase.FIRING);
                 } else if (cen == Entity.NONE) {
                     beginMyTurn();
                 }
@@ -2153,8 +2153,7 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements ItemListener
             } else {
                 endMyTurn();
                 if ((e.getPlayer() == null)
-                        && ((clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnloadStrandedTurn)
-                        || (clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnhideHiddenTurn))) {
+                        && (clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnhideHiddenTurn)) {
                     setStatusBarText(Messages
                             .getString("FiringDisplay.waitForAnother"));
                 } else {

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -2168,13 +2168,6 @@ public class FiringDisplay extends StatusBarPhaseDisplay implements ItemListener
                             "FiringDisplay.its_others_turn",
                             new Object[] { playerName }));
                 }
-//                String playerName;
-//                if (e.getPlayer() != null) {
-//                    playerName = e.getPlayer().getName();
-//                } else {
-//                    playerName = "Unknown";
-//                }
-//                setStatusBarText(Messages.getString("FiringDisplay.its_others_turn", playerName));
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -493,6 +493,13 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             return;
         }
 
+        //TMP wait for database to finish loading
+        try {
+            Thread.sleep(8000);
+        } catch (InterruptedException ex ){
+            return;
+        }
+
         client = new Client(playerName, serverAddress, port);
         ClientGUI gui = new ClientGUI(client, controller);
         controller.clientgui = gui;

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2511,7 +2511,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
     
     private void updateConvertModeButton() {
 
-        if (cmd.length() > 0 && cmd.getLastStep().getType() != MoveStepType.CONVERT_MODE) {
+        if ( (cmd == null) ||
+                (cmd.length() > 0) && (cmd.getLastStep().getType() != MoveStepType.CONVERT_MODE)) {
             setModeConvertEnabled(false);
             return;
         }
@@ -4254,7 +4255,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         if (isIgnoringEvents()) {
             return;
         }
-        // On simultaneous phases, each player ending their turn will generalte a turn change
+        // On simultaneous phases, each player ending their turn will generate a turn change
         // We want to ignore turns from other players and only listen to events we generated
         // Except on the first turn
         if (clientgui.getClient().getGame().getPhase().isSimultaneous(clientgui.getClient().getGame())
@@ -4263,9 +4264,11 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             return;
         }
         
-        // if all our entities are actually done, don't start up the turn.
+        // if all our entities are actually done and not hidden, don't start up the turn.
         if (clientgui.getClient().getGame().getPlayerEntities(clientgui.getClient().getLocalPlayer(), false)
-                .stream().allMatch(Entity::isDone)) {
+                .stream().allMatch(Entity::isDone) &&
+                !clientgui.getClient().getGame().getPlayerEntities(clientgui.getClient().getLocalPlayer(), false)
+                        .stream().anyMatch(Entity::isHidden)) {
             return;
         }
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4281,8 +4281,6 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             // Can the player unload entities stranded on immobile transports?
             if (clientgui.getClient().canUnloadStranded()) {
                 unloadStranded();
-            } else if (clientgui.getClient().canUnhideHidden()) {
-                unhideHidden(GamePhase.MOVEMENT);
             } else if (cen == Entity.NONE) {
                 beginMyTurn();
             }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4278,13 +4278,16 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             // Can the player unload entities stranded on immobile transports?
             if (clientgui.getClient().canUnloadStranded()) {
                 unloadStranded();
+            } else if (clientgui.getClient().canUnhideHidden()) {
+                unhideHidden();
             } else if (cen == Entity.NONE) {
                 beginMyTurn();
             }
         } else {
             endMyTurn();
             if ((e.getPlayer() == null)
-                    && (clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnloadStrandedTurn)) {
+                    && ((clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnloadStrandedTurn)
+            || (clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnhideHiddenTurn))) {
                 setStatusBarText(Messages
                         .getString("MovementDisplay.waitForAnother"));
             } else {

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4282,7 +4282,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             if (clientgui.getClient().canUnloadStranded()) {
                 unloadStranded();
             } else if (clientgui.getClient().canUnhideHidden()) {
-                unhideHidden();
+                unhideHidden(GamePhase.MOVEMENT);
             } else if (cen == Entity.NONE) {
                 beginMyTurn();
             }

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -33,6 +33,7 @@ import megamek.common.Entity;
 import megamek.common.EntitySelector;
 import megamek.common.Game;
 import megamek.common.GameTurn;
+import megamek.common.enums.GamePhase;
 import megamek.common.preference.*;
 
 /**
@@ -206,7 +207,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
     /**
      * Give the player the opportunity to unhide all entities that are hidden
      */
-    protected void unhideHidden() {
+    protected void unhideHidden(GamePhase phase) {
         Vector<Entity> hidden = new Vector<>();
         String[] names = null;
         Entity entity = null;
@@ -243,7 +244,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
 
         // Show the choices to the player
         int[] indexes = clientgui.doChoiceDialog(
-                Messages.getString("StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.title"),
+                phase.toString()+" "+Messages.getString("StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.title"),
                 Messages.getString("StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.message"),
                 names);
 

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -212,7 +212,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         Entity entity = null;
 
         // Let the player know what's going on.
-        setStatusBarText(Messages.getString("MovementDisplay.AllPlayersUnload"));
+        setStatusBarText(Messages.getString("StatusBarPhaseDisplay.AllPlayersUnhideHidden"));
 
         // Collect the stranded entities into the vector.
         Iterator<Entity> entities = clientgui.getClient().getSelectedEntities(
@@ -243,8 +243,8 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
 
         // Show the choices to the player
         int[] indexes = clientgui.doChoiceDialog(
-                Messages.getString("MovementDisplay.UnloadStrandedUnitsDialog.title"),
-                Messages.getString("MovementDisplay.UnloadStrandedUnitsDialog.message"),
+                Messages.getString("StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.title"),
+                Messages.getString("StatusBarPhaseDisplay.UnhideHiddenUnitsDialog.message"),
                 names);
 
         // Convert the indexes into selected entity IDs and tell the server.

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -1333,19 +1333,30 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
         if (clientgui.getClient().getGame().getPhase() == phase) {
 
             if (clientgui.getClient().isMyTurn()) {
-                if (cen == Entity.NONE) {
+                if (clientgui.getClient().canUnhideHidden()) {
+                    unhideHidden(phase);
+                } else if (cen == Entity.NONE) {
                     beginMyTurn();
                 }
                 setStatusBarText(Messages
                         .getString("TargetingPhaseDisplay.its_your_turn"));
             } else {
                 endMyTurn();
-                if (e.getPlayer() != null) {
+                if ((e.getPlayer() == null)
+                        && (clientgui.getClient().getGame().getTurn() instanceof GameTurn.UnhideHiddenTurn)) {
+                    setStatusBarText(Messages
+                            .getString("FiringDisplay.waitForAnother"));
+                } else {
+                    String playerName;
+                    if (e.getPlayer() != null) {
+                        playerName = e.getPlayer().getName();
+                    } else {
+                        playerName = "Unknown";
+                    }
                     setStatusBarText(Messages.getString(
                             "TargetingPhaseDisplay.its_others_turn",
-                            e.getPlayer().getName()));
+                            new Object[] { playerName }));
                 }
-
             }
         }
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9870,9 +9870,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             return false;
         }
 
-        // Hidden units shouldn't be counted for turn order, unless deploying
-        if (isHidden() && phase != GamePhase.DEPLOYMENT
-                && phase != GamePhase.FIRING) {
+        // Hidden units shouldn't be counted for turn order, unless deploying or unhidable
+        if (isHidden() && (phase != GamePhase.DEPLOYMENT)
+                && (phase != GamePhase.TARGETING)
+                && (phase != GamePhase.MOVEMENT)
+                && (phase != GamePhase.FIRING)) {
             return false;
         }
 
@@ -9927,6 +9929,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * or sprinting.
      */
     public boolean isEligibleForFiring() {
+        
+        if (isHidden()) {
+            return true;
+        }
+
         // if you're charging, no shooting
         if (isUnjammingRAC() || isCharging() || isMakingDfa() || isRamming()) {
             return false;
@@ -10149,6 +10156,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if (isAssaultDropInProgress()) {
             return false;
         }
+
+        if (isHidden()) {
+            return true;
+        }
+
         for (Mounted mounted : getWeaponList()) {
             WeaponType wtype = (WeaponType) mounted.getType();
             if ((wtype != null) && (wtype.hasFlag(WeaponType.F_ARTILLERY))) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9870,10 +9870,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             return false;
         }
 
-        // Hidden units shouldn't be counted for turn order, unless deploying or unhidable
+        // Hidden units shouldn't be counted for turn order, unless deploying
         if (isHidden() && (phase != GamePhase.DEPLOYMENT)
-                && (phase != GamePhase.TARGETING)
-                && (phase != GamePhase.MOVEMENT)
                 && (phase != GamePhase.FIRING)) {
             return false;
         }
@@ -9929,11 +9927,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * or sprinting.
      */
     public boolean isEligibleForFiring() {
-        
-        if (isHidden()) {
-            return true;
-        }
-
         // if you're charging, no shooting
         if (isUnjammingRAC() || isCharging() || isMakingDfa() || isRamming()) {
             return false;
@@ -10155,10 +10148,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public boolean isEligibleForTargetingPhase() {
         if (isAssaultDropInProgress()) {
             return false;
-        }
-
-        if (isHidden()) {
-            return true;
         }
 
         for (Mounted mounted : getWeaponList()) {

--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -506,6 +506,138 @@ public class GameTurn implements Serializable {
     }
 
     /**
+     * A type of game turn that indicates that one or more players should be given the opportunity
+     * to unload entities that are stranded on immobile transports. Each player declares which
+     * stranded units they will unload at the beginning of the movement phase, without being told
+     * what stranded units their opponent(s) are unloading.
+     * <p>
+     * According to
+     * <a href="http://www.classicbattletech.com/w3t/showflat.php?Cat=&Board=ask&Number=555466&page=2&view=collapsed&sb=5&o=0&fpart=">Randall Bills</a>,
+     * the "minimum move" rule allow stranded units to dismount at the start of the turn.
+     */
+    public static class UnhideHiddenTurn extends GameTurn {
+        //TODO needs real uid
+        private static final long serialVersionUID = 2403095752423407872L;
+        private int[] entityIds;
+
+        /**
+         * Any player that owns an entity whose ID is in the passed array should be given a chance
+         * to unload it.
+         *
+         * @param ids the array of <code>int</code> IDs of stranded entities. This value must not be
+         *           <code>null</code> or empty.
+         * @throws IllegalArgumentException if a <code>null</code> or empty value is passed for ids.
+         */
+        public UnhideHiddenTurn(int... ids) {
+            super(Player.PLAYER_NONE);
+
+            // Validate input.
+            if (ids == null) {
+                throw new IllegalArgumentException("the passed array of ids is null");
+            } else if (ids.length == 0) {
+                throw new IllegalArgumentException("the passed array of ids is empty");
+            }
+
+            // Create a copy of the array to prevent any post-call shenanigans.
+            entityIds = new int[ids.length];
+            System.arraycopy(ids, 0, entityIds, 0, ids.length);
+        }
+
+        /**
+         * Any player that owns an entity in the passed enumeration should be given a chance to
+         * unload it.
+         *
+         * @param entities the <code>Enumeration</code> of stranded entities. This value must not be
+         *                <code>null</code> or empty.
+         * @throws IllegalArgumentException if a <code>null</code> or empty value is passed for
+         * entities.
+         */
+        public UnhideHiddenTurn(Iterator<Entity> entities) {
+            super(Player.PLAYER_NONE);
+
+            // Validate input.
+            if (entities == null) {
+                throw new IllegalArgumentException("the passed enumeration of entities is null");
+            } else if (!entities.hasNext()) {
+                throw new IllegalArgumentException("the passed enumeration of entities is empty");
+            }
+
+            // Get the first entity.
+            Entity entity = entities.next();
+
+            // Do we need to get more entities?
+            if (entities.hasNext()) {
+                // It's a bit of a hack, but get the Game from the first/ entity, and create a
+                // temporary array that can hold the IDs of every entity in the game.
+                int[] ids = new int[entity.game.getNoOfEntities()];
+                int length = 0;
+
+                // Store the first entity's ID.
+                ids[length++] = entity.getId();
+
+                // Walk the list of remaining stranded entities.
+                while (entities.hasNext()) {
+                    ids[length++] = entities.next().getId();
+                }
+
+                // Create an array that just holds the stranded entity ids.
+                entityIds = new int[length];
+                System.arraycopy(ids, 0, entityIds, 0, length);
+            } else {
+                // There was only one stranded entity.
+                entityIds = new int[1];
+                entityIds[0] = entity.getId();
+            }
+        }
+
+        public int[] getEntityIds() {
+            return entityIds;
+        }
+
+        /**
+         * Determine if the given entity is a valid one to use for this turn.
+         *
+         * @param entity the <code>Entity</code> being tested for the move.
+         * @param game The {@link Game} the entity belongs to
+         * @return <code>true</code> if the entity can be moved.
+         */
+        @Override
+        public boolean isValidEntity(final @Nullable Entity entity, final Game game) {
+            // Null entities don't need to be checked.
+            if (entity == null) {
+                return false;
+            }
+
+            // Check if any entity in the array is valid.
+            final int entityId = entity.getId();
+            return IntStream.range(0, entityIds.length).anyMatch(index -> entityId == entityIds[index]);
+        }
+
+        /**
+         * @return true if the player and entity are both valid.
+         */
+        @Override
+        public boolean isValid(final int playerId, final @Nullable Entity entity, final Game game) {
+            return isValidEntity(entity, game) && (entity.getOwnerId() == playerId);
+        }
+
+        /**
+         * @return true if the player is valid.
+         */
+        @Override
+        public boolean isValid(int playerId, Game game) {
+            return IntStream.range(0, entityIds.length)
+                    .anyMatch(index -> (game.getEntity(entityIds[index]) != null)
+                            && (playerId == game.getEntity(entityIds[index]).getOwnerId()));
+        }
+
+        @Override
+        public String toString() {
+            return super.toString() + ", entity IDs: [" + Arrays.toString(entityIds) + ']';
+        }
+    }
+
+    /**
      * A type of game turn that allows only entities belonging to certain units to move.
      */
     public static class UnitNumberTurn extends GameTurn {

--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -506,14 +506,10 @@ public class GameTurn implements Serializable {
     }
 
     /**
-     * A type of game turn that indicates that one or more players should be given the opportunity
-     * to unload entities that are stranded on immobile transports. Each player declares which
-     * stranded units they will unload at the beginning of the movement phase, without being told
-     * what stranded units their opponent(s) are unloading.
-     * <p>
-     * According to
-     * <a href="http://www.classicbattletech.com/w3t/showflat.php?Cat=&Board=ask&Number=555466&page=2&view=collapsed&sb=5&o=0&fpart=">Randall Bills</a>,
-     * the "minimum move" rule allow stranded units to dismount at the start of the turn.
+     * indicates that one or more players should be given the opportunity
+     * to unhide hidden entities. Each player declares which
+     * hidden units they will unhide at the beginning of the phase, without being told
+     * what hidden units their opponent(s) are unhiding..
      */
     public static class UnhideHiddenTurn extends GameTurn {
         //TODO needs real UID
@@ -522,9 +518,9 @@ public class GameTurn implements Serializable {
 
         /**
          * Any player that owns an entity whose ID is in the passed array should be given a chance
-         * to unload it.
+         * to unhide it.
          *
-         * @param ids the array of <code>int</code> IDs of stranded entities. This value must not be
+         * @param ids the array of <code>int</code> IDs of hidden entities. This value must not be
          *           <code>null</code> or empty.
          * @throws IllegalArgumentException if a <code>null</code> or empty value is passed for ids.
          */
@@ -545,9 +541,9 @@ public class GameTurn implements Serializable {
 
         /**
          * Any player that owns an entity in the passed enumeration should be given a chance to
-         * unload it.
+         * unhide it.
          *
-         * @param entities the <code>Enumeration</code> of stranded entities. This value must not be
+         * @param entities the <code>Enumeration</code> of hidden entities. This value must not be
          *                <code>null</code> or empty.
          * @throws IllegalArgumentException if a <code>null</code> or empty value is passed for
          * entities.

--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -516,8 +516,8 @@ public class GameTurn implements Serializable {
      * the "minimum move" rule allow stranded units to dismount at the start of the turn.
      */
     public static class UnhideHiddenTurn extends GameTurn {
-        //TODO needs real uid
-        private static final long serialVersionUID = 2403095752423407872L;
+        //TODO needs real UID
+        private static final long serialVersionUID = 6667777111L;
         private int[] entityIds;
 
         /**

--- a/megamek/src/megamek/common/actions/UnhideHiddenAction.java
+++ b/megamek/src/megamek/common/actions/UnhideHiddenAction.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package megamek.common.actions;
+
+/**
+ * Concrete implementation of and entity action for unhiding hidden entities
+ * <code>Enity.NONE</code> <em>is</em> a valid value for entityId.
+ */
+public class UnhideHiddenAction extends AbstractEntityAction {
+    /**
+     *
+     */
+    private static final long serialVersionUID = -8319076127334875298L;
+    private int playerId;
+
+    public UnhideHiddenAction(int playerId, int entityId) {
+        super(entityId);
+        this.playerId = playerId;
+    }
+
+    public int getPlayerId() {
+        return playerId;
+    }
+}

--- a/megamek/src/megamek/common/net/Packet.java
+++ b/megamek/src/megamek/common/net/Packet.java
@@ -101,6 +101,7 @@ public class Packet {
 
     public static final int COMMAND_REROLL_INITIATIVE = 440;
     public static final int COMMAND_UNLOAD_STRANDED = 450;
+    public static final int COMMAND_UNHIDE_HIDDEN = 455;
 
     public static final int COMMAND_SET_ARTILLERY_AUTOHIT_HEXES = 460;
     public static final int COMMAND_SENDING_ARTILLERYATTACKS = 470;

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -3323,6 +3323,7 @@ public class Server implements Runnable {
     private Vector<GameTurn> checkTurnOrderStrandedOrHidden(TurnVectors team_order) {
         Vector<GameTurn> turns = new Vector<>(team_order.getTotalTurns()
                 + team_order.getEvenTurns());
+
         // Stranded units only during movement phases, rebuild the turns vector
         if (game.getPhase() == GamePhase.MOVEMENT) {
             // See if there are any loaded units stranded on immobile transports.
@@ -3337,7 +3338,7 @@ public class Server implements Runnable {
         }
 
         // Hidden units only during movement and fire phases, rebuild the turns vector
-        if ((game.getPhase() == GamePhase.MOVEMENT) || (game.getPhase() == GamePhase.FIRING)) {
+        if ((game.getPhase() == GamePhase.MOVEMENT) || (game.getPhase() == GamePhase.FIRING) || (game.getPhase() == GamePhase.TARGETING) ) {
             // See if there are any loaded units stranded on immobile transports.
             Iterator<Entity> hiddenUnits = game.getSelectedEntities(
                     entity -> entity.isHidden());
@@ -3523,7 +3524,8 @@ public class Server implements Runnable {
         // N.B. ProtoMechs declare weapons fire based on their point.
         for (Iterator<Entity> loop = game.getEntities(); loop.hasNext();) {
             final Entity entity = loop.next();
-            if (entity.isSelectableThisTurn()) {
+            boolean isSelectable = entity.isSelectableThisTurn();
+            if (isSelectable) {
                 final Player player = entity.getOwner();
                 if ((entity instanceof SpaceStation)
                         && ((game.getPhase() == GamePhase.MOVEMENT)
@@ -32955,7 +32957,7 @@ public class Server implements Runnable {
         Entity entity;
 
         // Is this the right phase?
-        if ((game.getPhase() != GamePhase.MOVEMENT) && (game.getPhase() != GamePhase.FIRING)) {
+        if ((game.getPhase() != GamePhase.TARGETING) && (game.getPhase() != GamePhase.MOVEMENT) && (game.getPhase() != GamePhase.FIRING)) {
             LogManager.getLogger().error("Server got unhide hidden packet in wrong phase "+game.getPhase());
             return;
         }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -52,6 +52,7 @@ import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.other.TSEMPWeapon;
 import megamek.server.commands.*;
 import megamek.server.victory.VictoryResult;
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 
 import java.io.*;
@@ -32975,7 +32976,7 @@ public class Server implements Runnable {
             return;
         }
 
-        // Did the player already send an 'unload' request?
+        // Did the player already send an 'unhide' request?
         // N.B. we're also building the list of players who
         // have declared their "unload stranded" actions.
         declared = new Vector<>();
@@ -33054,6 +33055,7 @@ public class Server implements Runnable {
                     // Unload the entity. Get the unit's transporter.
                     entity.setHidden(false);
                     //TODO may need to unset hiding phase
+                    LogManager.getLogger().error("TODO - update other clients, may need to unset hiding phase");
                 }
             }
 


### PR DESCRIPTION
**DRAFT** - but comments welcome
This addresses https://github.com/MegaMek/megamek/issues/3400
It uses the pattern established by UnloadStrandedGameTurn to insert an UnhideHiddenGameTurn turn at the beginning of the turn order vector for TargetingPhase (for reveal during for Movement) and OffboardPhase (for reveal during FiringPhase.) This pops up a dialog where the user can unhide any units before regular play continues.


**Minor Issues:**
Needs more testing overall.
Need to make sure does not conflict with the old way of revealing by using the unit inspector, including resetting the reveal phase property. 
Client displays do not show unhidden units until one more turn has happened (need to figure out how to push the updated info to clients.)
Need to test with bots to make sure it doesn't hang them up. Not expecting them to use it correctly. ;)
Popup dialog is ugly.