### PR TITLE
correct Infantry victory report formatting

### DIFF
--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -723,15 +723,12 @@ public class Infantry extends Entity {
     public Vector<Report> victoryReport() {
         Vector<Report> vDesc = new Vector<>();
 
-        Report r = new Report(7025);
-        r.type = Report.PUBLIC;
+        Report r = new Report(7025, Report.PUBLIC);
         r.addDesc(this);
         vDesc.addElement(r);
 
-        r = new Report(7041);
-        r.type = Report.PUBLIC;
+        r = new Report(7041, Report.PUBLIC);
         r.add(getCrew().getGunnery());
-        r.newlines = 0;
         vDesc.addElement(r);
 
         r = new Report(7070, Report.PUBLIC);


### PR DESCRIPTION
Fixes #3811 by adding a newline to the Infantry (and BA) victory report. In the code this is done by removing line 734, r.newlines=0. 

![image](https://user-images.githubusercontent.com/17069663/206877595-190e74bb-fd77-4710-aa0b-654768d77581.png)
