### PR TITLE
StringUtility: Renaming isNullOrEmpty to the proper isNullOrBlank

### DIFF
--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -198,7 +198,7 @@ public final class Version implements Comparable<Version>, Serializable {
     }
 
     public void fillFromText(final @Nullable String text) {
-        if (StringUtility.isNullOrEmpty(text)) {
+        if (StringUtility.isNullOrBlank(text)) {
             final String message = String.format(
                     "Cannot parse the version from %s. This may lead to severe issues that cannot be otherwise explained.",
                     ((text == null) ? "a null string" : text));

--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -34,7 +34,7 @@ public class ChatProcessor {
 
     boolean shouldBotAcknowledgeDefeat(String message, BotClient bot) {
         boolean result = false;
-        if (!StringUtility.isNullOrEmpty(message) &&
+        if (!StringUtility.isNullOrBlank(message) &&
             (message.contains("declares individual victory at the end of the turn.")
              || message.contains("declares team victory at the end of the turn."))) {
             String[] splitMessage = message.split(" ");
@@ -60,7 +60,7 @@ public class ChatProcessor {
     boolean shouldBotAcknowledgeVictory(String message, BotClient bot) {
         boolean result = false;
 
-        if (!StringUtility.isNullOrEmpty(message) && message.contains(DefeatCommand.wantsDefeat)) {
+        if (!StringUtility.isNullOrBlank(message) && message.contains(DefeatCommand.wantsDefeat)) {
             String[] splitMessage = message.split(" ");
             int i = 1;
             String name = splitMessage[i];

--- a/megamek/src/megamek/client/bot/HexHasPathToCenterCache.java
+++ b/megamek/src/megamek/client/bot/HexHasPathToCenterCache.java
@@ -87,7 +87,7 @@ public final class HexHasPathToCenterCache {
      * @param hexCoords The coordinates, {@link Coords#toFriendlyString()}, of the starting hex.
      */
     void remove(String hexCoords) {
-        if (StringUtility.isNullOrEmpty(hexCoords)) {
+        if (StringUtility.isNullOrBlank(hexCoords)) {
             return;
         }
         Set<Key> keySet = new HashSet<>(cache.keySet());
@@ -114,7 +114,7 @@ public final class HexHasPathToCenterCache {
          * @throws IllegalArgumentException if hexCoords is NULL or Empty or movementMode is NULL.
          */
         Key(String hexCoords, EntityMovementMode movementMode) {
-            if (StringUtility.isNullOrEmpty(hexCoords)) {
+            if (StringUtility.isNullOrBlank(hexCoords)) {
                 throw new IllegalArgumentException("Starting Coords is NULL or Empty.");
             }
             if (movementMode == null) {

--- a/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
+++ b/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
@@ -186,7 +186,7 @@ public class BehaviorSettings implements Serializable {
      * @param description The name to be used.
      */
     public void setDescription(final String description) throws PrincessException {
-        if (StringUtility.isNullOrEmpty(description)) {
+        if (StringUtility.isNullOrBlank(description)) {
             throw new PrincessException("Description is required!");
         }
         this.description = description.trim();
@@ -207,7 +207,7 @@ public class BehaviorSettings implements Serializable {
      * @param target The target to be added.
      */
     public void addStrategicTarget(final String target) {
-        if (StringUtility.isNullOrEmpty(target)) {
+        if (StringUtility.isNullOrBlank(target)) {
             return;
         }
         strategicBuildingTargets.add(target);

--- a/megamek/src/megamek/client/bot/princess/FiringPlan.java
+++ b/megamek/src/megamek/client/bot/princess/FiringPlan.java
@@ -320,7 +320,7 @@ public class FiringPlan extends ArrayList<WeaponFireInfo> implements Comparable<
     String getWeaponNames() {
         StringBuilder out = new StringBuilder("");
         for (WeaponFireInfo wfi : this) {
-            if (!StringUtility.isNullOrEmpty(out)) {
+            if (!StringUtility.isNullOrBlank(out)) {
                 out.append(",");
             }
 

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -167,7 +167,7 @@ public abstract class PathRanker implements IPathRanker {
                 if (!isAirborneAeroOnGroundMap && !getOwner().wantsToFallBack(mover)) {
                     Targetable closestToEnd = findClosestEnemy(mover, finalCoords, game);
                     String validation = validRange(finalCoords, closestToEnd, startingTargetDistance, maxRange, inRange);
-                    if (!StringUtility.isNullOrEmpty(validation)) {
+                    if (!StringUtility.isNullOrBlank(validation)) {
                         msg.append("\n\t").append(validation);
                         continue;
                     }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1302,7 +1302,7 @@ public class Princess extends BotClient {
             final List<Entity> ents = game.getEntitiesVector();
             for (final Entity ent : ents) {
                 final String errors = getFireControl(ent).checkAllGuesses(ent, game);
-                if (!StringUtility.isNullOrEmpty(errors)) {
+                if (!StringUtility.isNullOrBlank(errors)) {
                     LogManager.getLogger().warn(errors);
                 }
             }
@@ -1780,7 +1780,7 @@ public class Princess extends BotClient {
 
     public int calculateAdjustment(final String ticks) {
         int adjustment = 0;
-        if (StringUtility.isNullOrEmpty(ticks)) {
+        if (StringUtility.isNullOrBlank(ticks)) {
             return 0;
         }
         for (final char tick : ticks.toCharArray()) {

--- a/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
@@ -305,7 +305,7 @@ public class RandomMapDialog extends JDialog implements ActionListener {
         fileChooser.setDialogTitle(title);
 
         // If we have a file to start with, select it.
-        if (!StringUtility.isNullOrEmpty(fileName)) {
+        if (!StringUtility.isNullOrBlank(fileName)) {
             fileChooser.setSelectedFile(new File(targetDir + fileName));
         }
 

--- a/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ResizeMapDialog.java
@@ -330,7 +330,7 @@ public class ResizeMapDialog extends JDialog implements ActionListener, KeyListe
         fileChooser.setDialogTitle(title);
 
         // If we have a file to start with, select it.
-        if (!StringUtility.isNullOrEmpty(fileName)) {
+        if (!StringUtility.isNullOrBlank(fileName)) {
             fileChooser.setSelectedFile(new File(targetDir + fileName));
         }
 

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
@@ -99,7 +99,7 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
         initComponents();
 
         // if the player name is specified, overwrite the preference with it
-        if (!StringUtility.isNullOrEmpty(playerName)) {
+        if (!StringUtility.isNullOrBlank(playerName)) {
             setPlayerName(playerName);
         }
     }

--- a/megamek/src/megamek/client/ui/swing/widget/VerifiableTextField.java
+++ b/megamek/src/megamek/client/ui/swing/widget/VerifiableTextField.java
@@ -88,7 +88,7 @@ public class VerifiableTextField extends JTextField implements FocusListener {
      * @return TRUE if the field's text value is NULL or an empty {@link String}.
      */
     public boolean isTextNullOrEmpty() {
-        return StringUtility.isNullOrEmpty(getText());
+        return StringUtility.isNullOrBlank(getText());
     }
 
     /**

--- a/megamek/src/megamek/codeUtilities/StringUtility.java
+++ b/megamek/src/megamek/codeUtilities/StringUtility.java
@@ -25,7 +25,7 @@ public class StringUtility {
      * @param text The string to be evaluated.
      * @return true if the passed in value is either null or a blank string
      */
-    public static boolean isNullOrEmpty(final @Nullable String text) {
+    public static boolean isNullOrBlank(final @Nullable String text) {
         return (text == null) || text.isBlank();
     }
 
@@ -34,7 +34,7 @@ public class StringUtility {
      * @return true if the passed in <code>StringBuilder</code> is null, or its contents are null
      * or empty
      */
-    public static boolean isNullOrEmpty(final @Nullable StringBuilder text) {
-        return (text == null) || isNullOrEmpty(text.toString());
+    public static boolean isNullOrBlank(final @Nullable StringBuilder text) {
+        return (text == null) || isNullOrBlank(text.toString());
     }
 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14930,7 +14930,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         for (QuirkEntry q : quirks) {
             // If the quirk doesn't have a location, then it is a unit quirk,
             // not a weapon quirk.
-            if (StringUtility.isNullOrEmpty(q.getLocation())) {
+            if (StringUtility.isNullOrBlank(q.getLocation())) {
 
                 // Activate the unit quirk.
                 if (getQuirks().getOption(q.getQuirk()) == null) {

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -1146,7 +1146,7 @@ public class EntityListFile {
         }
 
         String extraData = crew.writeExtraDataToXMLLine(pos);
-        if (!StringUtility.isNullOrEmpty(extraData)) {
+        if (!StringUtility.isNullOrBlank(extraData)) {
             output.write(extraData);
         }
     }

--- a/megamek/src/megamek/common/QuirkEntry.java
+++ b/megamek/src/megamek/common/QuirkEntry.java
@@ -41,7 +41,7 @@ class QuirkEntry {
      * @param unitId The ID (chassis & model) of the unit to which the quirk belongs.
      */
     QuirkEntry(String quirk, String unitId) {
-        if (StringUtility.isNullOrEmpty(quirk)) {
+        if (StringUtility.isNullOrBlank(quirk)) {
             throw new IllegalArgumentException("Quirk definition missing for " + unitId);
         }
 
@@ -61,11 +61,11 @@ class QuirkEntry {
      * @param unitId     The ID (chassis & model) of the unit to which the quirk belongs.
      */
     QuirkEntry(String quirk, String location, int slot, String weaponName, String unitId) {
-        if (StringUtility.isNullOrEmpty(quirk)) {
+        if (StringUtility.isNullOrBlank(quirk)) {
             throw new IllegalArgumentException("Quirk definition missing for " + unitId);
-        } else if (StringUtility.isNullOrEmpty(location)) {
+        } else if (StringUtility.isNullOrBlank(location)) {
             throw new IllegalArgumentException("No location for " + quirk + " : " + unitId);
-        } else if (StringUtility.isNullOrEmpty(weaponName)) {
+        } else if (StringUtility.isNullOrBlank(weaponName)) {
             throw new IllegalArgumentException("No weapon for " + quirk + " : " + unitId);
         } else if ((slot < 0) || (slot > 11)) {
             throw new IllegalArgumentException("Invalid slot index (" + slot + ") for " + quirk + " : " + unitId);
@@ -137,7 +137,7 @@ class QuirkEntry {
      */
     public String toLog() {
         String out = getQuirk();
-        if (StringUtility.isNullOrEmpty(getLocation())) {
+        if (StringUtility.isNullOrBlank(getLocation())) {
             return out;
         }
 
@@ -167,7 +167,7 @@ class QuirkEntry {
         copy.setQuirk(String.copyValueOf(getQuirk().toCharArray()));
 
         // If location is empty, then this is not a weapon quirk.
-        if (StringUtility.isNullOrEmpty(getLocation())) {
+        if (StringUtility.isNullOrBlank(getLocation())) {
             return copy;
         }
 

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -104,7 +104,7 @@ public class AddBotUtil {
             }
         }
 
-        if (StringUtility.isNullOrEmpty(playerName)) {
+        if (StringUtility.isNullOrBlank(playerName)) {
             String argLine = fullLine.toString();
             argLine = argLine.replaceFirst("/replacePlayer", "");
             argLine = argLine.replaceFirst("-b:" + botName, "");
@@ -134,7 +134,7 @@ public class AddBotUtil {
         final BotClient botClient;
         if ("Princess".equalsIgnoreCase(botName.toString())) {
             botClient = makeNewPrincessClient(target, host, port);
-            if (!StringUtility.isNullOrEmpty(configName)) {
+            if (!StringUtility.isNullOrBlank(configName)) {
                 final BehaviorSettings behavior = BehaviorSettingsFactory.getInstance()
                         .getBehavior(configName.toString());
                 if (null != behavior) {

--- a/megamek/src/megamek/common/util/EmailService.java
+++ b/megamek/src/megamek/common/util/EmailService.java
@@ -147,7 +147,7 @@ public class EmailService {
     public Vector<Player> getEmailablePlayers(Game game) {
         Vector<Player> emailable = new Vector<>();
         for (var player: game.getPlayersVector()) {
-            if (!StringUtility.isNullOrEmpty(player.getEmail()) && !player.isBot()
+            if (!StringUtility.isNullOrBlank(player.getEmail()) && !player.isBot()
                     && !player.isObserver()) {
                 emailable.add(player);
             }

--- a/megamek/src/megamek/common/util/StringUtil.java
+++ b/megamek/src/megamek/common/util/StringUtil.java
@@ -105,7 +105,7 @@ public class StringUtil {
      * @return TRUE if the value can be parsed to a {@link Double} without throwing a {@link NumberFormatException}.
      */
     public static boolean isNumeric(String number) {
-        if (StringUtility.isNullOrEmpty(number)) {
+        if (StringUtility.isNullOrBlank(number)) {
             return false;
         }
         try {
@@ -124,7 +124,7 @@ public class StringUtil {
      *         and the parsed value is greater than or equal to zero.
      */
     public static boolean isPositiveInteger(String number) {
-        if (StringUtility.isNullOrEmpty(number)) {
+        if (StringUtility.isNullOrBlank(number)) {
             return false;
         }
         try {
@@ -142,7 +142,7 @@ public class StringUtil {
      *         and the parsed value is greater than or equal to zero.
      */
     public static boolean isInteger(String number) {
-        if (StringUtility.isNullOrEmpty(number)) {
+        if (StringUtility.isNullOrBlank(number)) {
             return false;
         }
         try {

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -104,7 +104,7 @@ public class BasicPathRankerTest {
             failure.append("\nExpected :").append(expected.getRank());
             failure.append("\nActual   :").append(actual.getRank());
         }
-        if (!StringUtility.isNullOrEmpty(failure.toString())) {
+        if (!StringUtility.isNullOrBlank(failure.toString())) {
             Assert.fail(failure.toString());
         }
     }   

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -1288,7 +1288,7 @@ public class FireControlTest {
             failure.append("\nExpected: ").append(expected.getDesc());
             failure.append("\nActual:   ").append(actualTHD.getDesc());
         }
-        if (!StringUtility.isNullOrEmpty(failure.toString())) {
+        if (!StringUtility.isNullOrBlank(failure.toString())) {
             Assert.fail(failure.toString());
         }
     }
@@ -2639,7 +2639,7 @@ public class FireControlTest {
             }
         }
 
-        if (!StringUtility.isNullOrEmpty(failure.toString())) {
+        if (!StringUtility.isNullOrBlank(failure.toString())) {
             Assert.fail(failure.toString());
         }
     }


### PR DESCRIPTION
This fixes a naming issue I caused during a legacy update

Requires https://github.com/MegaMek/mekhq/pull/3205