### PR TITLE
Issue #3776 [RFE] Add 0 (zero) as a selectable weapon/equipment quantity in Open unit, advanced search

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,6 +1,5 @@
 VERSION HISTORY:
 ----------------
-+ Issue #3776 - Add ability to filter out mechs with specified equipment.
 0.49.10 (2022-09-12 1500 UTC)
 + Data: Shorten RAT names for FM3145
 + PR #3887 - Excised Rumble Seat and move to Legacy quirk.

--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,5 +1,6 @@
 VERSION HISTORY:
 ----------------
++ Issue #3776 - Add ability to filter out mechs with specified equipment.
 0.49.10 (2022-09-12 1500 UTC)
 + Data: Shorten RAT names for FM3145
 + PR #3887 - Excised Rumble Seat and move to Legacy quirk.

--- a/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
+++ b/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
@@ -216,7 +216,7 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
         cbxEnableArmorSearch.addItemListener(this);
 
 
-        for (int i = 1; i <= 20; i++) {
+        for (int i = 0; i <= 20; i++) {
             cboQty.addItem(Integer.toString(i));
         }
         cboQty.setSelectedIndex(0);

--- a/megamek/src/megamek/common/MechSearchFilter.java
+++ b/megamek/src/megamek/common/MechSearchFilter.java
@@ -379,11 +379,26 @@ public class MechSearchFilter {
                     LogManager.getLogger().debug("ExpNode n is null");
                 }
 
-                if (currEq.equals(n.name) && currQty >= n.qty) {
+                // If the name matches, that means this is the weapon/equipment we are checking for.
+                // If the requested quantity is greater than 0, then the unit quantity must equal or exceed it.
+                // However, if the requested quantity is 0, then the simple fact that the weapon/equipment matches
+                // means that the unit isn't a match for the filter, as it has a weapon/equipment that is required to
+                // NOT be there.
+                if (currEq.equals(n.name) && n.qty > 0 && currQty >= n.qty) {
                     return true;
+                } else if (currEq.equals(n.name) && n.qty == 0) {
+                    return false;
                 }
             }
-            return false;
+
+            // If we reach this point. It means that the MechSummary didn't have a weapon/equipment that matched the leaf node. 
+            // If the leaf quantity is 0, that means that the mech is a match. If the leaf quantity is non-zero, that means the mech isn't
+            // a match.
+            if (n.qty == 0) {
+                return true;
+            } else {
+                return false;
+            }
         }
         // Otherwise, recurse on all the children and either AND the results
         // or OR them, based upon the operation in this node


### PR DESCRIPTION
The evaluate function (MechSearchFilter.java) was changed to handle 0 as a valid quantity. Additionally, the gui was modified to allow 0 as a selection in the drop-down (AdvancedSearchDialog.java).

Specifically, 0 was added to the available options for the weapon and unit drop-downs.
In the unit filter. If the name of the weapon/equipment in the mech summary matches that of a node with a requested quantity of 0, then the unit is not matched. If the name matches and the requested quantity is greater than 0 and the unit quantity is greater than or equal to the requested quantity, the unit matches.
If no equipment is found where the name matches the requested weapon/equipment, and the requested quantity is 0, then the unit matches. Otherwise it does not.