### PR TITLE
issue 3959 Unit Display Extra panel with long Last Target names

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -116,6 +116,8 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         lblLastTarget.setForeground(Color.WHITE);
         lblLastTarget.setOpaque(false);
         lastTargetR = new JTextArea("", 4, 25);
+        lastTargetR.setLineWrap(true);
+        lastTargetR.setWrapStyleWord(true);
         lastTargetR.setEditable(false);
         lastTargetR.setOpaque(false);
         lastTargetR.setForeground(Color.WHITE);


### PR DESCRIPTION
issue #3959 Unit Display Extra panel with long Last Target names

set the line wrap and wrap style word properties for the last target text area.  so it word wraps when the last target is really long.

![image](https://user-images.githubusercontent.com/116095479/200001332-ee0aa9fb-7a4d-4c07-84ab-16672eb6cf16.png)



 