### PR TITLE
Remove special treatment for Anti-Mek 8 BV calculation

### DIFF
--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -129,18 +129,6 @@ public class Crew implements Serializable {
     public static final String SPECIAL_BALLISTIC = "Ballistic";
     public static final String SPECIAL_MISSILE = "Missile";
 
-    private static final double[][] bvMod = new double[][]{
-            {2.42, 2.31, 2.21, 2.10, 1.93, 1.75, 1.68, 1.59, 1.50},
-            {2.21, 2.11, 2.02, 1.92, 1.76, 1.60, 1.54, 1.46, 1.38},
-            {1.93, 1.85, 1.76, 1.68, 1.54, 1.40, 1.35, 1.28, 1.21},
-            {1.66, 1.58, 1.51, 1.44, 1.32, 1.20, 1.16, 1.10, 1.04},
-            {1.38, 1.32, 1.26, 1.20, 1.10, 1.00, 0.95, 0.90, 0.85},
-            {1.31, 1.19, 1.13, 1.08, 0.99, 0.90, 0.86, 0.81, 0.77},
-            {1.24, 1.12, 1.07, 1.02, 0.94, 0.85, 0.81, 0.77, 0.72},
-            {1.17, 1.06, 1.01, 0.96, 0.88, 0.80, 0.76, 0.72, 0.68},
-            {1.10, 0.99, 0.95, 0.90, 0.83, 0.75, 0.71, 0.68, 0.64},
-    };
-
     //region extraData inner map keys
     public static final String MAP_GIVEN_NAME = "givenName";
     public static final String MAP_SURNAME = "surname";
@@ -985,13 +973,6 @@ public class Crew implements Serializable {
         return (getGunnery() != 4) || (getPiloting() != 5);
     }
 
-    /**
-     * @return the BV multiplier for this pilot's gunnery/piloting
-     */
-    public double getBVSkillMultiplier() {
-        return getBVImplantMultiplier() * getBVSkillMultiplier(getGunnery(), getPiloting());
-    }
-
     public double getBVImplantMultiplier() {
         int level = 1;
         if (options.booleanOption(OptionsConstants.MD_PAIN_SHUNT)) {
@@ -1004,19 +985,6 @@ public class Crew implements Serializable {
             level = 5;
         }
         return level / 4.0 + 0.75;
-    }
-
-    /**
-     * Returns the BV multiplier for a pilots gunnery/piloting. This function is
-     * static to evaluate the BV of a unit, even when they have not yet been
-     * assigned a pilot.
-     *
-     * @param gunnery  the gunnery skill of the pilot
-     * @param piloting the piloting skill of the pilot
-     * @return a multiplier to the BV of whatever unit the pilot is piloting.
-     */
-    public static double getBVSkillMultiplier(int gunnery, int piloting) {
-        return bvMod[MathUtility.clamp(gunnery, 0, 8)][MathUtility.clamp(piloting, 0, 8)];
     }
 
     public boolean hasEdgeRemaining() {

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -16,7 +16,6 @@
 package megamek.common;
 
 import megamek.client.generator.RandomGenderGenerator;
-import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.Gender;
 import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -973,20 +973,6 @@ public class Crew implements Serializable {
         return (getGunnery() != 4) || (getPiloting() != 5);
     }
 
-    public double getBVImplantMultiplier() {
-        int level = 1;
-        if (options.booleanOption(OptionsConstants.MD_PAIN_SHUNT)) {
-            level = 2;
-        }
-        if (options.booleanOption(OptionsConstants.MD_VDNI)) {
-            level = 3;
-        }
-        if (options.booleanOption(OptionsConstants.MD_BVDNI)) {
-            level = 5;
-        }
-        return level / 4.0 + 0.75;
-    }
-
     public boolean hasEdgeRemaining() {
         return (getOptions().intOption(OptionsConstants.EDGE) > 0);
     }

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -16,6 +16,7 @@
 package megamek.common;
 
 import megamek.client.generator.RandomGenderGenerator;
+import megamek.codeUtilities.MathUtility;
 import megamek.common.enums.Gender;
 import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
@@ -985,30 +986,13 @@ public class Crew implements Serializable {
     }
 
     /**
-     * @param game The {@link Game} to use to determine the modifier
      * @return the BV multiplier for this pilot's gunnery/piloting
      */
-    public double getBVSkillMultiplier(Game game) {
-        return getBVSkillMultiplier(true, game);
-    }
-
-    /**
-     * @param usePiloting whether or not to use the default value non-anti-mech
-     *                    infantry/BA should not use the anti-mech skill
-     * @param game The {@link Game} to use to determine the modifier
-     * @return the BV multiplier for this pilot's gunnery/piloting
-     */
-    public double getBVSkillMultiplier(boolean usePiloting, Game game) {
-        int pilotVal = getPiloting();
-        if (!usePiloting) {
-            pilotVal = 5;
-        }
-        return getBVImplantMultiplier() * getBVSkillMultiplier(getGunnery(), pilotVal, game);
+    public double getBVSkillMultiplier() {
+        return getBVImplantMultiplier() * getBVSkillMultiplier(getGunnery(), getPiloting());
     }
 
     public double getBVImplantMultiplier() {
-
-        // get the highest level
         int level = 1;
         if (options.booleanOption(OptionsConstants.MD_PAIN_SHUNT)) {
             level = 2;
@@ -1019,9 +1003,7 @@ public class Crew implements Serializable {
         if (options.booleanOption(OptionsConstants.MD_BVDNI)) {
             level = 5;
         }
-
-        return (level / 4.0) + 0.75;
-
+        return level / 4.0 + 0.75;
     }
 
     /**
@@ -1034,11 +1016,7 @@ public class Crew implements Serializable {
      * @return a multiplier to the BV of whatever unit the pilot is piloting.
      */
     public static double getBVSkillMultiplier(int gunnery, int piloting) {
-        return getBVSkillMultiplier(gunnery, piloting, null);
-    }
-
-    public static double getBVSkillMultiplier(int gunnery, int piloting, Game game) {
-        return bvMod[Math.max(Math.min(8, gunnery), 0)][Math.max(Math.min(8, piloting), 0)];
+        return bvMod[MathUtility.clamp(gunnery, 0, 8)][MathUtility.clamp(piloting, 0, 8)];
     }
 
     public boolean hasEdgeRemaining() {

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1791,8 +1791,14 @@ public class Infantry extends Entity {
         return super.getMovementModeAsString();
     }
 
+    /**
+     * @return True for all infantry that are allowed AM attacks. Mechanized infantry and infantry units with
+     * encumbering armor are not allowed to make AM attacks, while all other infantry are.
+     * Note that a conventional infantry unit without Anti-Mek gear (15 kg per trooper) can still make AM attacks
+     * but has a fixed 8 AM skill rating.
+     */
     public boolean canMakeAntiMekAttacks() {
-        return !isMechanized();
+        return !isMechanized() && !isArmorEncumbering();
     }
 
     @Override

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1793,12 +1793,12 @@ public class Infantry extends Entity {
 
     /**
      * @return True for all infantry that are allowed AM attacks. Mechanized infantry and infantry units with
-     * encumbering armor are not allowed to make AM attacks, while all other infantry are.
+     * encumbering armor or field guns are not allowed to make AM attacks, while all other infantry are.
      * Note that a conventional infantry unit without Anti-Mek gear (15 kg per trooper) can still make AM attacks
      * but has a fixed 8 AM skill rating.
      */
     public boolean canMakeAntiMekAttacks() {
-        return !isMechanized() && !isArmorEncumbering();
+        return !isMechanized() && !isArmorEncumbering() && !hasActiveFieldGun();
     }
 
     @Override
@@ -2063,13 +2063,14 @@ public class Infantry extends Entity {
         return (((double) getInternal(LOC_INFANTRY) / getOInternal(LOC_INFANTRY)) < 0.9);
     }
 
+    /** @return True if this infantry has any field gun (destroyed or not). */
     public boolean hasFieldGun() {
-        for (Mounted m : getWeaponList()) {
-            if (m.getLocation() == Infantry.LOC_FIELD_GUNS) {
-                return true;
-            }
-        }
-        return false;
+        return getWeaponList().stream().anyMatch(m -> m.getLocation() == LOC_FIELD_GUNS);
+    }
+
+    /** @return True if this infantry has any working (not destroyed) field gun. */
+    public boolean hasActiveFieldGun() {
+        return getWeaponList().stream().filter(m -> !m.isDestroyed()).anyMatch(m -> m.getLocation() == LOC_FIELD_GUNS);
     }
 
     @Override

--- a/megamek/src/megamek/common/LAMPilot.java
+++ b/megamek/src/megamek/common/LAMPilot.java
@@ -319,13 +319,4 @@ public class LAMPilot extends Crew {
     public boolean isCustom() {
         return getGunneryMech() != 4 || getGunneryAero() != 4 || getPilotingMech() != 5 || getPilotingAero() != 5;
     }
-
-    /** @return The BV multiplier for this LAM pilot's gunnery/piloting. */
-    @Override
-    public double getBVSkillMultiplier() {
-        return getBVImplantMultiplier() * getBVSkillMultiplier(
-                (getGunneryMech() + getGunneryAero()) / 2,
-                (getPilotingMech() + getPilotingAero()) / 2);
-    }
-
 }

--- a/megamek/src/megamek/common/LAMPilot.java
+++ b/megamek/src/megamek/common/LAMPilot.java
@@ -320,22 +320,12 @@ public class LAMPilot extends Crew {
         return getGunneryMech() != 4 || getGunneryAero() != 4 || getPilotingMech() != 5 || getPilotingAero() != 5;
     }
 
-    /**
-     * Returns the BV multiplier for this pilot's gunnery/piloting
-     *
-     * @param usePiloting
-     *            whether or not to use the default value non-anti-mech
-     *            infantry/BA should not use the anti-mech skill
-     * @param game The current {@link Game}
-     */
+    /** @return The BV multiplier for this LAM pilot's gunnery/piloting. */
     @Override
-    public double getBVSkillMultiplier(boolean usePiloting, Game game) {
-        int pilotVal = (getPilotingMech() + getPilotingAero()) / 2;
-        if (!usePiloting) {
-            pilotVal = 5;
-        }
-        return getBVImplantMultiplier()
-                * getBVSkillMultiplier((getGunneryMech() + getGunneryAero()) / 2, pilotVal, game);
+    public double getBVSkillMultiplier() {
+        return getBVImplantMultiplier() * getBVSkillMultiplier(
+                (getGunneryMech() + getGunneryAero()) / 2,
+                (getPilotingMech() + getPilotingAero()) / 2);
     }
 
 }

--- a/megamek/src/megamek/common/battlevalue/AeroBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/AeroBVCalculator.java
@@ -692,7 +692,7 @@ public class AeroBVCalculator {
         }
         finalBV += xbv;
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(aero);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(aero);
         return (int) Math.round(finalBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/AeroBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/AeroBVCalculator.java
@@ -695,7 +695,7 @@ public class AeroBVCalculator {
         // and then factor in pilot
         double pilotFactor = 1;
         if (!ignoreSkill) {
-            pilotFactor = aero.getCrew().getBVSkillMultiplier(aero.getGame());
+            pilotFactor = aero.getCrew().getBVSkillMultiplier();
         }
 
         return (int) Math.round(finalBV * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/AeroBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/AeroBVCalculator.java
@@ -692,12 +692,7 @@ public class AeroBVCalculator {
         }
         finalBV += xbv;
 
-        // and then factor in pilot
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = aero.getCrew().getBVSkillMultiplier();
-        }
-
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(aero);
         return (int) Math.round(finalBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/BattleArmorBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BattleArmorBVCalculator.java
@@ -212,7 +212,7 @@ public class BattleArmorBVCalculator {
             squadBV += battleArmor.getExtraC3BV((int) Math.round(squadBV));
         }
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(battleArmor);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(battleArmor);
         return (int) Math.round(squadBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/BattleArmorBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BattleArmorBVCalculator.java
@@ -212,8 +212,7 @@ public class BattleArmorBVCalculator {
             squadBV += battleArmor.getExtraC3BV((int) Math.round(squadBV));
         }
 
-        // Adjust BV for crew skills.
-        double pilotFactor = ignoreSkill ? 1 : battleArmor.getCrew().getBVSkillMultiplier();
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(battleArmor);
         return (int) Math.round(squadBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/BattleArmorBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BattleArmorBVCalculator.java
@@ -213,11 +213,7 @@ public class BattleArmorBVCalculator {
         }
 
         // Adjust BV for crew skills.
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = battleArmor.getCrew().getBVSkillMultiplier(battleArmor.isAntiMekTrained(), battleArmor.getGame());
-        }
-
+        double pilotFactor = ignoreSkill ? 1 : battleArmor.getCrew().getBVSkillMultiplier();
         return (int) Math.round(squadBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/BvMultiplier.java
+++ b/megamek/src/megamek/common/battlevalue/BvMultiplier.java
@@ -69,7 +69,8 @@ public class BvMultiplier {
     }
 
     /**
-     * Returns the BV multiplier for the given gunnery and piloting values.
+     * Returns the BV multiplier for the given gunnery and piloting values. Returns 1 for the neutral
+     * values 4/5.
      *
      * @param gunnery the gunnery skill of a pilot
      * @param piloting the piloting skill of a pilot
@@ -79,6 +80,13 @@ public class BvMultiplier {
         return bvMultipliers[MathUtility.clamp(gunnery, 0, 8)][MathUtility.clamp(piloting, 0, 8)];
     }
 
+    /**
+     * Returns the BV multiplier for any MD implants that the crew of the given entity has. When the crew
+     * doesn't have any relevant MD implants, returns 1.
+     *
+     * @param entity The entity to get the skill modifier for
+     * @return a multiplier to the BV of the given entity
+     */
     public static double bvImplantMultiplier(Entity entity) {
         int level = 1;
         if (entity.getCrew().getOptions().booleanOption(OptionsConstants.MD_PAIN_SHUNT)) {

--- a/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
@@ -500,7 +500,7 @@ public class CombatVehicleBVCalculator {
 
         finalBV = Math.round(finalBV + xbv);
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(combatVee);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(combatVee);
         int finalAdjustedBV = (int) Math.round(finalBV * pilotFactor);
         bvReport.addResultLine("Final Adjusted BV", "= ", finalAdjustedBV);
         return finalAdjustedBV;

--- a/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
@@ -502,7 +502,7 @@ public class CombatVehicleBVCalculator {
 
         double pilotFactor = 1;
         if (!ignoreSkill && (null != combatVee.getCrew())) {
-            pilotFactor = combatVee.getCrew().getBVSkillMultiplier(combatVee.getGame());
+            pilotFactor = combatVee.getCrew().getBVSkillMultiplier();
         }
 
         int finalAdjustedBV = (int) Math.round((finalBV) * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
@@ -500,12 +500,8 @@ public class CombatVehicleBVCalculator {
 
         finalBV = Math.round(finalBV + xbv);
 
-        double pilotFactor = 1;
-        if (!ignoreSkill && (null != combatVee.getCrew())) {
-            pilotFactor = combatVee.getCrew().getBVSkillMultiplier();
-        }
-
-        int finalAdjustedBV = (int) Math.round((finalBV) * pilotFactor);
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(combatVee);
+        int finalAdjustedBV = (int) Math.round(finalBV * pilotFactor);
         bvReport.addResultLine("Final Adjusted BV", "= ", finalAdjustedBV);
         return finalAdjustedBV;
     }

--- a/megamek/src/megamek/common/battlevalue/DropShipBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/DropShipBVCalculator.java
@@ -483,7 +483,7 @@ public class DropShipBVCalculator {
         }
         finalBV += xbv;
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(dropShip);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(dropShip);
         return (int) Math.round(finalBV * pilotFactor);
     }
 

--- a/megamek/src/megamek/common/battlevalue/DropShipBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/DropShipBVCalculator.java
@@ -483,12 +483,7 @@ public class DropShipBVCalculator {
         }
         finalBV += xbv;
 
-        // and then factor in pilot
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = dropShip.getCrew().getBVSkillMultiplier();
-        }
-
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(dropShip);
         return (int) Math.round(finalBV * pilotFactor);
     }
 

--- a/megamek/src/megamek/common/battlevalue/DropShipBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/DropShipBVCalculator.java
@@ -486,7 +486,7 @@ public class DropShipBVCalculator {
         // and then factor in pilot
         double pilotFactor = 1;
         if (!ignoreSkill) {
-            pilotFactor = dropShip.getCrew().getBVSkillMultiplier(dropShip.getGame());
+            pilotFactor = dropShip.getCrew().getBVSkillMultiplier();
         }
 
         return (int) Math.round(finalBV * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/GunEmplacementBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/GunEmplacementBVCalculator.java
@@ -137,7 +137,7 @@ public class GunEmplacementBVCalculator {
 
         finalBV += xbv;
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(gunEmplacement);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(gunEmplacement);
         return (int) Math.round(finalBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/GunEmplacementBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/GunEmplacementBVCalculator.java
@@ -140,7 +140,7 @@ public class GunEmplacementBVCalculator {
         // and then factor in pilot
         double pilotFactor = 1;
         if (!ignoreSkill) {
-            pilotFactor = gunEmplacement.getCrew().getBVSkillMultiplier(gunEmplacement.getGame());
+            pilotFactor = gunEmplacement.getCrew().getBVSkillMultiplier();
         }
 
         return (int) Math.round(finalBV * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/GunEmplacementBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/GunEmplacementBVCalculator.java
@@ -137,12 +137,7 @@ public class GunEmplacementBVCalculator {
 
         finalBV += xbv;
 
-        // and then factor in pilot
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = gunEmplacement.getCrew().getBVSkillMultiplier();
-        }
-
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(gunEmplacement);
         return (int) Math.round(finalBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/InfantryBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/InfantryBVCalculator.java
@@ -212,7 +212,7 @@ public class InfantryBVCalculator {
                 "" + (int) Math.round(bv * utm));
         bv *= utm;
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(infantry);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(infantry);
         return (int) Math.round(bv * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/InfantryBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/InfantryBVCalculator.java
@@ -101,11 +101,10 @@ public class InfantryBVCalculator {
             wbv += primaryW.getBV(infantry) * (squadsize - secondn);
         }
         if (null != secondW) {
-            wbv += secondW.getBV(infantry) * (secondn);
+            wbv += secondW.getBV(infantry) * secondn;
         }
         wbv = wbv * (men / squadsize);
-        // if anti-mek then double this
-        // TODO : need to factor archaic weapons out of this
+
         double ambv = 0;
         if (infantry.canMakeAntiMekAttacks()) {
             if (primaryW != null && !primaryW.hasFlag(InfantryWeapon.F_INF_ARCHAIC)) {
@@ -213,7 +212,7 @@ public class InfantryBVCalculator {
                 "" + (int) Math.round(bv * utm));
         bv *= utm;
 
-        double pilotFactor = ignoreSkill ? 1 : infantry.getCrew().getBVSkillMultiplier();
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(infantry);
         return (int) Math.round(bv * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/InfantryBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/InfantryBVCalculator.java
@@ -213,10 +213,7 @@ public class InfantryBVCalculator {
                 "" + (int) Math.round(bv * utm));
         bv *= utm;
 
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = infantry.getCrew().getBVSkillMultiplier(infantry.isAntiMekTrained(), infantry.getGame());
-        }
+        double pilotFactor = ignoreSkill ? 1 : infantry.getCrew().getBVSkillMultiplier();
         return (int) Math.round(bv * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/JumpShipBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/JumpShipBVCalculator.java
@@ -478,7 +478,7 @@ public class JumpShipBVCalculator {
 
         finalBV = Math.round(finalBV + xbv);
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(jumpShip);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(jumpShip);
         return (int) Math.round(finalBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/JumpShipBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/JumpShipBVCalculator.java
@@ -478,12 +478,7 @@ public class JumpShipBVCalculator {
 
         finalBV = Math.round(finalBV + xbv);
 
-        // and then factor in pilot
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = jumpShip.getCrew().getBVSkillMultiplier();
-        }
-
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(jumpShip);
         return (int) Math.round(finalBV * pilotFactor);
     }
 }

--- a/megamek/src/megamek/common/battlevalue/JumpShipBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/JumpShipBVCalculator.java
@@ -481,7 +481,7 @@ public class JumpShipBVCalculator {
         // and then factor in pilot
         double pilotFactor = 1;
         if (!ignoreSkill) {
-            pilotFactor = jumpShip.getCrew().getBVSkillMultiplier(jumpShip.getGame());
+            pilotFactor = jumpShip.getCrew().getBVSkillMultiplier();
         }
 
         return (int) Math.round(finalBV * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -1087,7 +1087,7 @@ public class MekBVCalculator {
         }
         finalBV = (int) Math.round(finalBV + xbv);
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(mek);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(mek);
         return (int) Math.round(finalBV * pilotFactor);
     }
 

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -1090,7 +1090,7 @@ public class MekBVCalculator {
         // and then factor in pilot
         double pilotFactor = 1;
         if (!ignoreSkill) {
-            pilotFactor = mek.getCrew().getBVSkillMultiplier(mek.getGame());
+            pilotFactor = mek.getCrew().getBVSkillMultiplier();
         }
 
         return (int) Math.round(finalBV * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -1087,12 +1087,7 @@ public class MekBVCalculator {
         }
         finalBV = (int) Math.round(finalBV + xbv);
 
-        // and then factor in pilot
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = mek.getCrew().getBVSkillMultiplier();
-        }
-
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(mek);
         return (int) Math.round(finalBV * pilotFactor);
     }
 

--- a/megamek/src/megamek/common/battlevalue/ProtoMekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/ProtoMekBVCalculator.java
@@ -314,7 +314,7 @@ public class ProtoMekBVCalculator {
         int finalBV = (int) Math.round(dbv + obv + xbv);
         bvReport.addResultLine("Sum", "= ", finalBV);
 
-        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(protoMek);
+        double pilotFactor = ignoreSkill ? 1 : BvMultiplier.bvMultiplier(protoMek);
         bvReport.addLine("Multiply by Pilot Factor of ", "" + pilotFactor, "x ", pilotFactor);
         int retVal = (int) Math.round(finalBV * pilotFactor);
         bvReport.addResultLine("Final Battle Value", "= ", retVal);

--- a/megamek/src/megamek/common/battlevalue/ProtoMekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/ProtoMekBVCalculator.java
@@ -317,7 +317,7 @@ public class ProtoMekBVCalculator {
         // and then factor in pilot
         double pilotFactor = 1;
         if (!ignoreSkill) {
-            pilotFactor = protoMek.getCrew().getBVSkillMultiplier(protoMek.getGame());
+            pilotFactor = protoMek.getCrew().getBVSkillMultiplier();
         }
         bvReport.addLine("Multiply by Pilot Factor of ", "" + pilotFactor, "x ", pilotFactor);
         int retVal = (int) Math.round((finalBV) * pilotFactor);

--- a/megamek/src/megamek/common/battlevalue/ProtoMekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/ProtoMekBVCalculator.java
@@ -314,13 +314,9 @@ public class ProtoMekBVCalculator {
         int finalBV = (int) Math.round(dbv + obv + xbv);
         bvReport.addResultLine("Sum", "= ", finalBV);
 
-        // and then factor in pilot
-        double pilotFactor = 1;
-        if (!ignoreSkill) {
-            pilotFactor = protoMek.getCrew().getBVSkillMultiplier();
-        }
+        double pilotFactor = ignoreSkill ? 1 : SkillBVModifier.getBVSkillMultiplier(protoMek);
         bvReport.addLine("Multiply by Pilot Factor of ", "" + pilotFactor, "x ", pilotFactor);
-        int retVal = (int) Math.round((finalBV) * pilotFactor);
+        int retVal = (int) Math.round(finalBV * pilotFactor);
         bvReport.addResultLine("Final Battle Value", "= ", retVal);
         return retVal;
     }

--- a/megamek/src/megamek/common/battlevalue/SkillBVModifier.java
+++ b/megamek/src/megamek/common/battlevalue/SkillBVModifier.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.battlevalue;
+
+import megamek.codeUtilities.MathUtility;
+import megamek.common.Entity;
+import megamek.common.Infantry;
+import megamek.common.LAMPilot;
+
+/**
+ * Utility class for obtaining BV Skill Multipliers (TM p.315).
+ */
+public class SkillBVModifier {
+
+    private static final double[][] bvMod = new double[][] {
+            {2.42, 2.31, 2.21, 2.10, 1.93, 1.75, 1.68, 1.59, 1.50},
+            {2.21, 2.11, 2.02, 1.92, 1.76, 1.60, 1.54, 1.46, 1.38},
+            {1.93, 1.85, 1.76, 1.68, 1.54, 1.40, 1.35, 1.28, 1.21},
+            {1.66, 1.58, 1.51, 1.44, 1.32, 1.20, 1.16, 1.10, 1.04},
+            {1.38, 1.32, 1.26, 1.20, 1.10, 1.00, 0.95, 0.90, 0.85},
+            {1.31, 1.19, 1.13, 1.08, 0.99, 0.90, 0.86, 0.81, 0.77},
+            {1.24, 1.12, 1.07, 1.02, 0.94, 0.85, 0.81, 0.77, 0.72},
+            {1.17, 1.06, 1.01, 0.96, 0.88, 0.80, 0.76, 0.72, 0.68},
+            {1.10, 0.99, 0.95, 0.90, 0.83, 0.75, 0.71, 0.68, 0.64},
+    };
+
+    /**
+     * Returns the BV multiplier for the given gunnery and piloting values.
+     *
+     * @param gunnery the gunnery skill of a pilot
+     * @param piloting the piloting skill of a pilot
+     * @return a multiplier to the BV of whatever unit the pilot is piloting.
+     */
+    public static double getBVSkillMultiplier(int gunnery, int piloting) {
+        return bvMod[MathUtility.clamp(gunnery, 0, 8)][MathUtility.clamp(piloting, 0, 8)];
+    }
+
+    /**
+     * Returns the BV skill multiplier for the gunnery/piloting of the given entity's pilot (TM p.315).
+     * Returns 1 if the given entity's crew is null. Special treatment is given to infantry units where
+     * units unable to make anti-mek attacks use 5 as their anti-mek (piloting) value and LAM pilots that
+     * use the average of their aero and mek values.
+     *
+     * @param entity The entity to get the skill modifier for
+     * @return The BV skill multiplier for the given entity's pilot
+     */
+    public static double getBVSkillMultiplier(Entity entity) {
+        if (entity.getCrew() == null) {
+            return 1;
+        }
+        int gunnery = entity.getCrew().getGunnery();
+        int piloting = entity.getCrew().getPiloting();
+
+        if ((entity instanceof Infantry) && (!((Infantry) entity).canMakeAntiMekAttacks())) {
+            piloting = 5;
+        } else if (entity.getCrew() instanceof LAMPilot) {
+            LAMPilot lamPilot = (LAMPilot) entity.getCrew();
+            gunnery = (lamPilot.getGunneryMech() + lamPilot.getGunneryAero()) / 2;
+            piloting = (lamPilot.getPilotingMech() + lamPilot.getPilotingAero()) / 2;
+        }
+        return getBVSkillMultiplier(gunnery, piloting);
+    }
+
+    private SkillBVModifier() { }
+}

--- a/megamek/unittests/megamek/common/CrewTest.java
+++ b/megamek/unittests/megamek/common/CrewTest.java
@@ -19,6 +19,7 @@
  */
 package megamek.common;
 
+import megamek.common.battlevalue.BvMultiplier;
 import megamek.common.options.GameOptions;
 import org.junit.jupiter.api.Test;
 
@@ -41,14 +42,14 @@ public class CrewTest {
         // Test the default case.
         Game mockGame = null;
         double expected = 1.0;
-        double actual = Crew.getBVSkillMultiplier(gunnery, piloting);
+        double actual = BvMultiplier.bvSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         mockGame = mock(Game.class);
         GameOptions mockOptions = mock(GameOptions.class);
         when(mockGame.getOptions()).thenReturn(mockOptions);
         expected = 1.0;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
+        actual = BvMultiplier.bvSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 3/4 pilot.
@@ -56,7 +57,7 @@ public class CrewTest {
         piloting = 4;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 1.32;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
+        actual = BvMultiplier.bvSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 5/6 pilot.
@@ -64,7 +65,7 @@ public class CrewTest {
         piloting = 6;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 0.86;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
+        actual = BvMultiplier.bvSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 2/6 pilot.
@@ -72,7 +73,7 @@ public class CrewTest {
         piloting = 6;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 1.35;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
+        actual = BvMultiplier.bvSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 0/0 pilot.
@@ -80,7 +81,7 @@ public class CrewTest {
         piloting = 0;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 2.42;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
+        actual = BvMultiplier.bvSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
     }
 }

--- a/megamek/unittests/megamek/common/CrewTest.java
+++ b/megamek/unittests/megamek/common/CrewTest.java
@@ -41,14 +41,14 @@ public class CrewTest {
         // Test the default case.
         Game mockGame = null;
         double expected = 1.0;
-        double actual = Crew.getBVSkillMultiplier(gunnery, piloting, mockGame);
+        double actual = Crew.getBVSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         mockGame = mock(Game.class);
         GameOptions mockOptions = mock(GameOptions.class);
         when(mockGame.getOptions()).thenReturn(mockOptions);
         expected = 1.0;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting, mockGame);
+        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 3/4 pilot.
@@ -56,7 +56,7 @@ public class CrewTest {
         piloting = 4;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 1.32;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting, mockGame);
+        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 5/6 pilot.
@@ -64,7 +64,7 @@ public class CrewTest {
         piloting = 6;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 0.86;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting, mockGame);
+        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 2/6 pilot.
@@ -72,7 +72,7 @@ public class CrewTest {
         piloting = 6;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 1.35;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting, mockGame);
+        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
 
         // Test a 0/0 pilot.
@@ -80,7 +80,7 @@ public class CrewTest {
         piloting = 0;
         when(mockOptions.booleanOption(eq("alternate_pilot_bv_mod"))).thenReturn(false);
         expected = 2.42;
-        actual = Crew.getBVSkillMultiplier(gunnery, piloting, mockGame);
+        actual = Crew.getBVSkillMultiplier(gunnery, piloting);
         assertEquals(expected, actual, 0.001);
     }
 }


### PR DESCRIPTION
This is a fix for #3806 as far as BV calculation goes. 
Fixes #3748 

The code used to treat Anti-Mek 8 as if it was 5 as a special infantry treatment. TM p.309 seems clear that No Anti-Mek gear -> Anti-Mek = 8 for the purpose of BV calculation. MM assumes no Anti-Mek gear when Anti-Mek = 8 and lowers the weight of the unit; it adds weight for the gear when Anti-Mek < 8. Therefore Anti-Mek = 8 should not be treated as 5, but as 8. That is, 8 should be treated as 8. This makes the whole special treatment unnecessary. So this PR removes this special infantry treatment for BV.

This leads to values of BV that are lowest at Anti-Mek = 8 and rise with every improvement of the skill.

In LAMPilot the usePiloting parameter is also unnecessary and this method was never called with usePiloting=false for anything but Infantry.

![image](https://user-images.githubusercontent.com/17069663/181994573-5b0ec5d8-7503-4e2b-a740-8ff418fee0d6.png)
