### PR TITLE
bombing updates

### DIFF
--- a/megamek/src/megamek/common/CompositeTechLevel.java
+++ b/megamek/src/megamek/common/CompositeTechLevel.java
@@ -307,7 +307,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         extinct = merged;
     }
     
-    private static class DateRange implements Serializable, Comparable<DateRange> {
+    public static class DateRange implements Serializable, Comparable<DateRange> {
         private static final long serialVersionUID = 3144194494591950878L;
         
         Integer start = null;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -6005,6 +6005,48 @@ public class Compute {
     }
 
     /**
+     * Scatter from hex according to dive bombing rules (based on MoF),
+     * TW pg 246.  The scatter can happen in any direction.
+     *
+     * @param coords The <code>Coords</code> to scatter from
+     * @param moF The margin of failure, which deterimines scatter distance
+     * @return the <code>Coords</code> scattered to and distance (moF)
+     */
+    public static Coords scatterDiveBombs(Coords coords, int moF) {
+        return Compute.scatter(coords, moF);
+    }
+
+    /**
+     * Scatter from hex according to altitude bombing rules (based on MoF),
+     * TW pg 246.  The scatter only happens in the "front" three facings.
+     *
+     * @param coords The <code>Coords</code> to scatter from
+     * @param facing Direction we were going at the time the bomb was dropped
+     * @param moF How badly we failed
+     * @return the <code>Coords</code> scattered to and distance (moF)
+     */
+    public static Coords scatterAltitudeBombs(Coords coords, int facing, int moF) {
+        int dir = 0;
+        int scatterDirection = Compute.d6(1);
+        switch (scatterDirection) {
+            case 1:
+            case 2:
+                dir = (facing - 1) % 6;
+                break;
+            case 3:
+            case 4:
+                dir = facing;
+                break;
+            case 5:
+            case 6:
+                dir = (facing + 1) % 6;
+                break;
+        }
+
+        return coords.translated(dir, moF);
+    }
+
+    /**
      * scatter from hex according to direct fire artillery rules (based on MoF)
      *
      * @param coords The <code>Coords</code> to scatter from

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -6005,47 +6005,6 @@ public class Compute {
     }
 
     /**
-     * Scatter from hex according to dive bombing rules (based on MoF),
-     * TW pg 246.  The scatter can happen in any direction.
-     *
-     * @param coords The <code>Coords</code> to scatter from
-     * @param moF The margin of failure, which deterimines scatter distance
-     * @return the <code>Coords</code> scattered to and distance (moF)
-     */
-    public static Coords scatterDiveBombs(Coords coords, int moF) {
-        return Compute.scatter(coords, moF);
-    }
-
-    /**
-     * Scatter from hex according to altitude bombing rules (based on MoF),
-     * TW pg 246.  The scatter only happens in the "front" three facings.
-     *
-     * @param coords The <code>Coords</code> to scatter from
-     * @param facing
-     * @return the <code>Coords</code> scattered to and distance (moF)
-     */
-    public static Coords scatterAltitudeBombs(Coords coords, int facing) {
-        int dir = 0;
-        int scatterDirection = Compute.d6(1);
-        switch (scatterDirection) {
-            case 1:
-            case 2:
-                dir = (facing - 1) % 6;
-                break;
-            case 3:
-            case 4:
-                dir = facing;
-                break;
-            case 5:
-            case 6:
-                dir = (facing + 1) % 6;
-                break;
-        }
-        int dist = Compute.d6(1);
-        return coords.translated(dir, dist);
-    }
-
-    /**
      * scatter from hex according to direct fire artillery rules (based on MoF)
      *
      * @param coords The <code>Coords</code> to scatter from

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4612,7 +4612,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // Battle Armor bomb racks (Micro bombs) use gunnery skill and no other mods per TWp228 2018 errata
         if ((atype != null) && (atype.getAmmoType() == AmmoType.T_BA_MICRO_BOMB)) {
             if (ae.getPosition().equals(target.getPosition())) {
-                toHit = new ToHitData(ae.getCrew().getPiloting(), Messages.getString("WeaponAttackAction.GunSkill"));
+                toHit = new ToHitData(ae.getCrew().getGunnery(), Messages.getString("WeaponAttackAction.GunSkill"));
             } else { 
                 toHit = new ToHitData(TargetRoll.IMPOSSIBLE, Messages.getString("WeaponAttackAction.OutOfRange"));
             }

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -47,6 +47,7 @@ public class SerializationHelper {
                 megamek.client.bot.princess.BehaviorSettings.class,
                 megamek.common.Board.class,
                 megamek.common.Coords.class,
+                megamek.common.CompositeTechLevel.DateRange.class,
                 megamek.common.CriticalSlot.class,
                 megamek.common.Game.class,
                 megamek.common.Hex.class,

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -52,6 +52,7 @@ public class SerializationHelper {
                 megamek.common.Game.class,
                 megamek.common.Hex.class,
                 megamek.common.Mounted.class,
+                megamek.common.PilotingRollData.class,
                 megamek.common.Player.class,
                 megamek.common.Sensor.class,
                 megamek.common.TargetRollModifier.class,

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -196,8 +196,21 @@ public class BombAttackHandler extends WeaponHandler {
                             moF = -typeModifiedToHit.getMoS() - 2;
                         }
                     }
-
-                    drop = Compute.scatter(coords, moF);
+                    if (wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
+                        // Need to determine location in flight path
+                        int idx = 0;
+                        for (; idx < ae.getPassedThrough().size(); idx++) {
+                            if (ae.getPassedThrough().get(idx).equals(coords)) {
+                                break;
+                            }
+                        }
+                        // Retrieve facing at current step in flight path
+                        int facing = ae.getPassedThroughFacing().get(idx);
+                        // Scatter, based on location and facing
+                        drop = Compute.scatterAltitudeBombs(coords, facing, moF);
+                    } else {
+                        drop = Compute.scatterDiveBombs(coords, moF);
+                    }
 
                     if (game.getBoard().contains(drop)) {
                         // misses and scatters to another hex

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -196,21 +196,8 @@ public class BombAttackHandler extends WeaponHandler {
                             moF = -typeModifiedToHit.getMoS() - 2;
                         }
                     }
-                    if (wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
-                        // Need to determine location in flight path
-                        int idx = 0;
-                        for (; idx < ae.getPassedThrough().size(); idx++) {
-                            if (ae.getPassedThrough().get(idx).equals(coords)) {
-                                break;
-                            }
-                        }
-                        // Retrieve facing at current step in flight path
-                        int facing = ae.getPassedThroughFacing().get(idx);
-                        // Scatter, based on location and facing
-                        drop = Compute.scatterAltitudeBombs(coords, facing);
-                    } else {
-                        drop = Compute.scatterDiveBombs(coords, moF);
-                    }
+
+                    drop = Compute.scatter(coords, moF);
 
                     if (game.getBoard().contains(drop)) {
                         // misses and scatters to another hex

--- a/megamek/src/megamek/common/weapons/MicroBombHandler.java
+++ b/megamek/src/megamek/common/weapons/MicroBombHandler.java
@@ -67,7 +67,7 @@ public class MicroBombHandler extends AmmoWeaponHandler {
                     moF = -toHit.getMoS() - 2;
                 }
             }
-            coords = Compute.scatterDiveBombs(coords, moF);
+            coords = Compute.scatter(coords, moF);
             if (game.getBoard().contains(coords)) {
                 Report r = new Report(3195);
                 r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/MicroBombHandler.java
+++ b/megamek/src/megamek/common/weapons/MicroBombHandler.java
@@ -67,7 +67,9 @@ public class MicroBombHandler extends AmmoWeaponHandler {
                     moF = -toHit.getMoS() - 2;
                 }
             }
-            coords = Compute.scatter(coords, moF);
+
+            // magic number - BA-launched micro bombs only scatter 1 hex per TW-2018 p 228
+            coords = Compute.scatter(coords, 1);
             if (game.getBoard().contains(coords)) {
                 Report r = new Report(3195);
                 r.subject = subjectId;


### PR DESCRIPTION
-altitude bombs scatter by MoF rather than 1d6 per issue #4028 errata
-micro bombs use gunnery skill for TN instead of anti-mech skill, per TW page 228
-micro bombs only scatter one hex per TW page 228
-allow deserialization of some new classes
