### PR TITLE
enable display of fields of fire during TAG phase

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -1485,7 +1485,8 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
     
     public void FieldofFire(Entity unit, int[][] ranges, int arc, int loc, int facing) {
         // do nothing here outside the arty targeting phase
-        if (!clientgui.getClient().getGame().getPhase().isTargeting()) {
+        if (!clientgui.getClient().getGame().getPhase().isTargeting() &&
+                !clientgui.getClient().getGame().getPhase().isOffboard()) {
             return;
         }
         


### PR DESCRIPTION
Addresses #470

Five years later, a one-liner code change enables the display of fields of fire during the TAG phase so that you can see where you're shooting your TAG.