### PR TITLE
Exception guards for report search fields

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -237,10 +237,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
         comboEntity.setSelectedItem(lastChoice);
         if (comboEntity.getItemCount() <= 1) {
             comboEntity.setEnabled(false);
-        } else {
-            if (comboEntity.getSelectedIndex() < 0) {
-                comboEntity.setSelectedIndex(0);
-            }
+        } else if (comboEntity.getSelectedIndex() < 0) {
+            comboEntity.setSelectedIndex(0);
         }
     }
 
@@ -256,10 +254,8 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
         comboQuick.setSelectedItem(lastChoice);
         if (comboQuick.getItemCount() <= 1) {
             comboQuick.setEnabled(false);
-        } else {
-            if (comboQuick.getSelectedIndex() < 0) {
-                comboQuick.setSelectedIndex(0);
-            }
+        } else if (comboQuick.getSelectedIndex() < 0) {
+            comboQuick.setSelectedIndex(0);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -230,16 +230,17 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
         for (Iterator<Entity> ents = currentClient.getGame().getEntities(); ents.hasNext();) {
             Entity entity = ents.next();
             if (entity.getOwner().equals(currentClient.getLocalPlayer())) {
-                displayNane =addEntity(comboEntity, entity.getShortName());
+                displayNane = addEntity(comboEntity, entity.getShortName());
             }
         }
         lastChoice = (lastChoice != null ? lastChoice : displayNane);
-        if (comboEntity.getItemCount() == 1) {
-            comboEntity.setEnabled(false);
-        }
         comboEntity.setSelectedItem(lastChoice);
-        if (comboEntity.getSelectedIndex() < 0) {
-            comboEntity.setSelectedIndex(0);
+        if (comboEntity.getItemCount() <= 1) {
+            comboEntity.setEnabled(false);
+        } else {
+            if (comboEntity.getSelectedIndex() < 0) {
+                comboEntity.setSelectedIndex(0);
+            }
         }
     }
 
@@ -252,12 +253,13 @@ public class MiniReportDisplay extends JDialog implements ActionListener, Hyperl
         for (String keyword : keywords) {
             comboQuick.addItem(keyword);
         }
-        if (comboQuick.getItemCount() == 1) {
-            comboQuick.setEnabled(false);
-        }
         comboQuick.setSelectedItem(lastChoice);
-        if (comboQuick.getSelectedIndex() < 0) {
-            comboQuick.setSelectedIndex(0);
+        if (comboQuick.getItemCount() <= 1) {
+            comboQuick.setEnabled(false);
+        } else {
+            if (comboQuick.getSelectedIndex() < 0) {
+                comboQuick.setSelectedIndex(0);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes exceptions thrown in comboXYZ.setSelectedIndex(0) when the search combos in the report display are empty (happened to me when calling up the report at the end of a game).