### PR TITLE
swap advance setting to panel height from visible row count, handles …

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -227,7 +227,7 @@ AdvancedOptions.UnitToolTipSeenByResolution.name=UnitToolTip - Seen By Resolutio
 AdvancedOptions.DockOnLeft.name=Dock on left side of the board
 AdvancedOptions.DockMultipleOnYAxis.name=Dock multiple panels using the y axis
 AdvancedOptions.PlayersRemainingToShow.name=Number of Players remaining to show on the Phase Display Status Bar
-AdvancedOptions.UnitDisplayWeaponListCount.name=Unit Display - Weapon list visible count
+AdvancedOptions.UnitDisplayWeaponListHeight.name=Unit Display - Weapon list panel height
 
 #Board Editor
 BoardEditor.BridgeBuildingElevError=Bridge/Building Elevation is an offset from the surface of a hex and hence must be a positive value!

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -115,7 +115,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String ADVANCED_DOCK_ON_LEFT = "AdvancedDockOnLeft";
     public static final String ADVANCED_DOCK_MULTIPLE_ON_Y_AXIS = "AdvancedDockMultipleOnYAxis";
     public static final String ADVANCED_PLAYERS_REMAINING_TO_SHOW = "AdvancedPlayersRemainingToShow";
-    public static final String ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT = "AdvancedUnitDisplayWeaponListCount";
+    public static final String ADVANCED_UNIT_DISPLAY_WEAPON_LIST_HEIGHT = "AdvancedUnitDisplayWeaponListHeight";
 
     /* --End advanced settings-- */
 
@@ -439,7 +439,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(ADVANCED_DOCK_MULTIPLE_ON_Y_AXIS, true);
         setDefault(ADVANCED_PLAYERS_REMAINING_TO_SHOW, 3);
 
-        setDefault(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT, 10);
+        setDefault(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_HEIGHT, 200);
 
         store.setDefault(FOV_HIGHLIGHT_RINGS_RADII, "5 10 15 20 25");
         store.setDefault(FOV_HIGHLIGHT_RINGS_COLORS_HSB, "0.3 1.0 1.0 ; 0.45 1.0 1.0 ; 0.6 1.0 1.0 ; 0.75 1.0 1.0 ; 0.9 1.0 1.0 ; 1.05 1.0 1.0 ");
@@ -753,8 +753,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getBoolean(UNIT_DISPLAY_ENABLED);
     }
 
