### PR TITLE
Gracefully handle illegal armor type in BA TRO.

### DIFF
--- a/megamek/src/megamek/common/templates/BattleArmorTROView.java
+++ b/megamek/src/megamek/common/templates/BattleArmorTROView.java
@@ -95,8 +95,8 @@ public class BattleArmorTROView extends TROView {
         final String armorName = EquipmentType.getArmorTypeName(ba.getArmorType(BattleArmor.LOC_TROOPER_1),
                 TechConstants.isClan(ba.getArmorTechLevel(BattleArmor.LOC_TROOPER_1)));
         final EquipmentType armor = EquipmentType.get(armorName);
-        setModelData("armorType", armor.getName().replaceAll("^BA\\s+", ""));
-        setModelData("armorSlots", armor.getCriticals(ba));
+        setModelData("armorType", armor == null ? "Unknown" : armor.getName().replaceAll("^BA\\s+", ""));
+        setModelData("armorSlots", armor == null ? 0 : armor.getCriticals(ba));
         setModelData("armorMass", testBA.getWeightArmor() * 1000);
         setModelData("armorValue", ba.getOArmor(BattleArmor.LOC_TROOPER_1));
         setModelData("internal", ba.getOInternal(BattleArmor.LOC_TROOPER_1));


### PR DESCRIPTION
Output "Unknown" instead of throwing an NPE if the armor lookup fails.

Fixes MegaMek/megameklab#1165, in which the NPE is thrown due to non-existent Clan BA Advanced armor in the blk file.