### PR TITLE
Add nickname/callsign, if it exists, to reports

### DIFF
--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -334,10 +334,16 @@ public class Report implements Serializable {
             if ((indentation <= Report.DEFAULT_INDENTATION) || showImage) {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
-            add("<font color='0xffffff'><a href=\"" + ENTITY_LINK + entity.getId()
-                    + "\">" + entity.getShortName() + "</a></font>", true);
-            add("<B><font color='" + entity.getOwner().getColour().getHexString(0x00F0F0F0) + "'>"
-                    + entity.getOwner().getName() + "</font></B>");
+            String name = "<font color='0xffffff'><a href=\"" + ENTITY_LINK + entity.getId()
+                    + "\">" + entity.getShortName() + "</a></font>";
+            String color = entity.getOwner().getColour().getHexString(0x00F0F0F0);
+
+            if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
+                // pilot nickname, also known as callsign
+                name += " <font color='"+color+"'>\"" + entity.getCrew().getNickname().toUpperCase() + "\"</font>";
+            }
+            add(name, true);
+            add("<B><font color='" + color + "'>" + entity.getOwner().getName() + "</font></B>");
         }
     }
 


### PR DESCRIPTION
This resolves https://github.com/MegaMek/megamek/issues/3689. If a unit has a nickname (a.k.a. callsign) it is added to the report in the player's color. Example image attached.
![nicks-in-reports](https://user-images.githubusercontent.com/1423800/172075251-ad75ddad-f6ef-4bd6-a672-2651259ce1e5.PNG)
.