-    public int getUnitDisplayWeaponListCount() {
-        return store.getInt(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT);
+    public int getUnitDisplayWeaponListHeight() {
+        return store.getInt(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_HEIGHT);
     }
 
     public int getUnitDisplayLocaton() {
@@ -1380,8 +1380,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setValue(UNIT_DISPLAY_ENABLED, b);
     }
 
-    public void setUnitDisplayWeaponListCount(int i) {
-        store.setValue(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT, i);
+    public void setAdvancedUnitDisplayWeaponListHeight(int i) {
+        store.setValue(ADVANCED_UNIT_DISPLAY_WEAPON_LIST_HEIGHT, i);
     }
 
     public void toggleUnitDisplayLocation() {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -400,7 +400,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         WeaponListMouseAdapter mouseAdapter = new WeaponListMouseAdapter();
         weaponList.addMouseListener(mouseAdapter);
         weaponList.addMouseMotionListener(mouseAdapter);
-        //weaponList.setVisibleRowCount(GUIP.getUnitDisplayWeaponListCount());
         tWeaponScroll = new JScrollPane(weaponList);
         tWeaponScroll.setMinimumSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
         tWeaponScroll.setPreferredSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -295,7 +295,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
     private Targetable prevTarget = null;
     private JPanel panelMain;
     private JScrollPane tWeaponScroll;
-    private JPanel wPanel;
     private JComboBox<String> m_chAmmo;
     public JComboBox<String> m_chBayWeapon;
 
@@ -375,14 +374,25 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 SwingConstants.LEFT);
         wSortOrder.setOpaque(false);
         wSortOrder.setForeground(Color.WHITE);
-        panelMain.add(wSortOrder, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(15, 9, 1, 1).gridy(gridy).gridx(0));
+
+        JPanel pWeaponOrder = new JPanel(new GridBagLayout());
+        pWeaponOrder.setOpaque(false);
+        int pgridy = 0;
+
+        pWeaponOrder.add(wSortOrder, GBC.std().fill(GridBagConstraints.HORIZONTAL)
+               .insets(15, 9, 1, 1).gridy(pgridy).gridx(0));
         comboWeaponSortOrder = new MMComboBox<>("comboWeaponSortOrder", WeaponSortOrder.values());
-        panelMain.add(comboWeaponSortOrder,
+        pWeaponOrder.add(comboWeaponSortOrder,
                 GBC.eol().insets(15, 9, 15, 1)
                    .fill(GridBagConstraints.HORIZONTAL)
-                   .anchor(GridBagConstraints.CENTER).gridy(gridy)
+                   .anchor(GridBagConstraints.WEST).gridy(pgridy)
                    .gridx(1));
+
+        panelMain.add(pWeaponOrder, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .gridwidth(3)
+                .gridy(gridy).gridx(0));
+
         gridy++;
 
         // weapon list
@@ -390,22 +400,23 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         WeaponListMouseAdapter mouseAdapter = new WeaponListMouseAdapter();
         weaponList.addMouseListener(mouseAdapter);
         weaponList.addMouseMotionListener(mouseAdapter);
-        weaponList.setVisibleRowCount(GUIP.getUnitDisplayWeaponListCount());
+        //weaponList.setVisibleRowCount(GUIP.getUnitDisplayWeaponListCount());
         tWeaponScroll = new JScrollPane(weaponList);
-        wPanel = new JPanel(new BorderLayout());
-        wPanel.setOpaque(false);
-        wPanel.setMinimumSize(new Dimension(200, UIUtil.scaleForGUI(200)));
-        wPanel.add(tWeaponScroll, BorderLayout.WEST);
-        panelMain.add(wPanel,
+        tWeaponScroll.setMinimumSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
+        tWeaponScroll.setPreferredSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
+        panelMain.add(tWeaponScroll,
             GBC.eol().insets(15, 9, 15, 9)
                .fill(GridBagConstraints.HORIZONTAL)
-               .anchor(GridBagConstraints.WEST).gridy(gridy)
+               .anchor(GridBagConstraints.WEST)
+               .gridy(gridy)
+               .gridwidth(3)
                .gridx(0));
-        gridy++;
         weaponList.resetKeyboardActions();
         for (KeyListener key : weaponList.getKeyListeners()) {
             weaponList.removeKeyListener(key);
         }
+
+        gridy++;
 
         // adding Ammo choice + label
 
@@ -419,16 +430,29 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         wBayWeapon.setForeground(Color.WHITE);
         m_chBayWeapon = new JComboBox<>();
 
-        panelMain.add(wBayWeapon, GBC.std().insets(15, 1, 1, 1).gridy(gridy).gridx(0));
+        JPanel pAmmo = new JPanel(new GridBagLayout());
+        pAmmo.setOpaque(false);
+        pgridy = 0;
 
-        panelMain.add(m_chBayWeapon, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                              .insets(1, 1, 15, 1).gridy(gridy).gridx(1));
-        gridy++;
-        panelMain.add(wAmmo, GBC.std().insets(15, 9, 1, 1).gridy(gridy).gridx(0));
+        pAmmo.add(wBayWeapon, GBC.std().insets(15, 1, 1, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(m_chAmmo,
+        pAmmo.add(m_chBayWeapon, GBC.std().fill(GridBagConstraints.HORIZONTAL)
+                              .insets(15, 1, 15, 1).gridy(pgridy).gridx(1));
+
+        pgridy++;
+
+        pAmmo.add(wAmmo, GBC.std().insets(15, 9, 1, 1).gridy(pgridy).gridx(0));
+
+        pAmmo.add(m_chAmmo,
             GBC.eol().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 15, 1).gridy(gridy).gridx(1));
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 15, 1).gridy(pgridy).gridx(1));
+
+        panelMain.add(pAmmo, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .gridwidth(3)
+                .gridy(gridy).gridx(0));
+
         gridy++;
         // Adding Heat Buildup
 
@@ -439,14 +463,26 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         currentHeatBuildupR.setOpaque(false);
         currentHeatBuildupR.setForeground(Color.WHITE);
 
-        panelMain.add(currentHeatBuildupL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .anchor(GridBagConstraints.EAST).insets(9, 1, 1, 9)
-               .gridy(gridy).gridx(0));
+        JPanel pHeatBuildup = new JPanel(new GridBagLayout());
+        pHeatBuildup.setOpaque(false);
+        pgridy = 0;
 
-        panelMain.add(currentHeatBuildupR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 1, 9, 9).gridy(gridy).gridx(1));
+        pHeatBuildup.add(currentHeatBuildupL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .anchor(GridBagConstraints.WEST).insets(15, 9, 1, 9)
+               .gridy(pgridy).gridx(0));
+
+        pHeatBuildup.add(currentHeatBuildupR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 9, 9, 9).gridy(pgridy).gridx(1));
+
+        panelMain.add(pHeatBuildup, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .gridwidth(3)
+                .gridy(gridy).gridx(0));
+
         gridy++;
 
         // Adding weapon display labels
@@ -482,41 +518,61 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         wDamageTrooperR.setOpaque(false);
         wDamageTrooperR.setForeground(Color.WHITE);
 
-        panelMain.add(wNameL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(0));
 
-        panelMain.add(wHeatL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(1));
+        JPanel pCurrentWeapon = new JPanel(new GridBagLayout());
+        pCurrentWeapon.setOpaque(false);
+        pgridy = 0;
+        pCurrentWeapon.add(wNameL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 1, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wDamL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(2));
+        pCurrentWeapon.add(wHeatL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 1, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wArcHeatL, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                          .insets(1, 9, 1, 1).gridy(gridy).gridx(3));
+        pCurrentWeapon.add(wDamL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 1, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wDamageTrooperL, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                                .insets(1, 9, 1, 1).gridy(gridy).gridx(3));
-        gridy++;
-        panelMain.add(wNameR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(0));
+        pCurrentWeapon.add(wArcHeatL, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(15, 9, 1, 1).gridy(pgridy).gridx(3));
 
-        panelMain.add(wHeatR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(1));
+        pCurrentWeapon.add(wDamageTrooperL, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(15, 9, 1, 1).gridy(pgridy).gridx(3));
+        pgridy++;
+        pCurrentWeapon.add(wNameR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wDamR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(2));
+        pCurrentWeapon.add(wHeatR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wArcHeatR, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                          .insets(1, 9, 1, 1).gridy(gridy).gridx(3));
+        pCurrentWeapon.add(wDamR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wDamageTrooperR, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                                .insets(1, 9, 1, 1).gridy(gridy).gridx(3));
+        pCurrentWeapon.add(wArcHeatR, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(15, 1, 1, 1).gridy(pgridy).gridx(3));
+
+        pCurrentWeapon.add(wDamageTrooperR, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(15, 1, 1, 1).gridy(pgridy).gridx(3));
+
+        panelMain.add(pCurrentWeapon, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .gridwidth(3)
+                .gridy(gridy).gridx(0));
+
         gridy++;
         // Adding range labels
         wMinL = new JLabel(Messages.getString("MechDisplay.Min"), SwingConstants.CENTER);
@@ -602,107 +658,149 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         wInfantryRange5R.setOpaque(false);
         wInfantryRange5R.setForeground(Color.WHITE);
 
-        panelMain.add(wMinL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(0));
+        JPanel pRange = new JPanel(new GridBagLayout());
+        pRange.setOpaque(false);
+        pgridy = 0;
 
-        panelMain.add(wShortL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(1));
+        pRange.add(wMinL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 9, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wMedL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(2));
+        pRange.add(wShortL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 9, 9, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wLongL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(3));
+        pRange.add(wMedL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 9, 9, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wExtL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(4));
+        pRange.add(wLongL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 9, 9, 1).gridy(pgridy).gridx(3));
 
-        panelMain.add(wInfantryRange0L, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                .insets(1, 9, 9, 1).gridy(gridy).gridx(0));
+        pRange.add(wExtL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 9, 9, 1).gridy(pgridy).gridx(4));
 
