### PR TITLE
Fix AHB-X missing weapons

### DIFF
--- a/megamek/data/mechfiles/fighters/TRO3050U/IS/Ahab AHB-X.blk
+++ b/megamek/data/mechfiles/fighters/TRO3050U/IS/Ahab AHB-X.blk
@@ -92,6 +92,8 @@ SRM 6
 </Right Wing Equipment>
 
 <Aft Equipment>
+Medium Laser
+Medium Laser
 </Aft Equipment>
 
 <Wings Equipment>


### PR DESCRIPTION
Regarding issue #3903 
Add two missing medium lasers to aft weapons bay, as described in TRO 3050U.

(Is pull-requesting for this too excessive? It's such a minuscule change...)