### PR TITLE
Ratgenerator Editor row coloring

### DIFF
--- a/megamek/src/megamek/utilities/RATGeneratorEditor.java
+++ b/megamek/src/megamek/utilities/RATGeneratorEditor.java
@@ -1017,26 +1017,23 @@ public class RATGeneratorEditor extends JFrame {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
             super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-            if ((column == 0) && (value instanceof String)) {
-                String faction = (String) value;
+            int realModelRow = tblUnitModelEditor.convertRowIndexToModel(row);
+            String faction = (String) unitModelEditorModel.getValueAt(realModelRow, 0);
+            if (column == 0) {
                 if (!currentChassisFactions.contains(faction)) {
                     setForeground(Color.RED);
                 } else {
                     setForeground(null);
                 }
-                if (tblUnitChassisEditor.getSelectedRow() > -1) {
-                    int realRow = tblUnitChassisEditor.convertRowIndexToModel(tblUnitChassisEditor.getSelectedRow());
-                    String chassisSelectedFaction = unitChassisEditorModel.factions.get(realRow);
-                    if (faction.equals(chassisSelectedFaction)) {
-                        setBackground(Color.YELLOW);
-                    } else {
-                        setBackground(null);
-                    }
-                }
-
             }
-
-
+            setBackground(null);
+            if (tblUnitChassisEditor.getSelectedRow() > -1) {
+                int realRow = tblUnitChassisEditor.convertRowIndexToModel(tblUnitChassisEditor.getSelectedRow());
+                String chassisSelectedFaction = unitChassisEditorModel.factions.get(realRow);
+                if (faction.equals(chassisSelectedFaction)) {
+                    setBackground(Color.YELLOW);
+                }
+            }
             return this;
         }
     };
@@ -1045,18 +1042,15 @@ public class RATGeneratorEditor extends JFrame {
         @Override
         public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
             super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-            if ((column == 0) && (value instanceof String)) {
-                String faction = (String) value;
-                if (tblUnitModelEditor.getSelectedRow() > -1) {
-                    int realRow = tblUnitModelEditor.convertRowIndexToModel(tblUnitModelEditor.getSelectedRow());
-                    String modelSelectedFaction = unitModelEditorModel.factions.get(realRow);
-                    if (faction.equals(modelSelectedFaction)) {
-                        setBackground(Color.GREEN);
-                    } else {
-                        setBackground(null);
-                    }
+            int realChassisRow = tblUnitChassisEditor.convertRowIndexToModel(row);
+            String faction = (String) unitChassisEditorModel.getValueAt(realChassisRow, 0);
+            setBackground(null);
+            if (tblUnitModelEditor.getSelectedRow() > -1) {
+                int realRow = tblUnitModelEditor.convertRowIndexToModel(tblUnitModelEditor.getSelectedRow());
+                String modelSelectedFaction = unitModelEditorModel.factions.get(realRow);
+                if (faction.equals(modelSelectedFaction)) {
+                    setBackground(Color.GREEN);
                 }
-
             }
             return this;
         }

--- a/megamek/src/megamek/utilities/RATGeneratorEditor.java
+++ b/megamek/src/megamek/utilities/RATGeneratorEditor.java
@@ -388,6 +388,7 @@ public class RATGeneratorEditor extends JFrame {
         }
         tblUnitModelEditor.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         tblUnitModelEditor.setDefaultRenderer(String.class, unitListRenderer);
+        tblUnitModelEditor.getSelectionModel().addListSelectionListener(evt -> tblUnitChassisEditor.repaint());
 
         TableRowSorter<UnitEditorTableModel> unitEditorListSorter = new TableRowSorter<>(unitModelEditorModel);
         unitEditorListSorter.setComparator(0, Comparator.comparing(String::toString));
@@ -452,6 +453,8 @@ public class RATGeneratorEditor extends JFrame {
             columnModel.getColumn(i).setPreferredWidth(50);
         }
         tblUnitChassisEditor.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
+        tblUnitChassisEditor.setDefaultRenderer(String.class, chassisListRenderer);
+        tblUnitChassisEditor.getSelectionModel().addListSelectionListener(evt -> tblUnitModelEditor.repaint());
 
         TableRowSorter<UnitEditorTableModel> unitEditorListSorter = new TableRowSorter<>(unitChassisEditorModel);
         unitEditorListSorter.setComparator(0, Comparator.comparing(String::toString));
@@ -769,7 +772,7 @@ public class RATGeneratorEditor extends JFrame {
         HashMap<String, List<String>> data;
         private int mode;
         private AbstractUnitRecord unitRecord;
-        
+
         private String getUnitKey() {
             return (mode == MODE_CHASSIS) ? unitRecord.getChassisKey() : unitRecord.getKey();
         }
@@ -1021,8 +1024,40 @@ public class RATGeneratorEditor extends JFrame {
                 } else {
                     setForeground(null);
                 }
+                if (tblUnitChassisEditor.getSelectedRow() > -1) {
+                    int realRow = tblUnitChassisEditor.convertRowIndexToModel(tblUnitChassisEditor.getSelectedRow());
+                    String chassisSelectedFaction = unitChassisEditorModel.factions.get(realRow);
+                    if (faction.equals(chassisSelectedFaction)) {
+                        setBackground(Color.YELLOW);
+                    } else {
+                        setBackground(null);
+                    }
+                }
+
             }
 
+
+            return this;
+        }
+    };
+
+    TableCellRenderer chassisListRenderer = new DefaultTableCellRenderer() {
+        @Override
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column) {
+            super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+            if ((column == 0) && (value instanceof String)) {
+                String faction = (String) value;
+                if (tblUnitModelEditor.getSelectedRow() > -1) {
+                    int realRow = tblUnitModelEditor.convertRowIndexToModel(tblUnitModelEditor.getSelectedRow());
+                    String modelSelectedFaction = unitModelEditorModel.factions.get(realRow);
+                    if (faction.equals(modelSelectedFaction)) {
+                        setBackground(Color.GREEN);
+                    } else {
+                        setBackground(null);
+                    }
+                }
+
+            }
             return this;
         }
     };


### PR DESCRIPTION
As requested by @HammerGS this colors the rows in the model and chassis editor if a cell of the same faction in the other table is selected.

![image](https://user-images.githubusercontent.com/17069663/184298464-0a4d580a-b4c6-45b8-8b11-e261ad9f3563.png)
