### PR TITLE
Update check for indirect fire weapons in fire support formation.

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/FormationType.java
+++ b/megamek/src/megamek/client/ratgenerator/FormationType.java
@@ -1616,15 +1616,7 @@ public class FormationType {
         ft.allowedUnitTypes = FLAG_GROUND;
         ft.otherCriteria.add(new CountConstraint(3, ms -> ms.getEquipmentNames().stream()
                 .map(EquipmentType::get)
-                .filter(eq -> eq instanceof WeaponType && eq.hasModes())
-                .anyMatch(eq -> {
-                    for (Enumeration<EquipmentMode> e = eq.getModes(); e.hasMoreElements();) {
-                        if (e.nextElement().toString().equals("Indirect")) {
-                            return true;
-                        }
-                    }
-                    return false;
-                }),
+                .anyMatch(eq -> eq instanceof WeaponType && ((WeaponType) eq).hasIndirectFire()),
                 "Indirect fire weapon"));
         ft.reportMetrics.put("Indirect", ms -> ft.otherCriteria.get(0).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);

--- a/megamek/src/megamek/client/ratgenerator/FormationType.java
+++ b/megamek/src/megamek/client/ratgenerator/FormationType.java
@@ -1616,7 +1616,7 @@ public class FormationType {
         ft.allowedUnitTypes = FLAG_GROUND;
         ft.otherCriteria.add(new CountConstraint(3, ms -> ms.getEquipmentNames().stream()
                 .map(EquipmentType::get)
-                .anyMatch(eq -> eq instanceof WeaponType && ((WeaponType) eq).hasIndirectFire()),
+                .anyMatch(eq -> (eq instanceof WeaponType) && ((WeaponType) eq).hasIndirectFire()),
                 "Indirect fire weapon"));
         ft.reportMetrics.put("Indirect", ms -> ft.otherCriteria.get(0).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);


### PR DESCRIPTION
The check for a weapon that has an indirect fire mode no longer works as intended in the formation builder, since it now requires a game with an option set. As a result it is impossible to generate a fire support lance. But since then there is a simpler way to check anyway.