### PR TITLE
Enable AR-10 launchers to switch between AR-10 ammo types

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -13750,6 +13750,10 @@ public class AmmoType extends EquipmentType {
                 && (otherAmmo.getAmmoType() == AmmoType.T_MML)
                 && (currentAmmoType.getRackSize() == otherAmmo.getRackSize());
 
+        // AR10 ammo is explicitly excluded in equalsAmmoTypeOnly(), therefore check here
+        boolean ar10Match = (currentAmmoType.getAmmoType() == AmmoType.T_AR10)
+                && (otherAmmo.getAmmoType() == AmmoType.T_AR10);
+
         // LBXs can swap between cluster and slug ammo types
         boolean lbxAmmoMatch = (currentAmmoType.getAmmoType() == AmmoType.T_AC_LBX)
                 && (otherAmmo.getAmmoType() == AmmoType.T_AC_LBX)
@@ -13763,6 +13767,6 @@ public class AmmoType extends EquipmentType {
         boolean staticFeedMismatch = hasStaticFeed
                 && (currentAmmoType.getMunitionType() != otherAmmo.getMunitionType());
 
-        return (ammoOfSameType || mmlAmmoMatch || lbxAmmoMatch) && !caselessMismatch && !staticFeedMismatch;
+        return (ammoOfSameType || mmlAmmoMatch || lbxAmmoMatch || ar10Match) && !caselessMismatch && !staticFeedMismatch;
     }
 }


### PR DESCRIPTION
Fixes #2841 

I don't know why equalsAmmoTypeOnly() explicitly returns false for MML ammos and AR10 ammos but it does and it is called from MHQ so I didn't want to change it. Therefore the explicit logic for AR-10 in canSwitchToAmmo()