### PR TITLE
Java 17: Manifest File Add-Opens

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -74,7 +74,7 @@ jar {
         attributes "Main-Class" : mainClassName
         attributes "Class-Path" : project.sourceSets.main.runtimeClasspath.files
             .findAll { it.name.endsWith(".jar") }.collect { "${lib}/${it.name}" }.join(' ')
-        attributes "Add-Opens" : java.base/java.util java.base/java.util.concurrent
+        attributes "Add-Opens" : 'java.base/java.util java.base/java.util.concurrent'
         attributes "Build-Date" : LocalDateTime.now()
     }
 }

--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -74,6 +74,7 @@ jar {
         attributes "Main-Class" : mainClassName
         attributes "Class-Path" : project.sourceSets.main.runtimeClasspath.files
             .findAll { it.name.endsWith(".jar") }.collect { "${lib}/${it.name}" }.join(' ')
+        attributes "Add-Opens" : java.base/java.util java.base/java.util.concurrent
         attributes "Build-Date" : LocalDateTime.now()
     }
 }


### PR DESCRIPTION
The `add-opens` was only applying for the exe files, which means it was missing for JAR uses. I believe this fixes that issue.