### PR TITLE
correct issue with target info cleared when switching weapons

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -1479,7 +1479,8 @@ public class TargetingPhaseDisplay extends StatusBarPhaseDisplay implements
             return;
         }
 
-        if (event.getSource().equals(clientgui.getUnitDisplay().wPan.weaponList)) {
+        if ((clientgui.getClient().getGame().getPhase().isTargeting()) &&
+                (event.getSource().equals(clientgui.getUnitDisplay().wPan.weaponList))) {
             // update target data in weapon display
             updateTarget();
         }


### PR DESCRIPTION
#2684

TargetingPhaseDisplay valueChanged was updating the target while in the Firing Phase.  causing the target to be cleared.  

set it to only update when in the targeting phase