### PR TITLE
4043: Fixing No Server NPEs

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -158,8 +158,8 @@ public class MechSummaryCache {
             synchronized (lock) {
                 try {
                     lock.wait();
-                } catch (Exception e) {
-                    // Ignore
+                } catch (Exception ignored) {
+
                 }
             }
         }
@@ -232,10 +232,10 @@ public class MechSummaryCache {
                     fin.close();
                     istream.close();
                 }
-            } catch (Exception e) {
+            } catch (Exception ex) {
                 loadReport.append("  Unable to load unit cache: ")
-                        .append(e.getMessage()).append("\n");
-                LogManager.getLogger().error(loadReport.toString(), e);
+                        .append(ex.getMessage()).append("\n");
+                LogManager.getLogger().error(loadReport.toString(), ex);
             }
         }
 
@@ -639,7 +639,7 @@ public class MechSummaryCache {
                                     .append(failedEquipment.next()).append("\n");
                         }
                     }
-                } catch (EntityLoadingException ex) {
+                } catch (Exception ex) {
                     loadReport.append("    Loading from ").append(f).append("\n");
                     loadReport.append("***   Unable to load file: ");
                     StringWriter stringWriter = new StringWriter();
@@ -680,8 +680,8 @@ public class MechSummaryCache {
                 try {
                     zFile.close();
                     return false;
-                } catch (IOException e) {
-                    LogManager.getLogger().error("", e);
+                } catch (Exception ex) {
+                    LogManager.getLogger().error("", ex);
                 }
             }
             ZipEntry zEntry = (ZipEntry) i.nextElement();
@@ -773,7 +773,7 @@ public class MechSummaryCache {
                         }
                     }
                 }
-            } catch (IOException ex) {
+            } catch (Exception ex) {
                 LogManager.getLogger().error("", ex);
             }
         }

--- a/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ACWeapon.java
@@ -108,8 +108,9 @@ public abstract class ACWeapon extends AmmoWeapon {
             return dmg;
         }
 
-        if (Server.getServerInstance().getGame().getOptions()
-                .getOption(OptionsConstants.ADVCOMBAT_INCREASED_AC_DMG).booleanValue()) {
+        if ((Server.getServerInstance() != null)
+                && Server.getServerInstance().getGame().getOptions()
+                        .getOption(OptionsConstants.ADVCOMBAT_INCREASED_AC_DMG).booleanValue()) {
             dmg++;
         }
 

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserLarge.java
@@ -63,7 +63,10 @@ public class ISERLaserLarge extends LaserWeapon {
 
     @Override
     public int getLongRange() {
-        GameOptions options = Server.getServerInstance().getGame().getOptions();
+        if (Server.getServerInstance() == null) {
+            return super.getLongRange();
+        }
+        final GameOptions options = Server.getServerInstance().getGame().getOptions();
         if (options.getOption(OptionsConstants.ADVCOMBAT_INCREASED_ISERLL_RANGE) == null) {
             return super.getLongRange();
         } else if (options.getOption(OptionsConstants.ADVCOMBAT_INCREASED_ISERLL_RANGE).booleanValue()) {

--- a/megamek/src/megamek/common/weapons/prototypes/ISERLaserLargePrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/ISERLaserLargePrototype.java
@@ -87,7 +87,10 @@ public class ISERLaserLargePrototype extends LaserWeapon {
 
     @Override
     public int getLongRange() {
-        GameOptions options = Server.getServerInstance().getGame().getOptions();
+        if (Server.getServerInstance() == null) {
+            return super.getLongRange();
+        }
+        final GameOptions options = Server.getServerInstance().getGame().getOptions();
         if (options.getOption(OptionsConstants.ADVCOMBAT_INCREASED_ISERLL_RANGE) == null) {
             return super.getLongRange();
         } else if (options.getOption(OptionsConstants.ADVCOMBAT_INCREASED_ISERLL_RANGE).booleanValue()) {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -404,7 +404,7 @@ public class Server implements Runnable {
         gameManager.setGame(g);
     }
 
-    public @Nullable IGame getGame() {
+    public IGame getGame() {
         return gameManager.getGame();
     }
 
@@ -1311,9 +1311,9 @@ public class Server implements Runnable {
     }
 
     /**
-     * @return the current server instance
+     * @return the current server instance. This may be null if a server has not been started
      */
-    public static Server getServerInstance() {
+    public static @Nullable Server getServerInstance() {
         return serverInstance;
     }
 


### PR DESCRIPTION
This fixes #4043 and subsumes #4044. Server::getServerInstance and GameOptions::getOption are the only two methods that may return null, so protects for those two cases. This also fixes the nullable annotation on the wrong method mistake I made.