### PR TITLE
Issue 3564: Board Validation not catching different bldg classes

### DIFF
--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -1075,10 +1075,11 @@ public class Board implements Serializable {
                                 valid = false;
                                 currBuff.append("Building has an exit to a building of another Building Type (Light, Medium...).\n");
                             }
-                            if (hex.containsTerrain(Terrains.BLDG_CLASS) 
-                                    && ((adjHex.containsTerrain(Terrains.BLDG_CLASS) 
-                                            && (adjHex.getTerrain(Terrains.BLDG_CLASS).getLevel() != hex.getTerrain(Terrains.BLDG_CLASS).getLevel()))
-                                            || (!adjHex.containsTerrain(Terrains.BLDG_CLASS)))) {
+                            int thisClass = hex.containsTerrain(Terrains.BLDG_CLASS) ?
+                                    hex.getTerrain(Terrains.BLDG_CLASS).getLevel() : 0;
+                            int adjClass = adjHex.containsTerrain(Terrains.BLDG_CLASS) ?
+                                    adjHex.getTerrain(Terrains.BLDG_CLASS).getLevel() : 0;
+                            if (thisClass != adjClass) {
                                 valid = false;
                                 currBuff.append("Building has an exit in direction ").append(dir).append(" to a building of another Building Class.\n");
                             }


### PR DESCRIPTION
Board validation was not catching different building classes in connected bldg hexes when one hex had no bldg class. I don't know if the rules really need it, but at least the way MM handles it, a connected building should have a single class. So this updates the board validation. 

Fixes #3564
