### PR TITLE
Fix SV engine minimum weight

### DIFF
--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -337,11 +337,11 @@ public class Engine implements Serializable, ITechnology {
             double weight = entity.getBaseEngineValue() * movementFactor
                     * engineWeightMult * entity.getWeight();
             // Fusion engines have a minimum weight of 0.25t at D+ and 0.5t at C. Fission engines have
-            // a minimum of 0.5t at all tech ratings.
+            // a minimum of 5t at all tech ratings.
             if ((engineType == NORMAL_ENGINE) && (entity.getEngineTechRating() >= RATING_D)) {
                 weight = Math.max(weight, 0.25);
             } else if ((engineType == NORMAL_ENGINE) || (engineType == FISSION)) {
-                weight = Math.max(weight, 0.5);
+                weight = Math.max(weight, 5);
             }
 
             // Hovercraft have a minimum engine weight of 20% of the vehicle.


### PR DESCRIPTION
Minimum weight for a support vehicle fission or TL C fusion engine is 5 tons, not 0.5.

Fixes MegaMek/megameklab#910