### PR TITLE
weapon order

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1891,11 +1891,15 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             bing();
         }
 
-        private void setWeaponOrderPrefs() {
+        private void setWeaponOrderPrefs(GamePhase oldPhase) {
             for (Iterator<Entity> ents = client.getGame().getEntities(); ents.hasNext();) {
                 Entity entity = ents.next();
-                if ((entity.getOwner().equals(client.getLocalPlayer())) && (!entity.getWeaponSortOrder().isCustom())) {
-                        entity.setWeaponSortOrder(GUIP.getDefaultWeaponSortOrder());
+                if ((entity.getOwner().equals(client.getLocalPlayer()))
+                        && (!entity.getWeaponSortOrder().isCustom())
+                        && ((!entity.isDeployed()))
+                        || (oldPhase.isUnknown())) {
+                    entity.setWeaponSortOrder(GUIP.getDefaultWeaponSortOrder());
+                    client.sendEntityWeaponOrderUpdate(entity);
                 }
             }
         }
@@ -1918,11 +1922,11 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             GamePhase phase = getClient().getGame().getPhase();
             switchPanel(phase);
 
-            if (phase.isFiring())  {
-                setWeaponOrderPrefs();
+            if ((e.getOldPhase().isUnknown()) || (phase.isDeployment()))  {
+                setWeaponOrderPrefs(e.getOldPhase());
             }
 
-            menuBar.setPhase(getClient().getGame().getPhase());
+            menuBar.setPhase(phase);
             validate();
             cb.moveToEnd();
         }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1891,6 +1891,15 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             bing();
         }
 
+        private void setWeaponOrderPrefs() {
+            for (Iterator<Entity> ents = client.getGame().getEntities(); ents.hasNext();) {
+                Entity entity = ents.next();
+                if ((entity.getOwner().equals(client.getLocalPlayer())) && (!entity.getWeaponSortOrder().isCustom())) {
+                        entity.setWeaponSortOrder(GUIP.getDefaultWeaponSortOrder());
+                }
+            }
+        }
+
         @Override
         public void gamePhaseChange(GamePhaseChangeEvent e) {
             // This is a really lame place for this, but I couldn't find a
@@ -1906,7 +1915,12 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             bv.setChatterBoxActive(false);            
 
             // Swap to this phase's panel.
-            switchPanel(getClient().getGame().getPhase());
+            GamePhase phase = getClient().getGame().getPhase();
+            switchPanel(phase);
+
+            if (phase.isFiring())  {
+                setWeaponOrderPrefs();
+            }
 
             menuBar.setPhase(getClient().getGame().getPhase());
             validate();

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1891,13 +1891,12 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             bing();
         }
 
-        private void setWeaponOrderPrefs(GamePhase oldPhase) {
+        private void setWeaponOrderPrefs() {
             for (Iterator<Entity> ents = client.getGame().getEntities(); ents.hasNext();) {
                 Entity entity = ents.next();
                 if ((entity.getOwner().equals(client.getLocalPlayer()))
                         && (!entity.getWeaponSortOrder().isCustom())
-                        && ((!entity.isDeployed()))
-                        || (oldPhase.isUnknown())) {
+                        && (!entity.isDeployed())) {
                     entity.setWeaponSortOrder(GUIP.getDefaultWeaponSortOrder());
                     client.sendEntityWeaponOrderUpdate(entity);
                 }
@@ -1922,8 +1921,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             GamePhase phase = getClient().getGame().getPhase();
             switchPanel(phase);
 
-            if ((e.getOldPhase().isUnknown()) || (phase.isDeployment()))  {
-                setWeaponOrderPrefs(e.getOldPhase());
+            if (phase.isDeployment())  {
+                setWeaponOrderPrefs();
             }
 
             menuBar.setPhase(phase);

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1867,6 +1867,18 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         }
     }
 
+    private void setWeaponOrderPrefs(boolean prefChange) {
+        for (Iterator<Entity> ents = client.getGame().getEntities(); ents.hasNext();) {
+            Entity entity = ents.next();
+            if ((entity.getOwner().equals(client.getLocalPlayer()))
+                    && (!entity.getWeaponSortOrder().isCustom())
+                    && ((!entity.isDeployed()) || (prefChange))) {
+                entity.setWeaponSortOrder(GUIP.getDefaultWeaponSortOrder());
+                client.sendEntityWeaponOrderUpdate(entity);
+            }
+        }
+    }
+
     private GameListener gameListener = new GameListenerAdapter() {
         @Override
         public void gamePlayerChange(GamePlayerChangeEvent evt) {
@@ -1891,18 +1903,6 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             bing();
         }
 
-        private void setWeaponOrderPrefs() {
-            for (Iterator<Entity> ents = client.getGame().getEntities(); ents.hasNext();) {
-                Entity entity = ents.next();
-                if ((entity.getOwner().equals(client.getLocalPlayer()))
-                        && (!entity.getWeaponSortOrder().isCustom())
-                        && (!entity.isDeployed())) {
-                    entity.setWeaponSortOrder(GUIP.getDefaultWeaponSortOrder());
-                    client.sendEntityWeaponOrderUpdate(entity);
-                }
-            }
-        }
-
         @Override
         public void gamePhaseChange(GamePhaseChangeEvent e) {
             // This is a really lame place for this, but I couldn't find a
@@ -1922,7 +1922,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             switchPanel(phase);
 
             if (phase.isDeployment())  {
-                setWeaponOrderPrefs();
+                setWeaponOrderPrefs(false);
             }
 
             menuBar.setPhase(phase);
@@ -2567,6 +2567,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             maybeShowUnitDisplay();
         } else if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
             adaptToGUIScale();
+        } else if (e.getName().equals(GUIPreferences.DEFAULT_WEAPON_SORT_ORDER)) {
+            setWeaponOrderPrefs(true);
         }
         
     }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2569,6 +2569,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             adaptToGUIScale();
         } else if (e.getName().equals(GUIPreferences.DEFAULT_WEAPON_SORT_ORDER)) {
             setWeaponOrderPrefs(true);
+            getUnitDisplay().displayEntity(getUnitDisplay().getCurrentEntity());
         }
         
     }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/UnitDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/UnitDisplay.java
@@ -524,6 +524,9 @@ public class UnitDisplay extends JPanel {
      * Displays the specified entity in the panel.
      */
     public void displayEntity(Entity en) {
+        if (en == null) {
+            return;
+        }
         String enName = en.getShortName();
         switch (en.getDamageLevel()) {
             case Entity.DMG_CRIPPLED:

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2650,6 +2650,9 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             displaySelected();
         } else if (ev.getSource().equals(comboWeaponSortOrder)) {
             setWeaponComparator(comboWeaponSortOrder.getSelectedItem());
+            if (entity.getOwner().equals(unitDisplay.getClientGUI().getClient().getLocalPlayer())) {
+                unitDisplay.getClientGUI().getClient().sendEntityWeaponOrderUpdate(entity);
+            }
         }
         onResize();
     }


### PR DESCRIPTION
weapon order

- when one of my units is deployed set the weapon order to the default weapon sort order from the client settings
- when changing the weapon sort order in the unit display and the unit in my unit, send an sendEntityWeaponOrderUpdate, so that the update is remembered.
- on default weapon sort order preference change, set my units to the default weapon sort order from the client settings