### PR TITLE
improve bot evaluation of infantry weapons

### DIFF
--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -19,6 +19,9 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.capitalweapons.CapitalMissileWeapon;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import megamek.common.weapons.infantry.InfantryWeaponHandler;
+
 import org.apache.logging.log4j.LogManager;
 
 import java.text.DecimalFormat;
@@ -391,6 +394,15 @@ public class WeaponFireInfo {
         if ((weaponType.getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE) ||
            (weaponType.getDamage() == WeaponType.DAMAGE_ARTILLERY)) {
             return weaponType.getRackSize();
+        }
+        
+        // infantry weapons use number of troopers multiplied by weapon damage, 
+        // with # troopers counting as 1 for support vehicles
+        if ((weaponType.getDamage() == WeaponType.DAMAGE_VARIABLE) &&
+                (weaponType instanceof InfantryWeapon)) {
+            int numTroopers = (shooter instanceof Infantry) ? 
+                    ((Infantry) shooter).getShootingStrength() : 1;
+            return InfantryWeaponHandler.calculateBaseDamage(shooter, weapon, weaponType) * numTroopers;
         }
         
         // this is a special case - if we're considering hitting a swarmed target

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
@@ -88,21 +88,8 @@ public class InfantryWeaponHandler extends WeaponHandler {
             troopersHit = Compute.missilesHit(((Infantry) ae)
                 .getShootingStrength(), nHitMod);
         }
-        double damage;
-        if (ae.isConventionalInfantry()) {
-            //for conventional infantry, we have to calculate primary and secondary weapons
-            //to get damage per trooper
-            damage = ((Infantry) ae).getDamagePerTrooper();
-        } else if (ae.isSupportVehicle()) {
-            // Damage for some weapons depends on what type of ammo is being used
-            if (((AmmoType) weapon.getLinked().getType()).getMunitionType() == AmmoType.M_INFERNO) {
-                damage = ((InfantryWeapon) wtype).getInfernoVariant().getInfantryDamage();
-            } else {
-                damage = ((InfantryWeapon) wtype).getNonInfernoVariant().getInfantryDamage();
-            }
-        } else {
-            damage = ((InfantryWeapon) wtype).getInfantryDamage();
-        }
+        double damage = calculateBaseDamage(ae, weapon, wtype);
+        
         if ((ae instanceof Infantry)
                 && nRange == 0
                 && ae.hasAbility(OptionsConstants.MD_TSM_IMPLANT)) {
@@ -197,6 +184,26 @@ public class InfantryWeaponHandler extends WeaponHandler {
                 weapon.getLinked().setLinked(ammo);
             }
             super.useAmmo();
+        }
+    }
+    
+    /**
+     * Utility function to calculate variable damage based only on the firing entity.
+     */
+    public static double calculateBaseDamage(Entity ae, Mounted weapon, WeaponType wtype) {
+        if (ae.isConventionalInfantry()) {
+            //for conventional infantry, we have to calculate primary and secondary weapons
+            //to get damage per trooper
+            return ((Infantry) ae).getDamagePerTrooper();
+        } else if (ae.isSupportVehicle()) {
+            // Damage for some weapons depends on what type of ammo is being used
+            if (((AmmoType) weapon.getLinked().getType()).getMunitionType() == AmmoType.M_INFERNO) {
+                return ((InfantryWeapon) wtype).getInfernoVariant().getInfantryDamage();
+            } else {
+                return ((InfantryWeapon) wtype).getNonInfernoVariant().getInfantryDamage();
+            }
+        } else {
+            return ((InfantryWeapon) wtype).getInfantryDamage();
         }
     }
 }


### PR DESCRIPTION
Fixes #3505

Allows the bot to handle "VARIABLE" weapon damage, rather than discounting weapons with that special damage value entirely, also unifies some of the damage calculations. 