### PR TITLE
Issue 3448: Dry cost in MechSummary

### DIFF
--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -1,5 +1,6 @@
 /*
  * MechSummary.java - Copyright (C) 2002-2004 Josh Yockey
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -21,37 +22,36 @@ import java.util.Objects;
 import java.util.Vector;
 
 /**
- * Contains minimal information about a single entity
+ * The MechSummary of a unit offers compiled information about the unit without having to load the file.
  */
 public class MechSummary implements Serializable {
-    private static final long serialVersionUID = -6635709122122038237L;
-    private String m_sName;
-    private String m_sChassis;
-    private String m_sModel;
+
+    private String name;
+    private String chassis;
+    private String model;
     private int mulId;
-    private String m_sUnitType;
-    private String m_sUnitSubType;
-    private File m_sSourceFile;
-    private String m_sEntryName; // for files in zips
-    private int m_nYear;
-    private int m_nType;
+    private String unitType;
+    private String unitSubType;
+    private File sourceFile;
+    private String entryName; // for files in zips
+    private int year;
+    private int type;
     private int[] altTypes = new int[] { TechConstants.T_IS_TW_NON_BOX, TechConstants.T_IS_ADVANCED,
             TechConstants.T_IS_EXPERIMENTAL }; // tech level constant at standard, advanced, and experimental rules levels
-    private double m_nTons;
-    private int m_nBV;
-    /**
-     * Stores the BV of the unit computed using the geometric mean method.
-     */
-    private int m_gmBV;
-    private int m_rhBV;
-    private int m_rhgmBV;
-    private long m_nCost;
-    private long m_nUnloadedCost;
-    private long m_aCost;
-    private long m_lModified; // for comparison when loading
-    private String m_sLevel;
-    private int m_nAdvTechYear; // year after which the unit is advanced level
-    private int m_nStdTechYear; // year after which the unit is standard level
+    private double tons;
+    private int bv;
+
+    /** The BV of the unit computed using the geometric mean method. */
+    private int gmBV;
+    private int rhBV;
+    private int rhgmBV;
+    private long cost;
+    private long unloadedCost;
+    private long altCost;
+    private long modified; // for comparison when loading
+    private String level;
+    private int advTechYear; // year after which the unit is advanced level
+    private int stdTechYear; // year after which the unit is standard level
     private boolean canon;
     private boolean clan;
     private boolean support;
@@ -64,59 +64,47 @@ public class MechSummary implements Serializable {
     private String engineName;
     private int gyroType;
     private String myomerName;
-    /**
-     * For BattleArmor, we want to know the weight of an individual suit.
-     */
-    private double m_TWsuitTons;
-    private double m_TOsuitTons;
-    private double suitWeight;
-    
 
-    /** Stores the type of internal structure on this unit **/
+    /** For BattleArmor, we want to know the weight of an individual suit. */
+    private double twSuitTons;
+    private double toSuitTons;
+    private double suitWeight;
+
+    /** The type of internal structure on this unit **/
     private int internalsType;
     
     /**
      * Each location can have a separate armor type, but this is used for 
      * search purposes we we really only care about which types are present.
      */
-    private HashSet<Integer> armorTypeSet;
+    private final HashSet<Integer> armorTypeSet;
     
-    /**
-     * Stores the armor type for each location.
-     */
+    /** The armor type for each location. */
     private int[] armorLoc;
     
-    /**
-     * Stores the armor tech type for each location.
-     */
+    /** The armor tech type for each location. */
     private int[] armorLocTech;
-    
-    
+
+    /** A unique list of the names of the equipment mounted on this unit. */
+    private Vector<String> equipmentNames;
+
+    /** The number of times the piece of equipment in the corresponding equipmentNames list appears. */
+    private Vector<Integer> equipmentQuantities;
+
     public MechSummary() {
         armorTypeSet = new HashSet<>();
     }
-    
-    /**
-     * Store a unique list of the names of the equipment mounted on this unit.
-     */
-    private Vector<String> equipmentNames;
-    
-    /**
-     * The number of times the piece of equipment in the corresponding 
-     * <code>equipmentNames</code> list appears.
-     */
-    private Vector<Integer> equipmentQuantities;
 
     public String getName() {
-        return (m_sName);
+        return name;
     }
 
     public String getChassis() {
-        return (m_sChassis);
+        return chassis;
     }
 
     public String getModel() {
-        return (m_sModel);
+        return model;
     }
 
     public int getMulId() {
@@ -124,7 +112,7 @@ public class MechSummary implements Serializable {
     }
 
     public String getUnitType() {
-        return (m_sUnitType);
+        return unitType;
     }
 
     public boolean isCanon() {
@@ -140,7 +128,7 @@ public class MechSummary implements Serializable {
     }
 
     public String getUnitSubType() {
-        return m_sUnitSubType;
+        return unitSubType;
     }
 
     public static String determineETypeName(MechSummary ms) {
@@ -178,19 +166,19 @@ public class MechSummary implements Serializable {
     }
 
     public File getSourceFile() {
-        return (m_sSourceFile);
+        return sourceFile;
     }
 
     public String getEntryName() {
-        return (m_sEntryName);
+        return entryName;
     }
 
     public int getYear() {
-        return (m_nYear);
+        return year;
     }
 
     public int getType() {
-        return (m_nType);
+        return type;
     }
     
     public int[] getAltTypes() {
@@ -198,9 +186,9 @@ public class MechSummary implements Serializable {
     }
     
     public int getType(int year) {
-        if (year >= m_nStdTechYear) {
+        if (year >= stdTechYear) {
             return altTypes[0];
-        } else if (year >= m_nAdvTechYear) {
+        } else if (year >= advTechYear) {
             return altTypes[1];
         } else {
             return altTypes[2];
@@ -208,148 +196,148 @@ public class MechSummary implements Serializable {
     }
 
     public double getTons() {
-        return (m_nTons);
+        return tons;
     }
 
     public double getTOweight() {
-        return (m_TOsuitTons);
+        return toSuitTons;
     }
 
     public double getTWweight() {
-        return (m_TWsuitTons);
+        return twSuitTons;
     }
 
     public int getBV() {
-        return (m_nBV);
+        return bv;
     }
 
     public long getCost() {
-        return (m_nCost);
+        return cost;
     }
 
     public long getUnloadedCost() {
-        return (m_nUnloadedCost);
+        return unloadedCost;
     }
 
     public long getAlternateCost() {
-        return (m_aCost);
+        return altCost;
     }
 
     public long getModified() {
-        return (m_lModified);
+        return modified;
     }
 
     public String getLevel() {
-        return (m_sLevel);
+        return level;
     }
     
     public int getAdvancedTechYear() {
-        return m_nAdvTechYear;
+        return advTechYear;
     }
 
     public int getStandardTechYear() {
-        return m_nStdTechYear;
+        return stdTechYear;
     }
     
     public String getLevel(int year) {
-        if (m_sLevel.equals("F")) {
-            return m_sLevel;
+        if (level.equals("F")) {
+            return level;
         }
-        if (year >= m_nStdTechYear) {
-            if (m_nType == TechConstants.T_INTRO_BOXSET) {
-                return m_sLevel;
+        if (year >= stdTechYear) {
+            if (type == TechConstants.T_INTRO_BOXSET) {
+                return level;
             } else {
                 return String.valueOf(TechConstants.T_SIMPLE_STANDARD + 1);
             }
-        } else if (year >= m_nAdvTechYear) {
+        } else if (year >= advTechYear) {
             return String.valueOf(TechConstants.T_SIMPLE_ADVANCED + 1);
         } else {
             return String.valueOf(TechConstants.T_SIMPLE_EXPERIMENTAL + 1);
         }
     }
 
-    public void setName(String m_sName) {
-        this.m_sName = m_sName;
+    public void setName(String sName) {
+        this.name = sName;
     }
 
-    public void setChassis(String m_sChassis) {
-        this.m_sChassis = m_sChassis;
+    public void setChassis(String sChassis) {
+        this.chassis = sChassis;
     }
 
-    public void setModel(String m_sModel) {
-        this.m_sModel = m_sModel;
+    public void setModel(String sModel) {
+        this.model = sModel;
     }
 
     public void setMulId(int mulId) {
         this.mulId = mulId;
     }
 
-    public void setUnitType(String m_sUnitType) {
-        this.m_sUnitType = m_sUnitType;
+    public void setUnitType(String sUnitType) {
+        this.unitType = sUnitType;
     }
 
-    public void setSourceFile(File m_sSourceFile) {
-        this.m_sSourceFile = m_sSourceFile;
+    public void setSourceFile(File sSourceFile) {
+        this.sourceFile = sSourceFile;
     }
 
-    public void setEntryName(String m_sEntryName) {
-        this.m_sEntryName = m_sEntryName;
+    public void setEntryName(String sEntryName) {
+        this.entryName = sEntryName;
     }
 
-    public void setYear(int m_nYear) {
-        this.m_nYear = m_nYear;
+    public void setYear(int nYear) {
+        this.year = nYear;
     }
 
-    public void setType(int m_nType) {
-        this.m_nType = m_nType;
+    public void setType(int nType) {
+        this.type = nType;
     }
     
     public void setAltTypes(int[] altTypes) {
         this.altTypes = altTypes;
     }
     
-    public void setTons(double m_nTons) {
-        this.m_nTons = m_nTons;
+    public void setTons(double nTons) {
+        this.tons = nTons;
     }
 
-    public void setTOweight(double m_TOsuitTons) {
-        this.m_TOsuitTons = m_TOsuitTons;
+    public void setTOweight(double TOsuitTons) {
+        this.toSuitTons = TOsuitTons;
     }
 
-    public void setTWweight(double m_TWsuitTons) {
-        this.m_TWsuitTons = m_TWsuitTons;
+    public void setTWweight(double TWsuitTons) {
+        this.twSuitTons = TWsuitTons;
     }
 
-    public void setCost(long m_nCost) {
-        this.m_nCost = m_nCost;
+    public void setCost(long nCost) {
+        this.cost = nCost;
     }
 
-    public void setUnloadedCost(long m_nCost) {
-        m_nUnloadedCost = m_nCost;
+    public void setUnloadedCost(long nCost) {
+        unloadedCost = nCost;
     }
 
-    public void setAlternateCost(long m_aCost) {
-        this.m_aCost = m_aCost;
+    public void setAlternateCost(long aCost) {
+        this.altCost = aCost;
     }
 
-    public void setBV(int m_nBV) {
-        this.m_nBV = m_nBV;
+    public void setBV(int nBV) {
+        this.bv = nBV;
     }
 
-    public void setModified(long m_lModified) {
-        this.m_lModified = m_lModified;
+    public void setModified(long lModified) {
+        this.modified = lModified;
     }
 
     public void setLevel(String level) {
-        m_sLevel = level;
+        this.level = level;
     }
     
     public void setAdvancedYear(int year) {
-        m_nAdvTechYear = year;
+        advTechYear = year;
     }
     
     public void setStandardYear(int year) {
-        m_nStdTechYear = year;
+        stdTechYear = year;
     }
 
     public void setCanon(boolean canon) {
@@ -365,7 +353,7 @@ public class MechSummary implements Serializable {
     }
 
     public void setUnitSubType(String subType) {
-        m_sUnitSubType = subType;
+        unitSubType = subType;
     }
 
     public int getWeightClass() {
@@ -376,7 +364,7 @@ public class MechSummary implements Serializable {
             tons = getTons();
         }
         if (isSupport()) {
-            return EntityWeightClass.getSupportWeightClass(m_nTons, m_sUnitSubType);
+            return EntityWeightClass.getSupportWeightClass(this.tons, unitSubType);
         }
         return EntityWeightClass.getWeightClass(tons, getUnitType());
     }
@@ -423,22 +411,20 @@ public class MechSummary implements Serializable {
             }
             String eqName = mnt.getType().getInternalName();
             int index = equipmentNames.indexOf(eqName);
-            if (index == -1) { //We haven't seen this piece of equipment before
+            if (index == -1) { // We haven't seen this piece of equipment before
                 equipmentNames.add(eqName);
                 equipmentQuantities.add(1);
-            } else { //We've seen this before, update count
+            } else { // We've seen this before, update count
                 equipmentQuantities.set(index, equipmentQuantities.get(index)+1);
             }               
         }
     }
     
-    public Vector<String> getEquipmentNames()
-    {
+    public Vector<String> getEquipmentNames() {
         return equipmentNames;
     }
     
-    public Vector<Integer> getEquipmentQuantities()
-    {
+    public Vector<Integer> getEquipmentQuantities() {
         return equipmentQuantities;
     }
 
@@ -477,7 +463,6 @@ public class MechSummary implements Serializable {
         for (int value : locsArmor) {
             armorTypeSet.add(value);
         }
-        
     }
 
     public HashSet<Integer> getArmorType() {
@@ -507,7 +492,6 @@ public class MechSummary implements Serializable {
     public int getCockpitType() {
         return cockpitType;
     }
-
 
     public String getEngineName() {
         return engineName;
@@ -542,27 +526,27 @@ public class MechSummary implements Serializable {
     }
 
     public int getGMBV() {
-        return m_gmBV;
+        return gmBV;
     }
 
-    public void setGMBV(int m_gmBV) {
-        this.m_gmBV = m_gmBV;
+    public void setGMBV(int gmBV) {
+        this.gmBV = gmBV;
     }
 
     public int getRHBV() {
-        return m_rhBV;
+        return rhBV;
     }
 
-    public void setRHBV(int m_rhBV) {
-        this.m_rhBV = m_rhBV;
+    public void setRHBV(int rhBV) {
+        this.rhBV = rhBV;
     }
 
     public int getRHGMBV() {
-        return m_rhgmBV;
+        return rhgmBV;
     }
 
-    public void setRHGMBV(int m_rhgmBV) {
-        this.m_rhgmBV = m_rhgmBV;
+    public void setRHGMBV(int rhgmBV) {
+        this.rhgmBV = rhgmBV;
     }
 
     @Override
@@ -575,12 +559,12 @@ public class MechSummary implements Serializable {
         }
         final MechSummary other = (MechSummary) obj;
         // we match on chassis + model + unittype + sourcefile
-        return Objects.equals(m_sChassis, other.m_sChassis) && Objects.equals(m_sModel, other.m_sModel)
-                && Objects.equals(m_sUnitType, other.m_sUnitType) && Objects.equals(m_sSourceFile, other.m_sSourceFile);
+        return Objects.equals(chassis, other.chassis) && Objects.equals(model, other.model)
+                && Objects.equals(unitType, other.unitType) && Objects.equals(sourceFile, other.sourceFile);
     }
     
     @Override
     public int hashCode() {
-        return Objects.hash(m_sChassis, m_sModel, m_sUnitType, m_sSourceFile);
+        return Objects.hash(chassis, model, unitType, sourceFile);
     }
 }

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -32,6 +32,7 @@ public class MechSummary implements Serializable {
     private int mulId;
     private String unitType;
     private String unitSubType;
+    private String fullAccurateUnitType;
     private File sourceFile;
     private String entryName; // for files in zips
     private int year;
@@ -45,7 +46,10 @@ public class MechSummary implements Serializable {
     private int gmBV;
     private int rhBV;
     private int rhgmBV;
+    /** The full cost of the unit (including ammo). */
     private long cost;
+    /** The dry cost of the unit (excluding ammo). */
+    private long dryCost;
     private long unloadedCost;
     private long altCost;
     private long modified; // for comparison when loading
@@ -195,6 +199,10 @@ public class MechSummary implements Serializable {
         }
     }
 
+    public String getFullAccurateUnitType() {
+        return fullAccurateUnitType;
+    }
+
     public double getTons() {
         return tons;
     }
@@ -213,6 +221,10 @@ public class MechSummary implements Serializable {
 
     public long getCost() {
         return cost;
+    }
+
+    public long getDryCost() {
+        return dryCost;
     }
 
     public long getUnloadedCost() {
@@ -254,6 +266,10 @@ public class MechSummary implements Serializable {
         } else {
             return String.valueOf(TechConstants.T_SIMPLE_EXPERIMENTAL + 1);
         }
+    }
+
+    public void setFullAccurateUnitType(String type) {
+        fullAccurateUnitType = type;
     }
 
     public void setName(String sName) {
@@ -310,6 +326,10 @@ public class MechSummary implements Serializable {
 
     public void setCost(long nCost) {
         this.cost = nCost;
+    }
+
+    public void setDryCost(long nCost) {
+        this.dryCost = nCost;
     }
 
     public void setUnloadedCost(long nCost) {

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -375,6 +375,7 @@ public class MechSummaryCache {
         ms.setModel(e.getModel());
         ms.setMulId(e.getMulId());
         ms.setUnitType(UnitType.getTypeName(e.getUnitType()));
+        ms.setFullAccurateUnitType(Entity.getEntityTypeName(e.getEntityType()));
         ms.setSourceFile(f);
         ms.setEntryName(entry);
         ms.setYear(e.getYear());
@@ -413,6 +414,7 @@ public class MechSummaryCache {
         ms.setAdvancedYear(e.getProductionDate(e.isClan()));
         ms.setStandardYear(e.getCommonDate(e.isClan()));
         ms.setCost((long) e.getCost(false));
+        ms.setDryCost((long) e.getCost(true));
         ms.setUnloadedCost(((long) e.getCost(true)));
         ms.setAlternateCost((int) e.getAlternateCost());
         ms.setCanon(e.isCanon());

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -1,6 +1,7 @@
 /*
  * MegaMek - Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
  * Copyright © 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -30,9 +31,9 @@ import java.util.zip.ZipFile;
  * and server running in the same process can share it
  *
  * @author arlith
- * @author Others...
  */
 public class MechSummaryCache {
+    
     public interface Listener {
         void doneLoading();
     }
@@ -40,17 +41,17 @@ public class MechSummaryCache {
     private static final String FILENAME_UNITS_CACHE = "units.cache";
     private static final String FILENAME_LOOKUP = "name_changes.txt";
 
-    private static MechSummaryCache m_instance;
+    private static MechSummaryCache instance;
     private static boolean disposeInstance = false;
     private static boolean interrupted = false;
 
     private boolean initialized = false;
     private boolean initializing = false;
 
-    private MechSummary[] m_data;
-    private final Map<String, MechSummary> m_nameMap;
-    private final Map<String, MechSummary> m_fileNameMap;
-    private Map<String, String> hFailedFiles;
+    private MechSummary[] data;
+    private final Map<String, MechSummary> nameMap;
+    private final Map<String, MechSummary> fileNameMap;
+    private Map<String, String> failedFiles;
     private int cacheCount;
     private int fileCount;
     private int zipCount;
@@ -68,19 +69,18 @@ public class MechSummaryCache {
 
     public static synchronized MechSummaryCache getInstance(boolean ignoreUnofficial) {
         final boolean ignoringUnofficial = ignoreUnofficial;
-        if (m_instance == null) {
-            m_instance = new MechSummaryCache();
+        if (instance == null) {
+            instance = new MechSummaryCache();
         }
-        if (!m_instance.initialized && !m_instance.initializing) {
-            m_instance.initializing = true;
+        if (!instance.initialized && !instance.initializing) {
+            instance.initializing = true;
             interrupted = false;
             disposeInstance = false;
-            m_instance.loader = new Thread(() -> m_instance.loadMechData(ignoringUnofficial),
-                    "Mech Cache Loader");
-            m_instance.loader.setPriority(Thread.NORM_PRIORITY - 1);
-            m_instance.loader.start();
+            instance.loader = new Thread(() -> instance.loadMechData(ignoringUnofficial), "Mech Cache Loader");
+            instance.loader.setPriority(Thread.NORM_PRIORITY - 1);
+            instance.loader.start();
         }
-        return m_instance;
+        return instance;
     }
 
     /**
@@ -90,26 +90,26 @@ public class MechSummaryCache {
      * @param ignoreUnofficial If true, skips unofficial directories
      */
     public static void refreshUnitData(boolean ignoreUnofficial) {
-        m_instance.initializing = true;
-        m_instance.initialized = false;
+        instance.initializing = true;
+        instance.initialized = false;
         interrupted = false;
         disposeInstance = false;
         File unit_cache_path = new MegaMekFile(getUnitCacheDir(), FILENAME_UNITS_CACHE).getFile();
         long lastModified = unit_cache_path.exists() ? unit_cache_path.lastModified() : 0L;
 
-        m_instance.loader = new Thread(() -> m_instance.refreshCache(lastModified, ignoreUnofficial),
+        instance.loader = new Thread(() -> instance.refreshCache(lastModified, ignoreUnofficial),
                 "Mech Cache Loader");
-        m_instance.loader.setPriority(Thread.NORM_PRIORITY - 1);
-        m_instance.loader.start();
+        instance.loader.setPriority(Thread.NORM_PRIORITY - 1);
+        instance.loader.start();
     }
 
     public static void dispose() {
-        if (m_instance != null) {
+        if (instance != null) {
             synchronized (lock) {
                 interrupted = true;
-                m_instance.loader.interrupt();
+                instance.loader.interrupt();
                 // We can't do this, otherwise we can't notifyAll()
-                // m_instance = null;
+                // instance = null;
                 disposeInstance = true;
             }
         }
@@ -141,13 +141,13 @@ public class MechSummaryCache {
     }
 
     private MechSummaryCache() {
-        m_nameMap = new HashMap<>();
-        m_fileNameMap = new HashMap<>();
+        nameMap = new HashMap<>();
+        fileNameMap = new HashMap<>();
     }
 
     public MechSummary[] getAllMechs() {
         block();
-        return m_data;
+        return data;
     }
 
     private void block() {
@@ -164,15 +164,15 @@ public class MechSummaryCache {
 
     public MechSummary getMech(String sRef) {
         block();
-        if (m_nameMap.containsKey(sRef)) {
-            return m_nameMap.get(sRef);
+        if (nameMap.containsKey(sRef)) {
+            return nameMap.get(sRef);
         }
-        return m_fileNameMap.get(sRef);
+        return fileNameMap.get(sRef);
     }
 
     public Map<String, String> getFailedFiles() {
         block();
-        return hFailedFiles;
+        return failedFiles;
     }
 
     public void loadMechData() {
@@ -185,7 +185,7 @@ public class MechSummaryCache {
         long lLastCheck = 0;
         entityVerifier = EntityVerifier.getInstance(new MegaMekFile(getUnitCacheDir(),
                 EntityVerifier.CONFIG_FILENAME).getFile());
-        hFailedFiles = new HashMap<>();
+        failedFiles = new HashMap<>();
 
         EquipmentType.initializeTypes(); // load master equipment lists
 
@@ -203,8 +203,8 @@ public class MechSummaryCache {
                     InputStream istream = new BufferedInputStream(
                             new FileInputStream(unit_cache_path));
                     ObjectInputStream fin = new ObjectInputStream(istream);
-                    Integer num_units = (Integer) fin.readObject();
-                    for (int i = 0; i < num_units; i++) {
+                    Integer nuunits = (Integer) fin.readObject();
+                    for (int i = 0; i < nuunits; i++) {
                         if (interrupted) {
                             done();
                             fin.close();
@@ -262,44 +262,42 @@ public class MechSummaryCache {
 
     private void updateData(Vector<MechSummary> vMechs) {
         // convert to array
-        m_data = new MechSummary[vMechs.size()];
-        vMechs.copyInto(m_data);
-        m_nameMap.clear();
-        m_fileNameMap.clear();
+        data = new MechSummary[vMechs.size()];
+        vMechs.copyInto(data);
+        nameMap.clear();
+        fileNameMap.clear();
 
         // store map references
-        for (MechSummary element : m_data) {
+        for (MechSummary element : data) {
             if (interrupted) {
                 done();
                 return;
             }
-            m_nameMap.put(element.getName(), element);
+            nameMap.put(element.getName(), element);
             String entryName = element.getEntryName();
             if (entryName == null) {
-                m_fileNameMap.put(element.getSourceFile().getName(), element);
+                fileNameMap.put(element.getSourceFile().getName(), element);
             } else {
                 String unitName = entryName;
 
                 if (unitName.contains("\\")) {
-                    unitName = unitName
-                            .substring(unitName.lastIndexOf("\\") + 1);
+                    unitName = unitName.substring(unitName.lastIndexOf("\\") + 1);
                 }
 
                 if (unitName.contains("/")) {
-                    unitName = unitName
-                            .substring(unitName.lastIndexOf("/") + 1);
+                    unitName = unitName.substring(unitName.lastIndexOf("/") + 1);
                 }
 
-                m_fileNameMap.put(unitName, element);
+                fileNameMap.put(unitName, element);
             }
         }
     }
 
     private void logReport() {
-        loadReport.append(m_data.length).append(" units loaded.\n");
+        loadReport.append(data.length).append(" units loaded.\n");
 
-        if (!hFailedFiles.isEmpty()) {
-            loadReport.append("  ").append(hFailedFiles.size())
+        if (!failedFiles.isEmpty()) {
+            loadReport.append("  ").append(failedFiles.size())
                     .append(" units failed to load...\n");
         }
 
@@ -317,7 +315,7 @@ public class MechSummaryCache {
             }
 
             if (disposeInstance) {
-                m_instance = null;
+                instance = null;
                 initialized = false;
             }
         }
@@ -345,7 +343,7 @@ public class MechSummaryCache {
         Set<String> knownFiles = new HashSet<>();
         // Loop through current contents and make sure the file is still there.
         // Note which files are represented so we can skip them if they haven't changed
-        for (MechSummary ms : m_data) {
+        for (MechSummary ms : data) {
             if (interrupted) {
                 done();
                 return;
@@ -614,31 +612,25 @@ public class MechSummaryCache {
                     fileCount++;
                     Iterator<String> failedEquipment = e.getFailedEquipment();
                     if (failedEquipment.hasNext()) {
-                        loadReport.append("    Loading from ").append(f)
-                                .append("\n");
+                        loadReport.append("    Loading from ").append(f).append("\n");
                         while (failedEquipment.hasNext()) {
-                            loadReport
-                                    .append("      Failed to load equipment: ")
-                                    .append(failedEquipment.next())
-                                    .append("\n");
+                            loadReport.append("      Failed to load equipment: ")
+                                    .append(failedEquipment.next()).append("\n");
                         }
                     }
                 } catch (EntityLoadingException ex) {
-                    loadReport.append("    Loading from ").append(f)
-                            .append("\n");
+                    loadReport.append("    Loading from ").append(f).append("\n");
                     loadReport.append("***   Unable to load file: ");
                     StringWriter stringWriter = new StringWriter();
                     PrintWriter printWriter = new PrintWriter(stringWriter);
                     ex.printStackTrace(printWriter);
                     loadReport.append(stringWriter.getBuffer()).append("\n");
-                    hFailedFiles.put(f.toString(), ex.getMessage());
+                    failedFiles.put(f.toString(), ex.getMessage());
                 }
             }
         }
 
-        loadReport.append("  ...loaded ").append(thisDirectoriesFileCount)
-                .append(" files.\n");
-
+        loadReport.append("  ...loaded ").append(thisDirectoriesFileCount).append(" files.\n");
         return bNeedsUpdate;
     }
 
@@ -703,8 +695,7 @@ public class MechSummaryCache {
                 Iterator<String> failedEquipment = e.getFailedEquipment();
                 if (failedEquipment.hasNext()) {
                     loadReport.append("    Loading from zip file")
-                            .append(" >> ").append(zEntry.getName())
-                            .append("\n");
+                            .append(" >> ").append(zEntry.getName()).append("\n");
                     while (failedEquipment.hasNext()) {
                         loadReport.append("      Failed to load equipment: ")
                                 .append(failedEquipment.next()).append("\n");
@@ -719,7 +710,7 @@ public class MechSummaryCache {
                 ex.printStackTrace(printWriter);
                 loadReport.append(stringWriter.getBuffer()).append("\n");
                 if (!(ex.getMessage() == null)) {
-                    hFailedFiles.put(zEntry.getName(), ex.getMessage());
+                    failedFiles.put(zEntry.getName(), ex.getMessage());
                 }
             }
         }
@@ -752,10 +743,10 @@ public class MechSummaryCache {
                     if (index > 0) {
                         lookupName = line.substring(0, index);
                         entryName = line.substring(index + 1);
-                        if (!m_nameMap.containsKey(lookupName)) {
-                            MechSummary ms = m_nameMap.get(entryName);
+                        if (!nameMap.containsKey(lookupName)) {
+                            MechSummary ms = nameMap.get(entryName);
                             if (null != ms) {
-                                m_nameMap.put(lookupName, ms);
+                                nameMap.put(lookupName, ms);
                             }
                         }
                     }
@@ -765,7 +756,6 @@ public class MechSummaryCache {
             }
         }
     }
-
 
     public int getCacheCount() {
         return cacheCount;

--- a/megamek/src/megamek/utils/MechCacheCSVTool.java
+++ b/megamek/src/megamek/utils/MechCacheCSVTool.java
@@ -2,6 +2,9 @@
  * MegaMek - Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
  * Copyright © 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
  * Copyright © 2013 Nicholas Walczak (walczak@cs.umn.edu)
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -26,139 +29,99 @@ import java.util.stream.Stream;
 /**
  * This class provides a utility to read in all the data/mechfiles and print
  * that data out into a CSV format.
- * 
+ *
  * @author arlith
+ * @author Simon (Juliez)
  */
 public class MechCacheCSVTool {
 
     public static void main(String[] args) {
-        MechSummaryCache cache = MechSummaryCache.getInstance(true);
-        BufferedWriter fout;
-        try {
-            fout = new BufferedWriter(new PrintWriter("Units.csv"));
-        } catch (FileNotFoundException e) {
-            System.out.println("Could not open file for output!");
-            return;
-        }
-        MechSummary[] mechs = cache.getAllMechs();
-        
-        try {
-            StringBuffer csvLine = new StringBuffer();
+        try (BufferedWriter fout = new BufferedWriter(new PrintWriter("Units.csv"))) {
+            MechSummaryCache cache = MechSummaryCache.getInstance(true);
+            MechSummary[] units = cache.getAllMechs();
 
+            StringBuilder csvLine = new StringBuilder();
 
-            csvLine.append("Chassis,Model,MUL ID,Combined,Clan,Source,Weight,Intro Date,Experimental year,Advanced year,Standard year,Unit Type,Role,BV,Cost,Rules,Engine Name,Internal Structure," +
-                    "Myomer,Cockpit Type,Gyro Type," +
-                    "Armor Types," +
-                    "Equipment (multiple entries)\n");
+            csvLine.append("Chassis,Model,MUL ID,Combined,Clan,Source,Weight,Intro Date,Experimental year,Advanced year," +
+                    "Standard year,Unit Type,Role,BV,Cost,Rules,Engine Name,Internal Structure,Myomer," +
+                    "Cockpit Type,Gyro Type,Armor Types,Equipment (multiple entries)\n");
             fout.write(csvLine.toString());
-            for (MechSummary mech : mechs) {
-                if (mech.getUnitType().equals("Gun Emplacement")) {
+
+            for (MechSummary unit : units) {
+                if (unit.getUnitType().equals("Gun Emplacement")) {
                     continue;
                 }
-                
-                csvLine = new StringBuffer();
-                // Chasis Name
-                csvLine.append(mech.getChassis() + ",");
-                // Model Name
-                csvLine.append(mech.getModel() + ",");
-                // MUL ID
-                csvLine.append(mech.getMulId() + ",");
-                
-                // Combined Name
-                csvLine.append(mech.getChassis() + " " + mech.getModel() + ",");
-                
-                //
-                csvLine.append(mech.isClan() + ",");
-                
-                // Source Book
-                csvLine.append(mech.getSourceFile() + ",");
 
-                // Weight
-                csvLine.append(mech.getTons() + ",");
-                
-                // IntroDate
-                csvLine.append(mech.getYear() + ",");
-                
+                csvLine = new StringBuilder();
+                csvLine.append(unit.getChassis()).append(",");
+                csvLine.append(unit.getModel()).append(",");
+                csvLine.append(unit.getMulId()).append(",");
+                csvLine.append(unit.getChassis()).append(" ").append(unit.getModel()).append(",");
+                csvLine.append(unit.isClan()).append(",");
+                csvLine.append(unit.getSourceFile()).append(",");
+                csvLine.append(unit.getTons()).append(",");
+                csvLine.append(unit.getYear()).append(",");
+
                 // Experimental Tech Year
-                if (mech.getAdvancedTechYear() <= mech.getYear()) {
-                    csvLine.append(",");
-                } else {
-                    csvLine.append(mech.getYear() + ",");
+                if (unit.getAdvancedTechYear() > unit.getYear()) {
+                    csvLine.append(unit.getYear());
                 }
-                         
+                csvLine.append(",");
 
                 // Advanced Tech Year
-                if (mech.getAdvancedTechYear() > 0) {
-                    csvLine.append(mech.getAdvancedTechYear()).append(",");
-                } else {
-                    csvLine.append(",");
+                if (unit.getAdvancedTechYear() > 0) {
+                    csvLine.append(unit.getAdvancedTechYear());
                 }
+                csvLine.append(",");
 
                 // Standard Tech Year
-                if (mech.getStandardTechYear() > 0) {
-                    csvLine.append(mech.getStandardTechYear()).append(",");
-                } else {
-                    csvLine.append(",");
+                if (unit.getStandardTechYear() > 0) {
+                    csvLine.append(unit.getStandardTechYear());
                 }
+                csvLine.append(",");
 
-                // Unit Type
-                csvLine.append(mech.getFullAccurateUnitType()).append(",");
+                csvLine.append(unit.getFullAccurateUnitType()).append(",");
+                csvLine.append(UnitRoleHandler.getRoleFor(unit)).append(",");
+                csvLine.append(unit.getBV()).append(",");
+                csvLine.append(unit.getDryCost()).append(",");
+                csvLine.append(unit.getLevel()).append(",");
+                csvLine.append(unit.getEngineName()).append(",");
 
-                //Role
-                csvLine.append(UnitRoleHandler.getRoleFor(mech) + ",");
-
-                // BV
-                csvLine.append(mech.getBV()  + ",");
-                
-                // Cost
-                csvLine.append(mech.getDryCost() + ",");
-
-                //Level
-                csvLine.append(mech.getLevel() + ",");
-                
-                // Engine Type
-                csvLine.append(mech.getEngineName() + ",");
-                
                 // Internals Type
-                if (mech.getInternalsType() >= 0) {
-                    String isString;
-                    if (mech.isClan()) {
-                        isString = "Clan ";
-                    } else {
-                        isString = "IS ";
-                    }
-                    isString += EquipmentType.structureNames[mech.getInternalsType()] + ",";
+                if (unit.getInternalsType() >= 0) {
+                    String isString = unit.isClan() ? "Clan " : "IS ";
+                    isString += EquipmentType.structureNames[unit.getInternalsType()] + ",";
                     csvLine.append(isString);
-                } else if (mech.getInternalsType() < 0) {
+                } else if (unit.getInternalsType() < 0) {
                     csvLine.append("Not Applicable,");
                 }
-                
+
                 // Myomer type
-                csvLine.append(mech.getMyomerName()+ ",");
-                
+                csvLine.append(unit.getMyomerName()).append(",");
+
                 // Cockpit Type
-                if ((mech.getCockpitType() >= 0) && (mech.getCockpitType() < Mech.COCKPIT_STRING.length)) {
-                    if (mech.getUnitType().equals("Mek")) {
-                        csvLine.append(Mech.COCKPIT_STRING[mech.getCockpitType()]+ ",");
+                if ((unit.getCockpitType() >= 0) && (unit.getCockpitType() < Mech.COCKPIT_STRING.length)) {
+                    if (unit.getUnitType().equals("Mek")) {
+                        csvLine.append(Mech.COCKPIT_STRING[unit.getCockpitType()]).append(",");
                     } else
-                        csvLine.append(Aero.COCKPIT_STRING[mech.getCockpitType()]+ ",");
-                    } else {
+                        csvLine.append(Aero.COCKPIT_STRING[unit.getCockpitType()]).append(",");
+                } else {
                     csvLine.append("Not Applicable,");
                 }
-                
+
                 // Gyro Type
-                if (mech.getGyroType() >= 0) {
-                    csvLine.append(Mech.GYRO_STRING[mech.getGyroType()] + ",");
-                } else if (mech.getGyroType() < 0) {
-                    csvLine.append("Not Applicable,");    
-                   }
-                
+                if (unit.getGyroType() >= 0) {
+                    csvLine.append(Mech.GYRO_STRING[unit.getGyroType()]).append(",");
+                } else if (unit.getGyroType() < 0) {
+                    csvLine.append("Not Applicable,");
+                }
+
                 // Armor type - prints different armor types on the unit
                 Vector<Integer> armorType = new Vector<>();
                 Vector<Integer> armorTech = new Vector<>();
                 int[] at, att;
-                at = mech.getArmorTypes();
-                att = mech.getArmorTechTypes();
+                at = unit.getArmorTypes();
+                att = unit.getArmorTechTypes();
                 for (int i = 0; i < at.length; i++) {
                     boolean contains = false;
                     for (int j = 0; j < armorType.size(); j++) {
@@ -175,11 +138,11 @@ public class MechCacheCSVTool {
                 }
                 for (int i = 0; i < armorType.size(); i++) {
                     csvLine.append(EquipmentType.getArmorTypeName(armorType.get(i),
-                            TechConstants.isClan(armorTech.get(i))) + ",");
+                            TechConstants.isClan(armorTech.get(i)))).append(",");
                 }
-                
+
                 // Equipment Names
-                for (String name : mech.getEquipmentNames()) {
+                for (String name : unit.getEquipmentNames()) {
                     // Ignore armor critical
                     if (Stream.of(EquipmentType.armorNames).anyMatch(name::contains)) {
                         continue;
@@ -190,25 +153,9 @@ public class MechCacheCSVTool {
                         continue;
                     }
 
-                    // Ignore Bays
-                    if (name.contains("Bay")) {
-                        continue;
-                    }
-
-                    // Ignore Ammo
-                    if (name.contains("Ammo")) {
-                        continue;
-                    }
-
-                    // Ignore Rifle
-                    if (name.contains("Infantry Auto Rifle")) {
-                        continue;
-                    }
-
-                    if (name.contains("SwarmMek")
-                            || name.contains("SwarmWeaponMek")
-                            || name.contains("StopSwarm")
-                            || name.contains("LegAttack")) {
+                    if (name.contains("Bay") || name.contains("Ammo") || name.contains("Infantry Auto Rifle")
+                            || name.contains("SwarmMek") || name.contains("SwarmWeaponMek")
+                            || name.contains("StopSwarm") || name.contains("LegAttack")) {
                         continue;
                     }
 
@@ -217,9 +164,10 @@ public class MechCacheCSVTool {
                 csvLine.append("\n");
                 fout.write(csvLine.toString());
             }
-            fout.close();
+        } catch (FileNotFoundException e) {
+            System.out.println("Could not open file for output!");
         } catch (IOException e) {
-            System.out.println("IOException!");
+            System.out.println("IOException: " + e.getMessage());
             e.printStackTrace();
         }
     }

--- a/megamek/src/megamek/utils/MechCacheCSVTool.java
+++ b/megamek/src/megamek/utils/MechCacheCSVTool.java
@@ -102,12 +102,7 @@ public class MechCacheCSVTool {
                 }
 
                 // Unit Type
-                try {
-                    Entity e = new MechFileParser(mech.getSourceFile(), mech.getEntryName()).getEntity();
-                    csvLine.append(Entity.getEntityTypeName(e.getEntityType()));
-                } catch (megamek.common.loaders.EntityLoadingException e) {
-                }
-                csvLine.append(",");
+                csvLine.append(mech.getFullAccurateUnitType()).append(",");
 
                 //Role
                 csvLine.append(UnitRoleHandler.getRoleFor(mech) + ",");
@@ -116,7 +111,7 @@ public class MechCacheCSVTool {
                 csvLine.append(mech.getBV()  + ",");
                 
                 // Cost
-                csvLine.append(mech.getCost() + ",");
+                csvLine.append(mech.getDryCost() + ",");
 
                 //Level
                 csvLine.append(mech.getLevel() + ",");


### PR DESCRIPTION
This adds the dry cost (without ammo) to the MechSummary as well as the detailed unit type given by Entity.getEntityTypeName (both requested by the MUL team).

The "Write dry cost" commit contains the changes, the other commits are lots of code formatting.
Since both are new fields, this should have no impact anywhere outside this PR's files.

Fixes #3448 for MM