### PR TITLE
Fix landing/takeoff length for small craft and dropships

### DIFF
--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -1012,4 +1012,14 @@ public class SmallCraft extends Aero {
     protected int calculateWalk() {
         return walkMP;
     }
+
+    @Override
+    public int getTakeOffLength() {
+        return 20;
+    }
+
+    @Override
+    public int getLandingLength() {
+        return 8;
+    }
 }


### PR DESCRIPTION
@NickAragua  Additional fix to the aerodyne hovering fix from earlier. Dropships already override their landing length and will inherit the takeoff length from the small craft class.