### PR TITLE
RFE add search functionality to the mini report dialog

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1898,6 +1898,8 @@ MiniReportDisplay.Destroyed=Destroyed
 MiniReportDisplay.title=Round Report
 MiniReportDisplay.Round=Round
 MiniReportDisplay.Phase=Phase
+MiniReportDisplay.ArrowUp=\u25B2
+MiniReportDisplay.ArrowDown=\u25BC
 
 #Assorted Movement Phase Display Text for buttons, nags, dialogs...
 MovementDisplay.AbandonDialog.message=Do you want to abandon this unit?

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1895,6 +1895,7 @@ Minimap.TotalHeightLabel=T
 #Mini round report display
 MiniReportDisplay.Damage=Damage
 MiniReportDisplay.Destroyed=Destroyed
+MiniReportDisplay.Details=Details
 MiniReportDisplay.title=Round Report
 MiniReportDisplay.Round=Round
 MiniReportDisplay.Phase=Phase

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1893,6 +1893,8 @@ Minimap.NoHeightLabel=N
 Minimap.TotalHeightLabel=T
 
 #Mini round report display
+MiniReportDisplay.Damage=Damage
+MiniReportDisplay.Destroyed=Destroyed
 MiniReportDisplay.title=Round Report
 MiniReportDisplay.Round=Round
 MiniReportDisplay.Phase=Phase

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -636,7 +636,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
     private void showRoundReport() {
         ignoreHotKeys = true;
         if (miniReportDisplay == null) {
-            miniReportDisplay = new MiniReportDisplay(frame, client);
+            miniReportDisplay = new MiniReportDisplay(frame, this);
         }
 
         miniReportDisplay.setVisible(true);

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -16,33 +16,48 @@ package megamek.client.ui.swing;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.BASE64ToolKit;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.Player;
+import megamek.common.Entity;
 import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
 
 import javax.swing.*;
+import javax.swing.text.Document;
 import javax.swing.text.html.HTMLEditorKit;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
+import java.util.Iterator;
 
 /**
  * Shows reports, with an Okay JButton
  */
 public class MiniReportDisplay extends JDialog implements ActionListener {
     private JButton butOkay;
+    private JButton butPlayerSearchUp;
+    private JButton butPlayerSearchDown;
+    private JButton butEntitySearchUp;
+    private JButton butEntitySearchDown;
+    private JButton butQuickSearchUp;
+    private JButton butQuickSearchDown;
+    private JComboBox<String> comboPlayer = new JComboBox<>();
+    private JComboBox<String> comboEntity = new JComboBox<>();
+    private JComboBox<String> comboQuick = new JComboBox<>();
     private Client currentClient;
     private JTabbedPane tabs;
 
-    private static final String MRD_TITLE = Messages.getString("MiniReportDisplay.title");
-    private static final String MRD_ROUND = Messages.getString("MiniReportDisplay.Round");
-    private static final String MRD_PHASE = Messages.getString("MiniReportDisplay.Phase");
-    private static final String MRD_OKAY= Messages.getString("Okay");
+    private static final String MSG_TITLE = Messages.getString("MiniReportDisplay.title");
+    private static final String MSG_ROUND = Messages.getString("MiniReportDisplay.Round");
+    private static final String MSG_PHASE = Messages.getString("MiniReportDisplay.Phase");
+    private static final String MSG_DAMAGE = Messages.getString("MiniReportDisplay.Damage");
+    private static final String MSG_DESTROYED = Messages.getString("MiniReportDisplay.Destroyed");
+    private static final String MSG_OKAY= Messages.getString("Okay");
+
+    private static final int MRD_MAXNAMELENGHT = 60;
 
     public MiniReportDisplay(JFrame parent, Client client) {
-        super(parent, MRD_TITLE, false);
+        super(parent, MSG_TITLE, false);
 
         if (client == null) {
             return;
@@ -51,12 +66,38 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         currentClient = client;
         currentClient.getGame().addGameListener(gameListener);
 
-        butOkay = new JButton(MRD_OKAY);
+        butOkay = new JButton(MSG_OKAY);
         butOkay.addActionListener(this);
-        
-        getContentPane().setLayout(new BorderLayout());
 
-        getContentPane().add(BorderLayout.SOUTH, butOkay);
+        butPlayerSearchUp = new JButton("\u25B2");
+        butPlayerSearchUp.addActionListener(this);
+        butPlayerSearchDown = new JButton("\u25BC");
+        butPlayerSearchDown.addActionListener(this);
+        butEntitySearchUp = new JButton("\u25B2");
+        butEntitySearchUp.addActionListener(this);
+        butEntitySearchDown = new JButton("\u25BC");
+        butEntitySearchDown.addActionListener(this);
+        butQuickSearchUp = new JButton("\u25B2");
+        butQuickSearchUp.addActionListener(this);
+        butQuickSearchDown = new JButton("\u25BC");
+        butQuickSearchDown.addActionListener(this);
+
+        setLayout(new BorderLayout());
+
+        JPanel p = new JPanel();
+        p.add(BorderLayout.EAST, comboPlayer);
+        p.add(BorderLayout.EAST, butPlayerSearchUp);
+        p.add(BorderLayout.EAST, butPlayerSearchDown);
+        p.add(BorderLayout.EAST, comboEntity);
+        p.add(BorderLayout.EAST, butEntitySearchUp);
+        p.add(BorderLayout.EAST, butEntitySearchDown);
+        p.add(BorderLayout.EAST, comboQuick);
+        p.add(BorderLayout.EAST, butQuickSearchUp);
+        p.add(BorderLayout.EAST, butQuickSearchDown);
+
+        p.add(BorderLayout.WEST, butOkay);
+        JScrollPane sp = new JScrollPane(p);
+        add(BorderLayout.SOUTH, sp);
         
         setupReportTabs();
                 
@@ -72,16 +113,156 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
             public void windowClosing(WindowEvent e) {
                 actionPerformed(new ActionEvent(butOkay,
                         ActionEvent.ACTION_PERFORMED, butOkay.getText()));
+
             }
         });
 
         butOkay.requestFocus();
     }
 
+    private void searchTextPane(String searchPattern, Boolean searchDown) {
+        Component selCom = tabs.getSelectedComponent();
+        searchPattern = searchPattern.toUpperCase();
+
+        if (selCom instanceof JScrollPane
+                && ((JScrollPane) selCom).getViewport().getView() instanceof JComponent) {
+            for (Component comp : ((JScrollPane) selCom).getViewport().getComponents()) {
+                JScrollPane sp =(JScrollPane) selCom;
+
+                if (comp instanceof JTextPane) {
+                    try {
+                        JTextPane textPane = (JTextPane) comp;
+                        Document doc = textPane.getDocument();
+                        String text = doc.getText(0, doc.getLength());
+                        int currentPos = textPane.getCaretPosition();
+
+                        if (currentPos > text.length() - searchPattern.length()) {
+                            textPane.setCaretPosition(0);
+                            currentPos = 0;
+                        }
+
+                        int newPos = UIUtil.findPattern(text, searchPattern, currentPos, searchDown);
+
+                        if (newPos != -1) {
+                            textPane.setCaretPosition(newPos);
+                            textPane.moveCaretPosition(newPos + searchPattern.length());
+                            textPane.getCaret().setSelectionVisible(true);
+                        }
+                    } catch (Exception e) {
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    private void updatePlayerChoice() {
+        String lastChoice = (String) comboPlayer.getSelectedItem();
+        lastChoice = (lastChoice != null ? lastChoice : currentClient.getName());
+        comboPlayer.removeAllItems();
+        comboPlayer.setEnabled(true);
+        for (Player player  : currentClient.getGame().getPlayersVectorSorted()) {
+            String playerDisplay = String.format("%-12s", player.getName());
+            comboPlayer.addItem(playerDisplay);
+        }
+        if (comboPlayer.getItemCount() == 1) {
+            comboPlayer.setEnabled(false);
+        }
+        comboPlayer.setSelectedItem(lastChoice);
+        if (comboPlayer.getSelectedIndex() < 0) {
+            comboPlayer.setSelectedIndex(0);
+        }
+    }
+
+    private String addEntity(JComboBox comboBox, String name) {
+        boolean found = false;
+        int len = (name.length() < MRD_MAXNAMELENGHT ? name.length() : MRD_MAXNAMELENGHT);
+        String displayNane = String.format("%-12s", name).substring(0, len);
+        found = false;
+        for (int i = 0; i < comboBox.getItemCount(); i++) {
+            if (comboBox.getItemAt(i).equals(displayNane)) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            comboBox.addItem(displayNane);
+        }
+        return displayNane;
+    }
+
+    private void updateEntityChoice() {
+        String lastChoice = (String) comboEntity.getSelectedItem();
+        comboEntity.removeAllItems();
+        comboEntity.setEnabled(true);
+        String displayNane = "";
+        for (Iterator<Entity> ents = currentClient.getGame().getEntities(); ents.hasNext();) {
+            Entity entity = ents.next();
+            if (entity.getOwner().equals(currentClient.getLocalPlayer())) {
+                displayNane =addEntity(comboEntity, entity.getShortName());
+            }
+        }
+        lastChoice = (lastChoice != null ? lastChoice : displayNane);
+        if (comboEntity.getItemCount() == 1) {
+            comboEntity.setEnabled(false);
+        }
+        comboEntity.setSelectedItem(lastChoice);
+        comboEntity.setSelectedItem(lastChoice);
+        if (comboEntity.getSelectedIndex() < 0) {
+            comboEntity.setSelectedIndex(0);
+        }
+    }
+
+    private void updateQuickChoice() {
+        String lastChoice = (String) comboQuick.getSelectedItem();
+        lastChoice = (lastChoice != null ? lastChoice : MSG_DAMAGE);
+        comboQuick.removeAllItems();
+        comboQuick.setEnabled(true);
+        comboQuick.addItem(MSG_DAMAGE);
+        comboQuick.addItem(MSG_DESTROYED);
+        comboQuick.addItem(MSG_PHASE);
+        if (comboQuick.getItemCount() == 1) {
+            comboQuick.setEnabled(false);
+        }
+        comboQuick.setSelectedItem(lastChoice);
+        if (comboQuick.getSelectedIndex() < 0) {
+            comboQuick.setSelectedIndex(0);
+        }
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        if (visible) {
+            updatePlayerChoice();
+            updateEntityChoice();
+            updateQuickChoice();
+        }
+        super.setVisible(visible);
+    }
+
     @Override
     public void actionPerformed(ActionEvent ae) {
         if (ae.getSource().equals(butOkay)) {
             savePrefHide();
+        } else if (ae.getSource().equals(butPlayerSearchDown)) {
+            String searchPattern = comboPlayer.getSelectedItem().toString().trim();
+            searchTextPane(searchPattern, true);
+        } else if (ae.getSource().equals(butPlayerSearchUp)) {
+            String searchPattern = comboPlayer.getSelectedItem().toString().trim();
+            searchTextPane(searchPattern, false);
+        } else if (ae.getSource().equals(butEntitySearchDown)) {
+            String searchPattern = comboEntity.getSelectedItem().toString().trim();
+            searchTextPane(searchPattern, true);
+        } else if (ae.getSource().equals(butEntitySearchUp)) {
+            String searchPattern = comboEntity.getSelectedItem().toString().trim();
+            searchTextPane(searchPattern,false);
+        } else if (ae.getSource().equals(butQuickSearchDown)) {
+            String searchPattern = comboQuick.getSelectedItem().toString().trim();
+            searchTextPane(searchPattern, true);
+        } else if (ae.getSource().equals(butQuickSearchUp)) {
+            String searchPattern = comboQuick.getSelectedItem().toString().trim();
+            searchTextPane(searchPattern,false);
         }
     }
 
@@ -90,7 +271,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
 
         addReportPages();
         
-        getContentPane().add(BorderLayout.CENTER, tabs);
+        add(BorderLayout.CENTER, tabs);
     }
 
     public static void setupStylesheet(JTextPane pane) {
@@ -122,7 +303,9 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
             ta.setText("<pre>" + text + "</pre>");
             ta.setEditable(false);
             ta.setOpaque(false);
-            tabs.add(MRD_ROUND + " " + round, new JScrollPane(ta));
+            ta.setCaretPosition(0);
+            JScrollPane sp = new JScrollPane(ta);
+            tabs.add(MSG_ROUND + " " + round, sp);
         }
 
         // add the new current phase tab
@@ -133,9 +316,10 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         ta.setText("<pre>" + currentClient.phaseReport + "</pre>");
         ta.setEditable(false);
         ta.setOpaque(false);
+        ta.setCaretPosition(0);
 
         JScrollPane sp = new JScrollPane(ta);
-        tabs.add(MRD_PHASE, sp);
+        tabs.add(MSG_PHASE, sp);
 
         tabs.setSelectedIndex(tabs.getTabCount() - 1);
     }
@@ -150,6 +334,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                 default:
                     if (!e.getNewPhase().equals((e.getOldPhase()))) {
                         addReportPages();
+                        updateEntityChoice();
                     }
             }
         }

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -25,7 +25,6 @@ import megamek.common.event.GamePhaseChangeEvent;
 
 import javax.swing.*;
 import javax.swing.text.Document;
-import javax.swing.text.Utilities;
 import javax.swing.text.html.HTMLEditorKit;
 import java.awt.*;
 import java.awt.event.*;
@@ -53,6 +52,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     private static final String MSG_PHASE = Messages.getString("MiniReportDisplay.Phase");
     private static final String MSG_DAMAGE = Messages.getString("MiniReportDisplay.Damage");
     private static final String MSG_DESTROYED = Messages.getString("MiniReportDisplay.Destroyed");
+    private static final String MSG_ARROWUP = Messages.getString("MiniReportDisplay.ArrowUp");
+    private static final String MSG_ARROWDOWN = Messages.getString("MiniReportDisplay.ArrowDown");
     private static final String MSG_OKAY= Messages.getString("Okay");
 
     private static final int MRD_MAXNAMELENGHT = 60;
@@ -70,17 +71,17 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         butOkay = new JButton(MSG_OKAY);
         butOkay.addActionListener(this);
 
-        butPlayerSearchUp = new JButton("\u25B2");
+        butPlayerSearchUp = new JButton(MSG_ARROWUP);
         butPlayerSearchUp.addActionListener(this);
-        butPlayerSearchDown = new JButton("\u25BC");
+        butPlayerSearchDown = new JButton(MSG_ARROWDOWN);
         butPlayerSearchDown.addActionListener(this);
-        butEntitySearchUp = new JButton("\u25B2");
+        butEntitySearchUp = new JButton(MSG_ARROWUP);
         butEntitySearchUp.addActionListener(this);
-        butEntitySearchDown = new JButton("\u25BC");
+        butEntitySearchDown = new JButton(MSG_ARROWDOWN);
         butEntitySearchDown.addActionListener(this);
-        butQuickSearchUp = new JButton("\u25B2");
+        butQuickSearchUp = new JButton(MSG_ARROWUP);
         butQuickSearchUp.addActionListener(this);
-        butQuickSearchDown = new JButton("\u25BC");
+        butQuickSearchDown = new JButton(MSG_ARROWDOWN);
         butQuickSearchDown.addActionListener(this);
 
         setLayout(new BorderLayout());
@@ -131,8 +132,6 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                 && ((JScrollPane) selCom).getViewport().getView() instanceof JComponent) {
             JViewport v = ((JScrollPane) selCom).getViewport();
             for (Component comp : v.getComponents()) {
-                JScrollPane sp =(JScrollPane) selCom;
-
                 if (comp instanceof JTextPane) {
                     try {
                         JTextPane textPane = (JTextPane) comp;

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -70,7 +70,6 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
 
         butOkay = new JButton(MSG_OKAY);
         butOkay.addActionListener(this);
-
         butPlayerSearchUp = new JButton(MSG_ARROWUP);
         butPlayerSearchUp.addActionListener(this);
         butPlayerSearchDown = new JButton(MSG_ARROWDOWN);

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -133,7 +133,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                     try {
                         JTextPane textPane = (JTextPane) comp;
                         Document doc = textPane.getDocument();
-                        String text = doc.getText(0, doc.getLength());
+                        String text = doc.getText(0, doc.getLength()).toUpperCase();
                         int currentPos = textPane.getCaretPosition();
 
                         if (currentPos > text.length() - searchPattern.length()) {
@@ -141,7 +141,23 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                             currentPos = 0;
                         }
 
-                        int newPos = UIUtil.findPattern(text, searchPattern, currentPos, searchDown);
+                        int newPos = -1;
+
+                        if (searchDown){
+                            newPos = text.indexOf(searchPattern, currentPos);
+
+                            if (newPos == -1) {
+                                newPos = text.indexOf(searchPattern, 0);
+                            }
+
+                        }
+                        else {
+                            newPos = text.lastIndexOf(searchPattern, currentPos-searchPattern.length()-1);
+
+                            if (newPos == -1) {
+                                newPos = text.lastIndexOf(searchPattern, text.length()-searchPattern.length()-1);
+                            }
+                        }
 
                         if (newPos != -1) {
                             Rectangle r = (Rectangle) textPane.modelToView2D(newPos);
@@ -247,7 +263,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent ae) {
         if (ae.getSource().equals(butOkay)) {
-            savePrefHide();
+            savePref();
+            setVisible(false);
         } else if (ae.getSource().equals(butPlayerSearchDown)) {
             String searchPattern = comboPlayer.getSelectedItem().toString().trim();
             searchTextPane(searchPattern, true);
@@ -273,7 +290,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
     protected void processWindowEvent(WindowEvent e) {
         super.processWindowEvent(e);
         if ((e.getID() == WindowEvent.WINDOW_DEACTIVATED) || (e.getID() == WindowEvent.WINDOW_CLOSING)) {
-            savePrefHide();
+            savePref();
         }
     }
 
@@ -293,12 +310,11 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                         + "; font-size: 12pt; font-style:normal;}");
     }
 
-    private void savePrefHide() {
+    private void savePref() {
         GUIPreferences.getInstance().setMiniReportSizeWidth(getSize().width);
         GUIPreferences.getInstance().setMiniReportSizeHeight(getSize().height);
         GUIPreferences.getInstance().setMiniReportPosX(getLocation().x);
         GUIPreferences.getInstance().setMiniReportPosY(getLocation().y);
-        setVisible(false);
     }
 
     public void addReportPages() {
@@ -340,7 +356,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         public void gamePhaseChange(GamePhaseChangeEvent e) {
             switch (e.getOldPhase()) {
                 case VICTORY:
-                    savePrefHide();
+                    savePref();
+                    setVisible(false);
                     break;
                 default:
                     if (!e.getNewPhase().equals((e.getOldPhase()))) {

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -25,6 +25,7 @@ import megamek.common.event.GamePhaseChangeEvent;
 
 import javax.swing.*;
 import javax.swing.text.Document;
+import javax.swing.text.Utilities;
 import javax.swing.text.html.HTMLEditorKit;
 import java.awt.*;
 import java.awt.event.*;
@@ -113,12 +114,14 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
             public void windowClosing(WindowEvent e) {
                 actionPerformed(new ActionEvent(butOkay,
                         ActionEvent.ACTION_PERFORMED, butOkay.getText()));
-
             }
         });
 
         butOkay.requestFocus();
     }
+
+
+
 
     private void searchTextPane(String searchPattern, Boolean searchDown) {
         Component selCom = tabs.getSelectedComponent();
@@ -126,7 +129,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
 
         if (selCom instanceof JScrollPane
                 && ((JScrollPane) selCom).getViewport().getView() instanceof JComponent) {
-            for (Component comp : ((JScrollPane) selCom).getViewport().getComponents()) {
+            JViewport v = ((JScrollPane) selCom).getViewport();
+            for (Component comp : v.getComponents()) {
                 JScrollPane sp =(JScrollPane) selCom;
 
                 if (comp instanceof JTextPane) {
@@ -144,6 +148,9 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                         int newPos = UIUtil.findPattern(text, searchPattern, currentPos, searchDown);
 
                         if (newPos != -1) {
+                            Rectangle r = (Rectangle) textPane.modelToView2D(newPos);
+                            int y = UIUtil.calculateCenter(v.getExtentSize().height, v.getViewSize().height, r.height, r.y);
+                            v.setViewPosition(new Point(0,y));
                             textPane.setCaretPosition(newPos);
                             textPane.moveCaretPosition(newPos + searchPattern.length());
                             textPane.getCaret().setSelectionVisible(true);

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -121,9 +121,6 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         butOkay.requestFocus();
     }
 
-
-
-
     private void searchTextPane(String searchPattern, Boolean searchDown) {
         Component selCom = tabs.getSelectedComponent();
         searchPattern = searchPattern.toUpperCase();
@@ -272,6 +269,14 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
         }
     }
 
+    @Override
+    protected void processWindowEvent(WindowEvent e) {
+        super.processWindowEvent(e);
+        if ((e.getID() == WindowEvent.WINDOW_DEACTIVATED) || (e.getID() == WindowEvent.WINDOW_CLOSING)) {
+            savePrefHide();
+        }
+    }
+
     private void setupReportTabs() {
         tabs = new JTabbedPane();
 
@@ -340,6 +345,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener {
                 default:
                     if (!e.getNewPhase().equals((e.getOldPhase()))) {
                         addReportPages();
+                        updatePlayerChoice();
                         updateEntityChoice();
                     }
             }

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -1187,4 +1187,54 @@ public final class UIUtil {
         window.setLocation(location);
         window.setSize(size);
     }
+
+    /**
+     * search for searchPattern in text starting from startPos in direction searchDown
+     * if search hits text start or end wrap until hit startPos
+     * return the position of the match if found
+     * return -1 if not found
+     */
+    public static int findPattern (String text, String searchPattern, int startPos, boolean searchDown) {
+        boolean found = false;
+        int len = text.length() - searchPattern.length();
+        int currentPos = 0;
+        if (searchDown) {
+            currentPos = startPos + 1;
+        }
+        else {
+            currentPos = startPos - searchPattern.length() - 1;
+
+            if (currentPos < 1) {
+                currentPos = len;
+            }
+        }
+
+        while (startPos != currentPos) {
+            String match = text.substring(currentPos, currentPos + searchPattern.length());
+            if (searchPattern.equalsIgnoreCase(match)) {
+                found = true;
+                break;
+            }
+
+            if (searchDown) {
+                currentPos++;
+                if (currentPos > len) {
+                    currentPos = 0;
+                }
+            }
+            else {
+                currentPos--;
+                if (startPos == currentPos) {
+                    break;
+                }
+                if (currentPos < 1) {
+                    currentPos = len;
+                }
+            }
+        }
+        if (found) {
+            return currentPos;
+        }
+        return -1;
+    }
 }

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -1188,56 +1188,6 @@ public final class UIUtil {
         window.setSize(size);
     }
 
-    /**
-     * search for searchPattern in text starting from startPos in direction searchDown
-     * if search hits text start or end wrap until hit startPos
-     * return the position of the match if found
-     * return -1 if not found
-     */
-    public static int findPattern (String text, String searchPattern, int startPos, boolean searchDown) {
-        boolean found = false;
-        int len = text.length() - searchPattern.length();
-        int currentPos = 0;
-        if (searchDown) {
-            currentPos = startPos + 1;
-        }
-        else {
-            currentPos = startPos - searchPattern.length() - 1;
-
-            if (currentPos < 1) {
-                currentPos = len;
-            }
-        }
-
-        while (startPos != currentPos) {
-            String match = text.substring(currentPos, currentPos + searchPattern.length());
-            if (searchPattern.equalsIgnoreCase(match)) {
-                found = true;
-                break;
-            }
-
-            if (searchDown) {
-                currentPos++;
-                if (currentPos > len) {
-                    currentPos = 0;
-                }
-            }
-            else {
-                currentPos--;
-                if (startPos == currentPos) {
-                    break;
-                }
-                if (currentPos < 1) {
-                    currentPos = len;
-                }
-            }
-        }
-        if (found) {
-            return currentPos;
-        }
-        return -1;
-    }
-
     /*
     * Calculates center of view port for a given point
      */

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -1237,4 +1237,13 @@ public final class UIUtil {
         }
         return -1;
     }
+
+    /*
+    * Calculates center of view port for a given point
+     */
+    public static int calculateCenter(int vh, int h, int th, int y) {
+        y = Math.max(0, y - ((vh - th)/2));
+        y = Math.min(y, h - vh);
+        return y;
+    }
 }


### PR DESCRIPTION
RFE #4003 add search functionality to the mini report dialog

Edit: Fixes #4003 

search through the currently selected report tab based on the chosen options

search by players
search by owned units
search by keyword

![image](https://user-images.githubusercontent.com/116095479/203855237-0caa0dd1-659a-458e-9478-5b6bfaff4342.png)

![image](https://user-images.githubusercontent.com/116095479/203855349-b1bdc488-1ae8-4b48-995d-e440a38c8779.png)
