### PR TITLE
remove unused firing modes from TAG

### DIFF
--- a/megamek/src/megamek/common/TagInfo.java
+++ b/megamek/src/megamek/common/TagInfo.java
@@ -24,17 +24,12 @@ public class TagInfo implements Serializable {
     public int attackerId; // who fired the TAG
     public int targetType; // keeps track of the target's type
     public Targetable target; // entity the tag was fired at
-    public int priority; // how many homing missiles to grab at a time
     public boolean missed; // did the TAG hit?
-    public int shots = 0; // number of homing missiles allocated
 
-    public TagInfo(int attackerId, int targetType, Targetable target,
-            int priority, boolean missed) {
+    public TagInfo(int attackerId, int targetType, Targetable target, boolean missed) {
         this.attackerId = attackerId;
         this.targetType = targetType;
         this.target = target;
-        this.priority = priority;
         this.missed = missed;
-        this.shots = priority;
     }
 }

--- a/megamek/src/megamek/common/weapons/TAGHandler.java
+++ b/megamek/src/megamek/common/weapons/TAGHandler.java
@@ -53,25 +53,9 @@ public class TAGHandler extends WeaponHandler {
             r.subject = subjectId;
             vPhaseReport.addElement(r);
         } else {
-            int priority = 1;
-            EquipmentMode mode = (weapon.curMode());
-            if (mode != null) {
-                if (mode.getName() == "1-shot") {
-                    priority = 1;
-                } else if (mode.getName() == "2-shot") {
-                    priority = 2;
-                } else if (mode.getName() == "3-shot") {
-                    priority = 3;
-                } else if (mode.getName() == "4-shot") {
-                    priority = 4;
-                }
-            }
-            if (priority < 1) {
-                priority = 1;
-            }
-            // it is possible for 2 or more tags to hit the same entity
+
             TagInfo info = new TagInfo(ae.getId(), Targetable.TYPE_ENTITY,
-                    entityTarget, priority, false);
+                    entityTarget, false);
             game.addTagInfo(info);
             entityTarget.setTaggedBy(ae.getId());
             
@@ -88,25 +72,8 @@ public class TAGHandler extends WeaponHandler {
     @Override
     protected boolean handleSpecialMiss(Entity entityTarget, boolean bldgDamagedOnMiss,
                                         Building bldg, Vector<Report> vPhaseReport) {
-        int priority = 1;
-        EquipmentMode mode = (weapon.curMode());
-        if (mode != null) {
-            switch (mode.getName()) {
-                case "2-shot":
-                    priority = 2;
-                    break;
-                case "3-shot":
-                    priority = 3;
-                    break;
-                case "4-shot":
-                    priority = 4;
-                    break;
-                default:
-                    break;
-            }
-        }
         // add even misses, as they waste homing missiles.
-        TagInfo info = new TagInfo(ae.getId(), target.getTargetType(), target, priority, true);
+        TagInfo info = new TagInfo(ae.getId(), target.getTargetType(), target, true);
         game.addTagInfo(info);
         return false;
     }

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1090,21 +1090,9 @@ public class WeaponHandler implements AttackHandler, Serializable {
                     int nDamage;
                     if ((target.getTargetType() == Targetable.TYPE_HEX_TAG)
                             || (target.getTargetType() == Targetable.TYPE_BLDG_TAG)) {
-                        int priority = 1;
-                        EquipmentMode mode = (weapon.curMode());
-                        if (mode != null) {
-                            if (mode.getName() == "1-shot") {
-                                priority = 1;
-                            } else if (mode.getName() == "2-shot") {
-                                priority = 2;
-                            } else if (mode.getName() == "3-shot") {
-                                priority = 3;
-                            } else if (mode.getName() == "4-shot") {
-                                priority = 4;
-                            }
-                        }
+
                         TagInfo info = new TagInfo(ae.getId(),
-                                target.getTargetType(), target, priority, false);
+                                target.getTargetType(), target, false);
                         game.addTagInfo(info);
                         
                         ae.setSpotting(true);

--- a/megamek/src/megamek/common/weapons/tag/TAGWeapon.java
+++ b/megamek/src/megamek/common/weapons/tag/TAGWeapon.java
@@ -32,7 +32,6 @@ public abstract class TAGWeapon extends Weapon {
         super();
         flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON)
                 .or(F_TAG).or(F_NO_FIRES);
-        setModes(new String[] { "1-shot", "2-shot", "3-shot", "4-shot" });
     }
 
     @Override


### PR DESCRIPTION
Removes the firing modes that don't do anything from TAG type weapons; additionally, cleans up long-since unused code.