### PR TITLE
Fixes #2842 Thin snow increasing ground MP cost for Battle Armor

### DIFF
--- a/megamek/src/megamek/common/Terrain.java
+++ b/megamek/src/megamek/common/Terrain.java
@@ -440,8 +440,10 @@ public class Terrain implements Serializable {
                     }
                     return 1;
                 }
-                if ((moveMode == EntityMovementMode.WHEELED) || (moveMode == EntityMovementMode.INF_JUMP)
-                        || (moveMode == EntityMovementMode.INF_LEG) || (moveMode == EntityMovementMode.INF_MOTORIZED)) {
+                if ((moveMode == EntityMovementMode.WHEELED) || (e.isConventionalInfantry() &&
+                        ((moveMode == EntityMovementMode.INF_JUMP)
+                          || (moveMode == EntityMovementMode.INF_LEG)
+                          || (moveMode == EntityMovementMode.INF_MOTORIZED)))) {
                     return 1;
                 }
                 return 0;


### PR DESCRIPTION
Added check isConventionalInfantry() since BA are a type of infantry and left the move types since Mechanized Hover and Tracked infantry should not be affected.