### PR TITLE
MHQ 3167: Fixing Board Utilities Exception on Scenario Start

### DIFF
--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -16,6 +16,7 @@
 package megamek.common.util;
 
 import megamek.client.bot.princess.CardinalEdge;
+import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
 import megamek.common.util.generator.ElevationGenerator;
 import megamek.common.util.generator.SimplexGenerator;
@@ -1136,8 +1137,8 @@ public class BoardUtilities {
         int[] elevationCount = new int[range + 1];
         for (int w = 0; w < width; w++) {
             for (int h = 0; h < height; h++) {
-                elevationMap[w][h] = (int) Math.ceil(elevationMap[w][h] * scale) + inc;
-                elevationCount[elevationMap[w][h]]++;
+                elevationMap[w][h] = (int) Math.round(elevationMap[w][h] * scale) + inc;
+                elevationCount[MathUtility.clamp(elevationMap[w][h], 0, range)]++;
             }
         }
 


### PR DESCRIPTION
This fixes https://github.com/MegaMek/mekhq/issues/3167, and swaps it back to rounding instead of using Math.ceil (this swap was previous done to prevent this, but given it is now on both sides it's better to clamp it).