### PR TITLE
left mouse popup with single board short path

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -60,6 +60,7 @@ import megamek.common.util.CollectionUtil;
 import megamek.common.util.CrewSkillSummaryUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.utilities.BoardsTagger;
+import org.apache.commons.logging.Log;
 import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
@@ -286,6 +287,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         
         lisBoardsAvailable.addListSelectionListener(this);
         lisBoardsAvailable.addMouseListener(mapListMouseListener);
+        lisBoardsAvailable.addMouseMotionListener(mapListMouseListener);
         
         teamOverviewWindow.addWindowListener(teamOverviewWindowListener);
         
@@ -2237,7 +2239,8 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         
         lisBoardsAvailable.removeListSelectionListener(this);
         lisBoardsAvailable.removeMouseListener(mapListMouseListener);
-        
+        lisBoardsAvailable.removeMouseMotionListener(mapListMouseListener);
+
         teamOverviewWindow.removeWindowListener(teamOverviewWindowListener);
         
         mekTable.removeMouseListener(mekTableMouseAdapter);
@@ -2681,7 +2684,8 @@ public class ChatLounge extends AbstractPhaseDisplay implements
 
 
     public class MapListMouseAdapter extends MouseInputAdapter implements ActionListener {
-        
+        ScalingPopup popup;
+
         @Override
         public void actionPerformed(ActionEvent action) {
             String[] command = action.getActionCommand().split(":");
@@ -2702,9 +2706,9 @@ public class ChatLounge extends AbstractPhaseDisplay implements
 
         @Override
         public void mouseReleased(MouseEvent e) {
-            if (e.isPopupTrigger() && lisBoardsAvailable.isEnabled()) {
-                // If the right mouse button is pressed over an unselected map,
-                // clear the selection and select that entity instead
+            if (lisBoardsAvailable.isEnabled()) {
+                // If a mouse button is pressed over an unselected map,
+                // show the board selection popup
                 int index = lisBoardsAvailable.locationToIndex(e.getPoint());
                 if (index != -1 && lisBoardsAvailable.getCellBounds(index, index).contains(e.getPoint())) {
                     if (!lisBoardsAvailable.isSelectedIndex(index)) {
@@ -2715,7 +2719,25 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             }
         }
 
-        /** Shows the right-click menu on the mek table */
+        @Override
+        public void mouseMoved(MouseEvent e) {
+            if (popup == null) return;
+           Component c = e.getComponent();
+           Point p = e.getLocationOnScreen();
+           if (!popup.contains(p))
+           {
+               closePopup(e);
+           }
+        }
+
+        private void closePopup(MouseEvent e)
+        {
+            if (popup == null) return;;
+            popup.setVisible(false);
+            popup = null;
+        }
+
+        /** Shows the map selection menu on the map table */
         private void showPopup(MouseEvent e) {
             if (lisBoardsAvailable.isSelectionEmpty()) {
                 return;
@@ -2723,8 +2745,8 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             List<String> boards = lisBoardsAvailable.getSelectedValuesList();
             int activeButtons = mapSettings.getMapWidth() * mapSettings.getMapHeight();
             boolean enableRotation = (mapSettings.getBoardWidth() % 2) == 0;
-            ScalingPopup popup = MapListPopup.mapListPopup(boards, activeButtons, this, ChatLounge.this, enableRotation);
-            popup.show(e.getComponent(), e.getX(), e.getY());
+            popup = MapListPopup.mapListPopup(boards, activeButtons, this, ChatLounge.this, enableRotation);
+            popup.show(e.getComponent(), e.getX()-2, e.getY()-2);
         }
     }
     
@@ -3297,7 +3319,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         }
         
         private Image prepareImage(String boardName) {
-            File boardFile = new MegaMekFile(Configuration.boardsDir(), boardName + ".board").getFile();
+            File boardFile = new MegaMekFile(Configuration.boardsDir(), :q!:q! + ".board").getFile();
             Board board;
             StringBuffer errs = new StringBuffer();
             if (boardFile.exists()) {

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2707,7 +2707,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         @Override
         public void mouseReleased(MouseEvent e) {
             if (lisBoardsAvailable.isEnabled()) {
-                // If a mouse button is pressed over an unselected map,
+                // If a mouse button is pressed over a map,
                 // show the board selection popup
                 int index = lisBoardsAvailable.locationToIndex(e.getPoint());
                 if (index != -1 && lisBoardsAvailable.getCellBounds(index, index).contains(e.getPoint())) {
@@ -2722,15 +2722,14 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         @Override
         public void mouseMoved(MouseEvent e) {
             if (popup == null) return;
-           Component c = e.getComponent();
            Point p = e.getLocationOnScreen();
            if (!popup.contains(p))
            {
-               closePopup(e);
+               closePopup();
            }
         }
 
-        private void closePopup(MouseEvent e)
+        private void closePopup()
         {
             if (popup == null) return;;
             popup.setVisible(false);

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -3319,7 +3319,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         }
         
         private Image prepareImage(String boardName) {
-            File boardFile = new MegaMekFile(Configuration.boardsDir(), :q!:q! + ".board").getFile();
+            File boardFile = new MegaMekFile(Configuration.boardsDir(), boardName + ".board").getFile();
             Board board;
             StringBuffer errs = new StringBuffer();
             if (boardFile.exists()) {

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -60,7 +60,6 @@ import megamek.common.util.CollectionUtil;
 import megamek.common.util.CrewSkillSummaryUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.utilities.BoardsTagger;
-import org.apache.commons.logging.Log;
 import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
@@ -110,6 +109,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
     static final int MEKTABLE_ROWHEIGHT_FULL = 65;
     static final int MEKTREE_ROWHEIGHT_FULL = 40;
     private final static int TEAMOVERVIEW_BORDER = 45;
+    private final static int MAP_POPUP_OFFSET = -2; // a slight offset so cursor sits inside popup
     
     private JTabbedPane panTabs = new JTabbedPane();
     private JPanel panUnits = new JPanel();
@@ -2721,17 +2721,19 @@ public class ChatLounge extends AbstractPhaseDisplay implements
 
         @Override
         public void mouseMoved(MouseEvent e) {
-            if (popup == null) return;
-           Point p = e.getLocationOnScreen();
-           if (!popup.contains(p))
-           {
-               closePopup();
-           }
+            if (popup == null) {
+                return;
+            }
+            Point p = e.getLocationOnScreen();
+            if (!popup.contains(p)) {
+                closePopup();
+            }
         }
 
-        private void closePopup()
-        {
-            if (popup == null) return;;
+        private void closePopup() {
+            if (popup == null) {
+                return;
+            }
             popup.setVisible(false);
             popup = null;
         }
@@ -2745,7 +2747,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             int activeButtons = mapSettings.getMapWidth() * mapSettings.getMapHeight();
             boolean enableRotation = (mapSettings.getBoardWidth() % 2) == 0;
             popup = MapListPopup.mapListPopup(boards, activeButtons, this, ChatLounge.this, enableRotation);
-            popup.show(e.getComponent(), e.getX()-2, e.getY()-2);
+            popup.show(e.getComponent(), e.getX() + MAP_POPUP_OFFSET, e.getY() + MAP_POPUP_OFFSET);
         }
     }
     

--- a/megamek/src/megamek/client/ui/swing/lobby/MapListPopup.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MapListPopup.java
@@ -14,7 +14,9 @@
 package megamek.client.ui.swing.lobby;
 
 import java.awt.event.ActionListener;
+import java.io.File;
 import java.util.List;
+import java.util.Set;
 
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
@@ -38,13 +40,12 @@ class MapListPopup {
 
         ScalingPopup popup = new ScalingPopup();
         if (numButtons == 1) {
-            String name = boards.get(0);
-
-//            name = name.substring(name.lastIndexOf('/'));
-            JMenuItem mi = menuItem("Set " + name, MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + false, true, listener);
+            String name = mapShortName(boards.get(0));
+            JMenuItem mi = menuItem("Set \"" + name + "\" as Board 0", MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + false, true, listener);
             popup.add(mi);
             mi.setEnabled(oneSelected);
-            mi = menuItem("Set Rotated " + name, MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + true, true, listener);
+
+            mi = menuItem("Set Rotated \"" + name + "\" as Board 0", MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + true, true, listener);
             popup.add(mi);
             mi.setEnabled(oneSelected);
         } else {
@@ -60,13 +61,21 @@ class MapListPopup {
         return popup;
     }
 
+    /** @return the short map name given the long path */
+    private static String mapShortName(String mapPath) {
+        // File is the most robust way to split
+        File f = new File(mapPath);
+        return f.getName();
+    }
+
     /**
      * Returns the "set as board" submenu.
      */
     private static JMenu singleBoardMenu(boolean enabled, boolean rotated, ActionListener listener, 
             int numB, List<String> boards) {
+        String name = mapShortName(boards.get(0));
 
-        JMenu menu = new JMenu(!rotated ? "Set as Board..." : "Set as Board (rotated)...");
+        JMenu menu = new JMenu(!rotated ? "Set \"" + name + "\" as Board..." : " Set \"" + name + "\" as Board (rotated)...");
         menu.setEnabled(enabled);
         if (enabled) {
             for (int i = 0; i < numB; i++) {

--- a/megamek/src/megamek/client/ui/swing/lobby/MapListPopup.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MapListPopup.java
@@ -44,10 +44,11 @@ class MapListPopup {
             JMenuItem mi = menuItem("Set \"" + name + "\" as Board 0", MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + false, true, listener);
             popup.add(mi);
             mi.setEnabled(oneSelected);
-
-            mi = menuItem("Set Rotated \"" + name + "\" as Board 0", MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + true, true, listener);
-            popup.add(mi);
-            mi.setEnabled(oneSelected);
+            if (enableRotation) {
+                mi = menuItem("Set Rotated \"" + name + "\" as Board 0", MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + true, true, listener);
+                popup.add(mi);
+                mi.setEnabled(oneSelected);
+            }
         } else {
             popup.add(singleBoardMenu(oneSelected, false, listener, numButtons, boards));
 

--- a/megamek/src/megamek/client/ui/swing/lobby/MapListPopup.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MapListPopup.java
@@ -20,6 +20,7 @@ import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 
 import megamek.client.ui.swing.util.ScalingPopup;
+import org.apache.logging.log4j.core.util.FileUtils;
 
 class MapListPopup {
     
@@ -36,10 +37,22 @@ class MapListPopup {
         boolean oneSelected = boards.size() == 1;
 
         ScalingPopup popup = new ScalingPopup();
-        popup.add(singleBoardMenu(oneSelected, false, listener, numButtons, boards));
-        
-        if (enableRotation) {
-            popup.add(singleBoardMenu(oneSelected, true, listener, numButtons, boards));
+        if (numButtons == 1) {
+            String name = boards.get(0);
+
+//            name = name.substring(name.lastIndexOf('/'));
+            JMenuItem mi = menuItem("Set " + name, MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + false, true, listener);
+            popup.add(mi);
+            mi.setEnabled(oneSelected);
+            mi = menuItem("Set Rotated " + name, MLP_BOARD + ":" + 0 + ":" + boards.get(0) + ":" + true, true, listener);
+            popup.add(mi);
+            mi.setEnabled(oneSelected);
+        } else {
+            popup.add(singleBoardMenu(oneSelected, false, listener, numButtons, boards));
+
+            if (enableRotation) {
+                popup.add(singleBoardMenu(oneSelected, true, listener, numButtons, boards));
+            }
         }
         
         popup.add(multiBoardRandomMenu(!oneSelected, listener, numButtons, boards));


### PR DESCRIPTION
This addresses https://github.com/MegaMek/megamek/issues/3729
It changes the popup event detection to react to any mouse button click on the map buttons. Also, if there is only one map selection, it provides the select and rotate options for that map specifically, rather than using the hierarchical menus. This change is, I think, more intuitive for most users.
It also also uses the map name in the popup when one map is selected.