### PR TITLE
initiative reports update

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -22,7 +22,7 @@
 
 # 1000's -- Initiative phase, Offboard phase, and other assorted stuff.
 1000=<B>Initiative Phase for Round #<data></B>
-1005=<B>Initiative Phase for Deployment</B>
+1005=<B>Initiative Phase for Start of Game Deployment</B>
 1010=<B>Initiative Phase for Deployment for Round #<data></B>
 1015=<data> rolls a <data>.
 1020=<newline>The turn order for movement is:<newline>  <list>
@@ -35,8 +35,7 @@
 1032=\ \ Visibility is <data>.
 1033=\ \ Fog level is <data>.
 1035=<newline><B>Targeting Phase</B><newline>-------------------
-1040=<newline>The turn order for movement is:
-1041=<newline>The turn order for deployment is:
+1040=<newline>The turn order is:
 1045=<data> (<data>), rolled <data>
 1050=<data> (special turn)
 1060=<newline>Remaining units to deploy:

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -36,8 +36,12 @@
 1033=\ \ Fog level is <data>.
 1035=<newline><B>Targeting Phase</B><newline>-------------------
 1040=<newline>The turn order for movement is:
+1041=<newline>The turn order for deployment is:
 1045=<data> (<data>), rolled <data>
 1050=<data> (special turn)
