### PR TITLE
Remove unnecessary Searchlights checkbox for Meks/Tanks

### DIFF
--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -278,7 +278,8 @@ public class EquipChoicePanel extends JPanel {
         }
 
         // Set up searchlight
-        if (clientgui.getClient().getGame().getPlanetaryConditions().getLight() > PlanetaryConditions.L_DUSK) {
+        if (!entity.getsAutoExternalSearchlight()
+                && (client.getGame().getPlanetaryConditions().getLight() > PlanetaryConditions.L_DUSK)) {
             add(labSearchlight, GBC.std());
             add(chSearchlight, GBC.eol());
             chSearchlight.setSelected(entity.hasSearchlight()
@@ -376,8 +377,10 @@ public class EquipChoicePanel extends JPanel {
         }
 
         // update searchlight setting
-        entity.setExternalSearchlight(chSearchlight.isSelected());
-        entity.setSearchlightState(chSearchlight.isSelected());
+        if (!entity.getsAutoExternalSearchlight()) {
+            entity.setExternalSearchlight(chSearchlight.isSelected());
+            entity.setSearchlightState(chSearchlight.isSelected());
+        }
 
         if (entity.hasC3() && (choC3.getSelectedIndex() > -1)) {
             Entity chosen = client.getEntity(entityCorrespondance[choC3.getSelectedIndex()]);

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15571,4 +15571,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * <P>This method does nothing by default and must be overridden for unit types that get Clan CASE.
      */
     public void addClanCase() { }
+
+    /** @return True for unit types that have an automatic external searchlight (Meks and Tanks). */
+    public boolean getsAutoExternalSearchlight() {
+        return false;
+    }
 }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -6534,4 +6534,9 @@ public abstract class Mech extends Entity {
     public int getSpriteDrawPriority() {
         return 6;
     }
+
+    @Override
+    public boolean getsAutoExternalSearchlight() {
+        return true;
+    }
 }

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -3035,5 +3035,9 @@ public class Tank extends Entity {
         }
         return false;
     }
-    
+
+    @Override
+    public boolean getsAutoExternalSearchlight() {
+        return true;
+    }
 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -2057,8 +2057,7 @@ public class GameManager implements IGameManager {
                     a.setSI(currentSI);
                 }
             }
-            // Give the unit a spotlight, if it has the spotlight quirk
-            if (entity instanceof Mech || entity instanceof Tank) {
+            if (entity.getsAutoExternalSearchlight()) {
                 entity.setExternalSearchlight(true);
             }
             entityUpdate(entity.getId());


### PR DESCRIPTION
Removes the unnecessary Searchlights checkbox for Meks/Tanks in the lobby unit customization. This one:

![image](https://user-images.githubusercontent.com/59574316/172970463-d899daf4-ea55-47e7-a608-4428b0634802.png)

Fixes #3709 