-        panelMain.add(wInfantryRange1L, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(1));
+        pgridy++;
 
-        panelMain.add(wInfantryRange2L, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(2));
+        pRange.add(wInfantryRange0L, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 9, 9, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wInfantryRange3L, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(3));
+        pRange.add(wInfantryRange1L, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 9, 9, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wInfantryRange4L, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(4));
+        pRange.add(wInfantryRange2L, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 9, 9, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wInfantryRange5L, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(4));
+        pRange.add(wInfantryRange3L, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 9, 9, 1).gridy(pgridy).gridx(3));
 
-        gridy++;
+        pRange.add(wInfantryRange4L, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 9, 9, 1).gridy(pgridy).gridx(4));
+
+        pRange.add(wInfantryRange5L, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 9, 9, 1).gridy(pgridy).gridx(4));
+
+        pgridy++;
         // ----------------
 
-        panelMain.add(wMinR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(0));
+        pRange.add(wMinR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 9, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wShortR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(1));
+        pRange.add(wShortR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wMedR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(2));
+        pRange.add(wMedR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wLongR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(3));
+        pRange.add(wLongR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(3));
 
-        panelMain.add(wExtR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(4));
+        pRange.add(wExtR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(4));
 
-        panelMain.add(wInfantryRange0R, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                .insets(1, 9, 9, 1).gridy(gridy).gridx(0));
+        pRange.add(wInfantryRange0R, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wInfantryRange1R, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(1));
+        pRange.add(wInfantryRange1R, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wInfantryRange2R, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(2));
+        pRange.add(wInfantryRange2R, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wInfantryRange3R, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(3));
+        pRange.add(wInfantryRange3R, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(3));
 
-        panelMain.add(wInfantryRange4R, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(4));
+        pRange.add(wInfantryRange4R, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(4));
 
