### PR TITLE
MML 1088: Naval Combat Units can now take Maritime Lifeboats

### DIFF
--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -480,7 +480,7 @@ public class TestTank extends TestEntity {
             if (eq.hasFlag(MiscType.F_LIFEBOAT)) {
                 if (eq.hasSubType(MiscType.S_MARITIME_ESCAPE_POD | MiscType.S_MARITIME_LIFEBOAT)) {
                     // Allowed for all naval units and support vehicles with an amphibious chassis mod
-                    return supporVehicle ? !mode.equals(EntityMovementMode.HOVER) : !isNaval;
+                    return supporVehicle ? !mode.equals(EntityMovementMode.HOVER) : isNaval;
                 } else {
                     return isAero;
                 }


### PR DESCRIPTION
This fixes https://github.com/MegaMek/megameklab/issues/1088 , which is an accidental negation.