### PR TITLE
Tooltip bg fix

### DIFF
--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -257,12 +257,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static String RAT_PAD_BV = "RATPadBV";
     public static String RAT_SELECTED_RAT = "RATSelectedRAT";
 
-    private static final Color DEFAULT_WHITE = Color.WHITE;
-    private static final Color DEFAULT_BLACK = Color.BLACK;
+    // common colors
+    public static final Color DEFAULT_WHITE = Color.WHITE;
+    public static final Color DEFAULT_BLACK = Color.BLACK;
+    public static final Color DEFAULT_DARK_GRAY = new Color(64, 64, 64);
+    public static final Color DEFAULT_LIGHT_GRAY = new Color(196, 196, 196);
 
     // Text colors that read over light and dark backgrounds
-    private static final Color DEFAULT_DARK_GRAY = new Color(64, 64, 64);
-    private static final Color DEFAULT_LIGHT_GRAY = new Color(196, 196, 196);
     private static final Color DEFAULT_CYAN = new Color(0, 228, 228);
     private static final Color DEFAULT_MAGENTA = new Color(228, 0, 228);
     private static final Color DEFAULT_PINK = new Color(228, 20, 147);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5433,7 +5433,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // Distance from the selected unit and a planned movement end point
             if ((selectedEntity != null) && (selectedEntity.getPosition() != null)) {
                 int distance = selectedEntity.getPosition().distance(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR +" width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 if (distance == 1) {
                     txt.append(Messages.getString("BoardView1.Tooltip.Distance1"));
                 } else {
@@ -5595,7 +5595,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 }
             }
 
