### PR TITLE
RFE3747 add option to adjust the seen by in the unit tool tip

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -173,6 +173,7 @@ AdvancedOptions.MapTextColor.name=Map Text Color
 AdvancedOptions.WarningColor.name=Warning Color
 AdvancedOptions.TmmPipMode.name=TMM Pip Mode
 AdvancedOptions.TmmPipMode.tooltip=Show TMM value on unit: 0=No Pips 1=White Pips 2=Move Colored Pips
+AdvancedOptions.UnitToolTipSeenByResolution.name=UnitToolTip - Seen By Resolution [1=Someone,2=Team,3=Player]
 
 #Board Editor
 BoardEditor.BridgeBuildingElevError=Bridge/Building Elevation is an offset from the surface of a hex and hence must be a positive value!

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -103,7 +103,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_HEAT_COLOR_30 = "AdvancedHeatColor30";
     public static final String ADVANCED_HEAT_COLOR_OVERHEAT = "AdvancedHeatColorOverheat";
     public static final String ADVANCED_REPORT_COLOR_LINK = "AdvancedReportColorLink";
-
+    public static final String ADVANCED_UNITTOOLTIP_SEENBYRESOLUTION = "AdvancedUnitToolTipSeenByResolution";
 
     /* --End advanced settings-- */
 
@@ -384,6 +384,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_HEAT_COLOR_OVERHEAT, DEFAULT_HEAT_OVERHEAT_COLOR);
 
         setDefault(ADVANCED_REPORT_COLOR_LINK, DEFAULT_REPORT_LINK_COLOR);
+        setDefault(ADVANCED_UNITTOOLTIP_SEENBYRESOLUTION, 3);
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
@@ -1714,9 +1715,19 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return getColor(ADVANCED_REPORT_COLOR_LINK);
     }
 
+    public int getAdvancedUnitToolTipSeenByResolution() {
+        return getInt(ADVANCED_UNITTOOLTIP_SEENBYRESOLUTION);
+    }
+
+
     public void setReportLinkColor(Color color) {
         store.setValue(ADVANCED_REPORT_COLOR_LINK, getColorString(color));
     }
+
+    public void setAdvancedUnitToolTipSeenByResolution(int i) {
+        store.setValue(ADVANCED_UNITTOOLTIP_SEENBYRESOLUTION, i);
+    }
+
     /**
      * Sets the user preference for the Unit Display window to active.
      */

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5843,7 +5843,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         txt.append(" width=6></TD><TD>");
 
         // Entity tooltip
-        txt.append(UnitToolTip.getEntityTipGame(entity, getLocalPlayer()));
+        txt.append("<div WIDTH=500>" +  UnitToolTip.getEntityTipGame(entity, getLocalPlayer()) + "</div");
         txt.append("</TD></TR></TABLE>");
     }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -15,10 +15,7 @@ package megamek.client.ui.swing.tooltip;
 
 import java.awt.Color;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import megamek.client.ui.Messages;
@@ -729,18 +726,43 @@ public final class UnitToolTip {
 
         // If Double Blind, add information about who sees this Entity
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)) {
-            StringBuffer playerList = new StringBuffer();
+            StringBuffer tempList = new StringBuffer();
             boolean teamVision = game.getOptions().booleanOption(
                     OptionsConstants.ADVANCED_TEAM_VISION);
-            for (Player player : entity.getWhoCanSee()) {
+            int seenByResolution = GUIPreferences.getInstance().getAdvancedUnitToolTipSeenByResolution();
+            String tmpStr = "";
+
+            dance: for (Player player :  entity.getWhoCanSee()) {
                 if (player.isEnemyOf(entity.getOwner()) || !teamVision) {
-                    playerList.append(player.getName());
-                    playerList.append(", ");
+                    switch (seenByResolution) {
+                        case 1:
+                            tmpStr = "Someone";
+                            tempList.append(tmpStr);
+                            tempList.append(", ");
+                            break dance;
+                        case 2:
+                            tmpStr = game.getTeamForPlayer(player).toString();
+                            break;
+                        case 3:
+                            tmpStr = player.getName();
+                            break;
+                        case 4:
+                            tmpStr = player.toString();
+                            break;
+                        default:
+                            tmpStr ="";
+                            break dance;
+                    }
+
+                    if (tempList.indexOf(tmpStr) == -1) {
+                        tempList.append(tmpStr);
+                        tempList.append(", ");
+                    }
                 }
             }
-            if (playerList.length() > 1) {
-                playerList.delete(playerList.length() - 2, playerList.length());
-                result.append(addToTT("SeenBy", BR, playerList.toString()));
+            if (tempList.length() > 1) {
+                tempList.delete(tempList.length() - 2, tempList.length());
+                result.append(addToTT("SeenBy", BR, tempList.toString()));
             }            
         }
 

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -376,7 +376,7 @@ public class Game implements IGame, Serializable {
         for (Team team : teams) {
             for (Enumeration<Player> j = team.getPlayers(); j.hasMoreElements(); ) {
                 final Player player = j.nextElement();
-                if (p == player) {
+                if (p.equals(player)) {
                     return team;
                 }
             }


### PR DESCRIPTION
RFE #3747 add option to adjust the seen by in the unit tool tip

- set the unit tool tip width, so it will word wrap with long text instead of growing really wide.
- add in an advance option to adjust the seen by resolution 
  UnitToolTip - Seen By Resolution [1=Someone,2=Team,3=Player]

Someone
![image](https://user-images.githubusercontent.com/116095479/201149997-c46d5712-68b4-4e69-bff8-4fd9a7eea509.png)

Team
![image](https://user-images.githubusercontent.com/116095479/201149527-a025a9cd-9a1b-484e-b566-b880bc5db200.png)

Player
![image](https://user-images.githubusercontent.com/116095479/201150246-5fa1a2d3-f03a-493f-aa4f-742c696155e9.png)

