### PR TITLE
Correct Screen Launchers to be Capital weapons

### DIFF
--- a/megamek/src/megamek/common/weapons/bayweapons/ScreenLauncherBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/ScreenLauncherBayWeapon.java
@@ -43,7 +43,7 @@ public class ScreenLauncherBayWeapon extends AmmoBayWeapon {
         this.bv = 0;
         this.cost = 0;
         this.atClass = CLASS_SCREEN;
-        this.capital = false;
+        this.capital = true;
         rulesRefs = "237, TM";
     }
 

--- a/megamek/src/megamek/common/weapons/capitalweapons/ScreenLauncherWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalweapons/ScreenLauncherWeapon.java
@@ -45,7 +45,7 @@ public class ScreenLauncherWeapon extends AmmoWeapon {
         this.cost = 250000;
         this.shortAV = 15;
         this.maxRange = RANGE_SHORT;
-        this.capital = false;
+        this.capital = true;
         this.atClass = CLASS_SCREEN;
         rulesRefs = "237, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)


### PR DESCRIPTION
Screen Launchers weren't appearing as Large Craft equipment in MML (taken from a comment on discord). According to SO, p.103 and TO AUE p. 228 Screen launchers are Capital Weapons. According to TM p.237 they are only available to DS which agrees with the former. TM p.342 lists them as available to SC which contradicts TM p.237. Overall I assume they are indeed Capital and not available to SC and TM 342 is wrong.

With this PR they are Capital and appear to all Large Craft as Capital Weapons.

@HammerGS: I couldnt find this in any errata but I'm not sure what the best way is to search for forum entries (the forum search engine feels like no big help)