### PR TITLE
MHQ 3601: Fixing Specified Description Text

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractNagDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractNagDialog.java
@@ -39,8 +39,8 @@ public abstract class AbstractNagDialog extends AbstractButtonDialog {
                                 final String description, final String key) {
         super(frame, name, title);
         this.key = key;
-        setShow(checkNag());
         setDescription(description.isBlank() ? description : resources.getString(description));
+        setShow(checkNag());
         if (isShow()) {
             initialize();
         } else {


### PR DESCRIPTION
checkNag may set the description, so we can't set description first