### PR TITLE
AS Conversion Errata and corrections

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASSpecialAbilityConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASSpecialAbilityConverter.java
@@ -539,6 +539,11 @@ public class ASSpecialAbilityConverter {
                 }
             }
         }
+
+        // Armor 0 elements cannot get BAR
+        if (element.getFullArmor() == 0) {
+            element.getSpecialAbilities().removeSUA(BAR);
+        }
     }
 
     /** Adds the sua(s) to the element and writes a report line for each, if it is not yet present. */

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarHeavy.java
@@ -14,7 +14,9 @@
 package megamek.common.weapons.battlearmor;
 
 import megamek.common.AmmoType;
+import megamek.common.Mounted;
 import megamek.common.WeaponType;
+import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.weapons.Weapon;
 
 /**
@@ -60,5 +62,21 @@ public class CLBAMortarHeavy extends Weapon {
                 .setClanApproximate(false, false, true, false, false)
                 .setPrototypeFactions(F_FS, F_LC)
                 .setProductionFactions(F_LC);
+    }
+
+    @Override
+    public double getBattleForceDamage(int range, Mounted linked) {
+        if (range <= AlphaStrikeElement.SHORT_RANGE) {
+            return 0.249;
+        } else if (range <= AlphaStrikeElement.MEDIUM_RANGE) {
+            return 0.3;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        return true;
     }
 }

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMortarLight.java
@@ -14,7 +14,9 @@
 package megamek.common.weapons.battlearmor;
 
 import megamek.common.AmmoType;
+import megamek.common.Mounted;
 import megamek.common.WeaponType;
+import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.weapons.Weapon;
 
 /**
@@ -61,5 +63,15 @@ public class CLBAMortarLight extends Weapon {
                 .setClanApproximate(false, false, true, false, false)
                 .setPrototypeFactions(F_FS, F_LC)
                 .setProductionFactions(F_LC);
+    }
+
+    @Override
+    public double getBattleForceDamage(int range, Mounted linked) {
+        return (range <= AlphaStrikeElement.SHORT_RANGE) ? 0.276 : 0;
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        return true;
     }
 }

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarHeavy.java
@@ -14,8 +14,10 @@
 package megamek.common.weapons.battlearmor;
 
 import megamek.common.AmmoType;
+import megamek.common.Mounted;
 import megamek.common.TechAdvancement;
 import megamek.common.WeaponType;
+import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.weapons.Weapon;
 
 /**
@@ -55,4 +57,19 @@ public class ISBAMortarHeavy extends Weapon {
         techAdvancement.setAvailability(RATING_X, RATING_X, RATING_C, RATING_C);
     }
 
+    @Override
+    public double getBattleForceDamage(int range, Mounted linked) {
+        if (range <= AlphaStrikeElement.SHORT_RANGE) {
+            return 0.249;
+        } else if (range <= AlphaStrikeElement.MEDIUM_RANGE) {
+            return 0.3;
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        return true;
+    }
 }

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMortarLight.java
@@ -14,8 +14,10 @@
 package megamek.common.weapons.battlearmor;
 
 import megamek.common.AmmoType;
+import megamek.common.Mounted;
 import megamek.common.TechAdvancement;
 import megamek.common.WeaponType;
+import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.weapons.Weapon;
 
 /**
@@ -52,5 +54,15 @@ public class ISBAMortarLight extends Weapon {
         techAdvancement.setISAdvancement(3049, 3057, 3063);
         techAdvancement.setTechRating(RATING_B);
         techAdvancement.setAvailability(RATING_X, RATING_X, RATING_C, RATING_C);
+    }
+
+    @Override
+    public double getBattleForceDamage(int range, Mounted linked) {
+        return (range <= AlphaStrikeElement.SHORT_RANGE) ? 0.276 : 0;
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        return true;
     }
 }

--- a/megamek/src/megamek/test/ASWeaponDamageList.java
+++ b/megamek/src/megamek/test/ASWeaponDamageList.java
@@ -38,6 +38,7 @@ public class ASWeaponDamageList {
                     &&!(etype instanceof BayWeapon)) {
                 wpLine = new ArrayList<>();
                 wpLine.add(etype.getName());
+                wpLine.add(etype.getInternalName());
                 wpLine.add(etype.isClan()? "-Clan-" : "-IS-");
                 double mult = etype.hasFlag(WeaponType.F_ONESHOT) ? 0.1 : 1;
                 double s = mult * ((WeaponType)etype).getBattleForceDamage(AlphaStrikeElement.SHORT_RANGE, null);


### PR DESCRIPTION
More from https://bg.battletech.com/forums/errata/alpha-strike-companion/msg1881442/#msg1881442
Specifically:
- elements with armor 0 will no longer receive BAR
- added exact damage values for IS/CL BA Light Heavy/Mortar including 0.3 M dmg for heavy; they also now count for IF