### PR TITLE
Bot performance improvements

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1220,7 +1220,7 @@ public class Princess extends BotClient {
                     return mp;
                 }
             }
-
+            
             final List<MovePath> paths = getMovePathsAndSetNecessaryTargets(entity, false);
 
             if (null == paths) {
@@ -1392,7 +1392,7 @@ public class Princess extends BotClient {
                     getFireControlState().getAdditionalTargets().add(levelingTarget);
                     sendChat("Hex " + levelingTarget.getPosition().toFriendlyString() + " impedes route to destination, targeting for clearing.", Level.INFO);
                 }
-
+                
                 // if any of the long range paths, pruned, are within LOS of leveling coordinates, then we're actually
                 // just going to go back to the standard unit paths
                 List<MovePath> prunedPaths = new ArrayList<>();

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -167,7 +167,7 @@ public class EquipmentType implements ITechnology {
 
     protected TechAdvancement techAdvancement = new TechAdvancement();
 
-    protected BigInteger flags = BigInteger.valueOf(0);
+    protected BigInteger flags = BigInteger.ZERO;
 
     protected long subType = 0;
 
@@ -505,7 +505,7 @@ public class EquipmentType implements ITechnology {
     }
 
     public boolean hasFlag(BigInteger flag) {
-        return !(flags.and(flag)).equals(BigInteger.valueOf(0));
+        return !(flags.and(flag)).equals(BigInteger.ZERO);
     }
 
     public double getBV(Entity entity) {

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -15,6 +15,7 @@
 package megamek.common;
 
 import megamek.client.bot.princess.Princess;
+import megamek.common.MovePath.MoveStepType;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.AbstractPathFinder;
@@ -1851,6 +1852,24 @@ public class MovePath implements Cloneable, Serializable {
         return !game.getBoard().contains(getFinalCoords().translated(getFinalFacing()));
     }
 
+    /**
+     * Worker function that counts the number of steps of the given type 
+     * at the end of the given path before another step type occurs.
+     */
+    public int getEndStepCount(MoveStepType stepType) {
+        int stepCount = 0;
+        
+        for (int index = getStepVector().size() - 1; index >= 0; index--) {
+            if (getStepVector().get(index).getType() == stepType) {
+                stepCount++;
+            } else {
+                break;
+            }
+        }
+        
+        return stepCount;
+    }
+    
     /**
      * Debugging method that calculates a destruction-aware move path to the destination coordinates
      */

--- a/megamek/src/megamek/common/MunitionMutator.java
+++ b/megamek/src/megamek/common/MunitionMutator.java
@@ -1,5 +1,0 @@
-package megamek.common;
-
-public class MunitionMutator {
-
-}

--- a/megamek/src/megamek/common/MunitionMutator.java
+++ b/megamek/src/megamek/common/MunitionMutator.java
@@ -1,0 +1,5 @@
+package megamek.common;
+
+public class MunitionMutator {
+
+}

--- a/megamek/src/megamek/common/pathfinder/MovePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/MovePathFinder.java
@@ -27,6 +27,13 @@ import java.util.*;
  */
 public class MovePathFinder<C> extends AbstractPathFinder<CoordsWithFacing, C, MovePath> {
     /**
+     * This constant defines the maximum number of times it makes sense
+     * for a unit to turn in a row - if you're turning right four times, you might as well
+     * turn left twice instead.
+     */
+    private static final int MAX_TURN_COUNT = 3;
+    
+    /**
      * Node defined by coordinates and unit facing.
      * @author Saginatio
      */
@@ -254,13 +261,18 @@ public class MovePathFinder<C> extends AbstractPathFinder<CoordsWithFacing, C, M
 
             final ArrayList<MovePath> result = new ArrayList<>();
 
-            if (lType != MoveStepType.TURN_LEFT) {
+            // we're trying to prevent
+            // a) turning left and right endlessly
+            // b) spinning around endlessly
+            // especially during movement where turning costs 0 MP
+            if (lType != MoveStepType.TURN_LEFT &&
+                    (mp.getEndStepCount(MoveStepType.TURN_RIGHT) < MAX_TURN_COUNT)) {
                 result.add(mp.clone().addStep(MoveStepType.TURN_RIGHT));
             }
-            if (lType != MoveStepType.TURN_RIGHT) {
+            if (lType != MoveStepType.TURN_RIGHT &&
+                    (mp.getEndStepCount(MoveStepType.TURN_LEFT) < MAX_TURN_COUNT)) {
                 result.add(mp.clone().addStep(MoveStepType.TURN_LEFT));
             }
-
 
             /*
              * If the unit is prone or hull-down it limits movement options,
@@ -300,8 +312,8 @@ public class MovePathFinder<C> extends AbstractPathFinder<CoordsWithFacing, C, M
             return result;
         }
     }
-
-     /**
+    
+    /**
      * Creates a new instance of MovePathFinder. Sets DestinationMap to
      * {@link MovePathDestinationMap} and adds {@link MovePathLegalityFilter}.
      * Rest of the methods needed by AbstractPathFinder have to be passed as a

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -112,7 +112,7 @@ public class PathDecorator {
         desiredMPs.add(source.getCachedEntityState().getRunMPwithoutMASC());
         desiredMPs.add(source.getCachedEntityState().getRunMPNoGravity());
         desiredMPs.add(source.getCachedEntityState().getWalkMP());
-        
+        int alpha = 2;
         for (int desiredMP : desiredMPs) {
             List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
             retVal.addAll(clippedPaths);

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -112,7 +112,7 @@ public class PathDecorator {
         desiredMPs.add(source.getCachedEntityState().getRunMPwithoutMASC());
         desiredMPs.add(source.getCachedEntityState().getRunMPNoGravity());
         desiredMPs.add(source.getCachedEntityState().getWalkMP());
-        int alpha = 2;
+
         for (int desiredMP : desiredMPs) {
             List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
             retVal.addAll(clippedPaths);


### PR DESCRIPTION
Basically, two changes:

1. Profiling revealed that there were a lot of calls to BigInteger.valueOf(0); changed it to use the constant instead. Granted, the implementation of valueOf shortcuts to return the constant anyway, but still, we save a method call and an if statement each time. 

2. Jump-capable and infantry units love to pirouette like ballerinas, spinning around endlessly. Now, the bot's pathfinder won't attempt to have the unit change direction more than three times (if you turn left 4 times, you may as well turn right twice instead). In practice, this reduces the number of paths that get generated and evaluated for jump-capable units and "free turn" infantry.