### PR TITLE
Issue #3880 - Respect the setting for showing incline graphics

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -4881,6 +4881,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     @Override
     public void boardNewBoard(BoardEvent b) {
         updateBoard();
+        game.getBoard().initializeAllAutomaticTerrain(GUIPreferences.getInstance().getHexInclines());
         clearHexImageCache();
         clearShadowMap();
         repaint();
@@ -5020,6 +5021,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     }
                 }
             }
+            game.getBoard().initializeAllAutomaticTerrain(GUIPreferences.getInstance().getHexInclines());
             clearHexImageCache();
             updateBoard();
             clearShadowMap();


### PR DESCRIPTION
Fixes #3880 

The setting for showing the incline graphics will now be respected also when the setting is "Off" when starting or loading a game.