### PR TITLE
Single blind v2 - Makes requested changes and fixes a vanilla bug.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2335,7 +2335,27 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         }
         return true;
     }
-    
+
+    // New SingleBlind - I dont think this is used.
+    /**
+     * Returns true if the local player can see all the given entities.
+     * This is true except when a blind drop option is active and one or more
+     * of the entities are not on his team.
+     */
+    boolean canSingleBlind(Collection<Entity> entities) {
+        if (!game().getOptions().booleanOption(OptionsConstants.BASE_BLIND_DROP)
+                && !game().getOptions().booleanOption(OptionsConstants.BASE_REAL_BLIND_DROP)) {
+            return true;
+        }
+        for (Entity entity: entities) {
+            if (!entityInLocalTeam(entity)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
     /**
      * Returns true if the local player can see the given entity.
      * This is true except when a blind drop option is active and one or more

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2336,27 +2336,6 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         return true;
     }
 
-
-    /**
-     * @return true if the local player can see all the given entities.
-     * This is true except when a blind drop option is active and one or more
-     * of the entities are not on his team.
-     */
-    boolean canSingleBlind(Collection<Entity> entities) {
-        if (!game().getOptions().booleanOption(OptionsConstants.BASE_BLIND_DROP)
-                && !game().getOptions().booleanOption(OptionsConstants.BASE_REAL_BLIND_DROP)) {
-            return true;
-        }
-
-        for (Entity entity: entities) {
-            if (!entityInLocalTeam(entity)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-
     /**
      * Returns true if the local player can see the given entity.
      * This is true except when a blind drop option is active and one or more

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2336,9 +2336,9 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         return true;
     }
 
-    // New SingleBlind - I dont think this is used.
+
     /**
-     * Returns true if the local player can see all the given entities.
+     * @return true if the local player can see all the given entities.
      * This is true except when a blind drop option is active and one or more
      * of the entities are not on his team.
      */
@@ -2347,6 +2347,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
                 && !game().getOptions().booleanOption(OptionsConstants.BASE_REAL_BLIND_DROP)) {
             return true;
         }
+
         for (Entity entity: entities) {
             if (!entityInLocalTeam(entity)) {
                 return false;

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -1212,20 +1212,6 @@ public class LobbyActions {
         return entities.stream().noneMatch(this::isLocalEnemy);
     }
 
-    /**
-     * @return true if the local player can see all of the given entities.
-     * This is true except when a blind drop option is active and one or more
-     * of the entities are not on his team.
-     */
-    boolean canSingleBlind(Collection<Entity> entities) {
-        if (!isBlindDrop(game()) && !isRealBlindDrop(game())) {
-            return true;
-        }
-        return entities.stream().noneMatch(this::isLocalEnemy);
-    }
-
-
-
     boolean entityInLocalTeam(Entity entity) {
         return !localPlayer().isEnemyOf(entity.getOwner());
     }

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -1212,9 +1212,8 @@ public class LobbyActions {
         return entities.stream().noneMatch(this::isLocalEnemy);
     }
 
-    // New SingleBlind - I dont think this is used.
     /**
-     * Returns true if the local player can see all of the given entities.
+     * @return true if the local player can see all of the given entities.
      * This is true except when a blind drop option is active and one or more
      * of the entities are not on his team.
      */

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -1212,6 +1212,21 @@ public class LobbyActions {
         return entities.stream().noneMatch(this::isLocalEnemy);
     }
 
+    // New SingleBlind - I dont think this is used.
+    /**
+     * Returns true if the local player can see all of the given entities.
+     * This is true except when a blind drop option is active and one or more
+     * of the entities are not on his team.
+     */
+    boolean canSingleBlind(Collection<Entity> entities) {
+        if (!isBlindDrop(game()) && !isRealBlindDrop(game())) {
+            return true;
+        }
+        return entities.stream().noneMatch(this::isLocalEnemy);
+    }
+
+
+
     boolean entityInLocalTeam(Entity entity) {
         return !localPlayer().isEnemyOf(entity.getOwner());
     }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -51,6 +51,9 @@ public final class Player extends TurnOrdered {
 
     private boolean seeEntireBoard = false; // Player can observe double blind games
 
+    // New SingleBlind
+    private boolean seeEntireBoardBot = false; // Bot can observe double blind games
+
     // these are game-specific, and maybe should be separate from the player object
     private int startingPos = Board.START_ANY;
 
@@ -274,6 +277,41 @@ public final class Player extends TurnOrdered {
             game.getTeamForPlayer(this).cacheObserverStatus();
         }
     }
+
+    /**
+     * Hopefully, creates new singleBlind command that works only on bots
+     */
+
+
+    public void setSingleBlind(boolean singleBlind) {
+        seeEntireBoardBot = singleBlind;
+    }
+
+    /**
+     * This simply returns the value, without checking the observer flag
+     */
+    public boolean getSingleBlind() {
+        return seeEntireBoardBot;
+    }
+
+    /**
+     * If bot is false, see_entire_board does nothing
+     */
+    public boolean canSeeSingleBlind() {
+        return (bot && seeEntireBoardBot);
+    }
+
+    public void setSingleBlindObserver(boolean singleBlindObserver) {
+        this.bot = singleBlindObserver;
+        // If not a bot, clear the set single blind flag
+        if (!singleBlindObserver) {
+            setSingleBlind(false);
+        }
+        if (game != null && game.getTeamForPlayer(this) != null) {
+            game.getTeamForPlayer(this).cacheObserverStatus();
+        }
+    }
+
 
     public PlayerColour getColour() {
         return colour;

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -286,14 +286,14 @@ public final class Player extends TurnOrdered {
     }
 
     /**
-     * This simply returns the value, without checking the observer flag
+     * This simply returns the value, without checking the bot flag
      */
     public boolean getSingleBlind() {
         return seeEntireBoardBot;
     }
 
     /**
-     * If bot is false, see_entire_board does nothing
+     * If bot is false, seeEntireBoardBot does nothing
      */
     public boolean canSeeSingleBlind() {
         return (bot && seeEntireBoardBot);

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -279,10 +279,8 @@ public final class Player extends TurnOrdered {
     }
 
     /**
-     * Hopefully, creates new singleBlind command that works only on bots
+     * Creates new singleBlind command that works only on bots
      */
-
-
     public void setSingleBlind(boolean singleBlind) {
         seeEntireBoardBot = singleBlind;
     }
@@ -310,9 +308,8 @@ public final class Player extends TurnOrdered {
         if (game != null && game.getTeamForPlayer(this) != null) {
             game.getTeamForPlayer(this).cacheObserverStatus();
         }
+
     }
-
-
     public PlayerColour getColour() {
         return colour;
     }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -503,7 +503,7 @@ public class GameManager implements IGameManager {
 
     /**
      * Checks each player to see if they have entitites, and if true, sets the
-     * singleblindobserver flag for that player. An exception is that there are no
+     * singleblindobserver flag for that player if it is a bot. An exception is that there are no
      * observers during the lounge phase.
      */
     public void checkForSingleBlindObservers() {
@@ -512,7 +512,6 @@ public class GameManager implements IGameManager {
             p.setSingleBlindObserver((getGame().getEntitiesOwnedBy(p) >= 1) && !getGame().getPhase().isLounge());
         }
     }
-
 
     @Override
     public void removeAllEntitiesOwnedBy(Player player) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -174,6 +174,7 @@ public class GameManager implements IGameManager {
         commands.add(new SaveGameCommand(server));
         commands.add(new LoadGameCommand(server));
         commands.add(new SeeAllCommand(server, this));
+        commands.add(new SingleBlindCommand(server, this));
         commands.add(new SkipCommand(server, this));
         commands.add(new VictoryCommand(server, this));
         commands.add(new WhoCommand(server));
@@ -499,7 +500,21 @@ public class GameManager implements IGameManager {
             p.setObserver((getGame().getEntitiesOwnedBy(p) < 1) && !getGame().getPhase().isLounge());
         }
     }
-    
+
+    //New SingleBlind - I dont think this is used.
+    /**
+     * Checks each player to see if they have entitites, and if true, sets the
+     * singleblindobserver flag for that player. An exception is that there are no
+     * observers during the lounge phase.
+     */
+    public void checkForSingleBlindObservers() {
+        for (Enumeration<Player> e = getGame().getPlayers(); e.hasMoreElements(); ) {
+            Player p = e.nextElement();
+            p.setSingleBlindObserver((getGame().getEntitiesOwnedBy(p) >= 1) && !getGame().getPhase().isLounge());
+        }
+    }
+
+
     @Override
     public void removeAllEntitiesOwnedBy(Player player) {
         int pid = player.getId();
@@ -12932,7 +12947,7 @@ public class GameManager implements IGameManager {
         if (getGame().getPhase().isSimultaneous(getGame())) {
             // Update attack only to player who declared it & observers
             for (Player player : game.getPlayersVector()) {
-                if (player.canSeeAll() || player.isObserver()
+                if (player.canSeeSingleBlind() || player.canSeeAll() || player.isObserver()
                         || (entity.getOwnerId() == player.getId())) {
                     send(player.getId(), p);
                 }
@@ -28372,7 +28387,7 @@ public class GameManager implements IGameManager {
         for (Enumeration<Player> p = game.getPlayers(); p.hasMoreElements();) {
             Player player = p.nextElement();
 
-            if (player.canSeeAll() && !vCanSee.contains(player)) {
+            if (player.canSeeSingleBlind() || player.canSeeAll() && !vCanSee.contains(player)) {
                 vCanSee.addElement(player);
             }
         }
@@ -28522,7 +28537,7 @@ public class GameManager implements IGameManager {
         boolean bTeamVision = game.getOptions().booleanOption(OptionsConstants.ADVANCED_TEAM_VISION);
 
         // If they can see all, return the input list
-        if (pViewer.canSeeAll()) {
+        if (pViewer.canSeeSingleBlind() || pViewer.canSeeAll()) {
             return vEntities;
         }
 
@@ -30062,7 +30077,7 @@ public class GameManager implements IGameManager {
                 if ((aaa.getPlayerId() == p.getId())
                         || ((team != Player.TEAM_NONE)
                         && (team == game.getPlayer(aaa.getPlayerId()).getTeam()))
-                        || p.getSeeAll()) {
+                        || p.getSingleBlind() || p.getSeeAll()) {
                     v.addElement(aaa);
                 }
             }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -501,7 +501,6 @@ public class GameManager implements IGameManager {
         }
     }
 
-    //New SingleBlind - I dont think this is used.
     /**
      * Checks each player to see if they have entitites, and if true, sets the
      * singleblindobserver flag for that player. An exception is that there are no

--- a/megamek/src/megamek/server/commands/SingleBlindCommand.java
+++ b/megamek/src/megamek/server/commands/SingleBlindCommand.java
@@ -1,0 +1,88 @@
+/*
+ * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+package megamek.server.commands;
+
+import megamek.common.options.OptionsConstants;
+import megamek.server.GameManager;
+import megamek.server.Server;
+
+/**
+ * Allows a bot to see all units via /singleblind command.  Toggle.  Does not work on human players.
+ * 
+ * @author copied from seeall command by Dave Smith by Thom293
+ * @since July 3, 2022, 9:00pm
+ */
+public class SingleBlindCommand extends ServerCommand {
+
+    private final GameManager gameManager;
+
+    public SingleBlindCommand(Server server, GameManager gameManager) {
+        super(server, "singleblind",
+                "Allows a BOT player to see all in double blind game. Usage: /singleblind <password> <player id#>. For a list of player id #s, use the /who command (default is yourself)");
+        this.gameManager = gameManager;
+    }
+
+    /**
+     * Run this command with the arguments supplied
+     */
+    @Override
+    public void run(int connId, String... args) {
+        boolean doBlind = server.getGame().getOptions().booleanOption(
+                OptionsConstants.ADVANCED_DOUBLE_BLIND);
+
+        int playerArg = server.isPassworded() ? 2 : 1;
+
+        // If not double-blind, this command does nothing
+        if (!doBlind) {
+            server.sendServerChat(connId, "Double Blind rules not in effect.");
+            return;
+        }
+        if (server.isPassworded()
+                && (args.length < 2 || !server.isPassword(args[1]))) {
+            server.sendServerChat(connId, "The password is incorrect. Usage: /singleblind <password> <id#>");
+        } else {
+            try {
+                int playerId;
+                String give_take;
+                // No playerArg provided. Use connId as playerId
+                if (args.length <= playerArg) {
+                    playerId = connId;
+                } else {
+                    playerId = Integer.parseInt(args[playerArg]);
+                }
+
+                boolean has_single_blind = server.getPlayer(playerId).getSingleBlind();
+                if (has_single_blind) {
+                    give_take = " no longer has";
+                } else {
+                    give_take = " has been granted";
+                }
+
+                if (playerId == connId) {
+                    server.sendServerChat(server.getPlayer(playerId).getName()
+                            + give_take + " vision of the entire map IF IT IS A BOT ");
+                } else {
+                    server.sendServerChat(server.getPlayer(playerId).getName()
+                            + give_take + " vision of the entire map, IF IT IS A BOT, by "
+                            + server.getPlayer(connId).getName());
+                }
+
+                server.getPlayer(playerId).setSingleBlind(!has_single_blind);
+                gameManager.sendEntities(playerId);
+            } catch (Exception ex) {
+                server.sendServerChat("/singleblind : singleblind failed. Is the player a Bot?  Type /who for a list of players with id #s.");
+            }
+        }
+    }
+}

--- a/megamek/src/megamek/server/commands/SingleBlindCommand.java
+++ b/megamek/src/megamek/server/commands/SingleBlindCommand.java
@@ -1,15 +1,20 @@
 /*
- * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 package megamek.server.commands;
 
@@ -18,7 +23,7 @@ import megamek.server.GameManager;
 import megamek.server.Server;
 
 /**
- * Allows a bot to see all units via /singleblind command.  Toggle.  Does not work on human players.
+ * Allows a bot to see all units via /singleblind command. Toggle. Does not work on human players.
  * 
  * @author copied from seeall command by Dave Smith by Thom293
  * @since July 3, 2022, 9:00pm
@@ -81,7 +86,7 @@ public class SingleBlindCommand extends ServerCommand {
                 server.getPlayer(playerId).setSingleBlind(!has_single_blind);
                 gameManager.sendEntities(playerId);
             } catch (Exception ex) {
-                server.sendServerChat("/singleblind : singleblind failed. Is the player a Bot?  Type /who for a list of players with id #s.");
+                server.sendServerChat("/singleblind : singleblind failed. Is the player a Bot? Type /who for a list of players with id #s.");
             }
         }
     }

--- a/megamek/src/megamek/server/commands/SingleBlindCommand.java
+++ b/megamek/src/megamek/server/commands/SingleBlindCommand.java
@@ -59,7 +59,7 @@ public class SingleBlindCommand extends ServerCommand {
         } else {
             try {
                 int playerId;
-                String give_take;
+                String giveTake;
                 // No playerArg provided. Use connId as playerId
                 if (args.length <= playerArg) {
                     playerId = connId;
@@ -67,23 +67,31 @@ public class SingleBlindCommand extends ServerCommand {
                     playerId = Integer.parseInt(args[playerArg]);
                 }
 
-                boolean has_single_blind = server.getPlayer(playerId).getSingleBlind();
-                if (has_single_blind) {
-                    give_take = " no longer has";
+                // If cannot get singleblind because not a bot, send failure message and stop messages below.
+                boolean canObtainSingleBlind = server.getPlayer(playerId).isBot();
+                if (!canObtainSingleBlind) {
+                    server.sendServerChat(connId, "/singleblind : singleblind attempt failed. Is the player a Bot? Type /who for a list of players with id #s.");
+                    return;
+                }
+
+                boolean hasSingleBlind = server.getPlayer(playerId).canSeeSingleBlind();
+                if (hasSingleBlind) {
+                    giveTake = " no longer has";
                 } else {
-                    give_take = " has been granted";
+                    giveTake = " has been granted";
                 }
 
                 if (playerId == connId) {
                     server.sendServerChat(server.getPlayer(playerId).getName()
-                            + give_take + " vision of the entire map IF IT IS A BOT ");
+                            + giveTake + " vision of the entire map with /singleblind, by "
+                            + server.getPlayer(connId).getName());
                 } else {
                     server.sendServerChat(server.getPlayer(playerId).getName()
-                            + give_take + " vision of the entire map, IF IT IS A BOT, by "
+                            + giveTake + " vision of the entire map with /singleblind, by "
                             + server.getPlayer(connId).getName());
                 }
 
-                server.getPlayer(playerId).setSingleBlind(!has_single_blind);
+                server.getPlayer(playerId).setSingleBlind(!hasSingleBlind);
                 gameManager.sendEntities(playerId);
             } catch (Exception ex) {
                 server.sendServerChat("/singleblind : singleblind failed. Is the player a Bot? Type /who for a list of players with id #s.");


### PR DESCRIPTION
This is the same as the other PR with 2 exceptions:  It fixes an already existing bug from vanilla so now it will give a proper failure message, and this also makes Windchild's suggested changes.  I will close the other PR.  Original text below:

Added /singleblind toggle command that is only assignable to bots. Its gives them vision of the entire map, just like /seeall. It cannot be assigned to a human player.

Bots given vision with /singleblind do not share /singleblind vision with anyone on their team - so observers, other bots with units, or humans with units on their team do not see anything even if the bot can, therefore I don't think a vote mechanic is needed. One could certainly be added by someone with more skill than me later if desired.

Usage is just like see all. "/singleblind 1" to give to a bot in the player 1 spot.

Anyone is welcome to edit or improve this.

If approved, this will resolve https://github.com/MegaMek/megamek/issues/203 and moot or partially resolve https://github.com/MegaMek/megamek/issues/3749.

This should not change the current /seeall command or observer code in any way. This was created by basically just copying the /seeall command, renaming all copied references, and swapping the observer requirement for a bot requirement.

I believe all of the changes requested by Windchild have been made, and work.  But if not please let me know.