-            txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + "width=100%><TR><TD><FONT color=\"black\">");
+            txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
             if (aaa.getTurnsTilHit() == 1) {
                 txt.append(Messages.getString("BoardView1.Tooltip.ArtilleryAttack1", wpName, ammoName));
             } else {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -80,6 +80,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+import static megamek.client.ui.swing.tooltip.TipUtil.*;
 
 /**
  * Displays the board; lets the user scroll around and select points on it.
@@ -139,15 +140,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     private static Font FONT_10 = new Font("SansSerif", Font.PLAIN, 10);
     private static Font FONT_12 = new Font("SansSerif", Font.PLAIN, 12);
 
-    // Tooltip Colors - hardcoded to avoid unreadable text
-    // but could be moved to GUIPreferences Advance Options
-    private static final String LIGHT_BGCOLOR = "#999999";
-    private static final String BUILDING_BGCOLOR = "#CCCC99";
-    private static final String ALT_BGCOLOR = "#FFDDDD";
-    private static final String BLOCK_BGCOLOR = "#000060";
-    private static final String TERRAIN_BGCOLOR = "#8DAF8D";
-    private static String  HTML_OPEN = "<HTML><BODY BGCOLOR=#" + UnitToolTip.BGCOLOR + ">";
-    private static String  HTML_CLOSE = "</BODY></HTML>";
     Dimension hex_size;
 
     private Font font_note = FONT_10;
@@ -5433,7 +5425,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         }
         Hex mhex = game.getBoard().getHex(mcoords);
 
-        StringBuffer txt = new StringBuffer(HTML_OPEN);
+        StringBuffer txt = new StringBuffer(HTML_BEGIN);
         // Hex Terrain
         if (GUIPreferences.getInstance().getShowMapHexPopup() && (mhex != null)) {
             appendTerrainTooltip(txt, mhex);
@@ -5663,10 +5655,10 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
         }
 
-        txt.append(HTML_CLOSE);
+        txt.append(HTML_END);
 
         // Check to see if the tool tip is completely empty
-        if (txt.toString().equals(HTML_OPEN+HTML_CLOSE)) {
+        if (txt.toString().equals(HTML_BEGIN +HTML_END)) {
             return "";
         }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -140,12 +140,13 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     private static Font FONT_12 = new Font("SansSerif", Font.PLAIN, 12);
 
     // Tooltip Colors - hardcoded to avoid unreadable text
-    private static final String DEFAULT_BGCOLOR = "#999999";
+    // but could be moved to GUIPreferences Advance Options
+    private static final String LIGHT_BGCOLOR = "#999999";
     private static final String BUILDING_BGCOLOR = "#CCCC99";
     private static final String ALT_BGCOLOR = "#FFDDDD";
     private static final String BLOCK_BGCOLOR = "#000060";
     private static final String TERRAIN_BGCOLOR = "#8DAF8D";
-    private static String  HTML_OPEN = "<HTML><BODY BGCOLOR=#313131>";
+    private static String  HTML_OPEN = "<HTML><BODY BGCOLOR=#" + UnitToolTip.BGCOLOR + ">";
     private static String  HTML_CLOSE = "</BODY></HTML>";
     Dimension hex_size;
 
@@ -5724,7 +5725,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // In the BoardEditor, buildings have no entry in the
             // buildings list of the board, so get the info from the hex
             if (clientgui == null) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + LIGHT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.FuelTank",
                         mhex.terrainLevel(Terrains.FUEL_TANK_ELEV),
                         Terrains.getEditorName(Terrains.FUEL_TANK),
@@ -5732,7 +5733,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                         mhex.terrainLevel(Terrains.FUEL_TANK_MAGN)));
             } else {
                 FuelTank bldg = (FuelTank) game.getBoard().getBuildingAt(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + LIGHT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.FuelTank",
                         mhex.terrainLevel(Terrains.FUEL_TANK_ELEV), bldg.toString(),
                         bldg.getCurrentCF(mcoords), bldg.getMagnitude()));
@@ -5745,7 +5746,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // In the BoardEditor, buildings have no entry in the
             // buildings list of the board, so get the info from the hex
             if (clientgui == null) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + LIGHT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Building",
                         mhex.terrainLevel(Terrains.BLDG_ELEV), Terrains.getEditorName(Terrains.BUILDING),
                         mhex.terrainLevel(Terrains.BLDG_CF), Math.max(mhex.terrainLevel(Terrains.BLDG_ARMOR), 0),
@@ -5770,13 +5771,13 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // In the BoardEditor, buildings have no entry in the
             // buildings list of the board, so get the info from the hex
             if (clientgui == null) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + LIGHT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Bridge",
                         mhex.terrainLevel(Terrains.BRIDGE_ELEV), Terrains.getEditorName(Terrains.BRIDGE),
                         mhex.terrainLevel(Terrains.BRIDGE_CF)));
             } else {
                 Building bldg = game.getBoard().getBuildingAt(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + LIGHT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Bridge",
                         mhex.terrainLevel(Terrains.BRIDGE_ELEV), bldg.toString(), bldg.getCurrentCF(mcoords)));
             }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -139,6 +139,14 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     private static Font FONT_10 = new Font("SansSerif", Font.PLAIN, 10);
     private static Font FONT_12 = new Font("SansSerif", Font.PLAIN, 12);
 
+    // Tooltip Colors - hardcoded to avoid unreadable text
+    private static final String DEFAULT_BGCOLOR = "#999999";
+    private static final String BUILDING_BGCOLOR = "#CCCC99";
+    private static final String ALT_BGCOLOR = "#FFDDDD";
+    private static final String BLOCK_BGCOLOR = "#000060";
+    private static final String TERRAIN_BGCOLOR = "#8DAF8D";
+    private static String  HTML_OPEN = "<HTML><BODY BGCOLOR=#313131>";
+    private static String  HTML_CLOSE = "</BODY></HTML>";
     Dimension hex_size;
 
     private Font font_note = FONT_10;
@@ -5424,15 +5432,15 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         }
         Hex mhex = game.getBoard().getHex(mcoords);
 
-        StringBuffer txt = new StringBuffer("<HTML>");
+        StringBuffer txt = new StringBuffer(HTML_OPEN);
         // Hex Terrain
         if (GUIPreferences.getInstance().getShowMapHexPopup() && (mhex != null)) {
-            appendTerrainTooltip(txt, mhex, "#DDFFDD");
+            appendTerrainTooltip(txt, mhex);
 
             // Distance from the selected unit and a planned movement end point
             if ((selectedEntity != null) && (selectedEntity.getPosition() != null)) {
                 int distance = selectedEntity.getPosition().distance(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=#FFDDDD width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR +" width=100%><TR><TD><FONT color=\"black\">");
                 if (distance == 1) {
                     txt.append(Messages.getString("BoardView1.Tooltip.Distance1"));
                 } else {
@@ -5472,7 +5480,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 txt.append("</FONT></TD></TR></TABLE>");
             }
 
-            appendBuildingsTooltip(txt, mhex, "#999999");
+            appendBuildingsTooltip(txt, mhex);
 
             if (displayInvalidHexInfo) {
                 StringBuffer errBuff = new StringBuffer();
@@ -5534,7 +5542,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         // check if it's on any attacks
         for (AttackSprite aSprite : attackSprites) {
             if (aSprite.isInside(point)) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=#FFDDDD width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(aSprite.getTooltip().toString());
                 txt.append("</FONT></TD></TR></TABLE>");
             }
@@ -5567,7 +5575,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         }
         // Info block if there are more than 4 units in that hex
         if (entityCount > maxShown) {
-            txt.append("<TABLE BORDER=0 BGCOLOR=#000060 width=100%><TR><TD><FONT COLOR=WHITE>There ");
+            txt.append("<TABLE BORDER=0 BGCOLOR=" + BLOCK_BGCOLOR + " width=100%><TR><TD><FONT COLOR=WHITE>There ");
             if (entityCount-maxShown == 1) {
                 txt.append("is 1 more<BR>unit");
             } else {
@@ -5594,7 +5602,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 }
             }
 
-            txt.append("<TABLE BORDER=0 BGCOLOR=#FFDDDD width=100%><TR><TD><FONT color=\"black\">");
+            txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + "width=100%><TR><TD><FONT color=\"black\">");
             if (aaa.getTurnsTilHit() == 1) {
                 txt.append(Messages.getString("BoardView1.Tooltip.ArtilleryAttack1", wpName, ammoName));
             } else {
@@ -5654,10 +5662,10 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
         }
 
-        txt.append("</html>");
+        txt.append(HTML_CLOSE);
 
         // Check to see if the tool tip is completely empty
-        if (txt.toString().equals("<html></html>")) { 
+        if (txt.toString().equals(HTML_OPEN+HTML_CLOSE)) {
             return "";
         }
 
@@ -5677,13 +5685,13 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     /**
      * Appends HTML describing the terrain of a given hex
      */
-    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex, String bgColor) {
+    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex) {
         if (mhex == null) {
             return;
         }
 
         Coords mcoords = mhex.getCoords();
-        txt.append("<TABLE BORDER=0 BGCOLOR="+bgColor+" width=100%><TR><TD><FONT color=\"black\">");
+        txt.append("<TABLE BORDER=0 BGCOLOR=" + TERRAIN_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
 
         txt.append(Messages.getString("BoardView1.Tooltip.Hex", mcoords.getBoardNum(), mhex.getLevel()));
         txt.append("<br>");
@@ -5705,7 +5713,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     /**
      * Appends HTML describing the buildings and minefields in a given hex
      */
-    public void appendBuildingsTooltip(StringBuffer txt, @Nullable Hex mhex, String bgColor) {
+    public void appendBuildingsTooltip(StringBuffer txt, @Nullable Hex mhex) {
         if (mhex == null) {
             return;
         }
@@ -5716,7 +5724,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // In the BoardEditor, buildings have no entry in the
             // buildings list of the board, so get the info from the hex
             if (clientgui == null) {
-                txt.append("<TABLE BORDER=0 BGCOLOR="+bgColor+" width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.FuelTank",
                         mhex.terrainLevel(Terrains.FUEL_TANK_ELEV),
                         Terrains.getEditorName(Terrains.FUEL_TANK),
@@ -5724,7 +5732,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                         mhex.terrainLevel(Terrains.FUEL_TANK_MAGN)));
             } else {
                 FuelTank bldg = (FuelTank) game.getBoard().getBuildingAt(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=#999999 width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.FuelTank",
                         mhex.terrainLevel(Terrains.FUEL_TANK_ELEV), bldg.toString(),
                         bldg.getCurrentCF(mcoords), bldg.getMagnitude()));
@@ -5737,14 +5745,14 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // In the BoardEditor, buildings have no entry in the
             // buildings list of the board, so get the info from the hex
             if (clientgui == null) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=#999999 width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Building",
                         mhex.terrainLevel(Terrains.BLDG_ELEV), Terrains.getEditorName(Terrains.BUILDING),
                         mhex.terrainLevel(Terrains.BLDG_CF), Math.max(mhex.terrainLevel(Terrains.BLDG_ARMOR), 0),
                         BasementType.getType(mhex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).toString()));
             } else {
                 Building bldg = game.getBoard().getBuildingAt(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=#CCCC99 width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + BUILDING_BGCOLOR +" width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Building",
                         mhex.terrainLevel(Terrains.BLDG_ELEV), bldg.toString(),
                         bldg.getCurrentCF(mcoords), bldg.getArmor(mcoords),
@@ -5762,13 +5770,13 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             // In the BoardEditor, buildings have no entry in the
             // buildings list of the board, so get the info from the hex
             if (clientgui == null) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=#999999 width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Bridge",
                         mhex.terrainLevel(Terrains.BRIDGE_ELEV), Terrains.getEditorName(Terrains.BRIDGE),
                         mhex.terrainLevel(Terrains.BRIDGE_CF)));
             } else {
                 Building bldg = game.getBoard().getBuildingAt(mcoords);
-                txt.append("<TABLE BORDER=0 BGCOLOR=#999999 width=100%><TR><TD><FONT color=\"black\">");
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + DEFAULT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
                 txt.append(Messages.getString("BoardView1.Tooltip.Bridge",
                         mhex.terrainLevel(Terrains.BRIDGE_ELEV), bldg.toString(), bldg.getCurrentCF(mcoords)));
             }
