### PR TITLE
RFE3975 allow the report display dialog to be always active during a game

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1894,6 +1894,8 @@ Minimap.TotalHeightLabel=T
 
 #Mini round report display
 MiniReportDisplay.title=Round Report
+MiniReportDisplay.Round=Round
+MiniReportDisplay.Phase=Phase
 
 #Assorted Movement Phase Display Text for buttons, nags, dialogs...
 MovementDisplay.AbandonDialog.message=Do you want to abandon this unit?

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -230,6 +230,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
      */
     private Map<String, String> mainNames = new HashMap<>();
 
+    private MiniReportDisplay miniReportDisplay;
+
     /**
      * The <code>JPanel</code> containing the main display area.
      */
@@ -633,7 +635,11 @@ public class ClientGUI extends JPanel implements BoardViewListener,
      */
     private void showRoundReport() {
         ignoreHotKeys = true;
-        new MiniReportDisplay(frame, client).setVisible(true);
+        if (miniReportDisplay == null) {
+            miniReportDisplay = new MiniReportDisplay(frame, client);
+        }
+
+        miniReportDisplay.setVisible(true);
         ignoreHotKeys = false;
     }
 

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -455,7 +455,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         toggleFiringSolutions.setEnabled(isInGameBoardView);
         viewMovementEnvelope.setEnabled(isInGameBoardView);
         viewMovModEnvelope.setEnabled(isInGameBoardView);
-        gameRoundReport.setEnabled(isInGameBoardView);
+        gameRoundReport.setEnabled((isInGame && canSave));
         viewMekDisplay.setEnabled(isInGameBoardView);
         fireSaveWeaponOrder.setEnabled(isInGameBoardView);
     }

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -1371,7 +1371,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     }
 
     public void setMiniReportPosY(int i) {
-        store.setValue(MINIMAP_POS_Y, i);
+        store.setValue(MINI_REPORT_POS_Y, i);
     }
 
     public void setBoardEditLoadHeight(int i) {

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -130,7 +130,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         setupStylesheet(ta);
         BASE64ToolKit toolKit = new BASE64ToolKit();
         ta.setEditorKit(toolKit);
-        ta.setText("<pre>" + currentClient.roundReport + "</pre>");
+        ta.setText("<pre>" + currentClient.phaseReport + "</pre>");
         ta.setEditable(false);
         ta.setOpaque(false);
 

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -44,6 +44,10 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     public MiniReportDisplay(JFrame parent, Client client) {
         super(parent, MRD_TITLE, false);
 
+        if (client == null) {
+            return;
+        }
+
         currentClient = client;
         currentClient.getGame().addGameListener(gameListener);
 
@@ -144,7 +148,9 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                     savePrefHide();
                     break;
                 default:
-                    addReportPages();
+                    if (!e.getNewPhase().equals((e.getOldPhase()))) {
+                        addReportPages();
+                    }
             }
         }
     };

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -54,7 +54,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
 
         getContentPane().add(BorderLayout.SOUTH, butOkay);
         
-        setupReportTabs(client);
+        setupReportTabs();
                 
         setSize(GUIPreferences.getInstance().getMiniReportSizeWidth(),
                 GUIPreferences.getInstance().getMiniReportSizeHeight());
@@ -81,7 +81,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         }
     }
 
-    private void setupReportTabs(Client c) {
+    private void setupReportTabs() {
         tabs = new JTabbedPane();
 
         addReportPages();

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -16,12 +16,9 @@ package megamek.client.ui.swing;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.BASE64ToolKit;
-import megamek.common.Game;
-import megamek.common.enums.GamePhase;
 import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
-import megamek.common.event.GameTurnChangeEvent;
 
 import javax.swing.*;
 import javax.swing.text.html.HTMLEditorKit;
@@ -38,15 +35,19 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     private JButton butOkay;
     private Client currentClient;
     private JTabbedPane tabs;
-    private JScrollPane sp;
+
+    private static final String MRD_TITLE = Messages.getString("MiniReportDisplay.title");
+    private static final String MRD_ROUND = Messages.getString("MiniReportDisplay.Round");
+    private static final String MRD_PHASE = Messages.getString("MiniReportDisplay.Phase");
+    private static final String MRD_OKAY= Messages.getString("Okay");
 
     public MiniReportDisplay(JFrame parent, Client client) {
-        super(parent, Messages.getString("MiniReportDisplay.title"), false);
+        super(parent, MRD_TITLE, false);
 
         currentClient = client;
         currentClient.getGame().addGameListener(gameListener);
 
-        butOkay = new JButton(Messages.getString("Okay"));
+        butOkay = new JButton(MRD_OKAY);
         butOkay.addActionListener(this);
         
         getContentPane().setLayout(new BorderLayout());
@@ -76,7 +77,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent ae) {
         if (ae.getSource().equals(butOkay)) {
-            savePref();
+            savePrefHide();
         }
     }
 
@@ -96,7 +97,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                         + "; font-size: 12pt; font-style:normal;}");
     }
 
-    private void savePref() {
+    private void savePrefHide() {
         GUIPreferences.getInstance().setMiniReportSizeWidth(getSize().width);
         GUIPreferences.getInstance().setMiniReportSizeHeight(getSize().height);
         GUIPreferences.getInstance().setMiniReportPosX(getLocation().x);
@@ -117,7 +118,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
             ta.setText("<pre>" + text + "</pre>");
             ta.setEditable(false);
             ta.setOpaque(false);
-            tabs.add("Round " + round, new JScrollPane(ta));
+            tabs.add(MRD_ROUND + " " + round, new JScrollPane(ta));
         }
 
         // add the new current phase tab
@@ -130,7 +131,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         ta.setOpaque(false);
 
         JScrollPane sp = new JScrollPane(ta);
-        tabs.add("Phase", sp);
+        tabs.add(MRD_PHASE, sp);
 
         tabs.setSelectedIndex(tabs.getTabCount() - 1);
     }
@@ -138,9 +139,9 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     private GameListener gameListener = new GameListenerAdapter() {
         @Override
         public void gamePhaseChange(GamePhaseChangeEvent e) {
-            switch (currentClient.getGame().getPhase()) {
+            switch (e.getOldPhase()) {
                 case VICTORY:
-                    savePref();
+                    savePrefHide();
                     break;
                 default:
                     addReportPages();


### PR DESCRIPTION
RFE #3975 allow the report display dialog to be always active during a game

currently the report display dialog is modal, so you have to open then close it any time you want to view it. and you cant interact with the game board while it is open.

make it so that it can be left open and it updates as the phase changes.