### PR TITLE
show amount of heat over capacity on the weapon tab

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1905,6 +1905,7 @@ MechDisplay.TSEMPInterference=+2 to gunnery due to TSEMP interference
 MechDisplay.TSEMPShutdown=Shutdown due to TSEMP
 MechDisplay.SelectMulti.title=Choose Ammobin
 MechDisplay.SelectMulti.question=Which ammobin do you want do select?
+MechDisplay.over=over
 
 MechGroupView.title=Group View
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1162,12 +1162,15 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
         String heatText = Integer.toString(currentHeatBuildup);
         int heatOverCapacity = currentHeatBuildup - en.getHeatCapacityWithWater();
+        String sheatOverCapacity = "";
         if (heatOverCapacity > 0) {
             heatText += "*"; // overheat indication
+            String msg_over = Messages.getString("MechDisplay.over");
+            sheatOverCapacity = " " + heatOverCapacity + " " + msg_over;
         }
 
         currentHeatBuildupR.setForeground(GUIP.getColorForHeat(heatOverCapacity, Color.WHITE));
-        currentHeatBuildupR.setText(heatText + " (" + heatCapacityStr + ')');
+        currentHeatBuildupR.setText(heatText + " (" + heatCapacityStr + ')' + sheatOverCapacity);
 
         // change what is visible based on type
         if (entity.usesWeaponBays()) {


### PR DESCRIPTION
- show amount of heat over capacity on the weapon tab.  to help determine heat penalties and TSM heat quicker.

![image](https://user-images.githubusercontent.com/116095479/219965900-0a5b19a7-9841-476c-8f32-4a12ed232409.png)
