### PR TITLE
Fixing Gradle Build Deprecations

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -78,7 +78,7 @@ task officialUnitList(type: JavaExec, dependsOn: jar) {
     description = 'Compiles a list of all units that come from official sources and saves it in the docs folder.'
     group = 'build'
     classpath = sourceSets.main.runtimeClasspath
-    main = 'megamek.MegaMek'
+    mainClass = 'megamek.MegaMek'
     args '-oul'
     inputs.dir "${projectDir}/${unitFiles}"
     outputs.file "${fileStagingDir}/docs/OfficialUnitList.txt"
@@ -88,7 +88,7 @@ task equipmentList(type: JavaExec, dependsOn: jar) {
     description = 'Generate current equipment.txt'
     group = 'build'
     classpath = sourceSets.main.runtimeClasspath
-    main = 'megamek.MegaMek'
+    mainClass = 'megamek.MegaMek'
     args = [ '-eqdb', 'docs/equipment.txt' ]
     inputs.files sourceSets.main.allJava
     outputs.file "${fileStagingDir}/docs/equipment.txt"
@@ -124,7 +124,7 @@ task copyFiles(type: Copy) {
 task createImageAtlases(type: JavaExec, dependsOn: copyFiles) {
     description = 'Combines individual image files into a set of image atlases.'
     classpath = sourceSets.main.runtimeClasspath
-    main = "megamek.utilities.CreateImageAtlases"
+    mainClass = "megamek.utilities.CreateImageAtlases"
     workingDir = file(fileStagingDir)
     inputs.dir "${projectDir}/${data}/images/units"
     outputs.dir "${fileStagingDir}/${data}/images/units"
@@ -180,7 +180,7 @@ task stageFiles {
 task createStartScripts (type: CreateStartScripts) {
     description = 'Create shell script for generic distribution.'
     applicationName = 'mm'
-    mainClassName = project.mainClassName
+    mainClass = project.mainClassName
     outputDir = startScripts.outputDir
     classpath = jar.outputs.files + files(project.sourceSets.main.runtimeClasspath.files)
             .filter { it.name.endsWith(".jar") }
@@ -236,13 +236,12 @@ createExe {
     mainClassName = project.mainClassName
     outfile = 'MegaMek.exe'
     icon = "${projectDir}/data/images/misc/megamek.ico"
-    def inifile = outfile.replace('.exe', '.l4j.ini')
+    def iniFile = outfile.replace('.exe', '.l4j.ini')
     jar = "${project.tasks.getByName("jar").archiveFile.get()}"
-    inputs.file  jar
     outputs.file "${buildDir}/launch4j/${outfile}"
-    outputs.file "${buildDir}/launch4j/${inifile}"
+    outputs.file "${buildDir}/launch4j/${iniFile}"
     doLast {
-        new File("${buildDir}/${outputDir}/${inifile}").text = """# Launch4j runtime config
+        new File("${buildDir}/${outputDir}/${iniFile}").text = """# Launch4j runtime config
 # you can add arguments here that will be processed by the JVM at runtime
 ${project.ext.mmJvmOptions.join('\n')}
 """        
@@ -317,7 +316,6 @@ task buildFromRepo (type: GradleBuild) {
     group = 'distribution'
     dependsOn cloneMMRepo
     
-    buildFile = "${mmRepoDir}/build.gradle"
     dir = "${mmRepoDir}"
     tasks = [ ':megamek:assembleDist' ]
 }
@@ -354,7 +352,7 @@ publishing {
             pom {
                 name = "MegaMek"
                 description = "MegaMek"
-                url = "http://megamek.org"
+                url = "https://megamek.org"
                 licenses {
                     license {
                         name = "GNU General Public License, version 2"
@@ -387,7 +385,7 @@ jacocoTestReport {
     // tests are required to run before generating the report
     dependsOn test
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.required = true
+        html.required = true
     }
 }


### PR DESCRIPTION
buildFile -> No longer required, determined automatically
mainClassName -> Renamed to mainClass
report enabled -> Renamed to required
inputs.file jar -> no longer required