### PR TITLE
Change Beer Message to Gender Neutral

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -873,7 +873,9 @@
 6403=Crew of <data> (<data>) heads for the airlocks! <data> people escape successfully.
 6405=<font color='C00000'>Unfortunately, the pilot is not wearing a pressure suit.</font>
 6410=The pilot ejects safely and lands far from the battle!
-6415=<data> sits down with his colleagues and cracks open a beer!
+6415=<data> sits down with colleagues and cracks open a beer!
+6416=<data> swaps a flask, lies and war stories with an ally!
+6417=<data> shares a Timbiqui Dark and some rumors with a newfound companion!
 6420=<data> has been picked up by <data> (<data>).
 6425=The building in the hex absorbs <data> damage from the artillery strike!
 6426=<data> (<data>) protected by building.

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -32857,7 +32857,7 @@ public class GameManager implements IGameManager {
                     }
                     if (pe instanceof MechWarrior) {
                         // MWs have a beer together
-                        r = new Report(6415, Report.PUBLIC);
+                        r = new Report(6416, Report.PUBLIC);
                         r.add(pe.getDisplayName());
                         addReport(r);
                         continue;
@@ -32886,7 +32886,7 @@ public class GameManager implements IGameManager {
                     }
                     if (pe instanceof MechWarrior) {
                         // MWs have a beer together
-                        r = new Report(6415, Report.PUBLIC);
+                        r = new Report(6417, Report.PUBLIC);
                         r.add(pe.getDisplayName());
                         addReport(r);
                         continue;


### PR DESCRIPTION
First time doing this, so if I make an error I apologize. 

Current Beer message always says "his" no matter the gender of the MW.

Changed text of existing message to gender neutral by removing "his" from message.  

The message was called in 3 different situations depending on MW allegiance.  Owner-Owner, Owner-Ally, Owner-Enemy.  But same message was called each time.  Added two different messages for Owner-Ally and Owner-Enemy situations.

Tested and seems to work properly with 2 pilots.  Note if 3 different MW end up in the same text, it will generate 6 messages, but this is the current behavior in vanilla, and was not changed by me.

EDIT:  This fixes #3711 but not sure how to indicate that.