### PR TITLE
attack tool tip update

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
@@ -407,7 +407,7 @@ class AttackSprite extends Sprite {
         tipString.append(Integer.toHexString(attackColor.getRGB() & 0xFFFFFF));
         tipString.append(">");
         tipString.append(attackerDesc
-                + "&nbsp;&nbsp;" + Messages.getString("BoardView1.on") + "&nbsp;&nbsp;" + targetDesc);
+                + "<BR>&nbsp;&nbsp;" + Messages.getString("BoardView1.on") + "&nbsp;&nbsp;" + targetDesc);
         tipString.append("</FONT>");
         for (String wpD: weaponDescs) {
             tipString.append("<BR>"+wpD);

--- a/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
@@ -56,6 +56,12 @@ class AttackSprite extends Sprite {
 
     private final Targetable target;
 
+    private Coords aCoord;
+    private Coords tCoord;
+    private IdealHex aHex;
+    private IdealHex tHex;
+
+
     public AttackSprite(BoardView boardView1, final AttackAction attack) {
         super(boardView1);
         this.boardView1 = boardView1;
@@ -64,6 +70,10 @@ class AttackSprite extends Sprite {
         targetId = attack.getTargetId();
         ae = this.boardView1.game.getEntity(attack.getEntityId());
         target = this.boardView1.game.getTarget(targetType, targetId);
+        aCoord = ae.getPosition();
+        tCoord = target.getPosition();
+        aHex = new IdealHex(aCoord);
+        tHex = new IdealHex(tCoord);
 
         // color?
         attackColor = ae.getOwner().getColour().getColour();
@@ -236,10 +246,9 @@ class AttackSprite extends Sprite {
     }
 
     public boolean isInside(Coords mcoords) {
-        IdealHex s = new IdealHex(ae.getPosition());
-        IdealHex e = new IdealHex(target.getPosition());
-        IdealHex m = new IdealHex(mcoords);
-        return m.isIntersectedBy(s.cx, s.cy, e.cx, e.cy);
+        IdealHex mHex = new IdealHex(mcoords);
+
+        return ((mHex.isIntersectedBy(aHex.cx, aHex.cy, tHex.cx, tHex.cy)) && (mcoords.between(aCoord, tCoord)));
     }
 
     public int getEntityId() {

--- a/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
@@ -10,11 +10,7 @@ import java.util.ArrayList;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.StraightArrowPolygon;
-import megamek.common.Compute;
-import megamek.common.Coords;
-import megamek.common.Entity;
-import megamek.common.Targetable;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.actions.AttackAction;
 import megamek.common.actions.ChargeAttackAction;
 import megamek.common.actions.ClubAttackAction;
@@ -237,6 +233,13 @@ class AttackSprite extends Sprite {
     @Override
     public boolean isInside(Point point) {
         return attackPoly.contains(point.x - bounds.x, point.y - bounds.y);
+    }
+
+    public boolean isInside(Coords mcoords) {
+        IdealHex s = new IdealHex(ae.getPosition());
+        IdealHex e = new IdealHex(target.getPosition());
+        IdealHex m = new IdealHex(mcoords);
+        return m.isIntersectedBy(s.cx, s.cy, e.cx, e.cy);
     }
 
     public int getEntityId() {

--- a/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
@@ -7,6 +7,8 @@ import java.awt.Polygon;
 import java.awt.Rectangle;
 import java.awt.image.ImageObserver;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.StraightArrowPolygon;
@@ -267,8 +269,23 @@ class AttackSprite extends Sprite {
         final WeaponType wtype = (WeaponType) entity.getEquipment(
                 attack.getWeaponId()).getType();
         final String roll = attack.toHit(this.boardView1.game).getValueAsString();
-        final String table = attack.toHit(this.boardView1.game).getTableDesc();
-        weaponDescs.add(wtype.getName() + Messages.getString("BoardView1.needs") + roll + " " + table);
+        String table = attack.toHit(this.boardView1.game).getTableDesc();
+        if (!table.isEmpty()) {
+            table = " " + table;
+        }
+        boolean b = false;
+        ListIterator<String> i = weaponDescs.listIterator();
+        while (i.hasNext()) {
+             String s = i.next();
+            if (s.contains(wtype.getName())) {
+                i.set(s + ", " + roll + table);
+                b = true;
+            }
+        }
+
+        if (!b) {
+            weaponDescs.add(wtype.getName() + Messages.getString("BoardView1.needs") + roll + table);
+        }
     }
 
     public void addWeapon(KickAttackAction attack) {
@@ -390,7 +407,7 @@ class AttackSprite extends Sprite {
         tipString.append(Integer.toHexString(attackColor.getRGB() & 0xFFFFFF));
         tipString.append(">");
         tipString.append(attackerDesc
-                + "<BR>&nbsp;&nbsp;" + Messages.getString("BoardView1.on") + " " + targetDesc);
+                + "&nbsp;&nbsp;" + Messages.getString("BoardView1.on") + "&nbsp;&nbsp;" + targetDesc);
         tipString.append("</FONT>");
         for (String wpD: weaponDescs) {
             tipString.append("<BR>"+wpD);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5678,6 +5678,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
         }
 
+        txt.append("</div>");
         txt.append(HTML_END);
 
         // Check to see if the tool tip is completely empty
@@ -5695,7 +5696,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             ToolTipManager.sharedInstance().setDismissDelay(dismissDelay);
         }
 
-        txt.append("</div>");
         return txt.toString();
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5450,6 +5450,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         Hex mhex = game.getBoard().getHex(mcoords);
 
         StringBuffer txt = new StringBuffer(HTML_BEGIN);
+        txt.append("<div WIDTH=500>");
         // Hex Terrain
         if (GUIPreferences.getInstance().getShowMapHexPopup() && (mhex != null)) {
             appendTerrainTooltip(txt, mhex);
@@ -5694,6 +5695,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             ToolTipManager.sharedInstance().setDismissDelay(dismissDelay);
         }
 
+        txt.append("</div>");
         return txt.toString();
     }
 
@@ -5850,7 +5852,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         txt.append(" width=6></TD><TD>");
 
         // Entity tooltip
-        txt.append("<div WIDTH=500>" +  UnitToolTip.getEntityTipGame(entity, getLocalPlayer()) + "</div");
+        txt.append(UnitToolTip.getEntityTipGame(entity, getLocalPlayer()));
         txt.append("</TD></TR></TABLE>");
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5555,15 +5555,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
         }
 
-        // check if it's on any attacks
-        for (AttackSprite aSprite : attackSprites) {
-            if (aSprite.isInside(point)) {
-                txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
-                txt.append(aSprite.getTooltip().toString());
-                txt.append("</FONT></TD></TR></TABLE>");
-            }
-        }
-        
         // Add wreck info
         var wreckList = useIsometric() ? isometricWreckSprites : wreckSprites;
         for (var wSprite : wreckList) {
@@ -5599,6 +5590,15 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
             txt.append(" in this hex...</FONT>");
             txt.append("</TD></TR></TABLE>");
+        }
+
+        // check if it's on any attacks
+        for (AttackSprite aSprite : attackSprites) {
+            if (aSprite.isInside(mcoords)) {
+                txt.append("<TABLE BORDER=0 BGCOLOR=" + ALT_BGCOLOR + " width=100%><TR><TD><FONT color=\"black\">");
+                txt.append(aSprite.getTooltip().toString());
+                txt.append("</FONT></TD></TR></TABLE>");
+            }
         }
 
         // Artillery attacks

--- a/megamek/src/megamek/common/Coords.java
+++ b/megamek/src/megamek/common/Coords.java
@@ -520,4 +520,12 @@ public class Coords implements Serializable {
     public int getY() {
         return y;
     }
+
+    /**
+     * return true if this is between s and e
+     * based on distance
+     */
+    public boolean between(Coords s, Coords e) {
+        return (s.distance(e) == s.distance(this) + this.distance(e));
+    }
 }


### PR DESCRIPTION
attack tool tip update

- show attacks that cross the current hex, instead of attacks at current point.  this makes it easier for these to be displayed.
- display attacks after the unit info, so that it does not hide the unit info when there are many attacks.
- collapse multiple shots with the same weapon type into a single row. 

![image](https://user-images.githubusercontent.com/116095479/212554511-60ec9dac-1b92-4d4f-b476-5d2a11d4d4ea.png)

![image](https://user-images.githubusercontent.com/116095479/212554537-09a2fb88-0f8a-4dc1-9b94-2ef0d92a9c73.png)

![image](https://user-images.githubusercontent.com/116095479/212554574-9e6ab0d8-59e7-4fd6-8fb1-31b5102b6d94.png)

