### PR TITLE
issue 3978 on Extras tab Current Sensors issue when really long

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -525,8 +525,9 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
         refreshSensorChoices(en);
 
         if (null != en.getActiveSensor()) {
-            curSensorsL.setText((Messages.getString("MechDisplay.CurrentSensors")).concat(" ")
-                    .concat(en.getSensorDesc()));
+            String tmpStr = Messages.getString("MechDisplay.CurrentSensors") + " " + en.getSensorDesc();
+            tmpStr = String.format("<html><div WIDTH=%d>%s</div></html>",  250, tmpStr);
+            curSensorsL.setText(tmpStr);
         } else {
             curSensorsL.setText((Messages.getString("MechDisplay.CurrentSensors")).concat(" "));
         }


### PR DESCRIPTION
issue #3978  on Extras tab Current Sensors issue when really long. it causes the info to be shifted off screen. needs to word wrap when the text is really long.

![image](https://user-images.githubusercontent.com/116095479/201496826-00586e08-db63-492b-93b2-15a4a5b0aca1.png)
