### PR TITLE
Draw TMM pips in movement and firing

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -47,6 +47,10 @@ class EntitySprite extends Sprite {
 
     // Statics
     private static final int SMALL = 0;
+    private static final int STATUS_BAR_LENGTH = 24;
+    private static final int STATUS_BAR_X = 55;
+    private static final int MAX_TMM_PIPS = 6;
+    private static final int TMM_PIP_SIZE = STATUS_BAR_LENGTH / MAX_TMM_PIPS;
     private static final boolean DIRECT = true;
     private static final Color LABEL_TEXT_COLOR = Color.WHITE;
     private static final Color LABEL_CRITICAL_BACK = new Color(200, 0, 0, 200);
@@ -627,6 +631,8 @@ class EntitySprite extends Sprite {
                     stStr.add(new Status(damageColor, 0, SMALL));
                 }
             }
+
+
             
             // Unit Label
             // no scaling for the label, its size is changed by varying
@@ -746,32 +752,47 @@ class EntitySprite extends Sprite {
                 }
             }
 
-            // armor and internal status bars
-            int baseBarLength = 23;
+            // armor, internal and TMM status bars
             int barLength = 0;
             double percentRemaining = 0.00;
 
             percentRemaining = entity.getArmorRemainingPercent();
-            barLength = (int) (baseBarLength * percentRemaining);
+            barLength = (int) (STATUS_BAR_LENGTH * percentRemaining);
 
             graph.setColor(Color.darkGray);
-            graph.fillRect(56, 7, 23, 3);
+            graph.fillRect(STATUS_BAR_X +1, 7, STATUS_BAR_LENGTH, 3);
             graph.setColor(Color.lightGray);
-            graph.fillRect(55, 6, 23, 3);
+            graph.fillRect(STATUS_BAR_X, 6, STATUS_BAR_LENGTH, 3);
             graph.setColor(getStatusBarColor(percentRemaining));
-            graph.fillRect(55, 6, barLength, 3);
+            graph.fillRect(STATUS_BAR_X, 6, barLength, 3);
 
             if (!ge) {
                 // Gun emplacements don't have internal structure
                 percentRemaining = entity.getInternalRemainingPercent();
-                barLength = (int) (baseBarLength * percentRemaining);
+                barLength = (int) (STATUS_BAR_LENGTH * percentRemaining);
 
                 graph.setColor(Color.darkGray);
-                graph.fillRect(56, 11, 23, 3);
+                graph.fillRect(STATUS_BAR_X +1, 11, STATUS_BAR_LENGTH, 3);
                 graph.setColor(Color.lightGray);
-                graph.fillRect(55, 10, 23, 3);
+                graph.fillRect(STATUS_BAR_X, 10, STATUS_BAR_LENGTH, 3);
                 graph.setColor(getStatusBarColor(percentRemaining));
-                graph.fillRect(55, 10, barLength, 3);
+                graph.fillRect(STATUS_BAR_X, 10, barLength, 3);
+            }
+
+            // show when done in movement, or on all during firing
+            if (!ge
+                    && ((entity.isDone() && bv.game.getPhase() == GamePhase.MOVEMENT)
+                    || (bv.game.getPhase() == GamePhase.FIRING))) {
+                int tmm = Compute.getTargetMovementModifier(bv.game, entity.getId()).getValue();
+                Color tmmColor = tmm < 0 ? Color.RED : tmm > MAX_TMM_PIPS ? Color.MAGENTA : Color.GREEN;
+                Color bgColor = tmm == 0 ? Color.BLACK : Color.DARK_GRAY;
+                tmm = tmm < 0 ? -tmm : tmm;
+                for (int i = 0; i < MAX_TMM_PIPS; i++ )
+                {
+                    graph.setColor( i < tmm ? tmmColor : bgColor);
+                    graph.fillRect(STATUS_BAR_X + (i * TMM_PIP_SIZE), 12 + TMM_PIP_SIZE,
+                            TMM_PIP_SIZE - 1, TMM_PIP_SIZE - 1);
+                }
             }
         }
 


### PR DESCRIPTION
This addresses https://github.com/MegaMek/megamek/issues/3664 by adding movement pips to the unit icon status bars.
If no movement occurs, there is no bar, otherwise there is a color coded six pip bar. Red means negative tmm. Blackis 0 TMM. Green is for TMM 1 -  6, Magenta for TMMs 7-12. There is no special provision for higher TMMs, it will just be a full magenta bar. Attached are screenshot at various zoom levels.
Currently there is no option to hide these. beyond what governs the other two status bars. Please let me know if an additional client preference option is needed. 
![zoomout](https://user-images.githubusercontent.com/1423800/172026033-e104650d-2fd3-4982-86e5-3f92fe86be38.PNG)
![zoom1](https://user-images.githubusercontent.com/1423800/172026034-3738855b-c21a-4c63-8a78-c2f343d2b752.PNG)
![Capture](https://user-images.githubusercontent.com/1423800/172026035-d9fdd85f-0b45-48a7-828f-7bcd21402370.PNG)

