### PR TITLE
Updated About Box copyright text per #3453

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -757,7 +757,7 @@ ClientGUI.PointBlankShot.Message={0} has moved adjacent to the hidden {1}. Take 
 ClientGUI.PointBlankShot.Title=Take pointblank shot?
 
 CommonAboutDialog.about=MegaMek is community effort to implement the Classic BattleTech rules in an\noperating-system-agnostic, network enabled manner. MegaMek is distributed\r\nunder the GNU General Public License. A copy of the license should be available\n in the installation directory. If you've enjoyed playing MegaMek, please share\nit with a friend. If you'd like to improve it, please be aware that your contributions\nmust ALSO be distributed under the GNU General Public License, Version 2 or later.\n
-CommonAboutDialog.copyright=MegaMek Copyright 2000-2022 - The MegaMek Team\n\nMechWarrior, BattleMech, 'Mech, and AeroTech are registered trademarks of\r\nThe Topps Company, Inc. Used without Permission. Original BattleTech material\r\nCopyright by WizKids, LLC. All Rights Reserved. Used without permission.
+CommonAboutDialog.copyright=MegaMek Copyright 2000-2005 Ben Mazur\nMegaMek Copyright 2018-2022 - The MegaMek Team. All rights reserved.\n\nMechWarrior, BattleMech, 'Mech, and AeroTech are registered trademarks of\r\nThe Topps Company, Inc. Used without Permission. Original BattleTech material\r\nCopyright by WizKids, LLC. All Rights Reserved. Used without permission.
 CommonAboutDialog.title=About MegaMek
 
 #In-game Button Captions

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -757,7 +757,7 @@ ClientGUI.PointBlankShot.Message={0} has moved adjacent to the hidden {1}. Take 
 ClientGUI.PointBlankShot.Title=Take pointblank shot?
 
 CommonAboutDialog.about=MegaMek is community effort to implement the Classic BattleTech rules in an\noperating-system-agnostic, network enabled manner. MegaMek is distributed\r\nunder the GNU General Public License. A copy of the license should be available\n in the installation directory. If you've enjoyed playing MegaMek, please share\nit with a friend. If you'd like to improve it, please be aware that your contributions\nmust ALSO be distributed under the GNU General Public License, Version 2 or later.\n
-CommonAboutDialog.copyright=MegaMek Copyright 2000-2005 Ben Mazur\n\nBattleTech, BattleMech, 'Mech, and MechWarrior are registered trademarks of\r\nWizKids, LLC. Original BattleTech material Copyright by WizKids, LLC.\nAll Rights Reserved. Used without permission.
+CommonAboutDialog.copyright=MegaMek Copyright 2000-2022 - The MegaMek Team\n\nMechWarrior, BattleMech, 'Mech, and AeroTech are registered trademarks of\r\nThe Topps Company, Inc. Used without Permission. Original BattleTech material\r\nCopyright by WizKids, LLC. All Rights Reserved. Used without permission.
 CommonAboutDialog.title=About MegaMek
 
 #In-game Button Captions


### PR DESCRIPTION
Recently fixed #3453 - as a side note @HammerGS suggested updating the copy right text in the MegaMek About box.  Please advise on any additional changes that should be made.

See Issue #3453 for reference.  This should close out the issue tracker referenced.