### PR TITLE
weapon list count

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -223,6 +223,7 @@ AdvancedOptions.PlanetaryConditionsShowIndicators.name=Planetary Conditions Show
 AdvancedOptions.UnitToolTipSeenByResolution.name=UnitToolTip - Seen By Resolution [1=Someone,2=Team,3=Player]
 AdvancedOptions.DockOnLeft.name=Dock on left side of the board
 AdvancedOptions.DockMultipleOnYAxis.name=Dock multiple panels using the y axis
+AdvancedOptions.UnitDisplayWeaponListCount.name=Unit Display - Weapon list visible count
 
 #Board Editor
 BoardEditor.BridgeBuildingElevError=Bridge/Building Elevation is an offset from the surface of a hex and hence must be a positive value!

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -114,6 +114,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_UNITTOOLTIP_SEENBYRESOLUTION = "AdvancedUnitToolTipSeenByResolution";
     public static final String ADVANCED_DOCK_ON_LEFT = "AdvancedDockOnLeft";
     public static final String ADVANCED_DOCK_MULTIPLE_ON_Y_AXIS = "AdvancedDockMultipleOnYAxis";
+    public static final String ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT = "AdvancedUnitDisplayWeaponListCount";
 
     /* --End advanced settings-- */
 
@@ -431,6 +432,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_DOCK_ON_LEFT, true);
         setDefault(ADVANCED_DOCK_MULTIPLE_ON_Y_AXIS, true);
 
+        setDefault(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT, 10);
+
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
         store.setDefault(FOV_HIGHLIGHT, false);
@@ -737,6 +740,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public boolean getUnitDisplayEnabled() {
         return store.getBoolean(UNIT_DISPLAY_ENABLED);
+    }
+
+    public int getUnitDisplayWeaponListCount() {
+        return store.getInt(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT);
     }
 
     public int getUnitDisplayLocaton() {
@@ -1340,6 +1347,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setUnitDisplayEnabled(boolean b) {
         store.setValue(UNIT_DISPLAY_ENABLED, b);
+    }
+
+    public void setUnitDisplayWeaponListCount(int i) {
+        store.setValue(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT, i);
     }
 
     public void toggleUnitDisplayLocation() {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -361,6 +361,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
     public static final int TARGET_DISPLAY_WIDTH = 200;
 
+    private static final GUIPreferences GUIP = GUIPreferences.getInstance();
+
     WeaponPanel(UnitDisplay unitDisplay) {
 
         this.unitDisplay = unitDisplay;
@@ -387,9 +389,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         WeaponListMouseAdapter mouseAdapter = new WeaponListMouseAdapter();
         weaponList.addMouseListener(mouseAdapter);
         weaponList.addMouseMotionListener(mouseAdapter);
+        weaponList.setVisibleRowCount(GUIP.getUnitDisplayWeaponListCount());
         tWeaponScroll = new JScrollPane(weaponList);
-        tWeaponScroll.setMinimumSize(new Dimension(200, 100));
-        tWeaponScroll.setPreferredSize(new Dimension(200, 100));
         panelMain.add(tWeaponScroll,
             GBC.eol().insets(15, 9, 15, 9)
                .fill(GridBagConstraints.HORIZONTAL)
@@ -762,7 +763,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         addListeners();
 
         adaptToGUIScale();
-        GUIPreferences.getInstance().addPreferenceChangeListener(this);
+        GUIP.addPreferenceChangeListener(this);
         setLayout(new BorderLayout());
         add(panelMain);
         panelMain.setOpaque(false);
@@ -1052,8 +1053,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             heatText += "*"; // overheat indication
         }
 
-        currentHeatBuildupR.setForeground(GUIPreferences.getInstance().getColorForHeat(
-                heatOverCapacity, Color.WHITE));
+        currentHeatBuildupR.setForeground(GUIP.getColorForHeat(heatOverCapacity, Color.WHITE));
         currentHeatBuildupR.setText(heatText + " (" + heatCapacityStr + ')');
 
         // change what is visible based on type
@@ -2690,8 +2690,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
     private void adaptToGUIScale() {
         UIUtil.adjustContainer(panelMain, UIUtil.FONT_SCALE1);
-        tWeaponScroll.setMinimumSize(new Dimension(200, UIUtil.scaleForGUI(200)));
-        tWeaponScroll.setPreferredSize(new Dimension(200, UIUtil.scaleForGUI(200)));
     }
 
     @Override
@@ -2699,6 +2697,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         // Update the text size when the GUI scaling changes
         if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
             adaptToGUIScale();
+        } else if (e.getName().equals(GUIPreferences.ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT)) {
+            weaponList.setVisibleRowCount(GUIP.getUnitDisplayWeaponListCount());
+            weaponList.revalidate();
+            weaponList.repaint();
         }
     }
 }


### PR DESCRIPTION
Fixes #3151

add advance setting to set the visible row count for the unit display - weapon list.  default to 10 rows.

![image](https://user-images.githubusercontent.com/116095479/216777587-e13fae8b-7dd4-4f8b-973f-6813998dbf39.png)

![image](https://user-images.githubusercontent.com/116095479/216777624-6ca6695f-f027-4276-a986-3603aadcebe2.png)
