### PR TITLE
show movement mode before move indicators

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1174,6 +1174,13 @@ public final class UnitToolTip {
                 if (jumpMPModified > 0) {
                     sMove += "/" + jumpMPModified;
                 }
+            }
+
+            sMove += DOT_SPACER;
+            String sMoveMode = entity.getMovementModeAsString();
+            sMove += sMoveMode;
+
+            if ((walkMP != walkMPModified) || (runMP != runMPModified) || (jumpMP != jumpMPModified)) {
                 if (entity.getGame().getPlanetaryConditions().getGravity()  != 1.0) {
                     sMove += DOT_SPACER;
                     String sGravity =  entity.getGame().getPlanetaryConditions().getGravity() + "g";
@@ -1187,10 +1194,6 @@ public final class UnitToolTip {
                     sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sHeat + "</FONT>";
                 }
             }
-
-            sMove += DOT_SPACER;
-            String sMoveMode = entity.getMovementModeAsString();
-            sMove += sMoveMode;
 
             if (entity instanceof IBomber) {
                 int bombMod = 0;


### PR DESCRIPTION
- show movement mode before movement indicators
- instead of indicators ⬝ movement mode ⬝ indicators 

![image](https://user-images.githubusercontent.com/116095479/219970916-32294d0a-0039-4234-8cfe-ffe4209f86e1.png)