+1060=<newline>Remaining units to deploy:
+1065=Round: #<data>
+1066=<data> (<data>), Start: <data>
 1100=<newline><B>Offboard Attack Phase</B><newline>-------------------
 1200=-------------------
 1205=<nothing>

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3114,56 +3114,29 @@ public class GameManager implements IGameManager {
         }
 
         if (game.getOptions().booleanOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)) {
-            if (deployment) {
-                r = new Report(1041, Report.PUBLIC);
-                addReport(r);
-                for (Enumeration<GameTurn> e = game.getTurns(); e.hasMoreElements(); ) {
-                    GameTurn t = e.nextElement();
-                    if (t instanceof GameTurn.SpecificEntityTurn) {
-                        Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
-                        if (entity.getDeployRound() == game.getRoundCount()) {
-                            r = new Report(1045);
-                            r.subject = entity.getId();
-                            r.addDesc(entity);
-                            r.add(entity.getInitiative().toString());
-                            addReport(r);
-                        }
-                    } else {
-                        Player player = game.getPlayer(t.getPlayerNum());
-                        if (null != player) {
-                            r = new Report(1050, Report.PUBLIC);
-                            r.add(player.getColorForPlayer());
-                            addReport(r);
-                        }
+            r = new Report(1040, Report.PUBLIC);
+            addReport(r);
+            for (Enumeration<GameTurn> e = game.getTurns(); e.hasMoreElements(); ) {
+                GameTurn t = e.nextElement();
+                if (t instanceof GameTurn.SpecificEntityTurn) {
+                    Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
+                    if ((entity.getDeployRound() <= game.getRoundCount())
+                    || ((game.getRoundCount() > 1) && (entity.getDeployRound() == game.getRoundCount()))) {
+                        r = new Report(1045);
+                        r.subject = entity.getId();
+                        r.addDesc(entity);
+                        r.add(entity.getInitiative().toString());
+                        addReport(r);
+                    }
+                } else {
+                    Player player = game.getPlayer(t.getPlayerNum());
+                    if (null != player) {
+                        r = new Report(1050, Report.PUBLIC);
+                        r.add(player.getColorForPlayer());
+                        addReport(r);
                     }
                 }
             }
-            if ((!deployment) || (game.getRoundCount() > 1)) {
-                r = new Report(1040, Report.PUBLIC);
-                addReport(r);
-                for (Enumeration<GameTurn> e = game.getTurns(); e.hasMoreElements(); ) {
-                    GameTurn t = e.nextElement();
-                    if (t instanceof GameTurn.SpecificEntityTurn) {
-                        Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
-                        if ((entity.getDeployRound() < game.getRoundCount())
-                        || ((game.getRoundCount() > 1) && (entity.getDeployRound() == game.getRoundCount()))) {
-                            r = new Report(1045);
-                            r.subject = entity.getId();
-                            r.addDesc(entity);
-                            r.add(entity.getInitiative().toString());
-                            addReport(r);
-                        }
-                    } else {
-                        Player player = game.getPlayer(t.getPlayerNum());
-                        if (null != player) {
-                            r = new Report(1050, Report.PUBLIC);
-                            r.add(player.getColorForPlayer());
-                            addReport(r);
-                        }
-                    }
-                }
-            }
-
         } else {
             for (Team team : game.getTeams()) {
                 // Teams with no active players can be ignored

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3207,7 +3207,7 @@ public class GameManager implements IGameManager {
             Comparator<Entity> comp = Comparator.comparingInt(Entity::getDeployRound);
             comp = comp.thenComparingInt(Entity::getOwnerId);
             comp = comp.thenComparingInt(Entity::getStartingPos);
-            List<Entity> ue = game.getEntitiesVector().stream().filter(e -> e.getDeployRound() > game.getRoundCount()).sorted(comp).toList();
+            List<Entity> ue = game.getEntitiesVector().stream().filter(e -> e.getDeployRound() > game.getRoundCount()).sorted(comp).collect(Collectors.toList());
             if (!ue.isEmpty()) {
                 r = new Report(1060, Report.PUBLIC);
                 addReport(r);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3145,7 +3145,8 @@ public class GameManager implements IGameManager {
                     GameTurn t = e.nextElement();
                     if (t instanceof GameTurn.SpecificEntityTurn) {
                         Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
-                        if (entity.getDeployRound() < game.getRoundCount()) {
+                        if ((entity.getDeployRound() < game.getRoundCount())
+                        || ((game.getRoundCount() > 1) && (entity.getDeployRound() == game.getRoundCount()))) {
                             r = new Report(1045);
                             r.subject = entity.getId();
                             r.addDesc(entity);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3206,38 +3206,38 @@ public class GameManager implements IGameManager {
             }
         }
 
-        // remaining deployments
-        Comparator<Entity> comp = Comparator.comparingInt(Entity::getDeployRound);
-        comp = comp.thenComparingInt(Entity::getOwnerId);
-        comp = comp.thenComparingInt(Entity::getStartingPos);
-        List<Entity> ue = game.getEntitiesVector().stream().filter(e -> e.getDeployRound() > game.getRoundCount()).sorted(comp).toList();
-        if (!ue.isEmpty()) {
-            r = new Report(1060, Report.PUBLIC);
-            addReport(r);
-            int round = -1;
+        if (!abbreviatedReport) {
+            // remaining deployments
+            Comparator<Entity> comp = Comparator.comparingInt(Entity::getDeployRound);
+            comp = comp.thenComparingInt(Entity::getOwnerId);
+            comp = comp.thenComparingInt(Entity::getStartingPos);
+            List<Entity> ue = game.getEntitiesVector().stream().filter(e -> e.getDeployRound() > game.getRoundCount()).sorted(comp).toList();
+            if (!ue.isEmpty()) {
+                r = new Report(1060, Report.PUBLIC);
+                addReport(r);
+                int round = -1;
 
-            for (Entity entity : ue) {
-                if (round != entity.getDeployRound()) {
-                    round = entity.getDeployRound();
-                    r = new Report(1065, Report.PUBLIC);
-                    r.add(round);
+                for (Entity entity : ue) {
+                    if (round != entity.getDeployRound()) {
+                        round = entity.getDeployRound();
+                        r = new Report(1065, Report.PUBLIC);
+                        r.add(round);
+                        addReport(r);
+                    }
+
+                    r = new Report(1066);
+                    r.subject = entity.getId();
+                    r.addDesc(entity);
+                    String s = IStartingPositions.START_LOCATION_NAMES[entity.getStartingPos()];
+                    r.add(s);
                     addReport(r);
                 }
 
-                r = new Report(1066);
-                r.subject = entity.getId();
-                r.addDesc(entity);
-                String s = IStartingPositions.START_LOCATION_NAMES[entity.getStartingPos()];
-                r.add(s);
+                r = new Report(1210, Report.PUBLIC);
+                r.newlines = 2;
                 addReport(r);
             }
 
-            r = new Report(1210, Report.PUBLIC);
-            r.newlines = 2;
-            addReport(r);
-        }
-
-        if (!abbreviatedReport) {
             // we don't much care about wind direction and such in a hard vacuum
             if (!game.getBoard().inSpace()) {
                 // Wind direction and strength

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3120,8 +3120,7 @@ public class GameManager implements IGameManager {
                 GameTurn t = e.nextElement();
                 if (t instanceof GameTurn.SpecificEntityTurn) {
                     Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
-                    if ((entity.getDeployRound() <= game.getRoundCount())
-                    || ((game.getRoundCount() > 1) && (entity.getDeployRound() == game.getRoundCount()))) {
+                    if (entity.getDeployRound() <= game.getRoundCount()) {
                         r = new Report(1045);
                         r.subject = entity.getId();
                         r.addDesc(entity);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3116,30 +3116,53 @@ public class GameManager implements IGameManager {
         if (game.getOptions().booleanOption(OptionsConstants.RPG_INDIVIDUAL_INITIATIVE)) {
             if (deployment) {
                 r = new Report(1041, Report.PUBLIC);
-            } else {
-                r = new Report(1040, Report.PUBLIC);
-            }
-            addReport(r);
-            for (Enumeration<GameTurn> e = game.getTurns(); e.hasMoreElements(); ) {
-                GameTurn t = e.nextElement();
-                if (t instanceof GameTurn.SpecificEntityTurn) {
-                    Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
-                    if (entity.getDeployRound() <= game.getRoundCount()) {
-                        r = new Report(1045);
-                        r.subject = entity.getId();
-                        r.addDesc(entity);
-                        r.add(entity.getInitiative().toString());
-                        addReport(r);
-                    }
-                } else {
-                    Player player = game.getPlayer(t.getPlayerNum());
-                    if (null != player) {
-                        r = new Report(1050, Report.PUBLIC);
-                        r.add(player.getColorForPlayer());
-                        addReport(r);
+                addReport(r);
+                for (Enumeration<GameTurn> e = game.getTurns(); e.hasMoreElements(); ) {
+                    GameTurn t = e.nextElement();
+                    if (t instanceof GameTurn.SpecificEntityTurn) {
+                        Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
+                        if (entity.getDeployRound() == game.getRoundCount()) {
+                            r = new Report(1045);
+                            r.subject = entity.getId();
+                            r.addDesc(entity);
+                            r.add(entity.getInitiative().toString());
+                            addReport(r);
+                        }
+                    } else {
+                        Player player = game.getPlayer(t.getPlayerNum());
+                        if (null != player) {
+                            r = new Report(1050, Report.PUBLIC);
+                            r.add(player.getColorForPlayer());
+                            addReport(r);
+                        }
                     }
                 }
             }
+            if ((!deployment) || (game.getRoundCount() > 1)) {
+                r = new Report(1040, Report.PUBLIC);
+                addReport(r);
+                for (Enumeration<GameTurn> e = game.getTurns(); e.hasMoreElements(); ) {
+                    GameTurn t = e.nextElement();
+                    if (t instanceof GameTurn.SpecificEntityTurn) {
+                        Entity entity = game.getEntity(((GameTurn.SpecificEntityTurn) t).getEntityNum());
+                        if (entity.getDeployRound() < game.getRoundCount()) {
+                            r = new Report(1045);
+                            r.subject = entity.getId();
+                            r.addDesc(entity);
+                            r.add(entity.getInitiative().toString());
+                            addReport(r);
+                        }
+                    } else {
+                        Player player = game.getPlayer(t.getPlayerNum());
+                        if (null != player) {
+                            r = new Report(1050, Report.PUBLIC);
+                            r.add(player.getColorForPlayer());
+                            addReport(r);
+                        }
+                    }
+                }
+            }
+
         } else {
             for (Team team : game.getTeams()) {
                 // Teams with no active players can be ignored


### PR DESCRIPTION
initiative reports update fixes #4060 

- when using (Unofficial) Individual Initiative, do not show rolls for units that will be deployed in later rounds.
- add a section to show the remain units to deploy, break down by round

![image](https://user-images.githubusercontent.com/116095479/212572810-7cba7065-09db-4209-81d4-f1905b74e93a.png)

![image](https://user-images.githubusercontent.com/116095479/212572937-84169c3f-690c-4b50-9043-034917db6327.png)
