### PR TITLE
issue 4032

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -29836,8 +29836,9 @@ public class GameManager implements IGameManager {
      * Creates a packet containing a Vector of Reports that represent a Tactical
      * Genius re-roll request which needs to update a current phase's report.
      */
-    private Packet createTacticalGeniusReportPacket() {
-        return new Packet(PacketCommand.SENDING_REPORTS_TACTICAL_GENIUS, vPhaseReport.clone());
+    private Packet createTacticalGeniusReportPacket(Player p) {
+        return new Packet(PacketCommand.SENDING_REPORTS_TACTICAL_GENIUS,
+                (p == null) || !doBlind() ? vPhaseReport.clone() : filterReportVector(vPhaseReport, p));
     }
 
     /**
@@ -30125,7 +30126,7 @@ public class GameManager implements IGameManager {
         }
 
         for (Player p : game.getPlayersVector()) {
-            send(p.getId(), tacticalGeniusReport ? createTacticalGeniusReportPacket() : createReportPacket(p));
+            send(p.getId(), tacticalGeniusReport ? createTacticalGeniusReportPacket(p) : createReportPacket(p));
         }
     }
 


### PR DESCRIPTION
Fixes  #4032 

- filter packet by player when using double blind, before sending Tactical Genius Report

![image](https://user-images.githubusercontent.com/116095479/216775373-d3de56cd-6867-42e3-bb30-34280bb2205f.png)
