### PR TITLE
3607: Prevent Entities from Fleeing While Swarming a Unit

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9580,13 +9580,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public boolean canFlee() {
         Coords pos = getPosition();
         return ((getWalkMP() > 0) || (this instanceof Infantry))
-               && !isProne()
-               && !isStuck()
-               && !isShutDown()
-               && !getCrew().isUnconscious()
-               && (isOffBoard() || ((pos != null)
-                   && ((pos.getX() == 0) || (pos.getX() == (game.getBoard().getWidth() - 1))
-                   || (pos.getY() == 0) || (pos.getY() == (game.getBoard().getHeight() - 1)))));
+                && !isProne()
+                && !isStuck()
+                && !isShutDown()
+                && !getCrew().isUnconscious()
+                && (getSwarmTargetId() == NONE)
+                && (isOffBoard() || ((pos != null)
+                        && ((pos.getX() == 0) || (pos.getX() == (getGame().getBoard().getWidth() - 1))
+                        || (pos.getY() == 0) || (pos.getY() == (getGame().getBoard().getHeight() - 1)))));
     }
 
     public void setEverSeenByEnemy(boolean b) {


### PR DESCRIPTION
This fixes the second bug raised in 3607 by preventing swarming entities from fleeing the board.