### PR TITLE
allow report display split pane to resize

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -106,6 +106,7 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
             panButtons.add(new JLabel(""));
         }
         panelTop.add(panButtons, GBC.eol().fill(GridBagConstraints.HORIZONTAL));
+        panelTop.setMinimumSize(new Dimension(0,0));
         splitPaneMain.setTopComponent(panelTop);
         add(splitPaneMain);
 

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -106,7 +106,7 @@ public class ReportDisplay extends AbstractPhaseDisplay implements
             panButtons.add(new JLabel(""));
         }
         panelTop.add(panButtons, GBC.eol().fill(GridBagConstraints.HORIZONTAL));
-        panelTop.setMinimumSize(new Dimension(0,0));
+        panelTop.setMinimumSize(new Dimension(0, 0));
         splitPaneMain.setTopComponent(panelTop);
         add(splitPaneMain);
 


### PR DESCRIPTION
when you have 2 rows of report phases in the report display it cause the resize of the split pane to freeze.  so the pilot display and chat log are hard to see.  only a few lines visible.


this allows it to resize in this case.

![image](https://user-images.githubusercontent.com/116095479/208266734-5cf1030e-331e-44e5-a909-1caf57192953.png)

