### PR TITLE
Fixes #3699 Deadfire LRMs and SRMs have incorrect range brackets

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1923,9 +1923,17 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 }
             } else if (atype.getAmmoType() == AmmoType.T_MML) {
                 if (atype.hasFlag(AmmoType.F_MML_LRM)) {
-                    ranges[0] = new int[] { 6, 7, 14, 21, 28 };
+                    if (atype.getMunitionType() == AmmoType.M_DEAD_FIRE) {
+                        ranges[0] = new int[] { 4, 5, 10, 15, 20 };
+                    } else {
+                        ranges[0] = new int[] { 6, 7, 14, 21, 28 };
+                    }
                 } else {
-                    ranges[0] = new int[] { 0, 3, 6, 9, 12 };
+                    if (atype.getMunitionType() == AmmoType.M_DEAD_FIRE) {
+                        ranges[0] = new int[] { 0, 2, 4, 6, 8 };
+                    } else {
+                        ranges[0] = new int[] { 0, 3, 6, 9, 12 };
+                    }
                 }
             } else if (atype.getAmmoType() == AmmoType.T_IATM) {
                 if (atype.getMunitionType() == AmmoType.M_EXTENDED_RANGE) {
@@ -1939,7 +1947,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 }
             }
         }
-
         // No minimum range for hotload
         if ((mounted.getLinked() != null) && mounted.getLinked().isHotLoaded()) {
             ranges[0][0] = 0;
@@ -2078,17 +2085,33 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             }
         } else if (atype.getAmmoType() == AmmoType.T_MML) {
             if (atype.hasFlag(AmmoType.F_MML_LRM)) {
-                wMinR.setText("6");
-                wShortR.setText("1 - 7");
-                wMedR.setText("8 - 14");
-                wLongR.setText("15 - 21");
-                wExtR.setText("21 - 28");
+                if (atype.getMunitionType() == AmmoType.M_DEAD_FIRE) {
+                    wMinR.setText("4");
+                    wShortR.setText("1 - 5");
+                    wMedR.setText("6 - 10");
+                    wLongR.setText("11 - 15");
+                    wExtR.setText("16 - 20");
+                } else {
+                    wMinR.setText("6");
+                    wShortR.setText("1 - 7");
+                    wMedR.setText("8 - 14");
+                    wLongR.setText("15 - 21");
+                    wExtR.setText("21 - 28");
+                }
             } else {
-                wMinR.setText("---");
-                wShortR.setText("1 - 3");
-                wMedR.setText("4 - 6");
-                wLongR.setText("7 - 9");
-                wExtR.setText("10 - 12");
+                if (atype.getMunitionType() == AmmoType.M_DEAD_FIRE) {
+                    wMinR.setText("---");
+                    wShortR.setText("1 - 2");
+                    wMedR.setText("3 - 4");
+                    wLongR.setText("5 - 6");
+                    wExtR.setText("7 - 8");
+                } else {
+                    wMinR.setText("---");
+                    wShortR.setText("1 - 3");
+                    wMedR.setText("4 - 6");
+                    wLongR.setText("7 - 9");
+                    wExtR.setText("10 - 12");
+                }
             }
         } else if (atype.getAmmoType() == AmmoType.T_IATM) {
             if (atype.getMunitionType() == AmmoType.M_EXTENDED_RANGE) {

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -13568,8 +13568,8 @@ public class AmmoType extends EquipmentType {
                     || (munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_SRM)
                     || (munition.getAmmoType() == AmmoType.T_SRM_IMP) || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && ((munition.getMunitionType() == AmmoType.M_DEAD_FIRE))) {
-                cost *= .6;
-                //TODO - DEAD-FIRE AMMO needs BV which is not a constant but launcher Ammo. 
+                cost *= 0.6;
+                // TODO - DEAD-FIRE AMMO needs BV which is not a constant but launcher Ammo. 
             }
 
             if (((munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_SRM)

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -176,6 +176,7 @@ public class AmmoType extends EquipmentType {
     public static final BigInteger F_CAP_MISSILE = BigInteger.valueOf(1).shiftLeft(11); // Other Capital-Missile
     public static final BigInteger F_SPACE_BOMB = BigInteger.valueOf(1).shiftLeft(12); // can be used to space bomb
     public static final BigInteger F_GROUND_BOMB = BigInteger.valueOf(1).shiftLeft(13); // can be used to ground bomb
+    public static final BigInteger F_MML_SRM = BigInteger.valueOf(1).shiftLeft(14); // SRM type
 
     // Numbers 14-15 out of order. See nuclear missiles, above
 
@@ -7839,6 +7840,7 @@ public class AmmoType extends EquipmentType {
         ammo.damagePerShot = 2;
         ammo.rackSize = 3;
         ammo.ammoType = AmmoType.T_MML;
+        ammo.flags = ammo.flags.or(F_HOTLOAD).or(F_MML_SRM);
         ammo.shots = 33;
         ammo.bv = 4;
         ammo.cost = 27000;
@@ -7892,6 +7894,7 @@ public class AmmoType extends EquipmentType {
         ammo.shots = 20;
         ammo.bv = 6;
         ammo.cost = 27000;
+        ammo.flags = ammo.flags.or(F_HOTLOAD).or(F_MML_SRM);
         ammo.rulesRefs = "229, TM";
         // March 2022 - CGL (Greekfire) requested MML adjustments to Tech Progression.
         ammo.techAdvancement.setTechBase(TECH_BASE_IS).setIntroLevel(false).setUnofficial(false).setTechRating(RATING_D)
@@ -7939,6 +7942,7 @@ public class AmmoType extends EquipmentType {
         ammo.damagePerShot = 2;
         ammo.rackSize = 7;
         ammo.ammoType = AmmoType.T_MML;
+        ammo.flags = ammo.flags.or(F_HOTLOAD).or(F_MML_SRM);
         ammo.shots = 14;
         ammo.bv = 8;
         ammo.cost = 27000;
@@ -7989,6 +7993,7 @@ public class AmmoType extends EquipmentType {
         ammo.damagePerShot = 2;
         ammo.rackSize = 9;
         ammo.ammoType = AmmoType.T_MML;
+        ammo.flags = ammo.flags.or(F_HOTLOAD).or(F_MML_SRM);
         ammo.shots = 11;
         ammo.bv = 11;
         ammo.cost = 27000;
@@ -13432,6 +13437,7 @@ public class AmmoType extends EquipmentType {
                     || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && (munition.getMunitionType() == AmmoType.M_AX_HEAD)) {
                 cost *= 0.5;
+                bv *= 1;
             }
 
             if (((munition.getAmmoType() == AmmoType.T_LRM) || (munition.getAmmoType() == AmmoType.T_LRM_IMP)
@@ -13439,6 +13445,7 @@ public class AmmoType extends EquipmentType {
                     || (munition.getAmmoType() == AmmoType.T_SRM_IMP) || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && (munition.getMunitionType() == AmmoType.M_SMOKE_WARHEAD)) {
                 cost *= 0.5;
+                bv *= 1;
             }
 
             if (((munition.getAmmoType() == AmmoType.T_LRM) || (munition.getAmmoType() == AmmoType.T_LRM_IMP)
@@ -13457,12 +13464,14 @@ public class AmmoType extends EquipmentType {
                     || (munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && (munition.getMunitionType() == AmmoType.M_SEMIGUIDED)) {
                 cost *= 3;
+                bv *= 1;
             }
 
             if (((munition.getAmmoType() == AmmoType.T_LRM) || (munition.getAmmoType() == AmmoType.T_LRM_IMP)
                     || (munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && (munition.getMunitionType() == AmmoType.M_SWARM)) {
                 cost *= 2;
+                bv *= 1;
             }
 
             if (((munition.getAmmoType() == AmmoType.T_LRM) || (munition.getAmmoType() == AmmoType.T_LRM_IMP)
@@ -13551,9 +13560,16 @@ public class AmmoType extends EquipmentType {
                     || (munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_SRM)
                     || (munition.getAmmoType() == AmmoType.T_SRM_IMP) || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && ((munition.getMunitionType() == AmmoType.M_ANTI_TSM)
-                            || (munition.getMunitionType() == AmmoType.M_DEAD_FIRE)
                             || (munition.getMunitionType() == AmmoType.M_FRAGMENTATION))) {
                 cost *= 2;
+            }
+
+            if (((munition.getAmmoType() == AmmoType.T_LRM) || (munition.getAmmoType() == AmmoType.T_LRM_IMP)
+                    || (munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_SRM)
+                    || (munition.getAmmoType() == AmmoType.T_SRM_IMP) || (munition.getAmmoType() == AmmoType.T_NLRM))
+                    && ((munition.getMunitionType() == AmmoType.M_DEAD_FIRE))) {
+                cost *= .6;
+                //TODO - DEAD-FIRE AMMO needs BV which is not a constant but launcher Ammo. 
             }
 
             if (((munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_SRM)

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -138,7 +138,7 @@ public class WeaponType extends EquipmentType {
     public static final BigInteger F_AERO_WEAPON = BigInteger.valueOf(1).shiftLeft(45);
     public static final BigInteger F_PROTO_WEAPON = BigInteger.valueOf(1).shiftLeft(46);
     public static final BigInteger F_TANK_WEAPON = BigInteger.valueOf(1).shiftLeft(47);
-    
+
 
     public static final BigInteger F_INFANTRY_ATTACK = BigInteger.valueOf(1).shiftLeft(48);
     public static final BigInteger F_INF_BURST = BigInteger.valueOf(1).shiftLeft(49);
@@ -152,34 +152,34 @@ public class WeaponType extends EquipmentType {
 
     // C3 Master Booster System
     public static final BigInteger F_C3MBS = BigInteger.valueOf(1).shiftLeft(56);
-    
+
     //Used for TSEMP Weapons.
     public static final BigInteger F_TSEMP = BigInteger.valueOf(1).shiftLeft(57);
     public static final BigInteger F_REPEATING = BigInteger.valueOf(1).shiftLeft(61);
-    
+
     //Naval Mass Drivers
     public static final BigInteger F_MASS_DRIVER = BigInteger.valueOf(1).shiftLeft(58);
 
     public static final BigInteger F_CWS = BigInteger.valueOf(1).shiftLeft(59);
-    
+
     public static final BigInteger F_MEK_MORTAR = BigInteger.valueOf(1).shiftLeft(60);
-    
+
     // Weapon required to make a bomb type function
     public static final BigInteger F_BOMB_WEAPON = BigInteger.valueOf(1).shiftLeft(61);
-    
+
     public static final BigInteger F_BA_INDIVIDUAL = BigInteger.valueOf(1).shiftLeft(62);
     //Next one's out of order. See F_INF_CLIMBINGCLAWS
-    
+
     //AMS and Point Defense Bays - Have to work differently from code using the F_AMS flag
     public static final BigInteger F_PDBAY = BigInteger.valueOf(1).shiftLeft(64);
     public static final BigInteger F_AMSBAY = BigInteger.valueOf(1).shiftLeft(65);
-    
+
     //Thunderbolt and similar large missiles, for use with AMS resolution
     public static final BigInteger F_LARGEMISSILE = BigInteger.valueOf(1).shiftLeft(66);
-    
+
     //Hyper-Laser
     public static final BigInteger F_HYPER = BigInteger.valueOf(1).shiftLeft(67);
-    
+
     // Fusillade works like a one-shot weapon but has a second round.
     public static final BigInteger F_DOUBLE_ONESHOT = BigInteger.valueOf(1).shiftLeft(68);
     // ER flamers do half damage in heat mode
@@ -192,7 +192,7 @@ public class WeaponType extends EquipmentType {
     public static final int RANGE_MED = RangeType.RANGE_MEDIUM;
     public static final int RANGE_LONG = RangeType.RANGE_LONG;
     public static final int RANGE_EXT = RangeType.RANGE_EXTREME;
-    
+
     // weapons for airborne units all have fixed weapon ranges:
     // no minimum, 6 short, 12 medium, 20 long, 25 extreme
     public static final int[] AIRBORNE_WEAPON_RANGES = { 0, 6, 12, 20, 25 };
@@ -245,7 +245,7 @@ public class WeaponType extends EquipmentType {
     public static final int WEAPON_BURST_7D6 = 14;
     // Used for BA vs BA damage for BA Plasma Rifle
     public static final int WEAPON_PLASMA = 15;
-    
+
     public static String[] classNames = { "Unknown", "Laser", "Point Defense", "PPC", "Pulse Laser", "Artilery", "AMS",
             "AC", "LBX", "LRM", "SRM", "MRM", "ATM", "Rocket Launcher", "Capital Laser", "Capital PPC", "Capital AC",
             "Capital Gauss", "Capital Missile", "AR10", "Screen", "Sub Capital Cannon", "Capital Mass Driver", "AMS" };
@@ -263,10 +263,10 @@ public class WeaponType extends EquipmentType {
     public static final int BFCLASS_SUBCAPITAL = 10;
     public static final int BFCLASS_CAPITAL_MISSILE = 11;
     public static final int BFCLASS_NUM = 12;
-    
+
     public static final String[] BF_CLASS_NAMES = {
-        "", "LRM", "SRM", "MML", "TORP", "AC", "FLAK", "iATM",
-        "REL", "CAP", "SCAP", "CMISS"
+            "", "LRM", "SRM", "MML", "TORP", "AC", "FLAK", "iATM",
+            "REL", "CAP", "SCAP", "CMISS"
     };
 
     // protected RangeType rangeL;
@@ -295,7 +295,7 @@ public class WeaponType extends EquipmentType {
     /**
      *  Used for the BA vs BA damage rules on TO pg 109.  Determines how much
      *  damage a weapon will inflict on BA, where the default WEAPON_DIRECT_FIRE
-     *  indicates normal weapon damage. 
+     *  indicates normal weapon damage.
      */
     protected int baDamageClass = WEAPON_DIRECT_FIRE;
 
@@ -446,6 +446,53 @@ public class WeaponType extends EquipmentType {
                 lRange = 9;
                 eRange = 12;
             }
+            if (atype.getMunitionType() == AmmoType.M_DEAD_FIRE) {
+                if (atype.hasFlag(AmmoType.F_MML_LRM)) {
+                    minRange = 4;
+                    sRange = 5;
+                    mRange = 10;
+                    lRange = 15;
+                    eRange = 20;
+                } else {
+                    minRange = 0;
+                    sRange = 2;
+                    mRange = 4;
+                    lRange = 6;
+                    eRange = 8;
+                }
+            }
+        }
+        if ((getAmmoType() == AmmoType.T_LRM) && hasLoadedAmmo) {
+            AmmoType atype = (AmmoType) weapon.getLinked().getType();
+            if ((atype.getAmmoType() == AmmoType.T_LRM) && (atype.getMunitionType() == AmmoType.M_DEAD_FIRE)) {
+                minRange = 4;
+                sRange = 5;
+                mRange = 10;
+                lRange = 15;
+                eRange = 20;
+            } else {
+                minRange = 6;
+                sRange = 7;
+                mRange = 14;
+                lRange = 21;
+                eRange = 28;
+            }
+        }
+        if ((getAmmoType() == AmmoType.T_SRM) && hasLoadedAmmo) {
+            AmmoType atype = (AmmoType) weapon.getLinked().getType();
+            if ((atype.getAmmoType() == AmmoType.T_SRM) && (atype.getMunitionType() == AmmoType.M_DEAD_FIRE)) {
+                minRange = 0;
+                sRange = 2;
+                mRange = 4;
+                lRange = 6;
+                eRange = 8;
+            } else {
+                minRange = 0;
+                sRange = 3;
+                mRange = 6;
+                lRange = 9;
+                eRange = 12;
+            }
         }
         if (hasFlag(WeaponType.F_PDBAY)) {
             if (hasModes() && weapon.curMode().equals("Point Defense")) {
@@ -459,7 +506,7 @@ public class WeaponType extends EquipmentType {
             eRange = RangeType.RANGE_BEARINGS_ONLY_OUT;
         }
         int[] weaponRanges =
-            { minRange, sRange, mRange, lRange, eRange };
+                { minRange, sRange, mRange, lRange, eRange };
         return weaponRanges;
     }
 
@@ -482,10 +529,10 @@ public class WeaponType extends EquipmentType {
     public int getExtremeRange() {
         return extremeRange;
     }
-    
+
     public int[] getWRanges() {
         return new int[]
-            { minimumRange, waterShortRange, waterMediumRange, waterLongRange, waterExtremeRange };
+                { minimumRange, waterShortRange, waterMediumRange, waterLongRange, waterExtremeRange };
     }
 
     public int getWShortRange() {
@@ -529,7 +576,7 @@ public class WeaponType extends EquipmentType {
     public int getInfantryDamageClass() {
         return infDamageClass;
     }
-    
+
     public int getBADamageClass() {
         return baDamageClass;
     }
@@ -537,10 +584,10 @@ public class WeaponType extends EquipmentType {
     public int[] getATRanges() {
         if (isCapital()) {
             return new int[]
-                { Integer.MIN_VALUE, 12, 24, 40, 50 };
+                    { Integer.MIN_VALUE, 12, 24, 40, 50 };
         }
         return new int[]
-            { Integer.MIN_VALUE, 6, 12, 20, 25 };
+                { Integer.MIN_VALUE, 6, 12, 20, 25 };
     }
     public int getMissileArmor() {
         return missileArmor;
@@ -675,13 +722,13 @@ public class WeaponType extends EquipmentType {
             }
 
             if (getToHitModifier() != 0) {
-                damage -= damage * getToHitModifier() * 0.05; 
+                damage -= damage * getToHitModifier() * 0.05;
             }
         }
 
         return damage / 10.0;
     }
-    
+
     /**
      * Damage calculation for BattleForce and AlphaStrike for missile weapons that may have advanced fire control
      * @param range - the range in hexes
@@ -691,7 +738,7 @@ public class WeaponType extends EquipmentType {
     public double getBattleForceDamage (int range, Mounted fcs) {
         return getBattleForceDamage(range);
     }
-    
+
     public double adjustBattleForceDamageForMinRange(double damage) {
         return damage * (12 - getMinimumRange()) / 12.0;
     }
@@ -706,7 +753,7 @@ public class WeaponType extends EquipmentType {
     public double getBattleForceDamage(int range, int baSquadSize) {
         return Compute.calculateClusterHitTableAmount(7, baSquadSize) * getBattleForceDamage(range);
     }
-    
+
     /**
      * Reports the class of weapons for those that are tracked separately from standard damage
      * @return
@@ -714,15 +761,15 @@ public class WeaponType extends EquipmentType {
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;
     }
-    
+
     /**
-     * 
+     *
      * @return - BattleForce scale damage for weapons that have the HEAT special ability
      */
     public int getBattleForceHeatDamage(int range) {
         return 0;
     }
-    
+
     public boolean hasIndirectFire() {
         return false;
     }
@@ -930,7 +977,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new CLLRM10OS());
         EquipmentType.addType(new CLLRM15OS());
         EquipmentType.addType(new CLLRM20OS());
-        
+
         EquipmentType.addType(new CLStreakLRM1());
         EquipmentType.addType(new CLStreakLRM2());
         EquipmentType.addType(new CLStreakLRM3());
@@ -1075,7 +1122,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new CLSRT4());
         EquipmentType.addType(new CLSRT5());
         EquipmentType.addType(new CLSRT6());
-        EquipmentType.addType(new CLSRT1OS());        
+        EquipmentType.addType(new CLSRT1OS());
         EquipmentType.addType(new CLSRT2OS());
         EquipmentType.addType(new CLSRT3OS());
         EquipmentType.addType(new CLSRT4OS());
@@ -1226,7 +1273,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new CLImprovedLaserLarge());
         EquipmentType.addType(new CLImprovedPulseLaserLarge());
         EquipmentType.addType(new CLImprovedPPC());
-      
+
         // Infantry Attacks
         EquipmentType.addType(new LegAttack());
         EquipmentType.addType(new SwarmAttack());
@@ -1240,7 +1287,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantrySupportSRMLightInfernoWeapon());
         EquipmentType.addType(new InfantrySupportPortableFlamerWeapon());
         EquipmentType.addType(new InfantryTWFlamerWeapon());
-        
+
         // Infantry Archaic Weapons
         EquipmentType.addType(new InfantryArchaicAxeWeapon());
         EquipmentType.addType(new InfantryArchaicBasicCrossbowWeapon());
@@ -1286,10 +1333,10 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryArchaicBladeJoustingLanceWeapon());
         EquipmentType.addType(new InfantryArchaicWhipWeapon());
         EquipmentType.addType(new InfantryArchaicShockStaffWeapon());
-        
+
         //Clan Archaic - Commented out can be considered Obsolete
         EquipmentType.addType(new InfantryArchaicClanVibroSwordWeapon());
-             
+
         // Infantry Pistols
         EquipmentType.addType(new InfantryPistolAutoPistolWeapon());
         EquipmentType.addType(new InfantryPistolAutoPistolNissanWeapon());
@@ -1333,7 +1380,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryPistolWhiteDwarfLaserPistolWeapon());
         EquipmentType.addType(new InfantryPistolSMGGHTSpec7aWeapon());
         EquipmentType.addType(new InfantryPistolVintageWeapon());
-        
+
         //Shrapnel Pistols
         EquipmentType.addType(new InfantryPistolAAGemini());
         EquipmentType.addType(new InfantryPistolAlamo17());
@@ -1362,7 +1409,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryPistolClanERLaserPistolWeapon());
         EquipmentType.addType(new InfantryPistolClanGaussPistolWeapon());
         EquipmentType.addType(new InfantryPistolClanPulseLaserPistolWeapon());
-        
+
         // Infantry Rifles
         EquipmentType.addType(new InfantryRifleAutoRifleWeapon());
         EquipmentType.addType(new InfantryRifleBlazerRifleWeapon());
@@ -1403,9 +1450,9 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryRifleThunderstrokeWeapon());
         EquipmentType.addType(new InfantryRifleTKAssaultWeapon());
         EquipmentType.addType(new InfantryRifleZeusHeavyWeapon());
-        EquipmentType.addType(new InfantryRifleVintageWeapon());        
+        EquipmentType.addType(new InfantryRifleVintageWeapon());
         EquipmentType.addType(new InfantryRifleVSPLaserWeapon());
-        
+
         // Infantry Shotguns
         EquipmentType.addType(new InfantryShotgunAutomaticWeapon());
         EquipmentType.addType(new InfantryShotgunAvengerCCWWeapon());
@@ -1417,7 +1464,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryShotgunSawnoffDoubleBarrelWeapon());
         EquipmentType.addType(new InfantryShotgunSawnoffPumpActionWeapon());
         EquipmentType.addType(new InfantryShotgunWakazashiWeapon());
-        
+
         //Shrapnel Shotguns
         EquipmentType.addType(new InfantryShotgunAMIKeymaster15());
         EquipmentType.addType(new InfantryShotgunAWAAS105());
@@ -1447,7 +1494,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryShotgunSGS9());
         EquipmentType.addType(new InfantryShotgunSGS9E());
         EquipmentType.addType(new InfantryShotgunWranglemanTriBarrel());
-        
+
         // Infantry SMG Weapons
         EquipmentType.addType(new InfantrySMGClanGaussWeapon());
         EquipmentType.addType(new InfantrySMGGuntherMP20Weapon());
@@ -1456,7 +1503,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantrySMGRorynexRM3XXIWeapon());
         EquipmentType.addType(new InfantrySMGRuganWeapon());
         EquipmentType.addType(new InfantrySMGWeapon());
-        
+
         // Shrapnel SMGs
         EquipmentType.addType(new InfantrySMGAWAStarlingMk7());
         EquipmentType.addType(new InfantrySMGAWAStarlingMk7LB());
@@ -1482,13 +1529,13 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantrySMGWC2());
         EquipmentType.addType(new InfantrySMGWC6());
         EquipmentType.addType(new InfantrySMGWolfBarronA7());
-        
+
         //Sniper Rifles
         EquipmentType.addType(new InfantrySniperRifleSniperWeapon());
         EquipmentType.addType(new InfantrySniperRifleRadiumLaserWeapon());
         EquipmentType.addType(new InfantrySniperStalkerWeapon());
         EquipmentType.addType(new InfantrySniperRifleMinolta9000Weapon());
-        
+
         //Shrapnel Sniper Files
         EquipmentType.addType(new InfantrySniperRifleBartonAMRAntiArmor());
         EquipmentType.addType(new InfantrySniperRifleBartonAMRStandard());
@@ -1505,8 +1552,8 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantrySniperRifleWilimtonRS14());
         EquipmentType.addType(new InfantrySniperRifleWilimtonRS17Stripped());
         EquipmentType.addType(new InfantrySniperRifleYuanLing());
-       
-         // Infantry Support Weapons
+
+        // Infantry Support Weapons
         EquipmentType.addType(new InfantrySupportMGPortableWeapon());
         EquipmentType.addType(new InfantrySupportMGSemiPortableWeapon());
         EquipmentType.addType(new InfantrySupportMk1LightAAWeapon());
@@ -1575,14 +1622,14 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantrySupportGungnirHeavyGaussWeapon());
         EquipmentType.addType(new InfantrySupportMagPulseHarpoonWeapon());
         EquipmentType.addType(new InfantrySupportSnubNoseSupportPPCWeapon());
-        
+
         // Infantry Grenade Weapons
         EquipmentType.addType(new InfantryGrenadeInfernoWeapon());
         EquipmentType.addType(new InfantryGrenadeMicroWeapon());
         EquipmentType.addType(new InfantryGrenadeMiniInfernoWeapon());
         EquipmentType.addType(new InfantryGrenadeRAGWeapon());
         EquipmentType.addType(new InfantryGrenadeStandardWeapon());
-                
+
         //Infantry TAG
         EquipmentType.addType(new InfantrySupportTAGWeapon());
 
@@ -1598,7 +1645,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryProstheticNeedleWeapon());
         EquipmentType.addType(new InfantryProstheticShockerWeapon());
         EquipmentType.addType(new InfantryProstheticVibroBladeWeapon());
-        EquipmentType.addType(new InfantryProstheticClimbingClawsWeapon());    
+        EquipmentType.addType(new InfantryProstheticClimbingClawsWeapon());
 
         EquipmentType.addType(new ISFireExtinguisher());
         EquipmentType.addType(new CLFireExtinguisher());
@@ -1811,7 +1858,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new MassDriverHeavy());
         EquipmentType.addType(new MassDriverMedium());
         EquipmentType.addType(new MassDriverLight());
-        
+
         // bomb-related weapons
         EquipmentType.addType(new ISAAAMissileWeapon());
         EquipmentType.addType(new CLAAAMissileWeapon());


### PR DESCRIPTION
With lots of help from Juliez (who has also reviewed and tested) I've got Dead Fire missiles implemented with the correct ranges and updates to display. 

One area I noticed we are missing is the correct BV for them but it is one of the weapons where every Ammo size has a different BV. I've added a TODO for this.