### PR TITLE
special "get damaged crits" logic for gun emplacement; minor bugfix

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
@@ -712,7 +712,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener, ListSe
                     invalidEnvironment = true;
                 }
 
-                if ((en instanceof Tank)
+                if ((en instanceof Tank) && !(en instanceof GunEmplacement)
                         && (en.getLocationStatus(Tank.LOC_REAR) > ILocationExposureStatus.NORMAL)) {
                     invalidEnvironment = true;
                 }

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -15,7 +15,6 @@
 package megamek.common;
 
 import megamek.client.ui.swing.calculationReport.CalculationReport;
-import megamek.client.ui.swing.calculationReport.DummyCalculationReport;
 import megamek.common.battlevalue.GunEmplacementBVCalculator;
 import megamek.common.cost.CostCalculator;
 import megamek.common.enums.AimingMode;
@@ -471,5 +470,23 @@ public class GunEmplacement extends Tank {
         
         return (occupiedStructure.getCurrentCF(getPosition()) + occupiedStructure.getArmor(getPosition()))
                 / ((double) (initialBuildingCF + initialBuildingArmor));
+    }
+    
+    /**
+     * Gun emplacements don't have critical slots per se, so we
+     * simply return 1 if the piece of equipment has been hit and 0 otherwise.
+     */
+    @Override
+    public int getDamagedCriticals(int type, int index, int loc) {
+        Mounted m = null;
+        if (type == CriticalSlot.TYPE_EQUIPMENT) {
+            m = getEquipment(index);
+            
+            if (m != null && m.isHit()) {
+                return 1;
+            }
+        }
+        
+        return 0;
     }
 }

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -444,7 +444,7 @@ public class GunEmplacement extends Tank {
 
         // very aggressive null defense
         if (deployed && (getGame() != null) && (getGame().getBoard() != null) && 
-                getPosition() != null) {
+                (getPosition() != null)) {
             Building occupiedStructure = getGame().getBoard().getBuildingAt(getPosition());
             
             if (occupiedStructure != null) {

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -450,10 +450,11 @@ public class GunEmplacement extends Tank {
             if (occupiedStructure != null) {
                 initialBuildingCF = occupiedStructure.getCurrentCF(getPosition());
                 initialBuildingArmor = occupiedStructure.getArmor(getPosition());
+                return;
             }
-        } else {
-            initialBuildingCF = initialBuildingArmor = 0;
-        }
+        }        
+        
+        initialBuildingCF = initialBuildingArmor = 0;
     }
     
     /**

--- a/megamek/src/megamek/common/GunEmplacement.java
+++ b/megamek/src/megamek/common/GunEmplacement.java
@@ -442,11 +442,15 @@ public class GunEmplacement extends Tank {
     public void setDeployed(boolean deployed) {
         super.setDeployed(deployed);
 
-        if (deployed) {
+        // very aggressive null defense
+        if (deployed && (getGame() != null) && (getGame().getBoard() != null) && 
+                getPosition() != null) {
             Building occupiedStructure = getGame().getBoard().getBuildingAt(getPosition());
             
-            initialBuildingCF = occupiedStructure.getCurrentCF(getPosition());
-            initialBuildingArmor = occupiedStructure.getArmor(getPosition());
+            if (occupiedStructure != null) {
+                initialBuildingCF = occupiedStructure.getCurrentCF(getPosition());
+                initialBuildingArmor = occupiedStructure.getArmor(getPosition());
+            }
         } else {
             initialBuildingCF = initialBuildingArmor = 0;
         }


### PR DESCRIPTION
Gun emplacements don't technically have critical slots, and a piece of equipment on a gun can only take one hit; so we just return 0 or 1. Among other things, this allows gun emplacements with damaged systems to show up in the repair bay, and for damage to those systems to carry over from MegaMek to MekHQ.

Also fix a null pointer exception when clicking on systems on gun emplacements in the unit display.