### PR TITLE
Don't overwrite lrm and srm ranges for non-deadfire.

### DIFF
--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -470,12 +470,6 @@ public class WeaponType extends EquipmentType {
                 mRange = 10;
                 lRange = 15;
                 eRange = 20;
-            } else {
-                minRange = 6;
-                sRange = 7;
-                mRange = 14;
-                lRange = 21;
-                eRange = 28;
             }
         }
         if ((getAmmoType() == AmmoType.T_SRM) && hasLoadedAmmo) {
@@ -486,12 +480,6 @@ public class WeaponType extends EquipmentType {
                 mRange = 4;
                 lRange = 6;
                 eRange = 8;
-            } else {
-                minRange = 0;
-                sRange = 3;
-                mRange = 6;
-                lRange = 9;
-                eRange = 12;
             }
         }
         if (hasFlag(WeaponType.F_PDBAY)) {


### PR DESCRIPTION
The range adjustment code does not need to assign ranges for missile launchers in the case of non-deadfire missiles, as these ranges have already been assigned using the weapon range brackets. This only causes a problem for LRMs, which apply the IS minimum range to Clan launchers as well, but I also removed the else block from the SRM section as it is superfluous.

Fixes #3757 