### PR TITLE
Fixed Null Pointer saving map setup then hitting 'cancel'.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1969,11 +1969,11 @@ public class ChatLounge extends AbstractPhaseDisplay implements
 
         int returnVal = fc.showSaveDialog(clientgui.frame);
         File selectedFile = fc.getSelectedFile();
-        if (!selectedFile.getName().toLowerCase().endsWith(".xml")) {
-            selectedFile = new File(selectedFile.getPath() + ".xml");
-        }
         if ((returnVal != JFileChooser.APPROVE_OPTION) || (selectedFile == null)) {
             return;
+        }
+        if (!selectedFile.getName().toLowerCase().endsWith(".xml")) {
+            selectedFile = new File(selectedFile.getPath() + ".xml");
         }
         if (selectedFile.exists()) {
             String msg = Messages.getString("ChatLounge.map.saveMapSetupReplace", selectedFile.getName());


### PR DESCRIPTION
Found and fixed an easy Null Pointer exception that occurs when in the MegaMek lobby maps tab when saving a map setup and subsequently cancelling from the file chooser dialog box.  The current code was checking for a file name ending with XML prior to checking for an !APPROVE_OPTION or NULL file.   Simply moved the existing null check ahead of the '.xml' check.

![saveMapSetupNullPointer](https://user-images.githubusercontent.com/83041327/180905361-fa1ba4e6-4b74-4d06-80a5-8f69c2eaef68.png)

![saveMapSetupNullPointer2](https://user-images.githubusercontent.com/83041327/180905388-5e7533c6-1960-4daf-a158-fb8dc3c20519.png)

Instead of creating an open issue, I just fixed it.  I did search the issues list for a similar open issue and did not find a match.
