### PR TITLE
issues from game board all the time

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -632,6 +632,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         setMiniReportDisplayDialog(new MiniReportDisplayDialog(getFrame(), this));
         getMiniReportDisplayDialog().setVisible(false);
 
+        playerListDialog = new PlayerListDialog(frame, client, false);
+
         Ruler.color1 = GUIP.getRulerColor1();
         Ruler.color2 = GUIP.getRulerColor2();
         ruler = new Ruler(frame, client, bv);

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -352,7 +352,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
 
     @Override
     public void actionPerformed(ActionEvent event) {
-        
         // Changes that are independent of the current state of MM
         // Boardview and others may listen to PreferenceChanges to detect these
         if (event.getActionCommand().equals(ClientGUI.VIEW_INCGUISCALE)) {
@@ -368,9 +367,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         } else if (event.getActionCommand().equals(ClientGUI.VIEW_PLANETARYCONDITIONS_OVERLAY)) {
             GUIP.togglePlanetaryConditionsOverlay();
 
-        } else if (event.getActionCommand().equals(ClientGUI.VIEW_TOGGLE_HEXCOORDS)) {
-            boolean coordsShown = GUIP.getBoolean(GUIPreferences.SHOW_COORDS);
-            GUIP.setValue(GUIPreferences.SHOW_COORDS, !coordsShown);
         } else if (event.getActionCommand().equals(ClientGUI.VIEW_LABELS)) {
             GUIP.setUnitLabelStyle(GUIP.getUnitLabelStyle().next());
         }


### PR DESCRIPTION
correct some issues caused by the game board all the time PR

- player list not populating in the lounge display, was not created at startup.
- the hex coordinates menu item not working, was setting value in 2 places