### PR TITLE
3630: Properly Cancel MASC Movement on Nag Cancel

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1231,6 +1231,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
                 if (!nag.getShowAgain()) {
                     GUIPreferences.getInstance().setNagForMASC(false);
                 }
+            } else {
+                return;
             }
         }
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1219,7 +1219,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             }
         }
 
-        if (cmd.hasActiveMASC() && GUIPreferences.getInstance().getNagForMASC()) {
+        if (GUIPreferences.getInstance().getNagForMASC() && cmd.hasActiveMASC()) {
             // pop up are you sure dialog
             ConfirmDialog nag = new ConfirmDialog(clientgui.frame,
                     Messages.getString("MovementDisplay.areYouSure"),
@@ -1234,21 +1234,20 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
             }
         }
 
-        if (cmd.hasActiveSupercharger() && GUIPreferences.getInstance().getNagForMASC()) {
-            if (!(ce() instanceof VTOL)) {
-                ConfirmDialog nag = new ConfirmDialog(clientgui.frame,
-                        Messages.getString("MovementDisplay.areYouSure"),
-                        Messages.getString("MovementDisplay.ConfirmSuperchargerRoll", ce().getSuperchargerTarget()),
-                        true);
-                nag.setVisible(true);
-                if (nag.getAnswer()) {
-                    // do they want to be bothered again?
-                    if (!nag.getShowAgain()) {
-                        GUIPreferences.getInstance().setNagForMASC(false);
-                    }
-                } else {
-                    return;
+        if (GUIPreferences.getInstance().getNagForMASC() && !(ce() instanceof VTOL)
+                && cmd.hasActiveSupercharger()) {
+            ConfirmDialog nag = new ConfirmDialog(clientgui.frame,
+                    Messages.getString("MovementDisplay.areYouSure"),
+                    Messages.getString("MovementDisplay.ConfirmSuperchargerRoll", ce().getSuperchargerTarget()),
+                    true);
+            nag.setVisible(true);
+            if (nag.getAnswer()) {
+                // do they want to be bothered again?
+                if (!nag.getShowAgain()) {
+                    GUIPreferences.getInstance().setNagForMASC(false);
                 }
+            } else {
+                return;
             }
         }
 


### PR DESCRIPTION
This fixes #3630.

Commit 1 collapses two if statements into one and reorders the if statements for better performance, commit 2 is the bugfix.