### PR TITLE
Logging: Removing Outdated Release Date

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -332,9 +332,9 @@ public class MegaMek {
     public static String getUnderlyingInformation(final String originProject,
                                                   final String currentProject) {
         final LocalDateTime buildDate = getBuildDate();
-        return String.format("Starting %s v%s\n\tBuild Date: %s\n\tRelease Date: %s\n\tToday: %s\n\tOrigin Project: %s\n\tJava Vendor: %s\n\tJava Version: %s\n\tPlatform: %s %s (%s)\n\tSystem Locale: %s\n\tTotal memory available to %s: %,.0f GB",
+        return String.format("Starting %s v%s\n\tBuild Date: %s\n\tToday: %s\n\tOrigin Project: %s\n\tJava Vendor: %s\n\tJava Version: %s\n\tPlatform: %s %s (%s)\n\tSystem Locale: %s\n\tTotal memory available to %s: %,.0f GB",
                 currentProject, MMConstants.VERSION, ((buildDate == null) ? "N/A" : buildDate),
-                MMConstants.RELEASE_DATE, LocalDate.now(), originProject,
+                LocalDate.now(), originProject,
                 System.getProperty("java.vendor"), System.getProperty("java.version"),
                 System.getProperty("os.name"), System.getProperty("os.version"),
                 System.getProperty("os.arch"), Locale.getDefault(), currentProject,

--- a/megamek/src/megamek/SuiteConstants.java
+++ b/megamek/src/megamek/SuiteConstants.java
@@ -27,7 +27,6 @@ public abstract class SuiteConstants {
     //region General Constants
     public static final String PROJECT_NAME = "MegaMek Suite";
     public static final Version VERSION = new Version("0.49.9-SNAPSHOT");
-    public static final LocalDate RELEASE_DATE = LocalDate.of(2022, 5, 27);
     public static final int MAXIMUM_D6_VALUE = 6;
 
     // This is used in creating the name of save files, e.g. the MekHQ campaign file


### PR DESCRIPTION
This functionality is better handled in the Build Date tracking setup, which was meant to replace this. However, I forgot to remove this after testing on the nightlies.