### PR TITLE
report keywords managed in client settings

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1947,7 +1947,6 @@ Minimap.TotalHeightLabel=T
 
 #Mini round report display
 MiniReportDisplay.Damage=Damage
-MiniReportDisplay.Destroyed=Destroyed
 MiniReportDisplay.Details=Details
 MiniReportDisplay.title=Round Report
 MiniReportDisplay.Round=Round

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1040,6 +1040,7 @@ CommonSettingsDialog.nagForPSR=Confirm all movement that requires a PSR.
 CommonSettingsDialog.nagForWiGELanding=Confirm when WiGE does not move far enough to remain airborne.
 CommonSettingsDialog.pathFiderTimeLimit=Pathfinder time limit (milliseconds):
 CommonSettingsDialog.protoMechUnitCodes=ProtoMech unit codes:
+CommonSettingsDialog.ReportKeywords=Report Keywords
 CommonSettingsDialog.rightDragScroll=By right-clicking on the map and dragging.
 CommonSettingsDialog.scrollSensitivity=Scroll sensitivity:
 CommonSettingsDialog.showDamageLevel=Show damage to units on the unit label

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -160,7 +160,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
     private final JCheckBox showUnitId = new JCheckBox(Messages.getString("CommonSettingsDialog.showUnitId"));
     private JComboBox<String> displayLocale;
     private final JCheckBox showIPAddressesInChat = new JCheckBox(Messages.getString("CommonSettingsDialog.showIPAddressesInChat"));
-
+    private JTextPane reportKeywordsTextPane;
     private final JCheckBox showDamageLevel = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageLevel"));
     private final JCheckBox showDamageDecal = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageDecal"));
     private final JCheckBox showMapsheets = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapsheets"));
@@ -260,6 +260,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
     private int savedFovHighlightAlpha;
     private int savedFovDarkenAlpha;
     private int savedNumStripesSlider;
+
+    private static final String MSG_REPORTKEYWORDS = Messages.getString("CommonSettingsDialog.ReportKeywords");
     HashMap<String, String> savedAdvancedOpt = new HashMap<>();
 
     /** Constructs the Client Settings Dialog with a clientgui (used within the client, i.e. in lobby and game). */
@@ -497,6 +499,16 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
         comps.add(row);
 
         addLineSpacer(comps);
+
+        JLabel reportKeywordsLabel = new JLabel(MSG_REPORTKEYWORDS + ": ");
+        reportKeywordsTextPane = new JTextPane();
+        row = new ArrayList<>();
+        row.add(reportKeywordsLabel);
+        row.add(reportKeywordsTextPane);
+        comps.add(row);
+
+        addLineSpacer(comps);
+
         comps.add(checkboxEntry(showIPAddressesInChat, Messages.getString("CommonSettingsDialog.showIPAddressesInChat.tooltip")));
         return createSettingsPanel(comps);
     }
@@ -581,6 +593,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
             stampFilenames.setSelected(cs.stampFilenames());
             stampFormat.setEnabled(stampFilenames.isSelected());
             stampFormat.setText(cs.getStampFormat());
+            reportKeywordsTextPane.setText(cs.getReportKeywords());
             showIPAddressesInChat.setSelected(cs.getShowIPAddressesInChat());
 
             defaultAutoejectDisabled.setSelected(cs.defaultAutoejectDisabled());
@@ -789,6 +802,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements
         // cs.setGameLogMaxSize(Integer.parseInt(gameLogMaxSize.getText()));
         cs.setStampFilenames(stampFilenames.isSelected());
         cs.setStampFormat(stampFormat.getText());
+        cs.setReportKeywords(reportKeywordsTextPane.getText());
         cs.setShowIPAddressesInChat(showIPAddressesInChat.isSelected());
 
         cs.setDefaultAutoejectDisabled(defaultAutoejectDisabled.isSelected());

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -17,6 +17,7 @@ import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.BASE64ToolKit;
 import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.Player;
@@ -25,6 +26,7 @@ import megamek.common.Report;
 import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.preference.PreferenceManager;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
@@ -56,7 +58,6 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
     private static final String MSG_ROUND = Messages.getString("MiniReportDisplay.Round");
     private static final String MSG_PHASE = Messages.getString("MiniReportDisplay.Phase");
     private static final String MSG_DAMAGE = Messages.getString("MiniReportDisplay.Damage");
