### PR TITLE
3939: Prevent Null Entities in a Bay's Loaded Units

### DIFF
--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -18,7 +18,9 @@ import megamek.common.enums.GamePhase;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 /**
  * Represents a volume of space set aside for carrying cargo of some sort
@@ -239,17 +241,12 @@ public class Bay implements Transporter, ITechnology {
     @Override
     public Vector<Entity> getLoadedUnits() {
         // Return a copy of our list of troops.
-        Vector<Entity> loaded = new Vector<>();
-        for (int unit : troops) {
-            Entity entity = game.getEntity(unit);
-            
-            if (entity != null) {
-                loaded.add(game.getEntity(unit));
-            }
-        }
-        return loaded;
+        return troops.stream()
+                .map(unit -> game.getEntity(unit))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(Vector::new));
     }
-    
+
     /**
      * Generate a raw list of the Ids stored in troops. 
      * Used by MHQ in cases where we can't get the entities via Game


### PR DESCRIPTION
This fixes #3939 