### PR TITLE
Color text in heat report

### DIFF
--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -1670,15 +1670,15 @@ public class GUIPreferences extends PreferenceStoreProxy {
             return defaultColor;
         } else if (heat <= 5) {
             return getColor(ADVANCED_HEAT_5_COLOR);
-        } else if (heat < 10) {
+        } else if (heat <= 10) {
             return getColor(ADVANCED_HEAT_10_COLOR);
-        } else if (heat < 15) {
+        } else if (heat <= 15) {
             return getColor(ADVANCED_HEAT_15_COLOR);
-        } else if (heat < 20) {
+        } else if (heat <= 20) {
             return  getColor(ADVANCED_HEAT_20_COLOR);
-        } else if (heat < 25) {
+        } else if (heat <= 25) {
             return  getColor(ADVANCED_HEAT_25_COLOR);
-        } else if (heat < 30) {
+        } else if (heat <= 30) {
             return  getColor(ADVANCED_HEAT_30_COLOR);
         }
         return  getColor(ADVANCED_HEAT_OVERHEAT_COLOR);

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -93,6 +93,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_NO_SAVE_NAG = "AdvancedNoSaveNag";
     public static final String ADVANCED_USE_CAMO_OVERLAY = "AdvancedUseCamoOverlay";
     public static final String ADVANCED_MAP_TEXT_COLOR = "AdvancedMapTextColor";
+    public static final String ADVANCED_REPORT_TEXT_COLOR = "AdvancedReportTextColor";
     public static final String ADVANCED_WARNING_COLOR = "AdvancedWarningColor";
     public static final String ADVANCED_TMM_PIP_MODE = "AdvancedTmmPipMode";
     public static final String ADVANCED_HEAT_5_COLOR = "ADVANCED_HEAT_5_COLOR";
@@ -257,41 +258,38 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static String RAT_PAD_BV = "RATPadBV";
     public static String RAT_SELECTED_RAT = "RATSelectedRAT";
 
-    public static final Color DEFAULT_WHITE = new Color(255, 255, 255);
-    public static final Color DEFAULT_BLACK = new Color(0, 0, 0);
+    private static final Color DEFAULT_WHITE = new Color(255, 255, 255);
+    private static final Color DEFAULT_BLACK = new Color(0, 0, 0);
 
     // Text colors that read over light and dark backgrounds
-    public static final Color DEFAULT_DARK_GRAY = new Color(64, 64, 64);
-    public static final Color DEFAULT_LIGHT_GRAY = new Color(196, 196, 196);
-    public static final Color DEFAULT_CYAN = new Color(0, 228, 228);
-    public static final Color DEFAULT_MAGENTA = new Color(228, 0, 228);
-    public static final Color DEFAULT_PINK = new Color(228, 20, 147);
-    public static final Color DEFAULT_RED = new Color(196, 0, 0);
-    public static final Color DEFAULT_GREEN = new Color(0, 196, 0);
-    public static final Color DEFAULT_BLUE = new Color(64, 96, 228);
-
+    private static final Color DEFAULT_DARK_GRAY = new Color(64, 64, 64);
+    private static final Color DEFAULT_LIGHT_GRAY = new Color(196, 196, 196);
+    private static final Color DEFAULT_CYAN = new Color(0, 228, 228);
+    private static final Color DEFAULT_MAGENTA = new Color(228, 0, 228);
+    private static final Color DEFAULT_PINK = new Color(228, 20, 147);
+    private static final Color DEFAULT_RED = new Color(196, 0, 0);
+    private static final Color DEFAULT_GREEN = new Color(0, 212, 0);
+    private static final Color DEFAULT_BLUE = new Color(64, 96, 228);
     private static final Color DEFAULT_MEDIUM_DARK_RED = new Color(150, 80, 80);  // medium dark red
     private static final Color DEFAULT_MEDIUM_YELLOW = new Color(180, 180, 100);
-    private static final Color DEFAULT_ORANGE = new Color(255, 140, 0);
+    private static final Color DEFAULT_ORANGE = new Color(248, 140, 0);
     private static final Color DEFAULT_YELLOW = new Color(216, 200, 0);
     private static final Color DEFAULT_MEDIUM_GREEN = new Color(100, 180, 100);
 
     // Heat Scale
-    private static final Color DEFAULT_HEAT_5 = new Color(64, 128, 255);
-    private static final Color DEFAULT_HEAT_10 = new Color(64, 164, 128);
-    private static final Color DEFAULT_HEAT_15 = new Color(48, 228, 48);
-    private static final Color DEFAULT_HEAT_20 = new Color(228, 198, 0);
-    private static final Color DEFAULT_HEAT_25 = new Color(228, 128, 0);
-    private static final Color DEFAULT_HEAT_30 = new Color(228, 64, 64);
-    private static final Color DEFAULT_HEAT_OVERHEAT = new Color(228, 12, 12);
+    private static final Color DEFAULT_HEAT_5_COLOR = new Color(64, 128, 255);
+    private static final Color DEFAULT_HEAT_10_COLOR = new Color(64, 164, 128);
+    private static final Color DEFAULT_HEAT_15_COLOR = new Color(48, 212, 48);
+    private static final Color DEFAULT_HEAT_20_COLOR = new Color(228, 198, 0);
+    private static final Color DEFAULT_HEAT_25_COLOR = new Color(248, 128, 0);
+    private static final Color DEFAULT_HEAT_30_COLOR = new Color(248, 64, 64);
+    private static final Color DEFAULT_HEAT_OVERHEAT_COLOR = new Color(248, 12, 12);
 
     // Map colors
-    private static final Color DEFAULT_FOLIAGE_GREEN = new Color(80, 230, 80);
-    private static final Color DEFAULT_ALLY_COLOR = new Color(60, 140, 240);  // greenish blue
-    private static final Color DEFAULT_ENEMY_COLOR = new Color(200, 40, 40); // red
-    private static final Color DEFAULT_MY_COLOR = new Color(40, 210, 40);  // light green
-
-
+    private static final Color DEFAULT_MAP_BRIGHT_GREEN = new Color(80, 230, 80);
+    private static final Color DEFAULT_MAP_BLUE = new Color(60, 140, 240);  // greenish blue
+    private static final Color DEFAULT_MAP_RED = new Color(200, 40, 40); // red
+    private static final Color DEFAULT_MAP_GREEN = new Color(40, 210, 40);  // light green
 
     protected static GUIPreferences instance = new GUIPreferences();
 
@@ -311,17 +309,17 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(ADVANCED_MECH_DISPLAY_MEDIUM_FONT_SIZE, 10);
         store.setDefault(BOARDEDIT_RNDDIALOG_START, false);
         setDefault(ADVANCED_MOVE_DEFAULT_CLIMB_MODE, true);
-        setDefault(ADVANCED_MOVE_DEFAULT_COLOR, Color.CYAN);
-        setDefault(ADVANCED_MOVE_ILLEGAL_COLOR, Color.DARK_GRAY);
-        setDefault(ADVANCED_MOVE_JUMP_COLOR, Color.RED);
+        setDefault(ADVANCED_MOVE_DEFAULT_COLOR, DEFAULT_CYAN.CYAN);
+        setDefault(ADVANCED_MOVE_ILLEGAL_COLOR, DEFAULT_DARK_GRAY);
+        setDefault(ADVANCED_MOVE_JUMP_COLOR, DEFAULT_RED);
         setDefault(ADVANCED_MOVE_MASC_COLOR, DEFAULT_ORANGE);
         setDefault(ADVANCED_MOVE_RUN_COLOR, DEFAULT_YELLOW);
         setDefault(ADVANCED_MOVE_BACK_COLOR, DEFAULT_YELLOW);
         setDefault(ADVANCED_MOVE_SPRINT_COLOR, DEFAULT_PINK);
         setDefault(ADVANCED_UNITOVERVIEW_SELECTED_COLOR, DEFAULT_MAGENTA);
