### PR TITLE
issue 4171

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -594,6 +594,7 @@ BoardView1.Tooltip.UnconnectedC3Computer=Unconnected C3 Computer
 BoardView1.Tooltip.Undamaged=UNDAMAGED
 BoardView1.Tooltip.UnjammingRAC=Unjamming RAC
 BoardView1.Tooltip.Unknown=UNKNOWN
+BoardView1.Tooltip.unknownOwner=Unknown owner
 BoardView1.Tooltip.Weapon={3} {1}{2}
 BoardView1.Tooltip.Wreckof=Wreck of 
 BoardView1.Tooltip.X=x 

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -79,15 +79,18 @@ public final class UnitToolTip {
 
         // Unit Chassis and Player
         Player owner = game.getPlayer(entity.getOwnerId());
+        Color ownerColor = (owner != null) ? owner.getColour().getColour() : uiGray();
+        String ownerName = (owner != null) ? owner.getName() : ReportMessages.getString("BoardView1.Tooltip.unknownOwner");
+
         String msg_clanbrackets =Messages.getString("BoardView1.Tooltip.ClanBrackets");
         String clanStr = entity.isClan() && !entity.isMixedTech() ? " " + msg_clanbrackets + " " : "";
         String sChassisPlayerInfo = entity.getChassis() + clanStr;
         sChassisPlayerInfo += " (" + (int) entity.getWeight() + "t)";
         sChassisPlayerInfo += "&nbsp;&nbsp;" + entity.getEntityTypeName(entity.getEntityType());
-        sChassisPlayerInfo += "<BR>" + owner.getName();
+        sChassisPlayerInfo += "<BR>" + ownerName;
         String msg_id = MessageFormat.format(" [ID: {0}]", entity.getId());
         sChassisPlayerInfo += UIUtil.guiScaledFontHTML(UIUtil.uiGray()) + msg_id + "</FONT>";
-        sChassisPlayerInfo = guiScaledFontHTML(entity.getOwner().getColour().getColour()) + sChassisPlayerInfo +  "</FONT>";
+        sChassisPlayerInfo = guiScaledFontHTML(ownerColor) + sChassisPlayerInfo +  "</FONT>";
 
         result += sChassisPlayerInfo;
 


### PR DESCRIPTION
#4171

fixes NPE in log, but could not reproduce the errors.

still may be an issue with the Ostol showing up in Salvage.   could be because the owner was null


00:41:33,811 ERROR [mekhq.MekHQ] {AWT-EventQueue-0}
mekhq.MekHQ.lambda$main$0(MekHQ.java:240) - Uncaught Exception Detected
java.lang.NullPointerException: Cannot invoke "megamek.common.Player.getName()" because "owner" is null
	at megamek.client.ui.swing.tooltip.UnitToolTip.getEntityTipTable(UnitToolTip.java:87)
	at megamek.client.ui.swing.tooltip.UnitToolTip.getEntityTipGame(UnitToolTip.java:57)
	at megamek.client.ui.swing.boardview.BoardView.appendEntityTooltip(BoardView.java:5923)

