### PR TITLE
Correct missing read/write on blk files

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1022,6 +1022,7 @@ public class BLKFile {
                         .map(String::valueOf)
                         .collect(Collectors.toCollection(Vector::new)));
             }
+            blk.writeBlockData("designtype", js.getDesignType());
             blk.writeBlockData("crew", js.getNCrew());
             blk.writeBlockData("officers", js.getNOfficers());
             blk.writeBlockData("gunners", js.getNGunners());

--- a/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
@@ -144,7 +144,7 @@ public class BLKSpaceStationFile extends BLKFile implements IMechLoader {
         }
 
         if (dataFile.exists("modular")) {
-            a.setBattleStation(true);
+            a.setModular(true);
         }
 
         // BattleStation


### PR DESCRIPTION
1. The military/civilian tag is not written for js/ws/ss, though it is checked on loading.
2. The modular tag is read when loading a space station, but the wrong field is set.

Partial fix for MegaMek/megameklab#1041