### PR TITLE
Suite Options: Adding Options Changed Events

### DIFF
--- a/megamek/src/megamek/MMOptionsChangedEvent.java
+++ b/megamek/src/megamek/MMOptionsChangedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek;
+
+import megamek.common.event.MMEvent;
+
+/**
+ * An event triggered after the MMOptions are changed.
+ * The event handlers cannot modify these options.
+ */
+public class MMOptionsChangedEvent extends MMEvent {
+    //region Constructors
+    public MMOptionsChangedEvent() {
+        super();
+    }
+    //endregion Constructors
+}

--- a/megamek/src/megamek/SuiteOptionsChangedEvent.java
+++ b/megamek/src/megamek/SuiteOptionsChangedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek;
+
+import megamek.common.event.MMEvent;
+
+/**
+ * An event triggered after the SuiteOptions are changed.
+ * The event handlers cannot modify these options.
+ */
+public class SuiteOptionsChangedEvent extends MMEvent {
+    //region Constructors
+    public SuiteOptionsChangedEvent() {
+        super();
+    }
+    //endregion Constructors
+}


### PR DESCRIPTION
I missed this when adding the base setup, and will require it for the Unit Display Dialog changes.