### PR TITLE
Adjust initiative bonus processing

### DIFF
--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -451,17 +451,11 @@ public final class Player extends TurnOrdered {
         // per TacOps:AR page 162-163, only the highest bonus should available should be used.
         for (Entity entity : game.getEntitiesVector()) {
             if (entity.getOwner().equals(this)) {
-                int HQInitBonus = entity.getHQIniBonus();
-                int quirkBonus = entity.getQuirkIniBonus();
-                
-                if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_MOBILE_HQS)
-                    && (HQInitBonus > bonus)) {
-                    bonus = HQInitBonus;
+                if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_MOBILE_HQS)) {
+                    bonus = Math.max(entity.getHQIniBonus(), bonus);
                 }
                 
-                if (quirkBonus > bonus) {
-                    bonus = quirkBonus;
-                }
+                bonus = Math.max(bonus, entity.getQuirkIniBonus());
             }
         }
         return bonus;

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -451,13 +451,16 @@ public final class Player extends TurnOrdered {
         // per TacOps:AR page 162-163, only the highest bonus should available should be used.
         for (Entity entity : game.getEntitiesVector()) {
             if (entity.getOwner().equals(this)) {
+                int HQInitBonus = entity.getHQIniBonus();
+                int quirkBonus = entity.getQuirkIniBonus();
+                
                 if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_MOBILE_HQS)
-                    && (entity.getHQIniBonus() > 0)) {
-                    bonus = entity.getHQIniBonus();
+                    && (HQInitBonus > bonus)) {
+                    bonus = HQInitBonus;
                 }
                 
-                if (entity.getQuirkIniBonus() > bonus) {
-                    bonus = entity.getQuirkIniBonus();
+                if (quirkBonus > bonus) {
+                    bonus = quirkBonus;
                 }
             }
         }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -440,38 +440,28 @@ public final class Player extends TurnOrdered {
      * @return the bonus to this player's initiative rolls granted by his units
      */
     public int getTurnInitBonus() {
-        int bonusHQ = 0;
-        int bonusMD = 0;
-        int bonusQ = 0;
+        int bonus = 0;
         if (game == null) {
             return 0;
         }
         if (game.getEntitiesVector() == null) {
             return 0;
         }
+        
+        // per TacOps:AR page 162-163, only the highest bonus should available should be used.
         for (Entity entity : game.getEntitiesVector()) {
             if (entity.getOwner().equals(this)) {
                 if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_MOBILE_HQS)
-                    && (bonusHQ == 0) && (entity.getHQIniBonus() > 0)) {
-                    bonusHQ = entity.getHQIniBonus();
+                    && (entity.getHQIniBonus() > 0)) {
+                    bonus = entity.getHQIniBonus();
                 }
                 
-                /*
-                 * REMOVED IN IO.
-                 * if (game.getOptions().booleanOption(OptionsConstants.
-                 * RPG_MANEI_DOMINI) && (bonusMD == 0) &&
-                 * (entity.getMDIniBonus() > 0)) { bonusMD =
-                 * entity.getMDIniBonus(); }
-                 */
-                if (entity.getQuirkIniBonus() > bonusQ) {
-                    //TODO: I am assuming that the quirk initiative bonuses go to the highest,
-                    //rather than being cumulative
-                    //http://www.classicbattletech.com/forums/index.php/topic,52903.new.html#new
-                    bonusQ = entity.getQuirkIniBonus();
+                if (entity.getQuirkIniBonus() > bonus) {
+                    bonus = entity.getQuirkIniBonus();
                 }
             }
         }
-        return bonusHQ + bonusMD + bonusQ;
+        return bonus;
     }
 
     /**

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -293,29 +293,19 @@ public final class Team extends TurnOrdered {
 
     /**
      * cycle through players team and select the best initiative
-     * take negatives only if the current bonus is zero
      */
     public int getTotalInitBonus(boolean bInitiativeCompensationBonus) {
         int dynamicBonus = Integer.MIN_VALUE;
         int constantb = Integer.MIN_VALUE;
         
         for (Player player : getPlayersVector()) {
-            int turnInitBonus = player.getTurnInitBonus();
-            int commandBonus = player.getCommandBonus();
+            dynamicBonus = Math.max(dynamicBonus, player.getTurnInitBonus());
+            dynamicBonus = Math.max(dynamicBonus, player.getCommandBonus());
             
-            if (turnInitBonus > dynamicBonus) {
-                dynamicBonus = turnInitBonus;
-            }
-            
-            if (commandBonus > dynamicBonus) {
-                dynamicBonus = commandBonus;
-            }
-
             // this is a special case: it's an arbitrary bonus associated with a player
-            if (player.getConstantInitBonus() > constantb) {
-                constantb = player.getConstantInitBonus();
-            }
+            constantb = Math.max(constantb, player.getConstantInitBonus());
         }
+        
         return constantb + dynamicBonus +
                 + getInitCompensationBonus(bInitiativeCompensationBonus);
     }

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -296,21 +296,27 @@ public final class Team extends TurnOrdered {
      * take negatives only if the current bonus is zero
      */
     public int getTotalInitBonus(boolean bInitiativeCompensationBonus) {
-        int turnb = 0;
+        int dynamicBonus = Integer.MIN_VALUE;
         int constantb = Integer.MIN_VALUE;
-        int commandb = Integer.MIN_VALUE;
-        constantb = Integer.MIN_VALUE;
+        
         for (Player player : getPlayersVector()) {
-            turnb += player.getTurnInitBonus();
-            if (player.getCommandBonus() > commandb) {
-                commandb = player.getCommandBonus();
+            int turnInitBonus = player.getTurnInitBonus();
+            int commandBonus = player.getCommandBonus();
+            
+            if (turnInitBonus > dynamicBonus) {
+                dynamicBonus = turnInitBonus;
+            }
+            
+            if (commandBonus > dynamicBonus) {
+                dynamicBonus = commandBonus;
             }
 
+            // this is a special case: it's an arbitrary bonus associated with a player
             if (player.getConstantInitBonus() > constantb) {
                 constantb = player.getConstantInitBonus();
             }
         }
-        return constantb + turnb + commandb
+        return constantb + dynamicBonus +
                 + getInitCompensationBonus(bInitiativeCompensationBonus);
     }
     

--- a/megamek/unittests/megamek/common/TeamTest.java
+++ b/megamek/unittests/megamek/common/TeamTest.java
@@ -106,30 +106,30 @@ public class TeamTest {
         Mockito.when(mockPlayer2.getTurnInitBonus()).thenReturn(2);
         Mockito.when(mockPlayer3.getTurnInitBonus()).thenReturn(3);
         initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
-        Assert.assertEquals(12, initBonus);
+        Assert.assertEquals(6, initBonus);
 
         Mockito.when(mockPlayer1.getTurnInitBonus()).thenReturn(-1);
         Mockito.when(mockPlayer2.getTurnInitBonus()).thenReturn(-2);
         Mockito.when(mockPlayer3.getTurnInitBonus()).thenReturn(-3);
         initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
-        Assert.assertEquals(0, initBonus);
+        Assert.assertEquals(6, initBonus);
 
         useInitCompBonus = true;
-
+ 
         initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
-        Assert.assertEquals(0, initBonus);
+        Assert.assertEquals(6, initBonus);
 
         Mockito.when(mockPlayer1.getInitCompensationBonus()).thenReturn(-1);
         Mockito.when(mockPlayer2.getInitCompensationBonus()).thenReturn(-2);
         Mockito.when(mockPlayer3.getInitCompensationBonus()).thenReturn(-3);
         initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
-        Assert.assertEquals(0, initBonus);
+        Assert.assertEquals(6, initBonus);
 
         Mockito.when(mockPlayer1.getInitCompensationBonus()).thenReturn(1);
         Mockito.when(mockPlayer2.getInitCompensationBonus()).thenReturn(2);
         Mockito.when(mockPlayer3.getInitCompensationBonus()).thenReturn(3);
         initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
-        Assert.assertEquals(3, initBonus);        
+        Assert.assertEquals(9, initBonus);        
     }
 
 


### PR DESCRIPTION
The way it works now is that, for each player, only the highest initiative bonus applies. Same goes for each team. Addresses #2738.