@@ -5818,7 +5826,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         // Table to add a bar to the left of an entity in
         // the player's color
         txt.append("<hr style=width:90%>");
-        txt.append("<TABLE><TR><TD bgcolor=#");
+        txt.append("<TABLE><TR><TD BGCOLOR=#");
         String color = "C0C0C0";
         if (!EntityVisibilityUtils.onlyDetectedBySensors(localPlayer, entity)) {
             color = entity.getOwner().getColour().getHexString();

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
@@ -43,6 +43,7 @@ import java.awt.*;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 
+import static megamek.client.ui.swing.tooltip.TipUtil.*;
 import static megamek.client.ui.swing.util.UIUtil.alternateTableBGColor;
 import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 import static megamek.client.ui.swing.util.UIUtil.uiGreen;
@@ -188,8 +189,8 @@ public class MekTableModel extends AbstractTableModel {
         } else {
             MapSettings mset = chatLounge.mapSettings;
             Player lPlayer = clientGui.getClient().getLocalPlayer();
-            unitTooltips.add("<HTML>" + UnitToolTip.getEntityTipLobby(entity, lPlayer, mset));
-            pilotTooltips.add("<HTML>" + PilotToolTip.getPilotTipDetailed(entity, true));
+            unitTooltips.add( HTML_BEGIN + UnitToolTip.getEntityTipLobby(entity, lPlayer, mset) + HTML_END);
+            pilotTooltips.add(HTML_BEGIN + PilotToolTip.getPilotTipDetailed(entity, true) + HTML_END);
         }
         final boolean rpgSkills = clientGui.getClient().getGame().getOptions().booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
         if (chatLounge.isCompact()) {

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -57,7 +57,7 @@ public final class PilotToolTip {
         
         // The crew info (names etc.) and portraits, if shown, are placed
         // in a table side by side
-        result.append("<TABLE BORDER=0 BGCOLOR="+BG_COLOR+" width=100%><TR><TD>");
+        result.append("<TABLE BORDER=0 BGCOLOR=" + BG_COLOR + " width=100%><TR><TD>");
 
         if (showPortrait) {
             result.append(crewPortraits(entity, showDefaultPortrait));

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -40,6 +40,7 @@ public final class PilotToolTip {
     
     /** the portrait base size */
     private final static int PORTRAIT_BASESIZE = 72;
+    final static String BG_COLOR = "#313131";
 
     public static StringBuilder getPilotTipDetailed(Entity entity, boolean showPortrait) {
         return getPilotTip(entity, true, showPortrait, true);
@@ -56,7 +57,7 @@ public final class PilotToolTip {
         
         // The crew info (names etc.) and portraits, if shown, are placed
         // in a table side by side
-        result.append(TABLE_BEGIN);
+        result.append("<TABLE BORDER=0 BGCOLOR="+BG_COLOR+" width=100%><TR><TD>");
 
         if (showPortrait) {
             result.append(crewPortraits(entity, showDefaultPortrait));
@@ -65,7 +66,7 @@ public final class PilotToolTip {
             result.append("<TD WIDTH=" + dist + "></TD>");
         }
 
-        result.append(crewInfo(entity));
+        result.append(crewInfoCell(entity));
 
         result.append(TABLE_END);
 
@@ -76,7 +77,7 @@ public final class PilotToolTip {
     }
     
     /** Returns a tooltip part with names and skills of the crew. */
-    private static StringBuilder crewInfo(final Entity entity) {
+    private static StringBuilder crewInfoCell(final Entity entity) {
         Crew crew = entity.getCrew();
         Game game = entity.getGame();
         StringBuilder result = new StringBuilder();

--- a/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
@@ -29,9 +29,24 @@ public final class TipUtil {
     
     final static boolean BR = true;
     final static boolean NOBR = false;
+
+    // Tooltip Colors - hardcoded to avoid unreadable text
+    // but could be moved to GUIPreferences Advance Options
+    public final static String BGCOLOR = "#313131";
+    public final static String FGCOLOR = "#EEE6D9";
+    public static final String LIGHT_BGCOLOR = "#999999";
+    public static final String BUILDING_BGCOLOR = "#CCCC99";
+    public static final String ALT_BGCOLOR = "#FFDDDD";
+    public static final String BLOCK_BGCOLOR = "#000060";
+    public static final String TERRAIN_BGCOLOR = "#8DAF8D";
+
     public final static String TABLE_BEGIN = "<TABLE CELLSPACING=0 CELLPADDING=0><TBODY><TR><TD VALIGN=TOP>";
     public final static String TABLE_END = "</TR></TBODY></TABLE>";
-    
+
+    public static final String HTML_BEGIN = "<HTML><BODY style=\"color: "+FGCOLOR + " background-color:"+BGCOLOR+";\">";
+    public static final String HTML_END = "</BODY></HTML>";
+
+
     /** 
      * Returns a List wherein each element consists of an option group of the given 
      * optGroups, which is e.g. crew.getOptions().getGroups() or entity.getQuirks().getGroups()

--- a/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
@@ -40,12 +40,11 @@ public final class TipUtil {
     public static final String BLOCK_BGCOLOR = "#000060";
     public static final String TERRAIN_BGCOLOR = "#8DAF8D";
 
+    // HTML block begins and ends
     public final static String TABLE_BEGIN = "<TABLE CELLSPACING=0 CELLPADDING=0><TBODY><TR><TD VALIGN=TOP>";
     public final static String TABLE_END = "</TR></TBODY></TABLE>";
-
     public static final String HTML_BEGIN = "<HTML><BODY style=\"color: "+FGCOLOR + " background-color:"+BGCOLOR+";\">";
     public static final String HTML_END = "</BODY></HTML>";
-
 
     /** 
      * Returns a List wherein each element consists of an option group of the given 

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -44,7 +44,6 @@ public final class UnitToolTip {
     
     /** The font size reduction for Quirks */
     final static float TT_SMALLFONT_DELTA = -0.2f;
-    public final static String BGCOLOR = "#313131";
 
 
     /** Returns the unit tooltip with values that are relevant in the lobby. */

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -44,7 +44,9 @@ public final class UnitToolTip {
     
     /** The font size reduction for Quirks */
     final static float TT_SMALLFONT_DELTA = -0.2f;
-    
+    final static String BG_COLOR = "#313131";
+
+
     /** Returns the unit tooltip with values that are relevant in the lobby. */
     public static StringBuilder getEntityTipLobby(Entity entity, Player localPlayer,
             MapSettings mapSettings) {
@@ -73,6 +75,7 @@ public final class UnitToolTip {
         }
 
         StringBuilder result = new StringBuilder();
+        result.append("<TABLE BORDER=0 BGCOLOR="+BG_COLOR+" width=100%><TR><TD>");
         Game game = entity.getGame();
         GUIPreferences guip = GUIPreferences.getInstance();
 
@@ -167,6 +170,8 @@ public final class UnitToolTip {
             result.append(scaledHTMLSpacer(3));
             result.append(c3Info(entity));
         }
+        result.append("</TD></TR></TABLE>");
+
         return result;
     }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -44,7 +44,7 @@ public final class UnitToolTip {
     
     /** The font size reduction for Quirks */
     final static float TT_SMALLFONT_DELTA = -0.2f;
-    final static String BGCOLOR = "#313131";
+    public final static String BGCOLOR = "#313131";
 
 
     /** Returns the unit tooltip with values that are relevant in the lobby. */

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -45,7 +45,6 @@ public final class UnitToolTip {
     /** The font size reduction for Quirks */
     final static float TT_SMALLFONT_DELTA = -0.2f;
 
-
     /** Returns the unit tooltip with values that are relevant in the lobby. */
     public static StringBuilder getEntityTipLobby(Entity entity, Player localPlayer,
             MapSettings mapSettings) {
@@ -66,7 +65,7 @@ public final class UnitToolTip {
     
     /** Assembles the whole unit tooltip. */
     private static StringBuilder getEntityTipTable(Entity entity, Player localPlayer,
-                                                   boolean inLobby, boolean pilotInfo, @Nullable MapSettings mapSettings) {
+           boolean inLobby, boolean pilotInfo, @Nullable MapSettings mapSettings) {
         
         // Tooltip info for a sensor blip
         if (EntityVisibilityUtils.onlyDetectedBySensors(localPlayer, entity)) {
@@ -74,7 +73,7 @@ public final class UnitToolTip {
         }
 
         StringBuilder result = new StringBuilder();
-        result.append("<TABLE BORDER=0 BGCOLOR="+ BGCOLOR +" width=100%><TR><TD>");
+        result.append("<TABLE BORDER=0 BGCOLOR=" + BGCOLOR + " width=100%><TR><TD>");
         Game game = entity.getGame();
         GUIPreferences guip = GUIPreferences.getInstance();
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -44,30 +44,30 @@ public final class UnitToolTip {
     
     /** The font size reduction for Quirks */
     final static float TT_SMALLFONT_DELTA = -0.2f;
-    final static String BG_COLOR = "#313131";
+    final static String BGCOLOR = "#313131";
 
 
     /** Returns the unit tooltip with values that are relevant in the lobby. */
     public static StringBuilder getEntityTipLobby(Entity entity, Player localPlayer,
             MapSettings mapSettings) {
-        return getEntityTip(entity, localPlayer, true, false, mapSettings);
+        return getEntityTipTable(entity, localPlayer, true, false, mapSettings);
     }
     
     /** Returns the unit tooltip with values that are relevant in-game. */
     public static StringBuilder getEntityTipGame(Entity entity, Player localPlayer) {
-        return getEntityTip(entity, localPlayer, false, true, null);
+        return getEntityTipTable(entity, localPlayer, false, true, null);
     }
 
     /** Returns the unit tooltip with values that are relevant in-game without the Pilot info. */
     public static StringBuilder getEntityTipNoPilot(Entity entity, Player localPlayer) {
-        return getEntityTip(entity, localPlayer, false, false, null);
+        return getEntityTipTable(entity, localPlayer, false, false, null);
     }
 
     // PRIVATE
     
     /** Assembles the whole unit tooltip. */
-    private static StringBuilder getEntityTip(Entity entity, Player localPlayer,
-            boolean inLobby, boolean pilotInfo, @Nullable MapSettings mapSettings) {
+    private static StringBuilder getEntityTipTable(Entity entity, Player localPlayer,
+                                                   boolean inLobby, boolean pilotInfo, @Nullable MapSettings mapSettings) {
         
         // Tooltip info for a sensor blip
         if (EntityVisibilityUtils.onlyDetectedBySensors(localPlayer, entity)) {
@@ -75,7 +75,7 @@ public final class UnitToolTip {
         }
 
         StringBuilder result = new StringBuilder();
-        result.append("<TABLE BORDER=0 BGCOLOR="+BG_COLOR+" width=100%><TR><TD>");
+        result.append("<TABLE BORDER=0 BGCOLOR="+ BGCOLOR +" width=100%><TR><TD>");
         Game game = entity.getGame();
         GUIPreferences guip = GUIPreferences.getInstance();
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -18,10 +18,10 @@
  */
 package megamek.client.ui.swing.unitDisplay;
 
+import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.boardview.BoardView;
 import megamek.client.ui.swing.tooltip.PilotToolTip;
-import megamek.client.ui.swing.tooltip.TipUtil;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.client.ui.swing.widget.*;
 import megamek.common.*;
@@ -29,8 +29,8 @@ import megamek.common.util.fileUtils.MegaMekFile;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.Enumeration;
-import java.util.Vector;
+
+import static megamek.client.ui.swing.tooltip.TipUtil.*;
 
 /**
  * Displays a summary info for a unit, using the same html formatting as use by the board view map tooltips.
@@ -132,7 +132,7 @@ public class SummaryPanel extends PicMap {
         }
 
         if (EntityVisibilityUtils.onlyDetectedBySensors(localPlayer, entity)) {
-            unitInfo.setText("<html>?</html>");
+            unitInfo.setText( HTML_BEGIN + padLeft( Messages.getString("BoardView1.sensorReturn")) +HTML_END);
         } else {
             // This is html tables inside tables to maintain transparency to the bg image but
             // also allow cells do have bg colors
@@ -145,14 +145,14 @@ public class SummaryPanel extends PicMap {
                 bv.appendTerrainTooltip(hexTxt, mhex);
                 bv.appendBuildingsTooltip(hexTxt, mhex);
             }
-            unitInfo.setText("<html> " + padLeft(hexTxt.toString()) + "</html>");
+            unitInfo.setText(HTML_BEGIN + padLeft(hexTxt.toString()) + HTML_END);
         }
         unitInfo.setOpaque(false);
     }
 
     private String padLeft(String html) {
         int dist = (int) (GUIPreferences.getInstance().getGUIScale() * 5);
-        return "<TABLE CELLSPACING=" + dist +" CELLPADDING=" + dist + " width=100%><TBODY><TR>"//<TD VALIGN=TOP>"
+        return "<TABLE CELLSPACING=" + dist +" CELLPADDING=" + dist + " width=100%><TBODY><TR>"
                 + "<td>"+html+"</td>"
                 +  "</TR></TBODY></TABLE>";
     }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -39,7 +39,7 @@ import java.util.Vector;
 public class SummaryPanel extends PicMap {
 
     private UnitDisplay unitDisplay;
-    private JLabel pilotInfo, unitInfo, hexInfo;
+    private JLabel unitInfo;
 
     /**
      * @param unitDisplay the UnitDisplay UI to attach to
@@ -52,14 +52,8 @@ public class SummaryPanel extends PicMap {
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS ));
         panel.add(Box.createRigidArea(new Dimension(0,10)));
 
-        pilotInfo = new JLabel("<html>UnitInfo</html>", SwingConstants.LEFT );
-        panel.add(pilotInfo);
-
-        unitInfo = new JLabel("<html>HexInfo</html>", SwingConstants.LEFT );
+        unitInfo = new JLabel("<html>UnitInfo</html>", SwingConstants.LEFT );
         panel.add(unitInfo);
-
-        hexInfo = new JLabel("<html>HexInfo</html>", SwingConstants.LEFT );
-        panel.add(hexInfo);
     }
 
 
@@ -133,41 +127,34 @@ public class SummaryPanel extends PicMap {
         Player localPlayer = unitDisplay.getClientGUI().getClient().getLocalPlayer();
 
         if (entity == null) {
-            pilotInfo.setIcon(null);
-            pilotInfo.setText("<html>No Pilot</html>");
             unitInfo.setText("<html>No Unit</html>");
-            hexInfo.setText("<html>No Hex</html>");
             return;
         }
 
         if (EntityVisibilityUtils.onlyDetectedBySensors(localPlayer, entity)) {
-            pilotInfo.setIcon(null);
-            pilotInfo.setText("<html>Sensor Return</html>");
             unitInfo.setText("<html>?</html>");
         } else {
-            pilotInfo.setText( "<html> " + padLeft(PilotToolTip.getPilotTipDetailed(entity, true).toString()) + "</html>");
-            unitInfo.setText("<html>" + padLeft(UnitToolTip.getEntityTipNoPilot(entity, localPlayer).toString()) + "</html>");
+            // This is html tables inside tables to maintain transparency to the bg image but
+            // also allow cells do have bg colors
+            StringBuffer hexTxt = new StringBuffer("");
+            hexTxt.append(PilotToolTip.getPilotTipDetailed(entity, true));
+            hexTxt.append(UnitToolTip.getEntityTipNoPilot(entity, localPlayer));
+            BoardView bv = unitDisplay.getClientGUI().getBoardView();
+            Hex mhex = entity.getGame().getBoard().getHex(entity.getPosition());
+            if (bv != null && mhex != null) {
+                bv.appendTerrainTooltip(hexTxt, mhex);
+                bv.appendBuildingsTooltip(hexTxt, mhex);
+            }
+            unitInfo.setText("<html> " + padLeft(hexTxt.toString()) + "</html>");
         }
-
-        BoardView bv = unitDisplay.getClientGUI().getBoardView();
-        Hex mhex = entity.getGame().getBoard().getHex(entity.getPosition());
-        if (bv != null && mhex != null) {
-            StringBuffer hexTxt = new StringBuffer("");//<HTML>");
-            bv.appendTerrainTooltip(hexTxt, mhex, "#999999");
-            bv.appendBuildingsTooltip(hexTxt, mhex, "#999999");
-            hexInfo.setText("<html>" + padLeft(hexTxt.toString()) + "</html>");
-        }
-
-        pilotInfo.setOpaque(false);
         unitInfo.setOpaque(false);
-        hexInfo.setOpaque(false);
     }
 
-    public final static String TABLE_BEGIN = "<TABLE CELLSPACING=0 CELLPADDING=5 width=100%><TBODY><TR><TD VALIGN=TOP>";
-
     private String padLeft(String html) {
-        int dist = (int) (GUIPreferences.getInstance().getGUIScale() * 10);
-        return TABLE_BEGIN + "<td width=" + dist + "></td><td>"+html+"</td>"+"<td width=" + dist + ">" +TipUtil.TABLE_END;
+        int dist = (int) (GUIPreferences.getInstance().getGUIScale() * 5);
+        return "<TABLE CELLSPACING=" + dist +" CELLPADDING=" + dist + " width=100%><TBODY><TR>"//<TD VALIGN=TOP>"
+                + "<td>"+html+"</td>"
+                +  "</TR></TBODY></TABLE>";
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -52,7 +52,7 @@ public class SummaryPanel extends PicMap {
         panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS ));
         panel.add(Box.createRigidArea(new Dimension(0,10)));
 
-        unitInfo = new JLabel("<html>UnitInfo</html>", SwingConstants.LEFT );
+        unitInfo = new JLabel("<HTML>UnitInfo</HTML>", SwingConstants.LEFT );
         panel.add(unitInfo);
     }
 
@@ -127,7 +127,7 @@ public class SummaryPanel extends PicMap {
         Player localPlayer = unitDisplay.getClientGUI().getClient().getLocalPlayer();
 
         if (entity == null) {
-            unitInfo.setText("<html>No Unit</html>");
+            unitInfo.setText(HTML_BEGIN + padLeft("No Unit") +HTML_END);
             return;
         }
 
@@ -152,9 +152,8 @@ public class SummaryPanel extends PicMap {
 
     private String padLeft(String html) {
         int dist = (int) (GUIPreferences.getInstance().getGUIScale() * 5);
-        return "<TABLE CELLSPACING=" + dist +" CELLPADDING=" + dist + " width=100%><TBODY><TR>"
-                + "<td>"+html+"</td>"
-                +  "</TR></TBODY></TABLE>";
+        return "<TABLE CELLSPACING=" + dist +" CELLPADDING=" + dist + " WIDTH=100%><TBODY><TR>"
+                + "<TD>"+html+"</TD></TR></TBODY></TABLE>";
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -163,9 +163,11 @@ public class SummaryPanel extends PicMap {
         hexInfo.setOpaque(false);
     }
 
+    public final static String TABLE_BEGIN = "<TABLE CELLSPACING=0 CELLPADDING=5 width=100%><TBODY><TR><TD VALIGN=TOP>";
+
     private String padLeft(String html) {
         int dist = (int) (GUIPreferences.getInstance().getGUIScale() * 10);
-        return TipUtil.TABLE_BEGIN + "<td width=" + dist + "></td><td>"+html+"</td>"+TipUtil.TABLE_END;
+        return TABLE_BEGIN + "<td width=" + dist + "></td><td>"+html+"</td>"+"<td width=" + dist + ">" +TipUtil.TABLE_END;
     }
 
     @Override


### PR DESCRIPTION
Fixes the tooltip and Unit Summary to have fixed background colors. While this decouples these colors from UI Theme and skin, it does allow for consistent appearance of colored text,
This addresses https://github.com/MegaMek/megamek/issues/3743