### PR TITLE
properly render illegal moves as gray

### DIFF
--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -1644,10 +1644,12 @@ public class GUIPreferences extends PreferenceStoreProxy {
      * @return The color associated with a movement type
      */
     public Color getColorForMovement(EntityMovementType movementType, boolean isMASCOrSuperCharger, boolean isBackwards) {
-        if (isMASCOrSuperCharger) {
-            return getColor(ADVANCED_MOVE_MASC_COLOR);
-        } else if (isBackwards) {
-            return getColor(ADVANCED_MOVE_BACK_COLOR);
+        if (movementType != EntityMovementType.MOVE_ILLEGAL) {
+            if (isMASCOrSuperCharger) {
+                return getColor(ADVANCED_MOVE_MASC_COLOR);
+            } else if (isBackwards) {
+                return getColor(ADVANCED_MOVE_BACK_COLOR);
+            }
         }
         return getColorForMovement(movementType);
     }


### PR DESCRIPTION
Fixes an issue I noticed with the recent builds - backwards moves were rendering as "running" even though they were clearly illegal (MP used > walk, etc).