### PR TITLE
Draw TMM of my potential move

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -272,8 +272,6 @@ public class MegaMek {
         mmg.startHost(resolver.password, resolver.port, resolver.registerServer,
                 resolver.announceUrl, resolver.mailPropertiesFile, gameFile,
                 resolver.playerName );
-
-        mmg.startClient(resolver.playerName+".2", resolver.serverAddress, resolver.port);
     }
 
     /**

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -272,6 +272,8 @@ public class MegaMek {
         mmg.startHost(resolver.password, resolver.port, resolver.registerServer,
                 resolver.announceUrl, resolver.mailPropertiesFile, gameFile,
                 resolver.playerName );
+
+        mmg.startClient(resolver.playerName+".2", resolver.serverAddress, resolver.port);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
@@ -290,7 +290,7 @@ class StepSprite extends Sprite {
         }
 
         if (isLastLegalStep) {
-            drawTMMAndRolls(step, isLastStep, jumped, bv.game, new Point(0, 0), graph, col, true);
+            drawTMMAndRolls(step, jumped, bv.game, new Point(0, 0), graph, col, true);
         }
 
         baseScaleImage = bv.createImage(tempImage.getSource());
@@ -485,7 +485,11 @@ class StepSprite extends Sprite {
         }
 
         EntityMovementType moveType = step.getMovementType(isLastStep);
-        if ((moveType == EntityMovementType.MOVE_VTOL_WALK) || (moveType == EntityMovementType.MOVE_VTOL_RUN) || (moveType == EntityMovementType.MOVE_VTOL_SPRINT) || (moveType == EntityMovementType.MOVE_SUBMARINE_WALK) || (moveType == EntityMovementType.MOVE_SUBMARINE_RUN)) {
+        if ((moveType == EntityMovementType.MOVE_VTOL_WALK)
+                || (moveType == EntityMovementType.MOVE_VTOL_RUN)
+                || (moveType == EntityMovementType.MOVE_VTOL_SPRINT)
+                || (moveType == EntityMovementType.MOVE_SUBMARINE_WALK)
+                || (moveType == EntityMovementType.MOVE_SUBMARINE_RUN)) {
             costStringBuf.append('{').append(step.getElevation()).append('}');
         }
 
@@ -506,7 +510,7 @@ class StepSprite extends Sprite {
         graph.drawString(costString, costX - 1, stepPos.y + 38);
     }
 
-    private void drawTMMAndRolls(MoveStep step, boolean isLastStep, boolean jumped, Game game,
+    private void drawTMMAndRolls(MoveStep step, boolean jumped, Game game,
                                  Point stepPos, Graphics graph, Color col, boolean shiftFlag) {
 
         StringBuilder subscriptStringBuf = new StringBuilder();


### PR DESCRIPTION
This addresses RFE https://github.com/MegaMek/megamek/issues/3662
This moves drawing MASC and Supercharger roll targets into a method combined with new functionality of drawing the potential Target Movement Modifier (TMM) on the final step of a planned movement.
Previously the MASC rolls drew every step, which was cluttered and unhelpful, so combining it with final TMM made sense.
![Capture](https://user-images.githubusercontent.com/1423800/170793999-57aedc93-75d9-4bf5-a22f-2a4dc9a132e2.PNG)
![Capture](https://user-images.githubusercontent.com/1423800/170794094-9c597257-ab0d-419f-8d3e-0a5bd00dffd3.PNG)