-        setDefault(ADVANCED_UNITOVERVIEW_VALID_COLOR, Color.CYAN);
-        setDefault(ADVANCED_FIRE_SOLN_CANSEE_COLOR, Color.CYAN);
-        setDefault(ADVANCED_FIRE_SOLN_NOSEE_COLOR, Color.RED);
+        setDefault(ADVANCED_UNITOVERVIEW_VALID_COLOR, DEFAULT_CYAN);
+        setDefault(ADVANCED_FIRE_SOLN_CANSEE_COLOR, DEFAULT_CYAN);
+        setDefault(ADVANCED_FIRE_SOLN_NOSEE_COLOR, DEFAULT_RED);
         setDefault(ADVANCED_ARMORMINI_UNITS_PER_BLOCK, 10);
         setDefault(ADVANCED_ARMORMINI_ARMOR_CHAR, "\u2B1B"); // Centered Filled Square    
         setDefault(ADVANCED_ARMORMINI_CAP_ARMOR_CHAR, "\u26CA"); // Shield
@@ -333,7 +331,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_ARMORMINI_FONT_SIZE_MOD, -2);
         setDefault(ADVANCED_WARNING_COLOR, DEFAULT_RED);
         setDefault(ADVANCED_TMM_PIP_MODE, 2); // show pips with colors based on move type
-        setDefault(ADVANCED_LOW_FOLIAGE_COLOR, DEFAULT_FOLIAGE_GREEN);
+        setDefault(ADVANCED_LOW_FOLIAGE_COLOR, DEFAULT_MAP_BRIGHT_GREEN);
         setDefault(ADVANCED_NO_SAVE_NAG, false);
         setDefault(ADVANCED_USE_CAMO_OVERLAY, true);
 
@@ -359,13 +357,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(ADVANCED_BUTTONS_PER_ROW, 5);
         store.setDefault(ADVANCED_ROUND_REPORT_SPRITES, true);
 
-        setDefault(ADVANCED_HEAT_5_COLOR, DEFAULT_HEAT_5);
-        setDefault(ADVANCED_HEAT_10_COLOR, DEFAULT_HEAT_10);
-        setDefault(ADVANCED_HEAT_15_COLOR, DEFAULT_HEAT_15);
-        setDefault(ADVANCED_HEAT_20_COLOR, DEFAULT_HEAT_20);
-        setDefault(ADVANCED_HEAT_25_COLOR, DEFAULT_HEAT_25);
-        setDefault(ADVANCED_HEAT_20_COLOR, DEFAULT_HEAT_30);
-        setDefault(ADVANCED_HEAT_OVERHEAT_COLOR, DEFAULT_HEAT_OVERHEAT);
+        setDefault(ADVANCED_HEAT_5_COLOR, DEFAULT_HEAT_5_COLOR);
+        setDefault(ADVANCED_HEAT_10_COLOR, DEFAULT_HEAT_10_COLOR);
+        setDefault(ADVANCED_HEAT_15_COLOR, DEFAULT_HEAT_15_COLOR);
+        setDefault(ADVANCED_HEAT_20_COLOR, DEFAULT_HEAT_20_COLOR);
+        setDefault(ADVANCED_HEAT_25_COLOR, DEFAULT_HEAT_25_COLOR);
+        setDefault(ADVANCED_HEAT_20_COLOR, DEFAULT_HEAT_30_COLOR);
+        setDefault(ADVANCED_HEAT_OVERHEAT_COLOR, DEFAULT_HEAT_OVERHEAT_COLOR);
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
@@ -400,7 +398,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(LOBBY_MEKTABLE_PILOT_WIDTH, 80);
         store.setDefault(LOBBY_MEKTABLE_PLAYER_WIDTH, 50);
         store.setDefault(LOBBY_MEKTABLE_BV_WIDTH, 50);
-        setDefault(ADVANCED_MAP_TEXT_COLOR, Color.BLACK);
+        setDefault(ADVANCED_MAP_TEXT_COLOR, DEFAULT_BLACK);
+        setDefault(ADVANCED_REPORT_TEXT_COLOR, DEFAULT_BLACK);
         store.setDefault(MAP_ZOOM_INDEX, 7);
         store.setDefault(MECH_SELECTOR_INCLUDE_MODEL, true);
         store.setDefault(MECH_SELECTOR_INCLUDE_NAME, true);
@@ -511,9 +510,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(RAT_PAD_BV, false);
         store.setDefault(RAT_SELECTED_RAT, "");
 
-        setDefault(ALLY_UNIT_COLOR, DEFAULT_ALLY_COLOR);
-        setDefault(ENEMY_UNIT_COLOR, DEFAULT_ENEMY_COLOR);
-        setDefault(MY_UNIT_COLOR, DEFAULT_MY_COLOR);
+        setDefault(ALLY_UNIT_COLOR, DEFAULT_MAP_BLUE);
+        setDefault(ENEMY_UNIT_COLOR, DEFAULT_MAP_RED);
+        setDefault(MY_UNIT_COLOR, DEFAULT_MAP_GREEN);
         setDefault(TEAM_COLORING, true);
 
         setDefault(SHOW_KEYBINDS_OVERLAY, true);