-        panelMain.add(wInfantryRange5R, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                            .insets(1, 9, 9, 1).gridy(gridy).gridx(5));
+        pRange.add(wInfantryRange5R, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(5));
 
-        gridy++;
+        pgridy++;
         // ----------------
-        panelMain.add(wAVL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(0));
+        pRange.add(wAVL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 9, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wShortAVR, GBC.std().fill(GridBagConstraints.HORIZONTAL)
-                          .insets(1, 9, 9, 1).gridy(gridy).gridx(1));
+        pRange.add(wShortAVR, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .insets(1, 1, 9, 1).gridy(pgridy).gridx(1));
 
-        panelMain.add(wMedAVR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(2));
+        pRange.add(wMedAVR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(2));
 
-        panelMain.add(wLongAVR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(3));
+        pRange.add(wLongAVR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(3));
 
-        panelMain.add(wExtAVR,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 9, 1).gridy(gridy).gridx(4));
+        pRange.add(wExtAVR,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(1, 1, 9, 1).gridy(pgridy).gridx(4));
+
+        panelMain.add(pRange, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .gridwidth(3)
+                .gridy(gridy).gridx(0));
 
         gridy++;
+
+        JPanel pTarget = new JPanel(new GridBagLayout());
+        pTarget.setOpaque(false);
+        pgridy = 0;
 
         // target panel
         wTargetL = new JLabel(Messages.getString("MechDisplay.Target"), SwingConstants.CENTER);
@@ -725,31 +823,43 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         wToHitR.setOpaque(false);
         wToHitR.setForeground(Color.WHITE);
 
-        panelMain.add(wTargetL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(0));
+        pTarget.add(wTargetL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 1, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wTargetR,
-            GBC.eol().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(1));
-        gridy++;
+        pTarget.add(wTargetR,
+            GBC.eol().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 9, 1, 1).gridy(pgridy).gridx(1));
+        pgridy++;
 
-        panelMain.add(wRangeL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(0));
+        pTarget.add(wRangeL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wRangeR,
-            GBC.eol().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(1));
-        gridy++;
+        pTarget.add(wRangeR,
+            GBC.eol().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(1));
+        pgridy++;
 
-        panelMain.add(wToHitL,
-            GBC.std().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(0));
+        pTarget.add(wToHitL,
+            GBC.std().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(0));
 
-        panelMain.add(wToHitR,
-            GBC.eol().fill(GridBagConstraints.HORIZONTAL)
-               .insets(1, 9, 1, 1).gridy(gridy).gridx(1));
+        pTarget.add(wToHitR,
+            GBC.eol().fill(GridBagConstraints.NONE)
+               .anchor(GridBagConstraints.WEST)
+               .insets(15, 1, 1, 1).gridy(pgridy).gridx(1));
+
+        panelMain.add(pTarget, GBC.std().fill(GridBagConstraints.NONE)
+                .anchor(GridBagConstraints.WEST)
+                .gridwidth(3)
+                .gridy(gridy).gridx(0));
+
         gridy++;
 
         // to-hit text
@@ -759,9 +869,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         toHitText.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 10));
         panelMain.add(toHitText,
             GBC.eol().fill(GridBagConstraints.BOTH)
+               .anchor(GridBagConstraints.WEST)
                .insets(15, 9, 15, 9).gridy(gridy).gridx(0)
+               .weighty(1)
                .gridheight(2));
-        gridy++;
 
         addListeners();
 
@@ -2700,11 +2811,11 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         // Update the text size when the GUI scaling changes
         if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
             adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.ADVANCED_UNIT_DISPLAY_WEAPON_LIST_COUNT)) {
-            weaponList.setVisibleRowCount(GUIP.getUnitDisplayWeaponListCount());
-            wPanel.setMinimumSize(new Dimension(200, UIUtil.scaleForGUI(200)));
-            weaponList.revalidate();
-            weaponList.repaint();
+        } else if (e.getName().equals(GUIPreferences.ADVANCED_UNIT_DISPLAY_WEAPON_LIST_HEIGHT)) {
+            tWeaponScroll.setMinimumSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
+            tWeaponScroll.setPreferredSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
+            tWeaponScroll.revalidate();
+            tWeaponScroll.repaint();
         }
     }
 }


### PR DESCRIPTION
- swap advance setting for for the weapon panel, to use panel height instead of using visible row count.  
- when using the visible row count, the panel would jump between different sizes when resizing the window.
- add additional panels, so that it handles small widths better.

![image](https://user-images.githubusercontent.com/116095479/219516296-3364ac2c-00b3-47fd-8ab2-d79d3708e54c.png)
![image](https://user-images.githubusercontent.com/116095479/219516520-fd7d86ea-93e9-4158-9c9a-b16701808577.png)
