### PR TITLE
Fix DockingCollar::toString to return the tag expected by the blk loader

### DIFF
--- a/megamek/src/megamek/common/DockingCollar.java
+++ b/megamek/src/megamek/common/DockingCollar.java
@@ -172,7 +172,7 @@ public class DockingCollar implements Transporter {
 
     @Override
     public String toString() {
-        return "Docking Collar";
+        return "dockingcollar";
     }
     
     public int getCollarNumber() {


### PR DESCRIPTION
All the other transporter classes use the string expected by BlkFile. This makes Docking Collar consistent with them and fixes the problem of the written tag not matching the expected tag.

Fixes MegaMek/megameklab#1110