@@ -654,6 +653,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public Color getMapTextColor() {
         return getColor(ADVANCED_MAP_TEXT_COLOR);
+    }
+
+    public Color getReportTextColor() {
+        return getColor(ADVANCED_REPORT_TEXT_COLOR);
     }
 
     public int getMapZoomIndex() {
@@ -1719,7 +1722,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
      */
     public static void AntiAliasifSet(Graphics graph) {
         if (getInstance().getAntiAliasing()) {
-            ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            ((Graphics2D) graph).setRenderingHint(
+                    RenderingHints.KEY_ANTIALIASING,
+                    RenderingHints.VALUE_ANTIALIAS_ON);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -95,6 +95,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_MAP_TEXT_COLOR = "AdvancedMapTextColor";
     public static final String ADVANCED_WARNING_COLOR = "AdvancedWarningColor";
     public static final String ADVANCED_TMM_PIP_MODE = "AdvancedTmmPipMode";
+    public static final String ADVANCED_HEAT_5_COLOR = "ADVANCED_HEAT_5_COLOR";
+    public static final String ADVANCED_HEAT_10_COLOR = "ADVANCED_HEAT_10_COLOR";
+    public static final String ADVANCED_HEAT_15_COLOR = "ADVANCED_HEAT_15_COLOR";
+    public static final String ADVANCED_HEAT_20_COLOR = "ADVANCED_HEAT_20_COLOR";
+    public static final String ADVANCED_HEAT_25_COLOR = "ADVANCED_HEAT_25_COLOR";
+    public static final String ADVANCED_HEAT_30_COLOR = "ADVANCED_HEAT_30_COLOR";
+    public static final String ADVANCED_HEAT_OVERHEAT_COLOR = "ADVANCED_HEAT_OVERHEAT_COLOR";
 
     /* --End advanced settings-- */
 
@@ -148,9 +155,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String MECH_SELECTOR_INCLUDE_LEVEL = "MechSelectorIncludeLevel";
     public static final String MECH_SELECTOR_INCLUDE_COST = "MechSelectorIncludeCost";
     public static final String MECH_SELECTOR_SHOW_ADVANCED = "MechSelectorShowAdvanced";
-    public static final String MECH_SELECTOR_UNIT_TYPE= "MechSelectorUnitType";
-    public static final String MECH_SELECTOR_WEIGHT_CLASS= "MechSelectorWeightClass";
-    public static final String MECH_SELECTOR_RULES_LEVELS= "MechSelectorRuleType";
+    public static final String MECH_SELECTOR_UNIT_TYPE = "MechSelectorUnitType";
+    public static final String MECH_SELECTOR_WEIGHT_CLASS = "MechSelectorWeightClass";
+    public static final String MECH_SELECTOR_RULES_LEVELS = "MechSelectorRuleType";
     public static final String MECH_SELECTOR_SORT_COLUMN = "MechSelectorSortColumn";
     public static final String MECH_SELECTOR_SORT_ORDER = "MechSelectorSortOrder";
     public static final String MECH_SELECTOR_SIZE_HEIGHT = "MechSelectorSizeHeight";
@@ -236,7 +243,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ENEMY_UNIT_COLOR = "EnemyUnitColor";
     public static final String SHOW_KEYBINDS_OVERLAY = "ShowKeybindsOverlay";
     public static final String UNIT_LABEL_STYLE = "UnitLabelStyle";
-    
+
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
     public static String RAT_BV_MIN = "RATBVMin";
@@ -249,7 +256,42 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static String RAT_YEAR_MAX = "RATYearMax";
     public static String RAT_PAD_BV = "RATPadBV";
     public static String RAT_SELECTED_RAT = "RATSelectedRAT";
-    
+
+    public static final Color DEFAULT_WHITE = new Color(255, 255, 255);
+    public static final Color DEFAULT_BLACK = new Color(0, 0, 0);
+
+    // Text colors that read over light and dark backgrounds
+    public static final Color DEFAULT_DARK_GRAY = new Color(64, 64, 64);
+    public static final Color DEFAULT_LIGHT_GRAY = new Color(196, 196, 196);
+    public static final Color DEFAULT_CYAN = new Color(0, 228, 228);
+    public static final Color DEFAULT_MAGENTA = new Color(228, 0, 228);
+    public static final Color DEFAULT_PINK = new Color(228, 20, 147);
+    public static final Color DEFAULT_RED = new Color(196, 0, 0);
+    public static final Color DEFAULT_GREEN = new Color(0, 196, 0);
+    public static final Color DEFAULT_BLUE = new Color(64, 96, 228);
+
+    private static final Color DEFAULT_MEDIUM_DARK_RED = new Color(150, 80, 80);  // medium dark red
+    private static final Color DEFAULT_MEDIUM_YELLOW = new Color(180, 180, 100);
+    private static final Color DEFAULT_ORANGE = new Color(255, 140, 0);
+    private static final Color DEFAULT_YELLOW = new Color(216, 200, 0);
+    private static final Color DEFAULT_MEDIUM_GREEN = new Color(100, 180, 100);
+
+    // Heat Scale
+    private static final Color DEFAULT_HEAT_5 = new Color(64, 128, 255);
+    private static final Color DEFAULT_HEAT_10 = new Color(64, 164, 128);
+    private static final Color DEFAULT_HEAT_15 = new Color(48, 228, 48);
+    private static final Color DEFAULT_HEAT_20 = new Color(228, 198, 0);
+    private static final Color DEFAULT_HEAT_25 = new Color(228, 128, 0);
+    private static final Color DEFAULT_HEAT_30 = new Color(228, 64, 64);
+    private static final Color DEFAULT_HEAT_OVERHEAT = new Color(228, 12, 12);
+
+    // Map colors
+    private static final Color DEFAULT_FOLIAGE_GREEN = new Color(80, 230, 80);
+    private static final Color DEFAULT_ALLY_COLOR = new Color(60, 140, 240);  // greenish blue
+    private static final Color DEFAULT_ENEMY_COLOR = new Color(200, 40, 40); // red
+    private static final Color DEFAULT_MY_COLOR = new Color(40, 210, 40);  // light green
+
+
 
     protected static GUIPreferences instance = new GUIPreferences();
 
@@ -272,11 +314,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_MOVE_DEFAULT_COLOR, Color.CYAN);
         setDefault(ADVANCED_MOVE_ILLEGAL_COLOR, Color.DARK_GRAY);
         setDefault(ADVANCED_MOVE_JUMP_COLOR, Color.RED);
-        setDefault(ADVANCED_MOVE_MASC_COLOR, new Color(255, 140, 0));
-        setDefault(ADVANCED_MOVE_RUN_COLOR, Color.YELLOW);
-        setDefault(ADVANCED_MOVE_BACK_COLOR, new Color(255, 255, 0));
-        setDefault(ADVANCED_MOVE_SPRINT_COLOR, new Color(255, 20, 147));
-        setDefault(ADVANCED_UNITOVERVIEW_SELECTED_COLOR, new Color(255, 0, 255));
+        setDefault(ADVANCED_MOVE_MASC_COLOR, DEFAULT_ORANGE);
+        setDefault(ADVANCED_MOVE_RUN_COLOR, DEFAULT_YELLOW);
+        setDefault(ADVANCED_MOVE_BACK_COLOR, DEFAULT_YELLOW);
+        setDefault(ADVANCED_MOVE_SPRINT_COLOR, DEFAULT_PINK);
+        setDefault(ADVANCED_UNITOVERVIEW_SELECTED_COLOR, DEFAULT_MAGENTA);
         setDefault(ADVANCED_UNITOVERVIEW_VALID_COLOR, Color.CYAN);
         setDefault(ADVANCED_FIRE_SOLN_CANSEE_COLOR, Color.CYAN);
         setDefault(ADVANCED_FIRE_SOLN_NOSEE_COLOR, Color.RED);
@@ -285,13 +327,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_ARMORMINI_CAP_ARMOR_CHAR, "\u26CA"); // Shield
         setDefault(ADVANCED_ARMORMINI_IS_CHAR, "\u25A3"); // Centered Square with Dot     
         setDefault(ADVANCED_ARMORMINI_DESTROYED_CHAR, "\u2715"); // Centered x 
-        setDefault(ADVANCED_ARMORMINI_COLOR_INTACT, new Color(100, 180, 100)); // medium green 
-        setDefault(ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG, new Color(180, 180, 100));  // medium yellow
-        setDefault(ADVANCED_ARMORMINI_COLOR_DAMAGED, new Color(150, 80, 80));  // medium dark red  
+        setDefault(ADVANCED_ARMORMINI_COLOR_INTACT, DEFAULT_MEDIUM_GREEN);
+        setDefault(ADVANCED_ARMORMINI_COLOR_PARTIAL_DMG, DEFAULT_MEDIUM_YELLOW);
+        setDefault(ADVANCED_ARMORMINI_COLOR_DAMAGED, DEFAULT_MEDIUM_DARK_RED);
         setDefault(ADVANCED_ARMORMINI_FONT_SIZE_MOD, -2);
-        setDefault(ADVANCED_WARNING_COLOR, Color.RED);
+        setDefault(ADVANCED_WARNING_COLOR, DEFAULT_RED);
         setDefault(ADVANCED_TMM_PIP_MODE, 2); // show pips with colors based on move type
-        setDefault(ADVANCED_LOW_FOLIAGE_COLOR, new Color(80, 230, 80));
+        setDefault(ADVANCED_LOW_FOLIAGE_COLOR, DEFAULT_FOLIAGE_GREEN);
         setDefault(ADVANCED_NO_SAVE_NAG, false);
         setDefault(ADVANCED_USE_CAMO_OVERLAY, true);
 
@@ -301,21 +343,29 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
         store.setDefault(ADVANCED_MOVE_STEP_DELAY, 50);
         store.setDefault(ADVANCED_DARKEN_MAP_AT_NIGHT, false);
-        setDefault(ADVANCED_MAPSHEET_COLOR, Color.BLUE);
+        setDefault(ADVANCED_MAPSHEET_COLOR, DEFAULT_BLUE);
         store.setDefault(ADVANCED_TRANSLUCENT_HIDDEN_UNITS, true);
         store.setDefault(ADVANCED_ATTACK_ARROW_TRANSPARENCY, 0x80);
-        setDefault(ADVANCED_BUILDING_TEXT_COLOR, Color.BLUE);
-        setDefault(ADVANCED_CHATBOX2_BACKCOLOR, new Color(255, 255, 255));
+        setDefault(ADVANCED_BUILDING_TEXT_COLOR, DEFAULT_BLUE);
+        setDefault(ADVANCED_CHATBOX2_BACKCOLOR, DEFAULT_WHITE);
         store.setDefault(ADVANCED_CHATBOX2_FONTSIZE, 12);
         store.setDefault(ADVANCED_CHATBOX2_TRANSPARANCY, 50);
         store.setDefault(ADVANCED_CHATBOX2_AUTOSLIDEDOWN, true);
-        store.setDefault(ADVANCED_ECM_TRANSPARENCY, 0x80);        
+        store.setDefault(ADVANCED_ECM_TRANSPARENCY, 0x80);
         store.setDefault(ADVANCED_KEY_REPEAT_DELAY, 0);
         store.setDefault(ADVANCED_KEY_REPEAT_RATE, 20);
         store.setDefault(ADVANCED_SHOW_FPS, false);
         store.setDefault(SHOW_COORDS, true);
         store.setDefault(ADVANCED_BUTTONS_PER_ROW, 5);
         store.setDefault(ADVANCED_ROUND_REPORT_SPRITES, true);
+
+        setDefault(ADVANCED_HEAT_5_COLOR, DEFAULT_HEAT_5);
+        setDefault(ADVANCED_HEAT_10_COLOR, DEFAULT_HEAT_10);
+        setDefault(ADVANCED_HEAT_15_COLOR, DEFAULT_HEAT_15);
+        setDefault(ADVANCED_HEAT_20_COLOR, DEFAULT_HEAT_20);
+        setDefault(ADVANCED_HEAT_25_COLOR, DEFAULT_HEAT_25);
+        setDefault(ADVANCED_HEAT_20_COLOR, DEFAULT_HEAT_30);
+        setDefault(ADVANCED_HEAT_OVERHEAT_COLOR, DEFAULT_HEAT_OVERHEAT);
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
@@ -375,7 +425,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(RND_ARMY_POS_X, 200);
         store.setDefault(RND_ARMY_POS_Y, 200);
         store.setDefault(RND_ARMY_SPLIT_POS, 300);
-        
+
         store.setDefault(MINIMAP_COLOURS, "defaultminimap.txt");
         store.setDefault(MINIMAP_ENABLED, true);
         store.setDefault(MMSYMBOL, true);
@@ -404,8 +454,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(NAG_FOR_DOOMED, true);
         store.setDefault(NAG_FOR_WIGE_LANDING, true);
 
-        setDefault(RULER_COLOR_1, Color.CYAN);
-        setDefault(RULER_COLOR_2, Color.MAGENTA);
+        setDefault(RULER_COLOR_1, DEFAULT_CYAN);
+        setDefault(RULER_COLOR_2, DEFAULT_MAGENTA);
         store.setDefault(RULER_POS_X, 0);
         store.setDefault(RULER_POS_Y, 0);
         store.setDefault(RULER_SIZE_HEIGHT, 300);
@@ -427,7 +477,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(SHOW_PILOT_PORTRAIT_TT, true);
 
         store.setDefault(USE_ISOMETRIC, false);
-        
+
         store.setDefault(WINDOW_SIZE_HEIGHT, 600);
         store.setDefault(WINDOW_SIZE_WIDTH, 800);
 
@@ -461,9 +511,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(RAT_PAD_BV, false);
         store.setDefault(RAT_SELECTED_RAT, "");
 
-        setDefault(ALLY_UNIT_COLOR, new Color(60, 140, 240));  // greenish blue
-        setDefault(ENEMY_UNIT_COLOR, new Color(200, 40, 40)); // red
-        setDefault(MY_UNIT_COLOR, new Color(40, 210, 40));  // light green
+        setDefault(ALLY_UNIT_COLOR, DEFAULT_ALLY_COLOR);
+        setDefault(ENEMY_UNIT_COLOR, DEFAULT_ENEMY_COLOR);
+        setDefault(MY_UNIT_COLOR, DEFAULT_MY_COLOR);
         setDefault(TEAM_COLORING, true);
 
         setDefault(SHOW_KEYBINDS_OVERLAY, true);
@@ -485,11 +535,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getAOHexShadows() {
         return store.getBoolean(AOHEXSHADOWS);
     }
-    
+
     public boolean getFloatingIso() {
         return store.getBoolean(FLOATINGISO);
     }
-    
+
     public boolean getMmSymbol() {
         return store.getBoolean(MMSYMBOL);
     }
@@ -497,7 +547,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getShadowMap() {
         return store.getBoolean(SHADOWMAP);
     }
-    
+
     public boolean getHexInclines() {
         return store.getBoolean(INCLINES);
     }
@@ -509,7 +559,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getAutoEndFiring() {
         return store.getBoolean(AUTO_END_FIRING);
     }
-    
+
     public boolean getTeamColoring() {
         return store.getBoolean(TEAM_COLORING);
     }
@@ -565,7 +615,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getFiringSolutions() {
         return store.getBoolean(FIRING_SOLUTIONS);
     }
-    
+
     public boolean getMoveEnvelope() {
         return store.getBoolean(MOVE_ENVELOPE);
     }
@@ -579,11 +629,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
     }
 
     public String getFovHighlightRingsRadii() {
-        return store.getString( FOV_HIGHLIGHT_RINGS_RADII );
+        return store.getString(FOV_HIGHLIGHT_RINGS_RADII);
     }
 
     public String getFovHighlightRingsColorsHsb() {
-        return store.getString( FOV_HIGHLIGHT_RINGS_COLORS_HSB );
+        return store.getString(FOV_HIGHLIGHT_RINGS_COLORS_HSB);
     }
 
     public boolean getFovDarken() {
@@ -593,11 +643,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public int getFovDarkenAlpha() {
         return store.getInt(FOV_DARKEN_ALPHA);
     }
-    
+
     public int getFovStripes() {
         return store.getInt(FOV_STRIPES);
     }
-    
+
     public boolean getFovGrayscale() {
         return store.getBoolean(FOV_GRAYSCALE);
     }
@@ -677,19 +727,19 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public int getMechSelectorSizeWidth() {
         return store.getInt(MECH_SELECTOR_SIZE_WIDTH);
     }
-    
+
     public int getMechSelectorPosX() {
         return store.getInt(MECH_SELECTOR_POS_X);
     }
-    
+
     public int getMechSelectorPosY() {
         return store.getInt(MECH_SELECTOR_POS_Y);
     }
-    
+
     public int getMechSelectorSplitPos() {
         return store.getInt(MECH_SELECTOR_SPLIT_POS);
     }
-    
+
     public int getRndArmySizeHeight() {
         return store.getInt(RND_ARMY_SIZE_HEIGHT);
     }
@@ -697,15 +747,15 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public int getRndArmySizeWidth() {
         return store.getInt(RND_ARMY_SIZE_WIDTH);
     }
-    
+
     public int getRndArmyPosX() {
         return store.getInt(RND_ARMY_POS_X);
     }
-    
+
     public int getRndArmyPosY() {
         return store.getInt(RND_ARMY_POS_Y);
     }
-    
+
     public int getRndArmySplitPos() {
         return store.getInt(RND_ARMY_SPLIT_POS);
     }
@@ -741,7 +791,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public int getMinimumSizeWidth() {
         return store.getInt(MINIMUM_SIZE_WIDTH);
     }
-    
+
     public int getBoardEditLoadHeight() {
         return store.getInt(BOARDEDIT_LOAD_SIZE_HEIGHT);
     }
@@ -822,7 +872,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getNagForDoomed() {
         return store.getBoolean(NAG_FOR_DOOMED);
     }
-    
+
     public boolean getNagForWiGELanding() {
         return store.getBoolean(NAG_FOR_WIGE_LANDING);
     }
@@ -862,7 +912,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getShowMapHexPopup() {
         return store.getBoolean(SHOW_MAPHEX_POPUP);
     }
-    
+
     public boolean getShowWpsinTT() {
         return store.getBoolean(SHOW_WPS_IN_TT);
     }
@@ -870,7 +920,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getshowArmorMiniVisTT() {
         return store.getBoolean(SHOW_ARMOR_MINIVIS_TT);
     }
-    
+
     public boolean getshowPilotPortraitTT() {
         return store.getBoolean(SHOW_PILOT_PORTRAIT_TT);
     }
@@ -902,7 +952,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public int getTooltipDistSuppression() {
         return store.getInt(TOOLTIP_DIST_SUPRESSION);
     }
-    
+
     public float getGUIScale() {
         return store.getFloat(GUI_SCALE);
     }
@@ -938,7 +988,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getShowUnitOverview() {
         return store.getBoolean(SHOW_UNIT_OVERVIEW);
     }
-    
+
     public String getSkinFile() {
         return store.getString(SKIN_FILE);
     }
@@ -966,7 +1016,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setShadowMap(boolean state) {
         store.setValue(SHADOWMAP, state);
     }
-    
+
     public void setHexInclines(boolean state) {
         store.setValue(INCLINES, state);
     }
@@ -990,7 +1040,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public boolean getShowDamageLevel() {
         return store.getBoolean(SHOW_DAMAGE_LEVEL);
     }
-    
+
     public boolean getShowDamageDecal() {
         return store.getBoolean(SHOW_DAMAGE_DECAL);
     }
@@ -1050,10 +1100,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setFiringSolutions(boolean state) {
         store.setValue(FIRING_SOLUTIONS, state);
     }
-    
+
     public void setMoveEnvelope(boolean state) {
         store.setValue(MOVE_ENVELOPE, state);
-    }   
+    }
 
     public void setFovHighlight(boolean state) {
         store.setValue(FOV_HIGHLIGHT, state);
@@ -1078,11 +1128,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setFovDarkenAlpha(int i) {
         store.setValue(FOV_DARKEN_ALPHA, i);
     }
-    
+
     public void setFovStripes(int i) {
         store.setValue(FOV_STRIPES, i);
     }
-    
+
     public void setFovGrayscale(boolean state) {
         store.setValue(FOV_GRAYSCALE, state);
     }
@@ -1150,19 +1200,19 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setMechSelectorSizeWidth(int i) {
         store.setValue(MECH_SELECTOR_SIZE_WIDTH, i);
     }
-    
+
     public void setMechSelectorPosX(int i) {
         store.setValue(MECH_SELECTOR_POS_X, i);
     }
-    
+
     public void setMechSelectorSplitPos(int i) {
         store.setValue(MECH_SELECTOR_SPLIT_POS, i);
     }
-    
+
     public void setMechSelectorPosY(int i) {
         store.setValue(MECH_SELECTOR_POS_Y, i);
     }
-    
+
     public void setRndArmySizeHeight(int i) {
         store.setValue(RND_ARMY_SIZE_HEIGHT, i);
     }
@@ -1170,15 +1220,15 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setRndArmySizeWidth(int i) {
         store.setValue(RND_ARMY_SIZE_WIDTH, i);
     }
-    
+
     public void setRndArmyPosX(int i) {
         store.setValue(RND_ARMY_POS_X, i);
     }
-    
+
     public void setRndArmySplitPos(int i) {
         store.setValue(RND_ARMY_SPLIT_POS, i);
     }
-    
+
     public void setRndArmyPosY(int i) {
         store.setValue(RND_ARMY_POS_Y, i);
     }
@@ -1206,7 +1256,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setMiniReportPosY(int i) {
         store.setValue(MINIMAP_POS_Y, i);
     }
-    
+
     public void setBoardEditLoadHeight(int i) {
         store.setValue(BOARDEDIT_LOAD_SIZE_HEIGHT, i);
     }
@@ -1214,7 +1264,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setBoardEditLoadWidth(int i) {
         store.setValue(BOARDEDIT_LOAD_SIZE_WIDTH, i);
     }
-    
+
     public void setTeamColoring(boolean bt) {
         store.setValue(TEAM_COLORING, bt);
     }
@@ -1282,7 +1332,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setNagForDoomed(boolean b) {
         store.setValue(NAG_FOR_DOOMED, b);
     }
-    
+
     public void setNagForWiGELanding(boolean b) {
         store.setValue(NAG_FOR_WIGE_LANDING, b);
     }
@@ -1314,7 +1364,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setShowMapHexPopup(boolean state) {
         store.setValue(SHOW_MAPHEX_POPUP, state);
     }
-    
+
     public void setShowWpsinTT(boolean state) {
         store.setValue(SHOW_WPS_IN_TT, state);
     }
@@ -1322,7 +1372,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setshowArmorMiniVisTT(boolean state) {
         store.setValue(SHOW_ARMOR_MINIVIS_TT, state);
     }
-    
+
     public void setshowPilotPortraitTT(boolean state) {
         store.setValue(SHOW_PILOT_PORTRAIT_TT, state);
     }
@@ -1398,11 +1448,11 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setShowDamageLevel(boolean b) {
         store.setValue(SHOW_DAMAGE_LEVEL, b);
     }
-    
+
     public void setShowDamageDecal(boolean b) {
         store.setValue(SHOW_DAMAGE_DECAL, b);
     }
-    
+
     public void setSkinFile(String s) {
         store.setValue(SKIN_FILE, s);
     }
@@ -1466,7 +1516,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setRATNumInf(String v) {
         store.setValue(RAT_NUM_INF, v);
     }
-    
+
     public String getRATYearMin() {
         return store.getString(RAT_YEAR_MIN);
     }
@@ -1490,7 +1540,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setRATPadBV(boolean v) {
         store.setValue(RAT_PAD_BV, v);
     }
-    
+
     public String getRATSelectedRAT() {
         return store.getString(RAT_SELECTED_RAT);
     }
@@ -1498,7 +1548,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setRATSelectedRAT(String v) {
         store.setValue(RAT_SELECTED_RAT, v);
     }
-    
+
     public void setBoardEdRndStart(boolean b) {
         store.setValue(BOARDEDIT_RNDDIALOG_START, b);
     }
@@ -1535,23 +1585,31 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public void setWarningColor(Color color) {
         store.setValue(ADVANCED_WARNING_COLOR, getColorString(color));
     }
-    
-    /** Sets the user preference for the Unit Display window to active. */
+
+    /**
+     * Sets the user preference for the Unit Display window to active.
+     */
     public void showUnitDisplay() {
         store.setValue(SHOW_UNIT_DISPLAY, true);
     }
-    
-    /** Sets the user preference for the Unit Display window to inactive. */
+
+    /**
+     * Sets the user preference for the Unit Display window to inactive.
+     */
     public void hideUnitDisplay() {
         store.setValue(SHOW_UNIT_DISPLAY, false);
     }
-    
-    /** Toggles the state of the user preference for the Unit Display. */
+
+    /**
+     * Toggles the state of the user preference for the Unit Display.
+     */
     public void toggleUnitDisplay() {
         store.setValue(SHOW_UNIT_DISPLAY, !getBoolean(SHOW_UNIT_DISPLAY));
     }
-    
-    /** Toggles the state of the user preference for the Keybinds overlay. */
+
+    /**
+     * Toggles the state of the user preference for the Keybinds overlay.
+     */
     public void toggleKeybindsOverlay() {
         store.setValue(SHOW_KEYBINDS_OVERLAY, !getBoolean(SHOW_KEYBINDS_OVERLAY));
     }
@@ -1572,16 +1630,16 @@ public class GUIPreferences extends PreferenceStoreProxy {
             case MOVE_RUN:
             case MOVE_VTOL_RUN:
             case MOVE_OVER_THRUST:
-                return getColor("AdvancedMoveRunColor");
+                return getColor(ADVANCED_MOVE_RUN_COLOR);
             case MOVE_JUMP:
-                return getColor("AdvancedMoveJumpColor");
+                return getColor(ADVANCED_MOVE_JUMP_COLOR);
             case MOVE_SPRINT:
             case MOVE_VTOL_SPRINT:
-                return getColor("AdvancedMoveSprintColor");
+                return getColor(ADVANCED_MOVE_SPRINT_COLOR);
             case MOVE_ILLEGAL:
-                return getColor("AdvancedMoveIllegalColor");
+                return getColor(ADVANCED_MOVE_ILLEGAL_COLOR);
             default:
-                return getColor("AdvancedMoveDefaultColor");
+                return getColor(ADVANCED_MOVE_DEFAULT_COLOR);
         }
     }
 
