### PR TITLE
Consolidate MASC/SC Target Number lookup

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -13968,13 +13968,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public int getMASCTarget() {
-        if ((game != null) && game.getOptions().booleanOption(OptionsConstants.ADVANCED_ALTERNATE_MASC_ENHANCED)) {
-            return ALTERNATE_MASC_FAILURE_ENHANCED[nMASCLevel];
-        } else if (game != null && game.getOptions().booleanOption(OptionsConstants.ADVANCED_ALTERNATE_MASC)) {
-            return ALTERNATE_MASC_FAILURE[nMASCLevel];
-        } else {
-            return MASC_FAILURE[nMASCLevel];
-        }
+        return getMASCorSuperchargerTarget(nMASCLevel);
     }
 
     /**
@@ -13991,7 +13985,19 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     public int getSuperchargerTarget() {
         // uses same TNs as MASC
-        return MASC_FAILURE[nSuperchargerLevel];
+        return getMASCorSuperchargerTarget(nSuperchargerLevel);
+    }
+
+    /** @return Target number taking into account game options */
+    private int getMASCorSuperchargerTarget(int nLevel)
+    {
+        if ((game != null) && game.getOptions().booleanOption(OptionsConstants.ADVANCED_ALTERNATE_MASC_ENHANCED)) {
+            return ALTERNATE_MASC_FAILURE_ENHANCED[nLevel];
+        } else if (game != null && game.getOptions().booleanOption(OptionsConstants.ADVANCED_ALTERNATE_MASC)) {
+            return ALTERNATE_MASC_FAILURE[nLevel];
+        } else {
+            return MASC_FAILURE[nLevel];
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -13989,8 +13989,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /** @return Target number taking into account game options */
-    private int getMASCorSuperchargerTarget(int nLevel)
-    {
+    private int getMASCorSuperchargerTarget(int nLevel) {
         if ((game != null) && game.getOptions().booleanOption(OptionsConstants.ADVANCED_ALTERNATE_MASC_ENHANCED)) {
             return ALTERNATE_MASC_FAILURE_ENHANCED[nLevel];
         } else if (game != null && game.getOptions().booleanOption(OptionsConstants.ADVANCED_ALTERNATE_MASC)) {


### PR DESCRIPTION
fixes an issue where only MASC was respecting the (unofficial)  alternate options that reduce initial Target Number.  Supercharger now uses them too, which matches the behavior describe by the options tooltip.