### PR TITLE
make planetary weather conditions more fault tolerant

### DIFF
--- a/megamek/data/scenarios/Example.mms
+++ b/megamek/data/scenarios/Example.mms
@@ -45,7 +45,7 @@ PlanetaryConditionsGravity=1.12
 PlanetaryConditionsLight=1
 # Weather: Default = None; 1/2/3/4 = Light/Moderate/Heavy/Gusting Rain; 5 = Downpour; 
 # 6/7/9 Light/Moderate/Heavy Snow; 8 = Snow Flurries; 10 = Sleet; 11 = Blizzard;
-# 12 = Ice Storm; 13/14 = Light/Heavy Hail
+# 12 = Ice Storm; Anything else resolves to default.
 PlanetaryConditionsWeather=13
 # Wind: Default = None; 1/2/3 = Light/Moderate/Strong Gale; 4 = Storm; 5 = Tornado F1-3; 6 = Tornado F4
 PlanetaryConditionsWind=4

--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -18,6 +18,8 @@ package megamek.common;
 
 import java.io.Serializable;
 
+import org.apache.logging.log4j.LogManager;
+
 /**
  * This class will hold all the information on planetary conditions and a variety of helper functions
  * for those conditions
@@ -799,7 +801,11 @@ public class PlanetaryConditions implements Serializable {
     }
 
     public void setWeather(int type) {
-        weatherConditions = type;
+        if ((type <= 0) || (type >= WE_SIZE)) {
+            LogManager.getLogger().error(String.format("Invalid weather type supplied: %d", type));
+        } else {
+            weatherConditions = type;
+        }
     }
 
     public int getWeather() {

--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -801,7 +801,7 @@ public class PlanetaryConditions implements Serializable {
     }
 
     public void setWeather(int type) {
-        if ((type <= 0) || (type >= WE_SIZE)) {
+        if ((type < 0) || (type >= WE_SIZE)) {
             LogManager.getLogger().error(String.format("Invalid weather type supplied: %d", type));
         } else {
             weatherConditions = type;


### PR DESCRIPTION
When setting planetary conditions, do not allow them to be set to an invalid value - instead, ignore the operation, log the error, and move on. Fixes #3475 