### PR TITLE
show movement for all entity types on unit tool tip

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1110,11 +1110,9 @@ public final class UnitToolTip {
                 }
             }
 
-            if (entity instanceof Tank) {
-                result.append(DOT_SPACER + entity.getMovementModeAsString());
-            }
+            result.append(DOT_SPACER + entity.getMovementModeAsString());
 
-            if (entity instanceof IBomber) {
+            if ((entity instanceof IBomber) && (!(entity instanceof LandAirMech))) {
                 int bombMod = 0;
                 bombMod = ((IBomber) entity).reduceMPByBombLoad(walkMP);
                 if (bombMod != walkMP) {

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1112,7 +1112,7 @@ public final class UnitToolTip {
 
             result.append(DOT_SPACER + entity.getMovementModeAsString());
 
-            if ((entity instanceof IBomber) && (!(entity instanceof LandAirMech))) {
+            if (entity instanceof IBomber) {
                 int bombMod = 0;
                 bombMod = ((IBomber) entity).reduceMPByBombLoad(walkMP);
                 if (bombMod != walkMP) {

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -1130,7 +1130,7 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
     @Override
     public int reduceMPByBombLoad(int t) {
         // bombs don't impact movement
-        return 0;
+        return t;
     }
 
     @Override


### PR DESCRIPTION
- show movement mode for all entity types on unit tool tip.  to make it easier to see what mode unit is in.  most useful for units that can convert modes.
- correct issue of movement reduced bomb indicator incorrectly showing on LAMs.

![image](https://user-images.githubusercontent.com/116095479/213937902-6908bba5-0296-4d41-8798-bdff0c53f44d.png)

![image](https://user-images.githubusercontent.com/116095479/213937923-308fd2cc-7116-42f7-8350-052f504b2ccf.png)



