### PR TITLE
AS Damage conversion: Sponson and Pintle turrets do not count for TUR

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASLocationMapper.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASLocationMapper.java
@@ -57,9 +57,6 @@ public class ASLocationMapper {
     public static double damageLocationMultiplier(Entity en, int loc, Mounted mount) {
         if (locationName(en, loc).startsWith("TUR") && (en instanceof Mech) && mount.isMechTurretMounted()) {
             return 1;
-        } else if (locationName(en, loc).startsWith("TUR") && (en instanceof Tank)
-                && (mount.isPintleTurretMounted() || mount.isSponsonTurretMounted())) {
-            return 1;
         } else if (en instanceof Warship) {
             return getWarShipLocationMultiplier(loc, mount.getLocation());
         } else if (en instanceof Jumpship) {


### PR DESCRIPTION
A correction to AS conversion, removing ST and PT-mounted weapons from TUR. Interestingly this only removes code.