### PR TITLE
AlphaStrike conversion changes

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASMovementConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASMovementConverter.java
@@ -125,10 +125,6 @@ final class ASMovementConverter {
             }
         }
 
-        if ((entity instanceof Protomech) && ((Protomech) entity).isGlider()) {
-            result.put("", 2);
-            report.addLine("ProtoMek Glider Movement", "2\"");
-        }
         addUMUMovement(result, conversionData);
         return result;
     }


### PR DESCRIPTION
* Proto gliders no longer get a 2" base movement (only their 8"g e.g.) (CGL requested to-be-errata change)
* Fixes a bug where the OV value was not computed using S damage when M damage is 0