@@ -1590,9 +1648,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
      */
     public Color getColorForMovement(EntityMovementType movementType, boolean isMASCOrSuperCharger, boolean isBackwards) {
         if (isMASCOrSuperCharger) {
-            return getColor("AdvancedMoveMASCColor");
+            return getColor(ADVANCED_MOVE_MASC_COLOR);
         } else if (isBackwards) {
-            return getColor("AdvancedMoveBackColor");
+            return getColor(ADVANCED_MOVE_BACK_COLOR);
         }
         return getColorForMovement(movementType);
     }
@@ -1601,23 +1659,29 @@ public class GUIPreferences extends PreferenceStoreProxy {
      * @return The color associated with a heat in the range 0-30
      */
     public Color getColorForHeat(int heat) {
-        return getColorForHeat(heat, Color.LIGHT_GRAY);
+        return getColorForHeat(heat, DEFAULT_LIGHT_GRAY);
     }
 
     /**
      * @return The color associated with a heat in the range 0-30
      */
     public Color getColorForHeat(int heat, Color defaultColor) {
-        if (heat <= 5) {
+        if (heat <= 0) {
             return defaultColor;
+        } else if (heat <= 5) {
+            return getColor(ADVANCED_HEAT_5_COLOR);
         } else if (heat < 10) {
-            return Color.GREEN;
+            return getColor(ADVANCED_HEAT_10_COLOR);
+        } else if (heat < 15) {
+            return getColor(ADVANCED_HEAT_15_COLOR);
         } else if (heat < 20) {
-            return Color.YELLOW;
+            return  getColor(ADVANCED_HEAT_20_COLOR);
+        } else if (heat < 25) {
+            return  getColor(ADVANCED_HEAT_25_COLOR);
         } else if (heat < 30) {
-            return Color.ORANGE;
+            return  getColor(ADVANCED_HEAT_30_COLOR);
         }
-        return Color.RED;
+        return  getColor(ADVANCED_HEAT_OVERHEAT_COLOR);
     }
 
     public void setUnitLabelStyle(LabelDisplayStyle style) {
@@ -1649,14 +1713,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     /**
      * Activates AntiAliasing for the <code>Graphics</code> graph
-     * if AA is activated in the Client settings. 
+     * if AA is activated in the Client settings.
+     *
      * @param graph Graphics context to activate AA for
      */
     public static void AntiAliasifSet(Graphics graph) {
         if (getInstance().getAntiAliasing()) {
-            ((Graphics2D) graph).setRenderingHint(
-                    RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON);
+            ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -93,7 +93,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_NO_SAVE_NAG = "AdvancedNoSaveNag";
     public static final String ADVANCED_USE_CAMO_OVERLAY = "AdvancedUseCamoOverlay";
     public static final String ADVANCED_MAP_TEXT_COLOR = "AdvancedMapTextColor";
-    public static final String ADVANCED_REPORT_TEXT_COLOR = "AdvancedReportTextColor";
     public static final String ADVANCED_WARNING_COLOR = "AdvancedWarningColor";
     public static final String ADVANCED_TMM_PIP_MODE = "AdvancedTmmPipMode";
     public static final String ADVANCED_HEAT_5_COLOR = "ADVANCED_HEAT_5_COLOR";
@@ -399,7 +398,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(LOBBY_MEKTABLE_PLAYER_WIDTH, 50);
         store.setDefault(LOBBY_MEKTABLE_BV_WIDTH, 50);
         setDefault(ADVANCED_MAP_TEXT_COLOR, DEFAULT_BLACK);
-        setDefault(ADVANCED_REPORT_TEXT_COLOR, DEFAULT_BLACK);
         store.setDefault(MAP_ZOOM_INDEX, 7);
         store.setDefault(MECH_SELECTOR_INCLUDE_MODEL, true);
         store.setDefault(MECH_SELECTOR_INCLUDE_NAME, true);
@@ -653,10 +651,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public Color getMapTextColor() {
         return getColor(ADVANCED_MAP_TEXT_COLOR);
-    }
-
-    public Color getReportTextColor() {
-        return getColor(ADVANCED_REPORT_TEXT_COLOR);
     }
 
     public int getMapZoomIndex() {

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -257,8 +257,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static String RAT_PAD_BV = "RATPadBV";
     public static String RAT_SELECTED_RAT = "RATSelectedRAT";
 
-    private static final Color DEFAULT_WHITE = new Color(255, 255, 255);
-    private static final Color DEFAULT_BLACK = new Color(0, 0, 0);
+    private static final Color DEFAULT_WHITE = Color.WHITE;
+    private static final Color DEFAULT_BLACK = Color.BLACK;
 
     // Text colors that read over light and dark backgrounds
     private static final Color DEFAULT_DARK_GRAY = new Color(64, 64, 64);

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -31,6 +31,7 @@ import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -221,10 +222,8 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
 
     public static void setupStylesheet(JTextPane pane) {
         pane.setContentType("text/html");
-        Font font = UIManager.getFont("Label.font");
-        int size = UIUtil.scaleForGUI(UIUtil.FONT_SCALE1);
-        ((HTMLEditorKit) pane.getEditorKit()).getStyleSheet().addRule(
-                "pre { font-family: " + font.getFamily() + "; font-size: " + size + "pt; font-style:normal;}");
+        StyleSheet styleSheet = ((HTMLEditorKit) pane.getEditorKit()).getStyleSheet();
+        Report.setupStylesheet(styleSheet);
     }
     
     public void appendReportTab(String additionalText) {

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -336,17 +336,17 @@ public class Report implements Serializable {
             if ((indentation <= Report.DEFAULT_INDENTATION) || showImage) {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
-            String ownerColorHex = entity.getOwner().getColour().getHexString(0x00F0F0F0);
 
+            Color ownerColor = entity.getOwner().getColour().getColour();
             String unitName = colorBlock(GUIPreferences.DEFAULT_BLACK,
                     hrefBlock(ENTITY_LINK + entity.getId(), entity.getShortName()));
 
             if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
-                unitName += colorBlock(ownerColorHex, ' '+ entity.getCrew().getNickname().toUpperCase());
+                unitName += colorBlock(ownerColor, ' '+ entity.getCrew().getNickname().toUpperCase());
             }
 
             add(unitName, true);
-            add(boldBlock(colorBlock(ownerColorHex, entity.getOwner().getName())));
+            add(boldBlock(colorBlock(ownerColor, entity.getOwner().getName())));
         }
     }
 

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -341,12 +341,12 @@ public class Report implements Serializable {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
 
-            Color ownerColor = entity.getOwner().getColour().getColour();;
+            Color ownerColor = entity.getOwner().getColour().getColour();
             String unitName =
                     href(ENTITY_LINK + entity.getId(), entity.getShortName());
 
             if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
-                unitName += fgColor(ownerColor, ' '+ entity.getCrew().getNickname().toUpperCase());
+                unitName += fgColor(ownerColor, ' ' :wq+ entity.getCrew().getNickname().toUpperCase());
             }
 
             add(unitName, true);

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -14,8 +14,10 @@
  */
 package megamek.common;
 
+import megamek.client.ui.swing.GUIPreferences;
 import org.apache.logging.log4j.LogManager;
 
+import java.awt.*;
 import java.io.Serializable;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -334,16 +336,17 @@ public class Report implements Serializable {
             if ((indentation <= Report.DEFAULT_INDENTATION) || showImage) {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
-            String name = "<font color='0xffffff'><a href=\"" + ENTITY_LINK + entity.getId()
-                    + "\">" + entity.getShortName() + "</a></font>";
-            String color = entity.getOwner().getColour().getHexString(0x00F0F0F0);
+            String ownerColorHex = entity.getOwner().getColour().getHexString(0x00F0F0F0);
+
+            String unitName = colorBlock(GUIPreferences.DEFAULT_BLACK,
+                    hrefBlock(ENTITY_LINK + entity.getId(), entity.getShortName()));
 
             if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
-                // pilot nickname, also known as callsign
-                name += " <font color='"+color+"'>\"" + entity.getCrew().getNickname().toUpperCase() + "\"</font>";
+                unitName += colorBlock(ownerColorHex, ' '+ entity.getCrew().getNickname().toUpperCase());
             }
-            add(name, true);
-            add("<B><font color='" + color + "'>" + entity.getOwner().getName() + "</font></B>");
+
+            add(unitName, true);
+            add(boldBlock(colorBlock(ownerColorHex, entity.getOwner().getName())));
         }
     }
 
@@ -555,6 +558,28 @@ public class Report implements Serializable {
         } catch (Exception ex) {
             LogManager.getLogger().error("Cannot add a new line", ex);
         }
+    }
+
+    /**f
+     * Adds a newline to the last report in the given Vector.
+     *
+     * @param v a Vector of Report objects
+     */
+    public static String colorBlock(Color color, String str) {
+        String hexColor = String.format("#%06x", Integer.valueOf(color.getRGB() & 0x00FFFFFF));
+        return colorBlock(hexColor, str);
+    }
+
+    public static String colorBlock(String hexColor, String str) {
+        return "<font color='" + hexColor + "'>" + str + "</font>";
+    }
+
+    public static String boldBlock(String str) {
+        return "<B>" + str + "</B>";
+    }
+
+    public static String hrefBlock(String href, String str) {
+        return "<font color='" + href + "'>" + str + "</font>";
     }
 
     /**

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -337,16 +337,17 @@ public class Report implements Serializable {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
 
-            Color ownerColor = entity.getOwner().getColour().getColour();
-            String unitName = colorBlock(GUIPreferences.DEFAULT_BLACK,
+//            String unitName = fgColorBlock(GUIPreferences.DEFAULT_BLACK,
+//                    hrefBlock(ENTITY_LINK + entity.getId(), entity.getShortName()));
+            String unitName = fgColorBlock(GUIPreferences.DEFAULT_BLACK,
                     hrefBlock(ENTITY_LINK + entity.getId(), entity.getShortName()));
-
+            Color ownerColor = entity.getOwner().getColour().getColour();
             if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
-                unitName += colorBlock(ownerColor, ' '+ entity.getCrew().getNickname().toUpperCase());
+                unitName += fgColorBlock(ownerColor, ' '+ entity.getCrew().getNickname().toUpperCase());
             }
 
             add(unitName, true);
-            add(boldBlock(colorBlock(ownerColor, entity.getOwner().getName())));
+            add(boldBlock(fgColorBlock(ownerColor, entity.getOwner().getName())));
         }
     }
 
@@ -560,26 +561,30 @@ public class Report implements Serializable {
         }
     }
 
-    /**f
-     * Adds a newline to the last report in the given Vector.
-     *
-     * @param v a Vector of Report objects
-     */
-    public static String colorBlock(Color color, String str) {
+    public String fgColorBlock(Color color, String str) {
         String hexColor = String.format("#%06x", Integer.valueOf(color.getRGB() & 0x00FFFFFF));
-        return colorBlock(hexColor, str);
+        return fgColorBlock(hexColor, str);
     }
 
-    public static String colorBlock(String hexColor, String str) {
-        return "<font color='" + hexColor + "'>" + str + "</font>";
+    public String fgColorBlock(String hexColor, String str) {
+        return "<span style='color:" + hexColor + "'>" + str + "</span>";
+    }
+
+    public String bgColorBlock(Color color, String str) {
+        String hexColor = String.format("#%06x", Integer.valueOf(color.getRGB() & 0x00FFFFFF));
+        return bgColorBlock(hexColor, str);
+    }
+
+    public String bgColorBlock(String hexColor, String str) {
+        return "<span style='background-color:"+ hexColor +"'>" + str + "</span>";
     }
 
     public static String boldBlock(String str) {
         return "<B>" + str + "</B>";
     }
 
-    public static String hrefBlock(String href, String str) {
-        return "<font color='" + href + "'>" + str + "</font>";
+    public String hrefBlock(String href, String str) {
+        return "<a href='" + href + "'>" + str + "</a>";
     }
 
     /**

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -15,8 +15,12 @@
 package megamek.common;
 
 import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import org.apache.logging.log4j.LogManager;
 
+import javax.swing.*;
+import javax.swing.text.html.HTMLEditorKit;
+import javax.swing.text.html.StyleSheet;
 import java.awt.*;
 import java.io.Serializable;
 import java.util.Enumeration;
@@ -337,17 +341,18 @@ public class Report implements Serializable {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
 
-//            String unitName = fgColorBlock(GUIPreferences.DEFAULT_BLACK,
-//                    hrefBlock(ENTITY_LINK + entity.getId(), entity.getShortName()));
-            String unitName = fgColorBlock(GUIPreferences.DEFAULT_BLACK,
-                    hrefBlock(ENTITY_LINK + entity.getId(), entity.getShortName()));
             Color ownerColor = entity.getOwner().getColour().getColour();
+//            String unitName = fgColor(GUIPreferences.getInstance().getReportTextColor(),
+//                    href(ENTITY_LINK + entity.getId(), entity.getShortName()));
+            String unitName =
+                    href(ENTITY_LINK + entity.getId(), entity.getShortName());
+
             if ((entity.getCrew().getSize() >= 1) && !entity.getCrew().getNickname().isBlank()) {
-                unitName += fgColorBlock(ownerColor, ' '+ entity.getCrew().getNickname().toUpperCase());
+                unitName += fgColor(ownerColor, ' '+ entity.getCrew().getNickname().toUpperCase());
             }
 
             add(unitName, true);
-            add(boldBlock(fgColorBlock(ownerColor, entity.getOwner().getName())));
+            add(bold(fgColor(ownerColor, entity.getOwner().getName())));
         }
     }
 
@@ -561,29 +566,51 @@ public class Report implements Serializable {
         }
     }
 
-    public String fgColorBlock(Color color, String str) {
-        String hexColor = String.format("#%06x", Integer.valueOf(color.getRGB() & 0x00FFFFFF));
-        return fgColorBlock(hexColor, str);
+    public static void setupStylesheet(StyleSheet styleSheet) {
+        Font font = UIManager.getFont("Label.font");
+        int size = UIUtil.scaleForGUI(UIUtil.FONT_SCALE1);
+
+        GUIPreferences guip = GUIPreferences.getInstance();
+        styleSheet.addRule(
+                "pre { font-family: " + font.getFamily() + "; font-size: " + size + "pt; font-style:normal;}");
+        styleSheet.addRule("a {color: #565656 }");
+        styleSheet.addRule("span.warning { color: "+ hexColor(guip.getWarningColor())+" }");
+
     }
 
-    public String fgColorBlock(String hexColor, String str) {
+    public String span(String name, String text) {
+        return "<span class='" + name + "'>" + text + "</span>";
+    }
+
+    public String warning(String text) {
+        return span("warning", text);
+    }
+
+    private static String hexColor(Color color) {
+        return String.format("#%06x", Integer.valueOf(color.getRGB() & 0x00FFFFFF));
+    }
+
+    public String fgColor(Color color, String str) {
+        return fgColor(hexColor(color), str);
+    }
+
+    public String fgColor(String hexColor, String str) {
         return "<span style='color:" + hexColor + "'>" + str + "</span>";
     }
 
-    public String bgColorBlock(Color color, String str) {
-        String hexColor = String.format("#%06x", Integer.valueOf(color.getRGB() & 0x00FFFFFF));
-        return bgColorBlock(hexColor, str);
+    public String bgColor(Color color, String str) {
+        return bgColor(hexColor(color), str);
     }
 
-    public String bgColorBlock(String hexColor, String str) {
+    public String bgColor(String hexColor, String str) {
         return "<span style='background-color:"+ hexColor +"'>" + str + "</span>";
     }
 
-    public static String boldBlock(String str) {
+    public static String bold(String str) {
         return "<B>" + str + "</B>";
     }
 
-    public String hrefBlock(String href, String str) {
+    public String href(String href, String str) {
         return "<a href='" + href + "'>" + str + "</a>";
     }
 

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -341,9 +341,7 @@ public class Report implements Serializable {
                 imageCode = "<span id='" + entity.getId() + "'></span>";
             }
 
-            Color ownerColor = entity.getOwner().getColour().getColour();
-//            String unitName = fgColor(GUIPreferences.getInstance().getReportTextColor(),
-//                    href(ENTITY_LINK + entity.getId(), entity.getShortName()));
+            Color ownerColor = entity.getOwner().getColour().getColour();;
             String unitName =
                     href(ENTITY_LINK + entity.getId(), entity.getShortName());
 
@@ -575,7 +573,6 @@ public class Report implements Serializable {
                 "pre { font-family: " + font.getFamily() + "; font-size: " + size + "pt; font-style:normal;}");
         styleSheet.addRule("a {color: #565656 }");
         styleSheet.addRule("span.warning { color: "+ hexColor(guip.getWarningColor())+" }");
-
     }
 
     public String span(String name, String text) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -17,6 +17,7 @@ import com.thoughtworks.xstream.XStream;
 import megamek.MMConstants;
 import megamek.MegaMek;
 import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.common.*;
 import megamek.common.Building.DemolitionCharge;
 import megamek.common.actions.*;
@@ -47,10 +48,12 @@ import megamek.server.commands.*;
 import megamek.server.victory.VictoryResult;
 import org.apache.logging.log4j.LogManager;
 
+import java.awt.*;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 import java.util.zip.GZIPOutputStream;
@@ -18612,7 +18615,8 @@ public class GameManager implements IGameManager {
             r.addDesc(entity);
             r.add(entity.heatBuildup);
             r.add(toSink);
-            r.add(entity.heat);
+            Color color = GUIPreferences.getInstance().getColorForHeat(entity.heat, Color.BLACK);
+            r.add(Report.colorBlock(color, String.valueOf(entity.heat)));
             addReport(r);
             entity.heatBuildup = 0;
             vPhaseReport.addAll(rhsReports);
@@ -31211,9 +31215,11 @@ public class GameManager implements IGameManager {
 
                 r = new Report(6436, Report.PUBLIC);
                 r.indent(1);
-                String fontColorOpen = curCF <= 0 ? "<font color='C00000'>" : "";
-                String fontColorClose = curCF <= 0 ? "</font>" : "";
-                r.add(String.format("%s%s%s", fontColorOpen, curCF, fontColorClose));
+                if (curCF <= 0) {
+                    r.add(Report.colorBlock(GUIPreferences.DEFAULT_RED, String.valueOf(curCF)));
+                } else {
+                    r.add(curCF);
+                }
                 vPhaseReport.add(r);
 
                 final int damageThresh = (int) Math.ceil(bldg.getPhaseCF(coords) / 10.0);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -18616,7 +18616,7 @@ public class GameManager implements IGameManager {
             r.add(entity.heatBuildup);
             r.add(toSink);
             Color color = GUIPreferences.getInstance().getColorForHeat(entity.heat, Color.BLACK);
-            r.add(r.boldBlock(r.fgColorBlock(color, String.valueOf(entity.heat))));
+            r.add(r.bold(r.fgColor(color, String.valueOf(entity.heat))));
             addReport(r);
             entity.heatBuildup = 0;
             vPhaseReport.addAll(rhsReports);
@@ -31216,7 +31216,7 @@ public class GameManager implements IGameManager {
                 r = new Report(6436, Report.PUBLIC);
                 r.indent(1);
                 if (curCF <= 0) {
-                    r.add(r.fgColorBlock(GUIPreferences.DEFAULT_RED, String.valueOf(curCF)));
+                    r.add(r.warning(String.valueOf(curCF)));
                 } else {
                     r.add(curCF);
                 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -18616,7 +18616,7 @@ public class GameManager implements IGameManager {
             r.add(entity.heatBuildup);
             r.add(toSink);
             Color color = GUIPreferences.getInstance().getColorForHeat(entity.heat, Color.BLACK);
-            r.add(Report.colorBlock(color, String.valueOf(entity.heat)));
+            r.add(r.boldBlock(r.fgColorBlock(color, String.valueOf(entity.heat))));
             addReport(r);
             entity.heatBuildup = 0;
             vPhaseReport.addAll(rhsReports);
@@ -31216,7 +31216,7 @@ public class GameManager implements IGameManager {
                 r = new Report(6436, Report.PUBLIC);
                 r.indent(1);
                 if (curCF <= 0) {
-                    r.add(Report.colorBlock(GUIPreferences.DEFAULT_RED, String.valueOf(curCF)));
+                    r.add(r.fgColorBlock(GUIPreferences.DEFAULT_RED, String.valueOf(curCF)));
                 } else {
                     r.add(curCF);
                 }


### PR DESCRIPTION
This addresses https://github.com/MegaMek/megamek/issues/3688
and begins to address https://github.com/MegaMek/megamek/a/3706

It adds color coded text to the heat report. The colors used can be set in the Advanced Options. By default they range from black-blue-green-yellow-orange-red in five heat unit increments from 0 to 30.
It also begins to centralize the report formatting into the Report class itself. This allows user customization of colors in Reports, and begins the path to use different (or no) markup languages in the reports. 

![heatlight](https://user-images.githubusercontent.com/1423800/172968331-a655b4a3-2508-40b8-b97d-0bdf41b721bd.PNG)
![heatdark](https://user-images.githubusercontent.com/1423800/172968336-19610a3f-fa65-4067-b393-51e4e92ece7b.PNG)
.