### PR TITLE
zero pad auto-board save images

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5026,8 +5026,8 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 if (!dir.exists()) {
                     dir.mkdirs();
                 }
-                File imgFile = new File(dir, "round_" + game.getRoundCount() + "_" + e.getOldPhase().ordinal() + "_"
-                        + e.getOldPhase() + ".png");
+                File imgFile = new File(dir, "round_" +  String.format("%03d" , game.getRoundCount())
+                        + '_' +  String.format("%03d" , e.getOldPhase().ordinal()) + '_' + e.getOldPhase() + ".png");
                 try {
                     ImageIO.write(getEntireBoardImage(false, true), "png", imgFile);
                 } catch (Exception ex) {


### PR DESCRIPTION
Zero pads round and phase numbers on auto-board save images. Addresses https://github.com/MegaMek/megamek/issues/3715 for alphabetical sorting when listing dir or feeding board save images to gif animators (imagemagick, etc.)