### PR TITLE
MML Issue 567: Disallow Commercial Armor for BattleMeks

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -85,37 +85,39 @@ public class TestMech extends TestEntity {
      * @return
      */
     public static List<EquipmentType> legalArmorsFor(long etype, boolean industrial, ITechManager techManager) {
-        List<EquipmentType> retVal = new ArrayList<>();
+        List<EquipmentType> legalArmors = new ArrayList<>();
         boolean industrialOnly = industrial
                 && (techManager.getTechLevel().ordinal() < SimpleTechLevel.EXPERIMENTAL.ordinal());
         boolean isLam = (etype & Entity.ETYPE_LAND_AIR_MECH) != 0;
-        for (int at = 0; at < EquipmentType.armorNames.length; at++) {
-            if ((at == EquipmentType.T_ARMOR_PATCHWORK)
-                    || (isLam && (at == EquipmentType.T_ARMOR_HARDENED))) {
+        for (int armorType = 0; armorType < EquipmentType.armorNames.length; armorType++) {
+            if ((armorType == EquipmentType.T_ARMOR_PATCHWORK)
+                    || (isLam && (armorType == EquipmentType.T_ARMOR_HARDENED))) {
                 continue;
             }
-            String name = EquipmentType.getArmorTypeName(at, techManager.useClanTechBase());
+            String name = EquipmentType.getArmorTypeName(armorType, techManager.useClanTechBase());
             EquipmentType eq = EquipmentType.get(name);
             if ((null != eq)
                     && eq.hasFlag(MiscType.F_MECH_EQUIPMENT)
+                    && ((armorType != EquipmentType.T_ARMOR_COMMERCIAL) || industrial)
                     && techManager.isLegal(eq)
                     && (!isLam || (eq.getCriticals(null) == 0))
                     && (!industrialOnly || ((MiscType) eq).isIndustrial())) {
-                retVal.add(eq);
+                legalArmors.add(eq);
             }
             if (techManager.useMixedTech()) {
-                name = EquipmentType.getArmorTypeName(at, !techManager.useClanTechBase());
+                name = EquipmentType.getArmorTypeName(armorType, !techManager.useClanTechBase());
                 EquipmentType eq2 = EquipmentType.get(name);
                 if ((null != eq2) && (eq != eq2)
                         && eq2.hasFlag(MiscType.F_MECH_EQUIPMENT)
+                        && ((armorType != EquipmentType.T_ARMOR_COMMERCIAL) || industrial)
                         && techManager.isLegal(eq2)
                         && (!isLam || (eq2.getCriticals(null) == 0))
                         && (!industrialOnly || ((null != eq) && ((MiscType) eq).isIndustrial()))) {
-                    retVal.add(eq2);
+                    legalArmors.add(eq2);
                 }
             }
         }
-        return retVal;
+        return legalArmors;
     }
     
     private Mech mech = null;


### PR DESCRIPTION
Fixes MML's 567 by removing Commercial Armor from the available armors for BattleMeks (only allowing them for Industrial Meks). The forum thread linked in the issue seems to have a pretty final statement from xotl on that matter. The actual change is lines 101 and 112, the rest is only a bit of renaming for readability.