### PR TITLE
prevent unload stranded unit lockup

### DIFF
--- a/megamek/src/megamek/common/GameTurn.java
+++ b/megamek/src/megamek/common/GameTurn.java
@@ -492,10 +492,12 @@ public class GameTurn implements Serializable {
         /**
          * @return true if the player is valid.
          */
-        public boolean isValid(int playerId, Game game) {
+        @Override
+        public boolean isValid(int playerId, IGame game) {
+            Game actualGame = (Game) game;
             return IntStream.range(0, entityIds.length)
-                    .anyMatch(index -> (game.getEntity(entityIds[index]) != null)
-                            && (playerId == game.getEntity(entityIds[index]).getOwnerId()));
+                    .anyMatch(index -> (actualGame.getEntity(entityIds[index]) != null)
+                            && (playerId == actualGame.getEntity(entityIds[index]).getOwnerId()));
         }
 
         @Override


### PR DESCRIPTION
Fixes #3724 

This was actually causing a lockup for anyone, whether princess or not, attempting to unload stranded units. Now, the UnloadStrandedEntityTurn properly overrides the isValid(playerId, game) method.

I considered changing the base class to using Game instead, but I don't want to go down that rabbit hole.