### PR TITLE
Check for ignored units while princess is building a target list for indirect fire

### DIFF
--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -196,8 +196,12 @@ public class ArtilleryTargetingControl {
         for (Iterator<Entity> enemies = game.getAllEnemyEntities(shooter); enemies.hasNext();) {
             Entity e = enemies.next();
             
-            // skip airborne entities, and those off board - we'll handle them later
-            if (!e.isAirborne() && !e.isAirborneVTOLorWIGE() && !e.isOffBoard()) {
+            // skip airborne entities, and those off board - we'll handle them later and don't target ignored units
+            if (!e.isAirborne()
+                    && !e.isAirborneVTOLorWIGE()
+                    && !e.isOffBoard()
+                    && !owner.getBehaviorSettings().getIgnoredUnitTargets().contains(e.getId())) {
+
                 targetSet.add(new HexTarget(e.getPosition(), Targetable.TYPE_HEX_ARTILLERY));
                 
                 // while we're here, consider shooting at hexes within "MAX_BLAST_RADIUS"


### PR DESCRIPTION
Per https://github.com/MegaMek/megamek/issues/3722, Princess is currently able to target ignored units with indirect fire, this change simply checks the ignore list while generating the list of targets for indirect fire.

This does not stop Princess from targeting units that might be stacked on top of ignore listed units that would require a more significant change, though I think that might be possible.