### PR TITLE
Resend PlanetaryConditions in LOUNGE

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -3387,6 +3387,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         protected Void doInBackground() throws Exception {
             Image image;
             while (!isCancelled()) {
+                // Create thumbnails for the MapSettings boards
                 String boardName = boards.poll(1, TimeUnit.SECONDS);
                 if (boardName != null && !baseImages.containsKey(boardName)) {
                     image = prepareImage(boardName);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -625,6 +625,13 @@ public class GameManager implements IGameManager {
                 player.setDone(getGame().getEntitiesOwnedBy(player) <= 0);
                 send(connId, new Packet(PacketCommand.PHASE_CHANGE, getGame().getPhase()));
             }
+
+            // LOUNGE triggers a Game.reset() on the client, which wipes out
+            // the PlanetaryCondition, so resend
+            if (game.getPhase() == GamePhase.LOUNGE) {
+                send(connId, createPlanetaryConditionsPacket());
+            }
+
             if ((game.getPhase() == GamePhase.FIRING)
                     || (game.getPhase() == GamePhase.TARGETING)
                     || (game.getPhase() == GamePhase.OFFBOARD)


### PR DESCRIPTION
This resolves https://github.com/MegaMek/megamek/issues/3730 by resending PlanetaryConditions in LOUNGE phase. This is needed as otherwise the planetary conditions are rest to default by the change to lounge phase.