### PR TITLE
Fixes the Mast Mount equipment issue for Support VTOLs

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -8584,7 +8584,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = 0.5;
         misc.tankslots = 0;
         misc.cost = 50000;
-        misc.flags = misc.flags.or(F_MAST_MOUNT).or(F_VTOL_EQUIPMENT);
+        misc.flags = misc.flags.or(F_MAST_MOUNT).or(F_VTOL_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT);
         misc.bv = BV_VARIABLE;
         misc.rulesRefs = "350, TO";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)


### PR DESCRIPTION
This is a band-aid fix for issue #3744 

There is a greater bug somewhere in the code that causes support VTOLs to not classify them as VTOLs. This issue affects any equipment only allowed on VTOLs such as the Mast Mount and VTOL Jet Booster. These may be the only items that are VTOL only so let me know if the underlying bug is worth a separate ticket.