### PR TITLE
AS Conversion: Booby Traps count as explosive

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASSpecialAbilityConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASSpecialAbilityConverter.java
@@ -471,6 +471,10 @@ public class ASSpecialAbilityConverter {
         if ((equipment.getType() instanceof MiscType) && equipment.getType().hasFlag(F_BOMB_BAY)) {
             return true;
         }
+        // According to ASC p.123 Booby Traps count as explosive contrary to TO AUE p.109
+        if ((equipment.getType() instanceof MiscType) && equipment.getType().hasFlag(F_BOOBY_TRAP)) {
+            return true;
+        }
         // Oneshot weapons internally have normal ammo allocated to them which must
         // be disqualified as explosive; such ammo has no location
         return equipment.getType().isExplosive(null) && (equipment.getExplosionDamage() > 0)


### PR DESCRIPTION
According to ASC p.123 booby traps prevent ENE, even tho in TW they're not explosive. 