### PR TITLE
3607: Fixing Null Swarming Entity Unit ToolTip NPE

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -34,6 +34,7 @@ import megamek.common.weapons.LegAttack;
 import megamek.common.weapons.StopSwarmAttack;
 import megamek.common.weapons.SwarmAttack;
 import megamek.common.weapons.SwarmWeaponAttack;
+import org.apache.logging.log4j.LogManager;
 
 import static megamek.client.ui.swing.tooltip.TipUtil.*;
 import static megamek.client.ui.swing.util.UIUtil.*;
@@ -674,7 +675,14 @@ public final class UnitToolTip {
 
         // Swarmed
         if (entity.getSwarmAttackerId() != Entity.NONE) {
-            result.append(addToTT("Swarmed", BR, game.getEntity(entity.getSwarmAttackerId()).getDisplayName()));
+            final Entity swarmAttacker = game.getEntity(entity.getSwarmAttackerId());
+            if (swarmAttacker == null) {
+                LogManager.getLogger().error(String.format(
+                        "Entity %s is currently swarmed by an unknown attacker with id %s",
+                        entity.getId(), entity.getSwarmAttackerId()));
+            }
+            result.append(addToTT("Swarmed", BR,
+                    (swarmAttacker == null) ? "ERROR" : swarmAttacker.getDisplayName()));
         }
 
         // Spotting


### PR DESCRIPTION
This fixes one of the two issues raised in #3607, adding the requisite null protection for the nullable Game::getEntity. I'll be handling the other in a separate PR.