### PR TITLE
MHQ 2901: Removing IS Factions from Lupus Generation for 2860-3000

### DIFF
--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -2947,7 +2947,7 @@
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
-		<availability>CC:2,MOC:2,CDS:2,CBS:2,CSV:2,CLAN:2,FWL:2,MERC:2,CCO:6,CGS:2,TC:2</availability>
+		<availability>CDS:2,CBS:2,CSV:2,CLAN:2,CCO:6,CGS:2</availability>
 		<model name='A'>
 			<availability>CLAN:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -2974,7 +2974,7 @@
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
-		<availability>CC:3,MOC:3,CDS:3,CBS:3,CSV:3,CLAN:3,FWL:3,MERC:3,CCO:8,CGS:3,TC:3</availability>
+		<availability>CDS:3,CBS:3,CSV:3,CLAN:3,CCO:8,CGS:3</availability>
 		<model name='A'>
 			<availability>CLAN:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -3261,7 +3261,7 @@
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
-		<availability>CC:3,MOC:3,CDS:3,CBS:4,CSV:4,CLAN:3,FWL:3,MERC:3,CCO:8,CGS:4,TC:3</availability>
+		<availability>CDS:3,CBS:4,CSV:4,CLAN:3,CCO:8,CGS:4</availability>
 		<model name='A'>
 			<availability>CLAN:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -3322,7 +3322,7 @@
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
-		<availability>CC:3,MOC:3,CDS:3,CBS:4,CSV:4,CLAN:3,FWL:3,MERC:3,CCO:8,CGS:4,TC:3</availability>
+		<availability>CDS:3,CBS:4,CSV:4,CLAN:3,CCO:8,CGS:4</availability>
 		<model name='A'>
 			<availability>CLAN:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -3402,7 +3402,7 @@
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
-		<availability>CC:2-,MOC:2-,CDS:2-,CBS:4-,CSV:4-,CLAN:2-,FWL:2-,MERC:2-,CCO:7,CGS:4-,BAN:3,TC:2-</availability>
+		<availability>CDS:2-,CBS:4-,CSV:4-,CLAN:2-,CCO:7,CGS:4-,BAN:3</availability>
 		<model name='A'>
 			<availability>CLAN:6</availability>
 		</model>

--- a/megamek/data/forcegenerator/3000.xml
+++ b/megamek/data/forcegenerator/3000.xml
@@ -3629,7 +3629,7 @@
 		</model>
 	</chassis>
 	<chassis name='Lupus' unitType='Mek' omni='Clan'>
-		<availability>CC:2-,MOC:2-,CDS:2-,CBS:3-,CSV:3-,CLAN:2-,FWL:2-,MERC:2-,CCO:5-,CGS:3-,BAN:2,TC:2-</availability>
+		<availability>CDS:2-,CBS:3-,CSV:3-,CLAN:2-,CCO:5-,CGS:3-,BAN:2</availability>
 		<model name='A'>
 			<availability>CLAN:6</availability>
 		</model>


### PR DESCRIPTION
This fixes https://github.com/MegaMek/mekhq/issues/2901

It appears to be a copy/paste issue from CDS.