### PR TITLE
saveSettings updates

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/MiniReportDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/MiniReportDisplayDialog.java
@@ -58,14 +58,18 @@ public class MiniReportDisplayDialog extends JDialog {
     }
     //endregion Constructors
 
+    public void saveSettings() {
+        GUIP.setMiniReportSizeWidth(getSize().width);
+        GUIP.setMiniReportSizeHeight(getSize().height);
+        GUIP.setMiniReportPosX(getLocation().x);
+        GUIP.setMiniReportPosY(getLocation().y);
+    }
+
     @Override
     protected void processWindowEvent(WindowEvent e) {
         super.processWindowEvent(e);
         if ((e.getID() == WindowEvent.WINDOW_DEACTIVATED) || (e.getID() == WindowEvent.WINDOW_CLOSING)) {
-            GUIP.setMiniReportSizeWidth(getSize().width);
-            GUIP.setMiniReportSizeHeight(getSize().height);
-            GUIP.setMiniReportPosX(getLocation().x);
-            GUIP.setMiniReportPosY(getLocation().y);
+            saveSettings();
         }
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/UnitDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/UnitDisplayDialog.java
@@ -65,24 +65,28 @@ public class UnitDisplayDialog extends JDialog {
     }
     //endregion Constructors
 
+    public void saveSettings() {
+        if ((getSize().width * getSize().height) > 0) {
+            if (GUIP.getUnitDisplayStartTabbed()) {
+                GUIP.setUnitDisplayPosX(getLocation().x);
+                GUIP.setUnitDisplayPosY(getLocation().y);
+                GUIP.setUnitDisplaySizeWidth(getSize().width);
+                GUIP.setUnitDisplaySizeHeight(getSize().height);
+            } else {
+                GUIP.setUnitDisplayNontabbedPosX(getLocation().x);
+                GUIP.setUnitDisplayNontabbedPosY(getLocation().y);
+                GUIP.setUnitDisplayNonTabbedSizeWidth(getSize().width);
+                GUIP.setUnitDisplayNonTabbedSizeHeight(getSize().height);
+                clientGUI.getUnitDisplay().saveSplitterLoc();
+            }
+        }
+    }
+
     @Override
     protected void processWindowEvent(WindowEvent e) {
         super.processWindowEvent(e);
         if ((e.getID() == WindowEvent.WINDOW_DEACTIVATED) || (e.getID() == WindowEvent.WINDOW_CLOSING)) {
-            if ((getSize().width * getSize().height) > 0) {
-                if (GUIP.getUnitDisplayStartTabbed()) {
-                    GUIP.setUnitDisplayPosX(getLocation().x);
-                    GUIP.setUnitDisplayPosY(getLocation().y);
-                    GUIP.setUnitDisplaySizeWidth(getSize().width);
-                    GUIP.setUnitDisplaySizeHeight(getSize().height);
-                } else {
-                    GUIP.setUnitDisplayNontabbedPosX(getLocation().x);
-                    GUIP.setUnitDisplayNontabbedPosY(getLocation().y);
-                    GUIP.setUnitDisplayNonTabbedSizeWidth(getSize().width);
-                    GUIP.setUnitDisplayNonTabbedSizeHeight(getSize().height);
-                    clientGUI.getUnitDisplay().saveSplitterLoc();
-                }
-            }
+            saveSettings();
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -367,6 +367,14 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         this.unitDisplayDialog = unitDisplayDialog;
     }
 
+    public JDialog getMiniMapDialog() {
+        return minimapW;
+    }
+
+    public void setMiniMapDialog(final JDialog miniMapDialog) {
+        this.minimapW = miniMapDialog;
+    }
+
     public MiniReportDisplay getMiniReportDisplay() {
         return miniReportDisplay;
     }
@@ -379,12 +387,16 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         return miniReportDisplayDialog;
     }
 
+    public void setMiniReportDisplayDialog(final MiniReportDisplayDialog miniReportDisplayDialog) {
+        this.miniReportDisplayDialog = miniReportDisplayDialog;
+    }
+
     public PlayerListDialog getPlayerListDialog() {
         return playerListDialog;
     }
 
-    public void setMiniReportDisplayDialog(final MiniReportDisplayDialog miniReportDisplayDialog) {
-        this.miniReportDisplayDialog = miniReportDisplayDialog;
+    public void setPlayerListDialog(final PlayerListDialog playerListDialog) {
+        this.playerListDialog = playerListDialog;
     }
 
     /**
@@ -570,7 +582,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         setMiniReportDisplayDialog(new MiniReportDisplayDialog(getFrame(), this));
         getMiniReportDisplayDialog().setVisible(false);
 
-        playerListDialog = new PlayerListDialog(frame, client, false);
+        setPlayerListDialog(new PlayerListDialog(frame, client, false));
 
         Ruler.color1 = GUIP.getRulerColor1();
         Ruler.color2 = GUIP.getRulerColor2();
@@ -579,7 +591,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         ruler.setSize(GUIP.getRulerSizeHeight(), GUIP.getRulerSizeWidth());
         UIUtil.updateWindowBounds(ruler);
 
-        minimapW = Minimap.createMinimap(frame, getBoardView(), getClient().getGame(), this);
+        setMiniMapDialog(Minimap.createMinimap(frame, getBoardView(), getClient().getGame(), this));
         cb = new ChatterBox(this);
         cb.setChatterBox2(cb2);
         cb2.setChatterBox(cb);
@@ -683,16 +695,16 @@ public class ClientGUI extends JPanel implements BoardViewListener,
      * Called when the user selects the "View->Player List" menu item.
      */
     public void showPlayerList() {
-        if (playerListDialog == null) {
-            playerListDialog = new PlayerListDialog(frame, client, false);
+        if (getPlayerListDialog() == null) {
+            setPlayerListDialog(new PlayerListDialog(frame, client, false));
         }
-        playerListDialog.setVisible(true);
+        getPlayerListDialog().setVisible(true);
     }
 
     public void miniReportDisplayAddReportPages() {
         ignoreHotKeys = true;
-        if (miniReportDisplay != null) {
-            miniReportDisplay.addReportPages();
+        if (getMiniReportDisplay() != null) {
+            getMiniReportDisplay().addReportPages();
         }
         ignoreHotKeys = false;
     }
@@ -712,17 +724,17 @@ public class ClientGUI extends JPanel implements BoardViewListener,
     }
 
     public void resetWindowPositions() {
-        if (minimapW != null) {
-            minimapW.setBounds(0, 0, minimapW.getWidth(), minimapW.getHeight());
+        if (getMiniMapDialog() != null) {
+            getMiniMapDialog().setBounds(0, 0, getMiniMapDialog().getWidth(), getMiniMapDialog().getHeight());
         }
         if (getUnitDisplayDialog() != null) {
             getUnitDisplayDialog().setBounds(0, 0, getUnitDisplay().getWidth(), getUnitDisplay().getHeight());
         }
-        if (miniReportDisplayDialog!= null) {
-            miniReportDisplayDialog.setBounds(0, 0, miniReportDisplayDialog.getWidth(), miniReportDisplayDialog.getHeight());
+        if (getMiniReportDisplayDialog() != null) {
+            getMiniReportDisplayDialog().setBounds(0, 0, getMiniReportDisplayDialog().getWidth(), getMiniReportDisplayDialog().getHeight());
         }
-        if (playerListDialog != null) {
-            playerListDialog.setBounds(0, 0, playerListDialog.getWidth(), playerListDialog.getHeight());
+        if (getPlayerListDialog() != null) {
+            getPlayerListDialog().setBounds(0, 0, getPlayerListDialog().getWidth(), getPlayerListDialog().getHeight());
         }
         if (gameOptionsDialog!= null) {
             gameOptionsDialog.setBounds(0, 0, gameOptionsDialog.getWidth(), gameOptionsDialog.getHeight());
@@ -998,30 +1010,26 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         GUIP.setWindowSizeWidth(frame.getSize().width);
         GUIP.setWindowSizeHeight(frame.getSize().height);
 
-        // Minimap
-        if ((minimapW != null) && ((minimapW.getSize().width * minimapW.getSize().height) > 0)) {
-            GUIP.setMinimapPosX(minimapW.getLocation().x);
-            GUIP.setMinimapPosY(minimapW.getLocation().y);
+        // Minimap Dialog
+        if ((getMiniMapDialog() != null) && ((getMiniMapDialog().getSize().width * getMiniMapDialog().getSize().height) > 0)) {
+            GUIP.setMinimapPosX(getMiniMapDialog().getLocation().x);
+            GUIP.setMinimapPosY(getMiniMapDialog().getLocation().y);
         }
 
-        // Mek display
-        if ((getUnitDisplayDialog() != null)
-                && ((getUnitDisplayDialog().getSize().width * getUnitDisplayDialog().getSize().height) > 0)) {
-            if (GUIP.getUnitDisplayStartTabbed()) {
-                GUIP.setUnitDisplayPosX(getUnitDisplayDialog().getLocation().x);
-                GUIP.setUnitDisplayPosY(getUnitDisplayDialog().getLocation().y);
-                GUIP.setUnitDisplaySizeWidth(getUnitDisplayDialog().getSize().width);
-                GUIP.setUnitDisplaySizeHeight(getUnitDisplayDialog().getSize().height);
-            }
-            else {
-                GUIP.setUnitDisplayNontabbedPosX(getUnitDisplayDialog().getLocation().x);
-                GUIP.setUnitDisplayNontabbedPosY(getUnitDisplayDialog().getLocation().y);
-                GUIP.setUnitDisplayNonTabbedSizeWidth(getUnitDisplayDialog().getSize().width);
-                GUIP.setUnitDisplayNonTabbedSizeHeight(getUnitDisplayDialog().getSize().height);
-                unitDisplay.saveSplitterLoc();
-            }
-
+        // Unit Display Dialog
+        if (getUnitDisplayDialog() != null) {
+            getUnitDisplayDialog().saveSettings();
             saveSplitPaneLocations();
+        }
+
+        // Mini Report Dialog
+        if (getMiniReportDisplayDialog() != null) {
+            getMiniReportDisplayDialog().saveSettings();
+        }
+
+        // Player List Dialog
+        if (getPlayerListDialog() != null) {
+            getPlayerListDialog().saveSettings();
         }
 
         // Ruler display
@@ -1497,8 +1505,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
      * Does not change the menu setting. 
      */
     void setMapVisible(boolean visible) {
-        if (minimapW != null) {
-            minimapW.setVisible(visible);
+        if (getMiniMapDialog() != null) {
+            getMiniMapDialog().setVisible(visible);
         }
     }
 
@@ -1512,8 +1520,8 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         if (visible) {
             showPlayerList();
         } else {
-            if (playerListDialog != null) {
-                playerListDialog.setVisible(visible);
+            if (getPlayerListDialog() != null) {
+                getPlayerListDialog().setVisible(visible);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -724,7 +724,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
     }
 
     private boolean resetMiniMapZoom(Container c) {
-        for (Component comp: c.getComponents()) {
+        for (Component comp : c.getComponents()) {
             if (comp instanceof Minimap) {
                 Minimap mm = (Minimap) comp;
                 mm.resetZoom();

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -723,9 +723,25 @@ public class ClientGUI extends JPanel implements BoardViewListener,
         }
     }
 
+    private boolean resetMiniMapZoom(Container c) {
+        for (Component comp: c.getComponents()) {
+            if (comp instanceof Minimap) {
+                Minimap mm = (Minimap) comp;
+                mm.resetZoom();
+                return true;
+            } else {
+                if (resetMiniMapZoom((Container) comp)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public void resetWindowPositions() {
         if (getMiniMapDialog() != null) {
             getMiniMapDialog().setBounds(0, 0, getMiniMapDialog().getWidth(), getMiniMapDialog().getHeight());
+            resetMiniMapZoom(getMiniMapDialog());
         }
         if (getUnitDisplayDialog() != null) {
             getUnitDisplayDialog().setBounds(0, 0, getUnitDisplay().getWidth(), getUnitDisplay().getHeight());

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -13,7 +13,6 @@
  */
 package megamek.client.ui.swing;
 
-import megamek.client.ui.Messages;
 import megamek.client.ui.swing.boardview.BoardView;
 import megamek.client.ui.swing.boardview.LabelDisplayStyle;
 import megamek.client.ui.swing.util.PlayerColour;
@@ -211,6 +210,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String MINI_MAP_POS_X = "MinimapPosX";
     public static final String MINI_MAP_POS_Y = "MinimapPosY";
     public static final String MINI_MAP_ZOOM = "MinimapZoom";
+    public static final String MINI_MAP_HEIGHT_DISPLAY_MODE = "MinimapHeightDisplayMode";
     public static final String MINI_MAP_AUTO_DISPLAY_REPORT_PHASE = "MinimapAutoDiplayReportPhase";
     public static final String MINI_MAP_AUTO_DISPLAY_NONREPORT_PHASE = "MinimapAutoDiplayNonReportPhase";
     public static final String MINIMUM_SIZE_HEIGHT = "MinimumSizeHeight";
@@ -950,6 +950,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getInt(MINI_MAP_ZOOM);
     }
 
+    public int getMinimapHeightDisplayMode() {
+        return store.getInt(MINI_MAP_HEIGHT_DISPLAY_MODE);
+    }
+
     public boolean getMiniReportEnabled() {
         return store.getBoolean(MINI_REPORT_ENABLED);
     }
@@ -1543,6 +1547,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setMinimapZoom(int zoom) {
         store.setValue(MINI_MAP_ZOOM, zoom);
+    }
+
+    public void setMinimapHeightDisplayMode(int zoom) {
+        store.setValue(MINI_MAP_HEIGHT_DISPLAY_MODE, zoom);
     }
 
     public void setMinimapAutoDisplayReportPhase(int i) {

--- a/megamek/src/megamek/client/ui/swing/PlayerListDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlayerListDialog.java
@@ -183,13 +183,17 @@ public class PlayerListDialog extends JDialog implements ActionListener, IPrefer
         }
     }
 
+    public void saveSettings() {
+        GUIP.setPlayerListPosX(getLocation().x);
+        GUIP.setPlayerListPosY(getLocation().y);
+    }
+
     @Override
     protected void processWindowEvent(WindowEvent e) {
         super.processWindowEvent(e);
         if ((e.getID() == WindowEvent.WINDOW_DEACTIVATED) || (e.getID() == WindowEvent.WINDOW_CLOSING)) {
             if (!modal) {
-                GUIP.setPlayerListPosX(getLocation().x);
-                GUIP.setPlayerListPosY(getLocation().y);
+                saveSettings();
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -126,7 +126,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     /** A list of information on hexes with roads or bridges. */
     private final List<int[]> roadHexes = new ArrayList<>();
     private int zoom = GUIP.getMinimapZoom();
-    private int heightDisplayMode = SHOW_NO_HEIGHT;
+    private int heightDisplayMode = GUIP.getMinimapHeightDisplayMode();
     
     private Coords firstLOS;
     private Coords secondLOS;
@@ -220,8 +220,6 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             client = clientGui.getClient();
         }
         initializeColors();
-        zoom = GUIP.getMinimapZoom();
-        heightDisplayMode = GUIP.getMinimapHeightDisplayMode();
         if (dialog != null) {
             initializeDialog();
             initializeListeners();

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -86,6 +86,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     private static final int[] HALF_ROAD_WIDTH = {0, 0, 0, 1, 2, 3, 3};
     private static final int[] UNIT_SIZES = {4, 5, 6, 7, 8, 9, 10};
     private static final int[] UNIT_SCALE = {7, 8, 9, 11, 12, 14, 16};
+    private static final int MIM_ZOOM = 0;
     private static final int MAX_ZOOM = HEX_SIDE.length - 1;
     
     private static final int SHOW_NO_HEIGHT = 0;
@@ -1272,6 +1273,12 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             initializeMap();
             GUIP.setMinimapZoom(zoom);
         }
+    }
+
+    public void resetZoom() {
+        zoom = MIM_ZOOM;
+        initializeMap();
+        GUIP.setMinimapZoom(zoom);
     }
 
     private void processMouseRelease(int x, int y, int modifiers) {

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -219,6 +219,8 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             client = clientGui.getClient();
         }
         initializeColors();
+        zoom = GUIP.getMinimapZoom();
+        heightDisplayMode = GUIP.getMinimapHeightDisplayMode();
         if (dialog != null) {
             initializeDialog();
             initializeListeners();
@@ -1297,6 +1299,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
                     zoomOut();
                 } else if ((x < 2 * BUTTON_HEIGHT) && (zoom > 3)) {
                     heightDisplayMode = ((++heightDisplayMode) > NBR_MODES) ? 0 : heightDisplayMode;
+                    GUIP.setMinimapHeightDisplayMode(heightDisplayMode);
                     initializeMap();
                 } else if (x > (getSize().width - BUTTON_HEIGHT)) {
                     zoomIn();


### PR DESCRIPTION
- When the main window is closed, save the locations for the unit display dialog, mini map dialog, mini report dialog, and player list dialog.  
- for mini map dialog, save the height display mode.  load this settings on startup.
- reset mini map zoom to min zoom when resetting windows.