-    private static final String MSG_DESTROYED = Messages.getString("MiniReportDisplay.Destroyed");
     private static final String MSG_ARROWUP = Messages.getString("MiniReportDisplay.ArrowUp");
     private static final String MSG_ARROWDOWN = Messages.getString("MiniReportDisplay.ArrowDown");
     private static final String MSG_DETAILS = Messages.getString("MiniReportDisplay.Details");
@@ -126,6 +127,7 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
 
         adaptToGUIScale();
         GUIPreferences.getInstance().addPreferenceChangeListener(this);
+        PreferenceManager.getClientPreferences().addPreferenceChangeListener(this);
         butOkay.requestFocus();
     }
 
@@ -236,7 +238,6 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
             comboEntity.setEnabled(false);
         }
         comboEntity.setSelectedItem(lastChoice);
-        comboEntity.setSelectedItem(lastChoice);
         if (comboEntity.getSelectedIndex() < 0) {
             comboEntity.setSelectedIndex(0);
         }
@@ -247,9 +248,10 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
         lastChoice = (lastChoice != null ? lastChoice : MSG_DAMAGE);
         comboQuick.removeAllItems();
         comboQuick.setEnabled(true);
-        comboQuick.addItem(MSG_DAMAGE);
-        comboQuick.addItem(MSG_DESTROYED);
-        comboQuick.addItem(MSG_PHASE);
+        String[] keywords =  PreferenceManager.getClientPreferences().getReportKeywords().split("\n");
+        for (String keyword : keywords) {
+            comboQuick.addItem(keyword);
+        }
         if (comboQuick.getItemCount() == 1) {
             comboQuick.setEnabled(false);
         }
@@ -431,6 +433,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
         // Update the text size when the GUI scaling changes
         if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
             adaptToGUIScale();
+        } else if (e.getName().equals(ClientPreferences.REPORT_KEYWORDS)) {
+            updateQuickChoice();
         }
     }
 }

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -57,6 +57,8 @@ public class ClientPreferences extends PreferenceStoreProxy {
     public static final String BOARD_HEIGHT = "BoardHeight";
     public static final String MAP_WIDTH = "MapWidth";
     public static final String MAP_HEIGHT = "MapHeight";
+    public static final String REPORT_KEYWORDS = "ReportKeywords";
+    private static final String REPORTKEYWORDSDEFAULTS = "Needs\nRolls\nTakes\nHit\nFalls\nSkill Roll\nPilot Skill\nPhase\nDestoryed\nDamage";
     public static final String IP_ADDRESSES_IN_CHAT = "IPAddressesInChat";
     //endregion Variable Declarations
     
@@ -86,6 +88,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
         store.setDefault(MAP_HEIGHT, 1);
         store.setDefault(DEBUG_OUTPUT_ON, false);
         store.setDefault(MEMORY_DUMP_ON, false);
+        store.setDefault(REPORT_KEYWORDS, REPORTKEYWORDSDEFAULTS);
         store.setDefault(IP_ADDRESSES_IN_CHAT, false);
         setLocale(store.getString(LOCALE));
         setMekHitLocLog();
@@ -281,6 +284,14 @@ public class ClientPreferences extends PreferenceStoreProxy {
 
     public void setGUIName(String guiName) {
         store.setValue(GUI_NAME, guiName);
+    }
+
+    public String getReportKeywords() {
+        return store.getString(REPORT_KEYWORDS);
+    }
+
+    public void setReportKeywords(String s) {
+        store.setValue(REPORT_KEYWORDS, s);
     }
 
     public boolean getShowIPAddressesInChat() {

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -58,7 +58,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
     public static final String MAP_WIDTH = "MapWidth";
     public static final String MAP_HEIGHT = "MapHeight";
     public static final String REPORT_KEYWORDS = "ReportKeywords";
-    private static final String REPORTKEYWORDSDEFAULTS = "Needs\nRolls\nTakes\nHit\nFalls\nSkill Roll\nPilot Skill\nPhase\nDestoryed\nDamage";
+    private static final String REPORTKEYWORDSDEFAULTS = "Needs\nRolls\nTakes\nHit\nFalls\nSkill Roll\nPilot Skill\nPhase\nDestroyed\nDamage";
     public static final String IP_ADDRESSES_IN_CHAT = "IPAddressesInChat";
     //endregion Variable Declarations
     


### PR DESCRIPTION
#4035

manage report keywords in client settings for the Mni Report Dialog

can add and remove keywords

![image](https://user-images.githubusercontent.com/116095479/207212514-e0ef640f-3788-453f-94bb-e550ec418545.png)

![image](https://user-images.githubusercontent.com/116095479/207212480-6e01092f-18a3-422c-a5b4-7642336af76c.png)


