### PR TITLE
Fixes #3727 Magma crust breakthrough and liquid magma damage not working as expected

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -201,6 +201,7 @@
 2395=<newline><data> (<data>) breaks through magma crust on a 6+, rolls <data>.
 2396=<newline><data> (<data>) breaks through magma crust on a 4+, rolls <data>.
 2400=<data> (<data>) falls into liquid magma, and is instantly destroyed!
+2404=<data> (<data>) takes additional damage from beginning and ending movement in a magma hex!
 2405=<data> (<data>) is damaged by the extreme heat of liquid magma!
 2410=<data> (<data>) breaks through ice from below
 2415=<data> collapes due to nuclear explosion ground zero.

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -5924,6 +5924,7 @@ public class GameManager implements IGameManager {
         // okay, proceed with movement calculations
         Coords lastPos = entity.getPosition();
         Coords curPos = entity.getPosition();
+        Hex firstHex = game.getBoard().getHex(curPos); // Used to check for start/end magma damage
         int curFacing = entity.getFacing();
         int curVTOLElevation = entity.getElevation();
         int curElevation;
@@ -6130,6 +6131,10 @@ public class GameManager implements IGameManager {
                 break;
             }
 
+            // Extra damage if first and last hex are magma
+            if (firstStep) {
+                firstHex = game.getBoard().getHex(curPos);
+            }
             // stop if the entity already killed itself
             if (entity.isDestroyed() || entity.isDoomed()) {
                 break;
@@ -7298,6 +7303,16 @@ public class GameManager implements IGameManager {
                     ServerHelper.checkAndApplyMagmaCrust(curHex, step.getElevation(), entity, curPos, false, vPhaseReport, this);
                 }
                 ServerHelper.checkEnteringMagma(curHex, step.getElevation(), entity, curPos, this);
+            }
+
+            // check for last move ending in magma TODO: build report for end of move
+            if (!i.hasMoreElements() && curHex.terrainLevel(Terrains.MAGMA) == 2
+                    && firstHex.terrainLevel(Terrains.MAGMA) == 2) {
+                r = new Report(2404);
+                r.addDesc(entity);
+                r.subject = entity.getId();
+                addReport(r);
+                doMagmaDamage(entity, false);
             }
 
             // check if we've moved into a swamp

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -4921,7 +4921,7 @@ public class GameManager implements IGameManager {
             // note that this must sequentially occur before the next 'entering liquid magma' check
             // otherwise, magma crust won't have a chance to break
             ServerHelper.checkAndApplyMagmaCrust(nextHex, nextElevation, entity, curPos, false, vPhaseReport, this);
-            ServerHelper.checkEnteringMagma(nextHex, nextElevation, entity, curPos, this);
+            ServerHelper.checkEnteringMagma(nextHex, nextElevation, entity, this);
 
             // is the next hex a swamp?
             PilotingRollData rollTarget = entity.checkBogDown(step, moveType, nextHex, curPos, nextPos,
@@ -7301,8 +7301,8 @@ public class GameManager implements IGameManager {
             if (stepMoveType != EntityMovementType.MOVE_JUMP) {
                 if (!curPos.equals(lastPos)) {
                     ServerHelper.checkAndApplyMagmaCrust(curHex, step.getElevation(), entity, curPos, false, vPhaseReport, this);
+                    ServerHelper.checkEnteringMagma(curHex, step.getElevation(), entity, this);
                 }
-                ServerHelper.checkEnteringMagma(curHex, step.getElevation(), entity, curPos, this);
             }
 
             // check for last move ending in magma TODO: build report for end of move
@@ -8450,7 +8450,7 @@ public class GameManager implements IGameManager {
             // Don't interact with terrain when jumping onto a building or a bridge
             if (entity.getElevation() == 0) {
                 ServerHelper.checkAndApplyMagmaCrust(curHex, entity.getElevation(), entity, curPos, true, vPhaseReport, this);
-                ServerHelper.checkEnteringMagma(curHex, entity.getElevation(), entity, curPos, this);
+                ServerHelper.checkEnteringMagma(curHex, entity.getElevation(), entity, this);
 
                 // jumped into swamp? maybe stuck!
                 if (curHex.getBogDownModifier(entity.getMovementMode(),
@@ -12072,7 +12072,7 @@ public class GameManager implements IGameManager {
         }
 
         ServerHelper.checkAndApplyMagmaCrust(destHex, entity.getElevation(), entity, dest, false, vPhaseReport, this);
-        ServerHelper.checkEnteringMagma(destHex, entity.getElevation(), entity, dest, this);
+        ServerHelper.checkEnteringMagma(destHex, entity.getElevation(), entity, this);
 
         Entity violation = Compute.stackingViolation(game, entity.getId(), dest);
         if (violation == null) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -4921,6 +4921,7 @@ public class GameManager implements IGameManager {
             // note that this must sequentially occur before the next 'entering liquid magma' check
             // otherwise, magma crust won't have a chance to break
             ServerHelper.checkAndApplyMagmaCrust(nextHex, nextElevation, entity, curPos, false, vPhaseReport, this);
+            ServerHelper.checkEnteringMagma(nextHex, nextElevation, entity, curPos, this);
 
             // is the next hex a swamp?
             PilotingRollData rollTarget = entity.checkBogDown(step, moveType, nextHex, curPos, nextPos,
@@ -7294,6 +7295,7 @@ public class GameManager implements IGameManager {
             // check for breaking magma crust unless we are jumping over the hex
             if (stepMoveType != EntityMovementType.MOVE_JUMP) {
                 ServerHelper.checkAndApplyMagmaCrust(curHex, step.getElevation(), entity, curPos, false, vPhaseReport, this);
+                ServerHelper.checkEnteringMagma(curHex, step.getElevation(), entity, curPos, this);
             }
 
             // check if we've moved into a swamp
@@ -8431,6 +8433,7 @@ public class GameManager implements IGameManager {
             // Don't interact with terrain when jumping onto a building or a bridge
             if (entity.getElevation() == 0) {
                 ServerHelper.checkAndApplyMagmaCrust(curHex, entity.getElevation(), entity, curPos, true, vPhaseReport, this);
+                ServerHelper.checkEnteringMagma(curHex, entity.getElevation(), entity, curPos, this);
 
                 // jumped into swamp? maybe stuck!
                 if (curHex.getBogDownModifier(entity.getMovementMode(),
@@ -12052,6 +12055,7 @@ public class GameManager implements IGameManager {
         }
 
         ServerHelper.checkAndApplyMagmaCrust(destHex, entity.getElevation(), entity, dest, false, vPhaseReport, this);
+        ServerHelper.checkEnteringMagma(destHex, entity.getElevation(), entity, dest, this);
 
         Entity violation = Compute.stackingViolation(game, entity.getId(), dest);
         if (violation == null) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -7294,7 +7294,9 @@ public class GameManager implements IGameManager {
 
             // check for breaking magma crust unless we are jumping over the hex
             if (stepMoveType != EntityMovementType.MOVE_JUMP) {
-                ServerHelper.checkAndApplyMagmaCrust(curHex, step.getElevation(), entity, curPos, false, vPhaseReport, this);
+                if (!curPos.equals(lastPos)) {
+                    ServerHelper.checkAndApplyMagmaCrust(curHex, step.getElevation(), entity, curPos, false, vPhaseReport, this);
+                }
                 ServerHelper.checkEnteringMagma(curHex, step.getElevation(), entity, curPos, this);
             }
 

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -445,9 +445,21 @@ public class ServerHelper {
                 hex.addTerrain(new Terrain(Terrains.MAGMA, 2));
                 gameManager.sendChangedHex(curPos);
                 for (Entity en : entity.getGame().getEntitiesVector(curPos)) {
-                    gameManager.doMagmaDamage(en, false);
+                    if (en != entity) {
+                        gameManager.doMagmaDamage(en, false);
+                    }
                 }
             }
+        }
+    }
+
+    /**
+     * Check for movement into magma hex and apply damage. TODO: If first and last step are in magma double it.
+     */
+    public static void checkEnteringMagma(Hex hex, int elevation, Entity entity, Coords curPos, GameManager gameManager) {
+
+        if ((hex.terrainLevel(Terrains.MAGMA) == 2) && (elevation == 0) && (entity.getMovementMode() != EntityMovementMode.HOVER)) {
+            gameManager.doMagmaDamage(entity, false);
         }
     }
 

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -454,7 +454,7 @@ public class ServerHelper {
     }
 
     /**
-     * Check for movement into magma hex and apply damage. TODO: If first and last step are in magma double it.
+     * Check for movement into magma hex and apply damage.
      */
     public static void checkEnteringMagma(Hex hex, int elevation, Entity entity, GameManager gameManager) {
 

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -456,7 +456,7 @@ public class ServerHelper {
     /**
      * Check for movement into magma hex and apply damage. TODO: If first and last step are in magma double it.
      */
-    public static void checkEnteringMagma(Hex hex, int elevation, Entity entity, Coords curPos, GameManager gameManager) {
+    public static void checkEnteringMagma(Hex hex, int elevation, Entity entity, GameManager gameManager) {
 
         if ((hex.terrainLevel(Terrains.MAGMA) == 2) && (elevation == 0) && (entity.getMovementMode() != EntityMovementMode.HOVER)) {
             gameManager.doMagmaDamage(entity, false);


### PR DESCRIPTION
From the original report, A is fixed. Magma crust breaking will only get checked per hex, not per moveStep. The popup showed the correct number but processMovement did not know this rule. In fact in testing this, this has been a bug since at least 0.47 and possibly before.

Per rules on p34/35 TO:AR damage should be applied if a mech starts its turn in magma, walks into a magma hex, or breaks a crust hex. Additionally, if a unit starts and ends its turn in a magma hex it should take additional damage.

TODO: units starting and ending their movement in a magma hex should take additional damage
units walking into a magma hex should not make a bog down check. RAW only mention jumping into the hex needing a bog down roll.