### PR TITLE
Correctly load damaged CI from MUL

### DIFF
--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -1163,7 +1163,7 @@ public class UnitEditorDialog extends JDialog {
                 } else {
                     entity.setInternal(internal, i);
                 }
-                if (entity.isConventionalInfantry()) {
+                if (entity instanceof Infantry) {
                     entity.applyDamage();
                 }
             }

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -1449,15 +1449,14 @@ public class MULParser {
                 }
             } else if (type.equals(INTERNAL)) {
                 if (entity.getOInternal(loc) < pointsVal) {
-                    warning.append("The entity, ")
-                            .append(entity.getShortName())
-                            .append(" does not start with ")
-                            .append(pointsVal)
-                            .append(" points of internal structure for " +
-                                    "location: ")
+                    warning.append("The entity, ").append(entity.getShortName()).append(" does not start with ")
+                            .append(pointsVal).append(" points of internal structure for location: ")
                             .append(loc).append(".\n");
                 } else {
                     entity.setInternal(pointsVal, loc);
+                    if (entity.isConventionalInfantry()) {
+                        entity.applyDamage();
+                    }
                 }
             } else if (type.equals(REAR)) {
                 if (!entity.hasRearArmor(loc)) {

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -1454,7 +1454,7 @@ public class MULParser {
                             .append(loc).append(".\n");
                 } else {
                     entity.setInternal(pointsVal, loc);
-                    if (entity.isConventionalInfantry()) {
+                    if (entity instanceof Infantry) {
                         entity.applyDamage();
                     }
                 }
@@ -2688,6 +2688,9 @@ public class MULParser {
         // mark armor, internal as destroyed
         en.setArmor(IArmorState.ARMOR_DESTROYED, loc, false);
         en.setInternal(IArmorState.ARMOR_DESTROYED, loc);
+        if (en instanceof Infantry) {
+            en.applyDamage();
+        }
         if (en.hasRearArmor(loc)) {
             en.setArmor(IArmorState.ARMOR_DESTROYED, loc, true);
         }


### PR DESCRIPTION
Applies a reduced trooper count from a .MUL to both the "men" and "shootingMen" fields so that the CI really knows how strong it is (when loading a damaged CI and then choosing "edit damage" in the lobby, this would show the wrong value.)