### PR TITLE
fix missing toHitText

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -185,8 +185,9 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
     }
 
     private void updatePlayerChoice() {
+        String name = String.format("%-12s", currentClient.getName());
         String lastChoice = (String) comboPlayer.getSelectedItem();
-        lastChoice = (lastChoice != null ? lastChoice : currentClient.getName());
+        lastChoice = (lastChoice != null ? lastChoice : name);
         comboPlayer.removeAllItems();
         comboPlayer.setEnabled(true);
         for (Player player  : currentClient.getGame().getPlayersVectorSorted()) {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -753,7 +753,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         toHitText.setEditable(false);
         toHitText.setLineWrap(true);
         toHitText.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 10));
-        add(toHitText,
+        panelMain.add(toHitText,
             GBC.eol().fill(GridBagConstraints.BOTH)
                .insets(15, 9, 15, 9).gridy(gridy).gridx(0)
                .gridheight(2));


### PR DESCRIPTION
correct issue caused by  #3983 RFE 3982 Scale the Client GUI using the GUI scale

the text area at bottom was missed, causing it to not show.

![image](https://user-images.githubusercontent.com/116095479/204601876-7fdf738a-12e7-4842-b47d-227d1d372f6d.png)
