### PR TITLE
Shadow Hawk LAM SHD-X2: Bomb Bays instead of Cargo

### DIFF
--- a/megamek/data/mechfiles/mechs/LAMS/Shadow Hawk LAM SHD-X2.mtf
+++ b/megamek/data/mechfiles/mechs/LAMS/Shadow Hawk LAM SHD-X2.mtf
@@ -72,10 +72,10 @@ Jump Jet
 Jump Jet
 ISERLargeLaser
 ISERLargeLaser
-Cargo (1 ton)
-Cargo (1 ton)
-Cargo (1 ton)
-Cargo (1 ton)
+Bomb Bay
+Bomb Bay
+Bomb Bay
+Bomb Bay
 -Empty-
 -Empty-
 


### PR DESCRIPTION
Was looking for additional fuel on any LAM and found that this one had Cargo instead of Bomb Bays. No idea if there is some necessity behind that. The bomb bays let it actually load bombs in MM. 