### PR TITLE
Resolved Javadoc errors preventing Gradle Javadoc task to complete.

### DIFF
--- a/megamek/src/megamek/codeUtilities/ObjectUtility.java
+++ b/megamek/src/megamek/codeUtilities/ObjectUtility.java
@@ -47,7 +47,7 @@ public class ObjectUtility {
 
     /**
      * @return the first non-<i>null</i> argument, else <i>null</i> if all are <i>null</i>
-     * @see #nonNull(T, T)
+     * @see #nonNull(Object, Object, Object...)
      */
     @SafeVarargs
     public static <T> T nonNull(final @Nullable T first, final @Nullable T second,

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -13895,8 +13895,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     /**
      * Get the number of turns Supercharger has been used continuously.
-     * <p/>
+     * <p>
      * This method should <strong>only</strong> be used during serialization.
+     * </p>
      *
      * @return the <code>int</code> number of turns Supercharger has been used.
      */
@@ -13906,8 +13907,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     /**
      * Set the number of turns Supercharger has been used continuously.
-     * <p/>
+     * <p>
      * This method should <strong>only</strong> be used during deserialization.
+     * </p>
      *
      * @param turns The <code>int</code> number of turns Supercharger has been used.
      */
@@ -13977,8 +13979,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     /**
      * Set whether Supercharger has been used.
-     * <p/>
+     * <p>
      * This method should <strong>only</strong> be used during deserialization.
+     * </p>
      *
      * @param used The <code>boolean</code> whether Supercharger has been used.
      */

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1107,7 +1107,7 @@ public class GameManager implements IGameManager {
     }
 
     /**
-     * Called during the end phase. Checks each entity for ASEW effects counters and decrements them by 1 if > 0
+     * Called during the end phase. Checks each entity for ASEW effects counters and decrements them by 1 if greater than 0
      */
     public void decrementASEWTurns() {
         for (Iterator<Entity> e = game.getEntities(); e.hasNext(); ) {


### PR DESCRIPTION
A few simple quick fixes to code comments that were preventing Gradle javadoc task to complete successfully.  Since java 8 the javadoc linter enforces more strict html and has some unmarshalling "bugs" for '>'.