### PR TITLE
Feature: Working Bridgelayer

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2208,6 +2208,7 @@ MovementDisplay.moveHullDown=Hull Down
 MovementDisplay.moveJump=Jump
 MovementDisplay.moveSwim=UMU
 MovementDisplay.MoveLaunch=Launch
+MovementDisplay.moveLayBridge=Lay Bridge
 MovementDisplay.moveLayMine=Lay Mine
 MovementDisplay.moveLoad=Load
 MovementDisplay.MoveLand=Land

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -633,7 +633,7 @@ public class Client implements IClientCommandHandler {
      * air units flight path. In the case of several equidistant hexes, the
      * attacker gets to choose. This method updates the server with the users
      * choice.
-     * 
+     *
      * @param targetId
      * @param attackerId
      * @param pos
@@ -741,7 +741,7 @@ public class Client implements IClientCommandHandler {
         }
         entity.setWeapOrderChanged(false);
     }
-    
+
     /** Sends the given forces to the server to be made top-level forces. */
     public void sendForceParent(Collection<Force> forceList, int newParentId) {
         send(new Packet(PacketCommand.FORCE_PARENT, forceList, newParentId));
@@ -802,25 +802,25 @@ public class Client implements IClientCommandHandler {
     public void sendUpdateEntity(Entity entity) {
         send(new Packet(PacketCommand.ENTITY_UPDATE, entity));
     }
-    
+
     /**
-     * Sends a packet containing multiple entity updates. Should only be used 
+     * Sends a packet containing multiple entity updates. Should only be used
      * in the lobby phase.
      */
     public void sendUpdateEntity(Collection<Entity> entities) {
         send(new Packet(PacketCommand.ENTITY_MULTIUPDATE, entities));
     }
-    
+
     /**
-     * Sends a packet containing multiple entity updates. Should only be used 
+     * Sends a packet containing multiple entity updates. Should only be used
      * in the lobby phase.
      */
     public void sendChangeOwner(Collection<Entity> entities, int newOwnerId) {
         send(new Packet(PacketCommand.ENTITY_ASSIGN, entities, newOwnerId));
     }
-    
+
     /**
-     * Sends a packet containing multiple entity updates. Should only be used 
+     * Sends a packet containing multiple entity updates. Should only be used
      * in the lobby phase.
      */
     public void sendChangeTeam(Collection<Player> players, int newTeamId) {
@@ -833,21 +833,21 @@ public class Client implements IClientCommandHandler {
     public void sendDeploymentUnload(Entity loader, Entity loaded) {
         send(new Packet(PacketCommand.ENTITY_DEPLOY_UNLOAD, loader.getId(), loaded.getId()));
     }
-    
+
     /**
      * Sends an "Update force" packet
      */
     public void sendUpdateForce(Collection<Force> changedForces, Collection<Entity> changedEntities) {
         send(new Packet(PacketCommand.FORCE_UPDATE, changedForces, changedEntities));
     }
-    
+
     /**
      * Sends an "Update force" packet
      */
     public void sendUpdateForce(Collection<Force> changedForces) {
         send(new Packet(PacketCommand.FORCE_UPDATE, changedForces, new ArrayList<>()));
     }
-    
+
     /**
      * Sends a packet instructing the server to add the given entities to the given force.
      * The server will handle this; the client does not have to implement the change.
@@ -855,7 +855,7 @@ public class Client implements IClientCommandHandler {
     public void sendAddEntitiesToForce(Collection<Entity> entities, int forceId) {
         send(new Packet(PacketCommand.FORCE_ADD_ENTITY, entities, forceId));
     }
-    
+
     /**
      * Sends a packet instructing the server to add the given entities to the given force.
      * The server will handle this; the client does not have to implement the change.
@@ -863,7 +863,7 @@ public class Client implements IClientCommandHandler {
     public void sendAssignForceFull(Collection<Force> forceList, int newOwnerId) {
         send(new Packet(PacketCommand.FORCE_ASSIGN_FULL, forceList, newOwnerId));
     }
-        
+
     /**
      * Sends a packet to the Server requesting to delete the given forces.
      */
@@ -873,7 +873,7 @@ public class Client implements IClientCommandHandler {
                 .boxed()
                 .collect(Collectors.toList())));
     }
-    
+
     /**
      * Sends an "Add force" packet
      */
@@ -979,7 +979,7 @@ public class Client implements IClientCommandHandler {
             cacheImgTag(e);
         }
     }
-    
+
     /**
      * Receives a force-related update containing affected forces and affected entities
      */
@@ -995,13 +995,13 @@ public class Client implements IClientCommandHandler {
             getGame().setEntity(entity.getId(), entity);
         }
     }
-    
+
     /** Receives a server packet commanding deletion of forces. Only valid in the lobby phase. */
     protected void receiveForcesDelete(Packet c) {
         @SuppressWarnings("unchecked")
         Collection<Integer> forceIds = (Collection<Integer>) c.getObject(0);
         Forces forces = game.getForces();
-        
+
         // Gather the forces and entities to be deleted
         Set<Force> delForces = new HashSet<>();
         Set<Entity> delEntities = new HashSet<>();
@@ -1019,7 +1019,7 @@ public class Client implements IClientCommandHandler {
             game.removeEntity(entity.getId(), IEntityRemovalConditions.REMOVE_NEVER_JOINED);
         }
     }
-    
+
     /**
      * Loads entity update data from the data in the net command.
      */
@@ -1031,9 +1031,9 @@ public class Client implements IClientCommandHandler {
         // Replace this entity in the game.
         getGame().setEntity(eindex, entity, movePath);
     }
-    
+
     /**
-     * Update multiple entities from the server. Used only in the lobby phase. 
+     * Update multiple entities from the server. Used only in the lobby phase.
      */
     @SuppressWarnings("unchecked")
     protected void receiveEntitiesUpdate(Packet c) {
@@ -1458,6 +1458,8 @@ public class Client implements IClientCommandHandler {
                     List<Hex> hexes = new ArrayList<>((Set<Hex>) c.getObject(1));
                     game.getBoard().setHexes(coords, hexes);
                     break;
+                case BLDG_ADD:
+                    receiveAddBuildings(c);
                 case BLDG_UPDATE:
                     receiveBuildingUpdate(c);
                     break;
@@ -1693,7 +1695,7 @@ public class Client implements IClientCommandHandler {
     public void sendTelemissileTargetCFRResponse(int index) {
         send(new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST, PacketCommand.CFR_TELEGUIDED_TARGET, index));
     }
-    
+
     public void sendTAGTargetCFRResponse(int index) {
         send(new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST, PacketCommand.CFR_TAG_TARGET, index));
     }
@@ -1866,17 +1868,21 @@ public class Client implements IClientCommandHandler {
     public void setCurrentHex(Coords hex) {
         currentHex = hex;
     }
-    
+
     /** Returns true when the player is a bot added/controlled by this client. */
     public boolean isLocalBot(Player player) {
         return bots.containsKey(player.getName());
     }
-    
-    /** 
+
+    /**
      * Returns the Client associated with the given local bot player. If
-     * the player is not a local bot, returns null. 
+     * the player is not a local bot, returns null.
      */
     public Client getBotClient(Player player) {
         return bots.get(player.getName());
+    }
+
+    protected void receiveAddBuildings(Packet packet) {
+        game.getBoard().addBuildings((Vector<Building>) packet.getObject(0));
     }
 }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -872,10 +872,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         updateBombButton();
 
         // Bridge Building
-        if ((ce.entityIsQuad() || ce.isVehicle())
-                && (ce.hasWorkingMisc(MiscType.F_LIGHT_BRIDGE_LAYER)
-                    || ce.hasWorkingMisc(MiscType.F_MEDIUM_BRIDGE_LAYER)
-                    || ce.hasWorkingMisc(MiscType.F_HEAVY_BRIDGE_LAYER))) {
+        if ((ce.entityIsQuad() || ce.isVehicle()) && (ce.hasWorkingMisc(MiscType.F_BRIDGE_KIT))) {
             boolean isWaterForward = false;
             getBtn(MoveCommand.MOVE_LAY_BRIDGE).setEnabled(true);
         }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -132,6 +132,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         MOVE_SHUTDOWN("moveShutDown", CMD_NON_INF),
         MOVE_STARTUP("moveStartup", CMD_NON_INF),
         MOVE_SELF_DESTRUCT("moveSelfDestruct", CMD_NON_INF),
+        MOVE_LAY_BRIDGE("moveLayBridge", CMD_MECH |CMD_TANK),
         // Infantry only
         MOVE_DIG_IN("moveDigIn", CMD_INF),
         MOVE_FORTIFY("moveFortify", CMD_INF | CMD_TANK),
@@ -869,6 +870,15 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         updateManeuverButton();
         updateStrafeButton();
         updateBombButton();
+
+        // Bridge Building
+        if ((ce.entityIsQuad() || ce.isVehicle())
+                && (ce.hasWorkingMisc(MiscType.F_LIGHT_BRIDGE_LAYER)
+                    || ce.hasWorkingMisc(MiscType.F_MEDIUM_BRIDGE_LAYER)
+                    || ce.hasWorkingMisc(MiscType.F_HEAVY_BRIDGE_LAYER))) {
+            boolean isWaterForward = false;
+            getBtn(MoveCommand.MOVE_LAY_BRIDGE).setEnabled(true);
+        }
 
         // Infantry and Tank - Fortify
         if (isInfantry
@@ -4785,6 +4795,9 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         } else if (actionCmd.equals(MoveCommand.MOVE_CALL_SUPPORT.getCmd())) {
             ((Infantry) ce).createLocalSupport();
             clientgui.getClient().sendUpdateEntity(ce());
+        } else if (actionCmd.equals(MoveCommand.MOVE_LAY_BRIDGE.getCmd())) {
+            cmd.addStep(MoveStepType.BRIDGING);
+            clientgui.getBoardView().drawMovementData(ce(), cmd);
         } else if (actionCmd.equals(MoveCommand.MOVE_DIG_IN.getCmd())) {
             cmd.addStep(MoveStepType.DIG_IN);
             clientgui.getBoardView().drawMovementData(ce(), cmd);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -874,6 +874,8 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
         // Bridge Building
         if ((ce.entityIsQuad() || ce.isVehicle()) && (ce.hasWorkingMisc(MiscType.F_BRIDGE_KIT))) {
             boolean isWaterForward = false;
+            // Check for water in forward facing hex or chasm and make sure the connecting side is ON the water (for highest CF
+            // or that the connecting side has a height difference no greater than one.
             getBtn(MoveCommand.MOVE_LAY_BRIDGE).setEnabled(true);
         }
 
@@ -1104,6 +1106,7 @@ public class MovementDisplay extends StatusBarPhaseDisplay {
 
         getBtn(MoveCommand.MOVE_CLIMB_MODE).setEnabled(false);
         getBtn(MoveCommand.MOVE_DIG_IN).setEnabled(false);
+        getBtn(MoveCommand.MOVE_LAY_BRIDGE).setEnabled(false);
         getBtn(MoveCommand.MOVE_CALL_SUPPORT).setEnabled(false);
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -401,12 +401,12 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     /** Stores the correct tooltip dismiss delay so it can be restored when exiting the boardview */
     private int dismissDelay = ToolTipManager.sharedInstance().getDismissDelay();
-    
-    /** A map overlay showing some important keybinds. */ 
+
+    /** A map overlay showing some important keybinds. */
     KeyBindingsOverlay keybindOverlay;
 
     PlanetaryConditionsOverlay planetaryConditionsOverlay;
-    
+
     /** The coords where the mouse was last. */
     Coords lastCoords;
 
@@ -431,7 +431,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         game.addGameListener(gameListener);
         game.getBoard().addBoardListener(this);
-        
+
         keybindOverlay = new KeyBindingsOverlay(game, clientgui);
         // Avoid showing the key binds when they can't be used (in the lobby map preview)
         if (controller != null) {
@@ -528,7 +528,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     drawDimension.setSize(width, height);
                     disp.isMouseOver(point, drawDimension);
                 }
-                
+
                 final Coords mcoords = getCoordsAt(point);
                 if (!mcoords.equals(lastCoords) && game.getBoard().contains(mcoords)) {
                     lastCoords = mcoords;
@@ -1074,7 +1074,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                         } catch (Exception e) {
                             // if we somehow messed up the math, log the error and simply act as if we have no background image.
                             Rectangle rasterBounds = bvBgImage.getRaster().getBounds();
-                            
+
                             String errorData = String.format("Error drawing background image. Raster Bounds: %.2f, %.2f, width:%.2f, height:%.2f, Attempted Draw Coordinates: %d, %d, width:%d, height:%d",
                                     rasterBounds.getMinX(), rasterBounds.getMinY(), rasterBounds.getWidth(), rasterBounds.getHeight(),
                                     xRem, yRem, w - xRem, h - yRem);
@@ -1247,7 +1247,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     }
 
     /**
-     * Debugging method that renders a hex in the approximate direction 
+     * Debugging method that renders a hex in the approximate direction
      * from the selected entity to the selected hex, of both exist.
      * @param g Graphics object on which to draw.
      */
@@ -1256,16 +1256,16 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         if (selectedEntity == null || selected == null) {
             return;
         }
-        
+
         int direction = selectedEntity.getPosition().approximateDirection(selected, 0, 0);
-        
+
         Coords donutCoords = selectedEntity.getPosition().translated(direction);
-        
+
         Point p = getCentreHexLocation(donutCoords.getX(), donutCoords.getY(), true);
         p.translate(HEX_W  / 2, HEX_H  / 2);
         drawHexBorder(g, p, Color.BLUE, 0, 6);
     }
-    
+
     /**
      * Debugging method that renders the bounding hex of a unit's movement envelope.
      * Warning: very slow when rendering the bounding hex for really fast units.
@@ -1322,7 +1322,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             drawHexBorder(g, p, Color.PINK, 0, 6);
         }
     }
-    
+
     /**
      * Debugging method that renders a obnoxious pink lines around hexes in "Board Clusters"
      * @param g Graphics object on which to draw.
@@ -1331,7 +1331,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     private void renderClusters(Graphics2D g) {
         BoardClusterTracker bct = new BoardClusterTracker();
         Map<Coords, BoardCluster> clusterMap = bct.generateClusters(selectedEntity, false, true);
-        
+
         for (BoardCluster cluster : clusterMap.values().stream().distinct().collect(Collectors.toList())) {
             for (Coords coords : cluster.contents.keySet()) {
                 Point p = getCentreHexLocation(coords.getX(), coords.getY(), true);
@@ -1552,7 +1552,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 for (int i = beg; i < n * (lDiff - 0.4); i++) {
                     gS.drawImage(hexShadow, (int) p1.getX(), (int) p1.getY(), null);
                     p1.setLocation(p1.getX() + deltaX, p1.getY() + deltaY);
-                }   
+                }
             } else {
                 for (int i = 0; i < n * lDiff; i++) {
                     gS.drawImage(hexShadow, (int) p1.getX(), (int) p1.getY(), null);
@@ -2472,7 +2472,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             g.setComposite(svComp);
         }
 
-        // To place roads under the shadow map, some supers 
+        // To place roads under the shadow map, some supers
         // have to be drawn before the shadow map, otherwise the supers are
         // drawn after. Unfortunately the supers images
         // themselves can't be checked for roads.
@@ -2672,8 +2672,8 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
             if (hex.terrainLevel(Terrains.FOLIAGE_ELEV) == 1) {
                 g.setColor(GUIP.getColor(
-                        GUIPreferences.ADVANCED_LOW_FOLIAGE_COLOR));  
-                drawCenteredString(Messages.getString("BoardView1.LowFoliage"), 
+                        GUIPreferences.ADVANCED_LOW_FOLIAGE_COLOR));
+                drawCenteredString(Messages.getString("BoardView1.LowFoliage"),
                         0, (int) (ypos * scale), font_elev, g);
                 ypos -= 10;
             }
@@ -4874,11 +4874,11 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     /**
      * Notifies listeners about the specified mouse action.
-     * 
+     *
      * @param coords          - coords the Coords.
      * @param mtype           - Board view event type
      * @param modifiers       - mouse event modifiers mask such as SHIFT_DOWN_MASK etc.
-     * @param mouseButton     - mouse button associated with this event 
+     * @param mouseButton     - mouse button associated with this event
      *                           0 = no button
      *                           1 = Button 1
      *                           2 = Button 2
@@ -4912,7 +4912,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     public void boardChangedHex(BoardEvent b) {
         hexImageCache.remove(b.getCoords());
         // Also repaint the surrounding hexes because of shadows, border etc.
-        for (int dir: allDirections) { 
+        for (int dir: allDirections) {
             hexImageCache.remove(b.getCoords().translated(dir));
         }
         clearShadowMap();
@@ -4959,12 +4959,12 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             final GameOptions gopts = game.getOptions();
 
             updateEcmList();
-            
+
             // For Entities that have converted to another mode, check for a different sprite
             if (game.getPhase().isMovement() && en.isConvertingNow()) {
                 tileManager.reloadImage(en);
             }
-            
+
             // for units that have been blown up, damaged or ejected, force a reload
             if ((e.getOldEntity() != null) &&
                     ((en.getDamageLevel() != e.getOldEntity().getDamageLevel()) ||
@@ -4972,7 +4972,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     (en.getCrew().isEjected() != e.getOldEntity().getCrew().isEjected()))) {
                 tileManager.reloadImage(en);
             }
-            
+
             redrawAllEntities();
             if (game.getPhase().isMovement()) {
                 refreshMoveVectors();
@@ -5096,7 +5096,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 default:
             }
             for (Entity en: game.getEntitiesVector()) {
-                if ((en.getDamageLevel() != Entity.DMG_NONE) && 
+                if ((en.getDamageLevel() != Entity.DMG_NONE) &&
                         ((en.damageThisRound != 0) || (en instanceof GunEmplacement))) {
                     tileManager.reloadImage(en);
                 }
@@ -5197,9 +5197,9 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             if (e.getPosition() == null) {
                 continue;
             }
-            
-            boolean entityIsEnemy = e.getOwner().isEnemyOf(localPlayer);           
-            
+
+            boolean entityIsEnemy = e.getOwner().isEnemyOf(localPlayer);
+
             // If this unit isn't spotted somehow, it's ECM doesn't show up
             if ((localPlayer != null)
                     && game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
@@ -5208,7 +5208,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     && !e.hasDetectedEntity(localPlayer)) {
                 continue;
             }
-            
+
             // hidden enemy entities don't show their ECM bubble
             if (entityIsEnemy && e.isHidden()) {
                 continue;
@@ -5248,12 +5248,12 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     && !ecmInfo.getEntity().hasDetectedEntity(localPlayer)) {
                 continue;
             }
-            
+
             // hidden enemy entities don't show their ECM bubble
             if (ecmInfo.getEntity().getOwner().isEnemyOf(localPlayer) && ecmInfo.getEntity().isHidden()) {
                 continue;
             }
-            
+
             final Coords ecmPos = ecmInfo.getPos();
             final int range = ecmInfo.getRange();
 
@@ -5856,6 +5856,10 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 sBridge = Messages.getString("BoardView1.Tooltip.Bridge",
                         mhex.terrainLevel(Terrains.BRIDGE_ELEV), Terrains.getEditorName(Terrains.BRIDGE),
                         mhex.terrainLevel(Terrains.BRIDGE_CF));
+            //} else if (game.getBoard().getBuildingAt(mcoords) == null) {
+            //    sBridge = Messages.getString("BoardView1.Tooltip.Bridge",
+            //           mhex.terrainLevel(Terrains.BRIDGE_ELEV), Terrains.getEditorName(Terrains.BRIDGE),
+            //            mhex.terrainLevel(Terrains.BRIDGE_CF));
             } else {
                 Building bldg = game.getBoard().getBuildingAt(mcoords);
                 sBridge = Messages.getString("BoardView1.Tooltip.Bridge",
@@ -5930,7 +5934,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     private ArrayList<ArtilleryAttackAction> getArtilleryAttacksAtLocation(Coords c) {
         ArrayList<ArtilleryAttackAction> v = new ArrayList<>();
-        
+
         for (Enumeration<ArtilleryAttackAction> attacks = game.getArtilleryAttacks(); attacks.hasMoreElements(); ) {
             ArtilleryAttackAction a = attacks.nextElement();
             Targetable target = a.getTarget(game);
@@ -6569,7 +6573,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         } else if (selectedTheme.equals("(No Theme)")) {
             selectedTheme = "";
         }
-        
+
         board.setTheme(selectedTheme);
         return selectedTheme;
     }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5856,10 +5856,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 sBridge = Messages.getString("BoardView1.Tooltip.Bridge",
                         mhex.terrainLevel(Terrains.BRIDGE_ELEV), Terrains.getEditorName(Terrains.BRIDGE),
                         mhex.terrainLevel(Terrains.BRIDGE_CF));
-            //} else if (game.getBoard().getBuildingAt(mcoords) == null) {
-            //    sBridge = Messages.getString("BoardView1.Tooltip.Bridge",
-            //           mhex.terrainLevel(Terrains.BRIDGE_ELEV), Terrains.getEditorName(Terrains.BRIDGE),
-            //            mhex.terrainLevel(Terrains.BRIDGE_CF));
             } else {
                 Building bldg = game.getBoard().getBuildingAt(mcoords);
                 sBridge = Messages.getString("BoardView1.Tooltip.Bridge",

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -606,6 +606,15 @@ class EntitySprite extends Sprite {
                 }
             }
 
+            // Bridgelayer
+            if (entity.isVehicle() || entity.entityIsQuad()) {
+                int bridgeWork = entity.getBridgeWork();
+                if ((bridgeWork >= entity.BRIDGE_START) && (bridgeWork <= entity.BRIDGE_DONE)) {
+                    stStr.add(new Status(Color.YELLOW, "Working", DIRECT));
+                    stStr.add(new Status(Color.PINK, "D", SMALL));
+                }
+            }
+
             // Aero
             if (isAero) {
                 IAero a = (IAero) entity;

--- a/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
@@ -1,15 +1,15 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
 */
 package megamek.client.ui.swing.boardview;
 
@@ -29,8 +29,8 @@ import java.awt.image.BufferedImage;
  * entering, exiting or turning.
  */
 class StepSprite extends Sprite {
-    
-    private final static GUIPreferences GUIP = GUIPreferences.getInstance(); 
+
+    private final static GUIPreferences GUIP = GUIPreferences.getInstance();
     private static AffineTransform shadowOffset = new AffineTransform();
     private static AffineTransform upDownOffset = new AffineTransform();
     private static AffineTransform stepOffset = new AffineTransform();
@@ -145,6 +145,7 @@ class StepSprite extends Sprite {
             case GO_PRONE:
             case HULL_DOWN:
             case DOWN:
+            case BRIDGING:
             case DIG_IN:
             case FORTIFY:
             case TAKE_COVER:
@@ -290,7 +291,7 @@ class StepSprite extends Sprite {
         tempImage.flush();
     }
 
-    /** Draws the given form in the given Color col with a shadow. */ 
+    /** Draws the given form in the given Color col with a shadow. */
     private void drawArrowShape(Graphics2D graph, Shape form, Color col) {
         graph.setColor(Color.darkGray);
         Shape currentArrow = stepOffset.createTransformedShape(form);
@@ -300,7 +301,7 @@ class StepSprite extends Sprite {
         currentArrow = shadowOffset.createTransformedShape(currentArrow);
         graph.fill(currentArrow);
     }
-    
+
     private void drawAnnouncement(Graphics2D graph, String text, MoveStep step, Color col) {
         if (step.isPastDanger()) {
             text = "(" + text + ")";

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -2000,6 +2000,6 @@ public class Board implements Serializable {
     }
 
     public void addBuildingToHash (Coords c, Building bldg) {
-        bldgByCoords.putIfAbsent(c, bldg);
+        bldgByCoords.put(c, bldg);
     }
 }

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -1891,7 +1891,24 @@ public class Board implements Serializable {
         return Collections.unmodifiableSet(tags);
     }
 
-    public void addNewBuildingHash() {
+    public void createNewBuildingHash() {
+        // Make a new hashtable.
+        bldgByCoords.clear();
+        //bldgByCoords = new Hashtable<>();
+
+        // Walk through the vector of buildings.
+        Enumeration<Building> loop = buildings.elements();
+        while (loop.hasMoreElements()) {
+            final Building bldg = loop.nextElement();
+
+            // Each building identifies the hexes it covers.
+            Enumeration<Coords> iter = bldg.getCoords();
+            while (iter.hasMoreElements()) {
+                bldgByCoords.put(iter.nextElement(), bldg);
+            }
+        }
+    }
+    public void createNewBuildingHashOld() {
         StringBuffer errBuff = null;
         buildings.removeAllElements();
         if (bldgByCoords == null) {

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -1891,7 +1891,7 @@ public class Board implements Serializable {
         return Collections.unmodifiableSet(tags);
     }
 
-    public void createNewBuildingHash() {
+    /* public void createNewBuildingHash() {
         // Make a new hashtable.
         bldgByCoords.clear();
         //bldgByCoords = new Hashtable<>();
@@ -2018,5 +2018,10 @@ public class Board implements Serializable {
 
     public void addBuildingToHash (Coords c, Building bldg) {
         bldgByCoords.put(c, bldg);
+    } */
+
+    public void addBuildings(Vector<Building> newBuildings) {
+        buildings.addAll(newBuildings);
+        createBldgByCoords();
     }
 }

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -44,7 +44,7 @@ public class Board implements Serializable {
     public static final int START_EDGE = 9;
     public static final int START_CENTER = 10;
     public static final int NUM_ZONES = 11;
-    
+
     // Board Dimensions
     // Used for things like artillery rules that reference the standard mapsheet dimensions
     public static final int DEFAULT_BOARD_HEIGHT = 17;
@@ -431,35 +431,35 @@ public class Board implements Serializable {
 
         // Always make the coords of the hex match the actual position on the board
         hex.setCoords(new Coords(x, y));
-        
+
         hex.clearExits();
         for (int i = 0; i < 6; i++) {
             Hex other = getHexInDir(x, y, i);
             hex.setExits(other, i, roadsAutoExit);
         }
-        
+
         // Internally handled terrain (inclines, cliff-bottoms)
         initializeAutomaticTerrain(x, y, /* useInclines: */ true);
-        
+
         // Add woods/jungle elevation where none was saved
         initializeFoliageElev(x, y);
-        
+
         if (event) {
             processBoardEvent(new BoardEvent(this, new Coords(x, y), BoardEvent.BOARD_CHANGED_HEX));
         }
     }
-    
+
     /** Adds the FOLIAGE_ELEV terrain when none is present. */
     private void initializeFoliageElev(int x, int y) {
         Hex hex = getHex(x, y);
 
         // If the foliage elevation is present or the hex doesn't even have foliage,
         // nothing needs to be done
-        if (hex.containsTerrain(Terrains.FOLIAGE_ELEV) || 
+        if (hex.containsTerrain(Terrains.FOLIAGE_ELEV) ||
                 (!hex.containsTerrain(Terrains.WOODS) && !hex.containsTerrain(Terrains.JUNGLE))) {
             return;
         }
-        
+
         // Foliage is missing, therefore add it with the standard TW values
         // elevation 3 for Ultra Woods/Jungle and 2 for Light/Heavy
         if (hex.terrainLevel(Terrains.WOODS) == 3 || hex.terrainLevel(Terrains.JUNGLE) == 3) {
@@ -468,9 +468,9 @@ public class Board implements Serializable {
             hex.addTerrain(new Terrain(Terrains.FOLIAGE_ELEV, 2));
         }
     }
-    
-    /** 
-     * Checks all hex edges of the hex at (x, y) if automatically handled 
+
+    /**
+     * Checks all hex edges of the hex at (x, y) if automatically handled
      * terrains such as inclines must be placed or removed.
      * @param x The hex X-coord.
      * @param y The hex Y-coord.
@@ -488,7 +488,7 @@ public class Board implements Serializable {
 
         // Get the currently set cliff-tops for correction. When exits
         // are not specified, the cliff-tops are removed.
-        if (hex.containsTerrain(Terrains.CLIFF_TOP) 
+        if (hex.containsTerrain(Terrains.CLIFF_TOP)
                 && hex.getTerrain(Terrains.CLIFF_TOP).hasExitsSpecified()) {
             origCliffTopExits = hex.getTerrain(Terrains.CLIFF_TOP).getExits();
         }
@@ -514,26 +514,26 @@ public class Board implements Serializable {
 
             // Should there be an incline top?
             if (((levelDiff == 1) || (levelDiff == 2))
-                    && !cliffTopExitInThisDir 
+                    && !cliffTopExitInThisDir
                     && !inWater
                     && !towardsWater) {
                 inclineTopExits += (1 << i);
             }
-            
+
             if (towardsWater
                     && !inWater
-                    && !cliffTopExitInThisDir 
+                    && !cliffTopExitInThisDir
                     && ((levelDiffToWaterSurface == 1) || levelDiffToWaterSurface == 2)) {
                 inclineTopExits += (1 << i);
             }
 
             // Should there be a high level cliff top?
-            if (levelDiff > 2 
+            if (levelDiff > 2
                     && !inWater
                     && (!towardsWater || levelDiffToWaterSurface > 2)) {
                 highInclineTopExits += (1 << i);
             }
-            
+
             // Should there be an incline bottom or a cliff bottom?
             // This needs to check for a cliff-top in the other hex and
             // in the opposite direction
@@ -565,7 +565,7 @@ public class Board implements Serializable {
         }
     }
 
-    /** 
+    /**
      * Adds automatically handled terrain such as inclines when the given
      * exits value is not 0, otherwise removes it.
      */
@@ -576,7 +576,7 @@ public class Board implements Serializable {
             hex.removeTerrain(terrainType);
         }
     }
-    
+
     /**
      * Rebuilds automatic terrains for the whole board.
      * @param useInclines Indicates whether to use inclines on hex exits.
@@ -775,7 +775,7 @@ public class Board implements Serializable {
         }
         return new BoardDimensions(boardx, boardy);
     }
-    
+
     /** Inspects the given board file and returns a set of its tags. */
     public static Set<String> getTags(final File filepath) {
         var result = new HashSet<String>();
@@ -801,7 +801,7 @@ public class Board implements Serializable {
         }
         return result;
     }
-    
+
     public static boolean isValid(String board) {
         Board tempBoard = new Board(16, 17);
         if (!board.endsWith(".board")) {
@@ -824,7 +824,7 @@ public class Board implements Serializable {
     public boolean isLegalDeployment(Coords c, Player p) {
         return isLegalDeployment(c, p.getStartingPos(), p.getStartWidth(), p.getStartOffset());
     }
-    
+
     /**
      * Can the given entity be deployed at these coordinates
      */
@@ -832,10 +832,10 @@ public class Board implements Serializable {
         if (e == null) {
             return false;
         }
-        
+
         return isLegalDeployment(c, e.getStartingPos(), e.getStartingWidth(), e.getStartingOffset());
     }
-    
+
     /**
      * Can an object be deployed at these coordinates, given a starting zone, width of starting zone and offset from edge of board?
      */
@@ -849,7 +849,7 @@ public class Board implements Serializable {
         int maxx = width - startingOffset;
         int miny = startingOffset;
         int maxy = height - startingOffset;
-        
+
         switch (zoneType) {
             case START_ANY:
                 return true;
@@ -1066,14 +1066,14 @@ public class Board implements Serializable {
                 }
                 StringBuffer currBuff = new StringBuffer();
                 boolean valid = hex.isValid(currBuff);
-                
-                // Multi-hex problems 
+
+                // Multi-hex problems
                 // A building hex must only have exits to other building hexes of the same Building Type and Class
                 if (hex.containsTerrain(Terrains.BUILDING) && hex.getTerrain(Terrains.BUILDING).hasExitsSpecified()) {
                     for (int dir = 0; dir < 6; dir++) {
                         Hex adjHex = getHexInDir(x, y, dir);
-                        if ((adjHex != null) 
-                                && adjHex.containsTerrain(Terrains.BUILDING) 
+                        if ((adjHex != null)
+                                && adjHex.containsTerrain(Terrains.BUILDING)
                                 && hex.containsTerrainExit(Terrains.BUILDING, dir)) {
                             if (adjHex.getTerrain(Terrains.BUILDING).getLevel() != hex.getTerrain(Terrains.BUILDING).getLevel()) {
                                 valid = false;
@@ -1090,7 +1090,7 @@ public class Board implements Serializable {
                         }
                     }
                 }
-                
+
                 // Return early if we aren't logging errors
                 if (!valid && (errBuff == null)) {
                     return false;
@@ -1837,13 +1837,13 @@ public class Board implements Serializable {
         }
     }
 
-    /** 
-     * Sets a tileset theme for all hexes of the board. 
+    /**
+     * Sets a tileset theme for all hexes of the board.
      * Passing null as newTheme resets the theme to the theme specified in the board file.
-     */ 
+     */
     public void setTheme(final @Nullable String newTheme) {
         boolean reset = newTheme == null;
-        
+
         for (int c = 0; c < width * height; c++) {
             if (reset) {
                 data[c].resetTheme();
@@ -1858,9 +1858,9 @@ public class Board implements Serializable {
      * @return true when the given Coord c is on the edge of the board.
      */
     public boolean isOnBoardEdge(Coords c) {
-        return (c.getX() == 0) 
+        return (c.getX() == 0)
                 || (c.getY() == 0)
-                || (c.getX() == (width - 1)) 
+                || (c.getX() == (width - 1))
                 || (c.getY() == (height - 1));
     }
 
@@ -1889,5 +1889,117 @@ public class Board implements Serializable {
      */
     public Set<String> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    public void addNewBuildingHash() {
+        StringBuffer errBuff = null;
+        buildings.removeAllElements();
+        if (bldgByCoords == null) {
+            bldgByCoords = new Hashtable<>();
+        } else {
+            bldgByCoords.clear();
+        }
+        // Walk through the hexes, creating buildings.
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                // Does this hex contain a building?
+                Hex curHex = getHex(x, y);
+                if ((curHex != null) && (curHex.containsTerrain(Terrains.BUILDING))) {
+                    // Yup, but is it a repeat?
+                    Coords coords = new Coords(x, y);
+                    if (!bldgByCoords.containsKey(coords)) {
+
+                        // Nope. Try to create an object for the new building.
+                        try {
+                            Building bldg = new Building(coords, this, Terrains.BUILDING,
+                                    BasementType.getType(curHex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)));
+                            buildings.addElement(bldg);
+
+                            // Each building will identify the hexes it covers.
+                            Enumeration<Coords> iter = bldg.getCoords();
+                            while (iter.hasMoreElements()) {
+                                bldgByCoords.put(iter.nextElement(), bldg);
+                            }
+                        } catch (IllegalArgumentException excep) {
+                            // Log the error and remove the
+                            // building from the board.
+                            if (errBuff == null) {
+                                LogManager.getLogger().error("Unable to create building.", excep);
+                            } else {
+                                errBuff.append("Unable to create building at ").append(coords)
+                                        .append("!\n").append(excep.getMessage()).append("\n");
+                            }
+                            curHex.removeTerrain(Terrains.BUILDING);
+                        }
+                    }
+                }
+
+                if ((curHex != null) && (curHex.containsTerrain(Terrains.FUEL_TANK))) {
+                    // Yup, but is it a repeat?
+                    Coords coords = new Coords(x, y);
+                    if (!bldgByCoords.containsKey(coords)) {
+                        // Nope. Try to create an object for the new building.
+                        try {
+                            int magnitude = curHex.getTerrain(Terrains.FUEL_TANK_MAGN).getLevel();
+                            FuelTank bldg = new FuelTank(coords, this, Terrains.FUEL_TANK, magnitude);
+                            buildings.addElement(bldg);
+
+                            // Each building will identify the hexes it covers.
+                            Enumeration<Coords> iter = bldg.getCoords();
+                            while (iter.hasMoreElements()) {
+                                bldgByCoords.put(iter.nextElement(), bldg);
+                            }
+                        } catch (IllegalArgumentException excep) {
+                            // Log the error and remove the fuel tank from the board.
+                            if (errBuff == null) {
+                                LogManager.getLogger().error("Unable to create fuel tank.", excep);
+                            } else {
+                                errBuff.append("Unable to create fuel tank at ").append(coords)
+                                        .append("!\n").append(excep.getMessage()).append("\n");
+                            }
+                            curHex.removeTerrain(Terrains.FUEL_TANK);
+                        }
+                    }
+                }
+
+                if ((curHex != null) && curHex.containsTerrain(Terrains.BRIDGE)) {
+                    // Yup, but is it a repeat?
+                    Coords coords = new Coords(x, y);
+                    if (!bldgByCoords.containsKey(coords)) {
+                        // Nope. Try to create an object for the new building.
+                        try {
+                            Building bldg = new Building(coords, this, Terrains.BRIDGE, BasementType.NONE);
+                            buildings.addElement(bldg);
+
+                            // Each building will identify the hexes it covers.
+                            Enumeration<Coords> iter = bldg.getCoords();
+                            while (iter.hasMoreElements()) {
+                                bldgByCoords.put(iter.nextElement(), bldg);
+                            }
+                        } catch (IllegalArgumentException excep) {
+                            // Log the error and remove the bridge from the board.
+                            if (errBuff == null) {
+                                LogManager.getLogger().error("Unable to create bridge.", excep);
+                            } else {
+                                errBuff.append("Unable to create bridge at ").append(coords)
+                                        .append("!\n").append(excep.getMessage()).append("\n");
+                            }
+                            curHex.removeTerrain(Terrains.BRIDGE);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Initialize all exits.
+        for (int y = 0; y < height; y++) {
+            for (int x = 0; x < width; x++) {
+                initializeHex(x, y, false);
+            }
+        }
+    }
+
+    public void addBuildingToHash (Coords c, Building bldg) {
+        bldgByCoords.putIfAbsent(c, bldg);
     }
 }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -11112,6 +11112,7 @@ public class MiscType extends EquipmentType {
         misc.industrial = true;
         // Going to assume this is something with building Bridges
         // Also the equipment used by infantry bridge builders.
+        misc.rulesRefs = "152, TO:AUE";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL);
         misc.techAdvancement.setISAdvancement(DATE_NONE, 2720, DATE_NONE);
         misc.techAdvancement.setTechRating(RATING_D);

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -281,6 +281,8 @@ public class MiscType extends EquipmentType {
     public static final BigInteger F_PROTOTYPE = BigInteger.valueOf(1).shiftLeft(225);
     // Fortify Equipment
     public static final BigInteger F_TRENCH_CAPABLE = BigInteger.valueOf(1).shiftLeft(226);
+    // Engineering Equipment
+    public static final BigInteger F_BRIDGE_KIT = BigInteger.valueOf(1).shiftLeft(227);
 
     // Secondary Flags for Physical Weapons
     public static final long S_CLUB = 1L << 0; // BMR - Indicates an Improvised Club
@@ -7106,7 +7108,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(EquipmentTypeLookup.LIGHT_BRIDGE_LAYER);
         misc.sortingName = "Bridge B";
         misc.flags = misc.flags.or(F_LIGHT_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
-                .or(F_SUPPORT_TANK_EQUIPMENT);
+                .or(F_SUPPORT_TANK_EQUIPMENT).or(F_BRIDGE_KIT);
         misc.industrial = true;
         misc.rulesRefs = "242, TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
@@ -7129,7 +7131,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(EquipmentTypeLookup.MEDIUM_BRIDGE_LAYER);
         misc.sortingName = "Bridge C";
         misc.flags = misc.flags.or(F_MEDIUM_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
-                .or(F_SUPPORT_TANK_EQUIPMENT);
+                .or(F_SUPPORT_TANK_EQUIPMENT).or(F_BRIDGE_KIT);
         misc.industrial = true;
         misc.rulesRefs = "242, TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
@@ -7152,7 +7154,7 @@ public class MiscType extends EquipmentType {
         misc.setInternalName(EquipmentTypeLookup.HEAVY_BRIDGE_LAYER);
         misc.sortingName = "Bridge D";
         misc.flags = misc.flags.or(F_HEAVY_BRIDGE_LAYER).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT)
-                .or(F_SUPPORT_TANK_EQUIPMENT);
+                .or(F_SUPPORT_TANK_EQUIPMENT).or(F_BRIDGE_KIT);
         misc.industrial = true;
         misc.rulesRefs = "242, TM";
         misc.techAdvancement.setTechBase(TECH_BASE_ALL).setIntroLevel(false).setUnofficial(false)
@@ -11103,7 +11105,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = 0;
         misc.criticals = 0;
         misc.hittable = false;
-        misc.flags = misc.flags.or(F_TOOLS).or(F_BA_EQUIPMENT);
+        misc.flags = misc.flags.or(F_TOOLS);
         misc.subType |= S_BRIDGE_KIT;
         misc.toHitModifier = 1;
         misc.bv = 0;

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -55,7 +55,7 @@ public class MovePath implements Cloneable, Serializable {
         NONE, FORWARDS, BACKWARDS, TURN_LEFT, TURN_RIGHT, GET_UP, GO_PRONE, START_JUMP, CHARGE, DFA,
         FLEE, LATERAL_LEFT, LATERAL_RIGHT, LATERAL_LEFT_BACKWARDS, LATERAL_RIGHT_BACKWARDS, UNJAM_RAC,
         LOAD, UNLOAD, EJECT, CLEAR_MINEFIELD, UP, DOWN, SEARCHLIGHT, LAY_MINE, HULL_DOWN, CLIMB_MODE_ON,
-        CLIMB_MODE_OFF, SWIM, DIG_IN, FORTIFY, SHAKE_OFF_SWARMERS, TAKEOFF, VTAKEOFF, LAND, ACC, DEC, EVADE,
+        CLIMB_MODE_OFF, SWIM, DIG_IN, FORTIFY, BRIDGING, SHAKE_OFF_SWARMERS, TAKEOFF, VTAKEOFF, LAND, ACC, DEC, EVADE,
         SHUTDOWN, STARTUP, SELF_DESTRUCT, ACCN, DECN, ROLL, OFF, RETURN, LAUNCH, THRUST, YAW, CRASH, RECOVER,
         RAM, HOVER, MANEUVER, LOOP, CAREFUL_STAND, JOIN, DROP, VLAND, MOUNT, UNDOCK, TAKE_COVER,
         CONVERT_MODE, BOOTLEGGER, TOW, DISCONNECT, BRACE;
@@ -1853,12 +1853,12 @@ public class MovePath implements Cloneable, Serializable {
     }
 
     /**
-     * Worker function that counts the number of steps of the given type 
+     * Worker function that counts the number of steps of the given type
      * at the end of the given path before another step type occurs.
      */
     public int getEndStepCount(MoveStepType stepType) {
         int stepCount = 0;
-        
+
         for (int index = getStepVector().size() - 1; index >= 0; index--) {
             if (getStepVector().get(index).getType() == stepType) {
                 stepCount++;
@@ -1866,10 +1866,10 @@ public class MovePath implements Cloneable, Serializable {
                 break;
             }
         }
-        
+
         return stepCount;
     }
-    
+
     /**
      * Debugging method that calculates a destruction-aware move path to the destination coordinates
      */

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -96,6 +96,7 @@ public class MoveStep implements Serializable {
     private boolean isStackingViolation = false;
     private boolean isDiggingIn = false;
     private boolean isTakingCover = false;
+    private boolean isBridgeBuilding = false;
     private int wigeBonus = 0;
     private int nWigeDescent = 0;
 
@@ -2047,6 +2048,20 @@ public class MoveStep implements Serializable {
 
             return;
         } // end AERO stuff
+
+        if (prev.isBridgeBuilding) {
+            if (!entity.isVehicle() && !entity.entityIsQuad()) {
+                return;
+            }
+            isBridgeBuilding = true;
+            movementType = EntityMovementType.MOVE_NONE;
+        } else if ((type == MoveStepType.BRIDGING)) {
+            if ((!entity.isVehicle() && !entity.entityIsQuad()) || !isFirstStep()) {
+                return;
+            }
+            isBridgeBuilding = true;
+            movementType = EntityMovementType.MOVE_NONE;
+        }
 
         if (prev.isDiggingIn) {
             isDiggingIn = true;

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -33927,7 +33927,6 @@ public class GameManager implements IGameManager {
                     game.getBoard().getBuildingsVector().add(bldg);
                     sendChangedBuildings(game.getBoard().getBuildingsVector());
                     game.getBoard().updateBuildings(game.getBoard().getBuildingsVector());
-                    //game.getBoard().getBuildingsVector().add(bldg);
                     game.getBoard().addBuildingToHash(c, bldg);
                     // There has to be a better way
                     // game.getBoard().addNewBuildingHash();

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -33928,34 +33928,6 @@ public class GameManager implements IGameManager {
                     newBuildings.add(bldg);
                     game.getBoard().addBuildings(newBuildings);
                     sendAddBuildings(newBuildings);
-
-                    /*game.getBoard().getBuildingsVector().add(bldg);
-                    //game.getBoard().addBuildingToHash(c, bldg);
-                    Map<Building, Vector<Coords>> update = new HashMap<>();
-                    Enumeration<Building> buildings = game.getBoard().getBuildings();
-                    while (buildings.hasMoreElements()) {
-                        Building bldg2 = buildings.nextElement();
-                        Vector<Coords> updateCoords = new Vector<>();
-                        Enumeration<Coords> buildingCoords = bldg2.getCoords();
-                        while (buildingCoords.hasMoreElements()) {
-                            Coords coords = buildingCoords.nextElement();
-                            if (bldg.getPhaseCF(coords) != bldg.getCurrentCF(coords)) {
-                                bldg.setPhaseCF(bldg.getCurrentCF(coords), coords);
-                                updateCoords.addElement(coords);
-                            }
-                        }
-                        update.put(bldg2, updateCoords);
-                    }
-                    createUpdateBuildingPacket(game.getBoard().getBuildingsVector());
-                    //game.getBoard().createNewBuildingHash();
-
-                    sendChangedBuildings(game.getBoard().getBuildingsVector());
-                    //game.getBoard().updateBuildings(game.getBoard().getBuildingsVector());
-                    //game.getBoard().addBuildingToHash(c, bldg);
-                    // There has to be a better way
-                    // game.getBoard().addNewBuildingHash();
-                    // Reverse engineering this might help?
-                    // game.getBoard().collapseBuilding(); */
                 }
             }
         }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -33919,12 +33919,17 @@ public class GameManager implements IGameManager {
                         bridgeCF = 45;
                     }
 
-                    frontHex.addTerrain(new Terrain(Terrains.BRIDGE, Building.HEAVY, true, (9 & 63)));
+                    frontHex.addTerrain(new Terrain(Terrains.BRIDGE, Building.HEAVY, true, 9));
                     frontHex.addTerrain(new Terrain(Terrains.BRIDGE_CF, bridgeCF));
                     frontHex.addTerrain(new Terrain(Terrains.BRIDGE_ELEV, height));
                     sendChangedHex(c);
                     Building bldg = new Building(c, game.getBoard(), Terrains.BRIDGE, BasementType.NONE);
-                    game.getBoard().getBuildingsVector().add(bldg);
+                    Vector<Building> newBuildings = new Vector<>();
+                    newBuildings.add(bldg);
+                    game.getBoard().addBuildings(newBuildings);
+                    sendAddBuildings(newBuildings);
+
+                    /*game.getBoard().getBuildingsVector().add(bldg);
                     //game.getBoard().addBuildingToHash(c, bldg);
                     Map<Building, Vector<Coords>> update = new HashMap<>();
                     Enumeration<Building> buildings = game.getBoard().getBuildings();
@@ -33950,7 +33955,7 @@ public class GameManager implements IGameManager {
                     // There has to be a better way
                     // game.getBoard().addNewBuildingHash();
                     // Reverse engineering this might help?
-                    // game.getBoard().collapseBuilding();
+                    // game.getBoard().collapseBuilding(); */
                 }
             }
         }
@@ -34291,5 +34296,9 @@ public class GameManager implements IGameManager {
     public Set<Coords> getHexUpdateSet() {
         return hexUpdateSet;
 
+    }
+
+    public void sendAddBuildings(Vector<Building> buildings) {
+        send(new Packet(PacketCommand.BLDG_ADD, buildings));
     }
 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -33925,9 +33925,28 @@ public class GameManager implements IGameManager {
                     sendChangedHex(c);
                     Building bldg = new Building(c, game.getBoard(), Terrains.BRIDGE, BasementType.NONE);
                     game.getBoard().getBuildingsVector().add(bldg);
+                    //game.getBoard().addBuildingToHash(c, bldg);
+                    Map<Building, Vector<Coords>> update = new HashMap<>();
+                    Enumeration<Building> buildings = game.getBoard().getBuildings();
+                    while (buildings.hasMoreElements()) {
+                        Building bldg2 = buildings.nextElement();
+                        Vector<Coords> updateCoords = new Vector<>();
+                        Enumeration<Coords> buildingCoords = bldg2.getCoords();
+                        while (buildingCoords.hasMoreElements()) {
+                            Coords coords = buildingCoords.nextElement();
+                            if (bldg.getPhaseCF(coords) != bldg.getCurrentCF(coords)) {
+                                bldg.setPhaseCF(bldg.getCurrentCF(coords), coords);
+                                updateCoords.addElement(coords);
+                            }
+                        }
+                        update.put(bldg2, updateCoords);
+                    }
+                    createUpdateBuildingPacket(game.getBoard().getBuildingsVector());
+                    //game.getBoard().createNewBuildingHash();
+
                     sendChangedBuildings(game.getBoard().getBuildingsVector());
-                    game.getBoard().updateBuildings(game.getBoard().getBuildingsVector());
-                    game.getBoard().addBuildingToHash(c, bldg);
+                    //game.getBoard().updateBuildings(game.getBoard().getBuildingsVector());
+                    //game.getBoard().addBuildingToHash(c, bldg);
                     // There has to be a better way
                     // game.getBoard().addNewBuildingHash();
                     // Reverse engineering this might help?

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -37,10 +37,7 @@ import megamek.common.options.IBasicOption;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
-import megamek.common.util.BoardUtilities;
-import megamek.common.util.EmailService;
-import megamek.common.util.SerializationHelper;
-import megamek.common.util.StringUtil;
+import megamek.common.util.*;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.*;
 import megamek.common.weapons.*;
@@ -33914,17 +33911,28 @@ public class GameManager implements IGameManager {
                     // Add the new bridge to the map
                     Coords c = ent.getPosition().translated(ent.getFacing(), 1);
                     Hex hex = game.getBoard().getHex(c);
-                    int height = hex.getLevel();
+                    Hex entityHex = game.getBoard().getHex(ent.getPosition());
+                    int height = entityHex.getLevel();
                     int bridgeCF = 0;
                     Hex frontHex = game.getBoard().getHex(c);
                     if (ent.hasWorkingMisc(MiscType.F_HEAVY_BRIDGE_LAYER)) {
                         bridgeCF = 45;
                     }
-                    frontHex.addTerrain(new Terrain(Terrains.BRIDGE, 1));
+
+                    frontHex.addTerrain(new Terrain(Terrains.BRIDGE, Building.HEAVY, true, (9 & 63)));
                     frontHex.addTerrain(new Terrain(Terrains.BRIDGE_CF, bridgeCF));
                     frontHex.addTerrain(new Terrain(Terrains.BRIDGE_ELEV, height));
-                    //frontHex.addTerrain(new Terrain(Terrains.)
                     sendChangedHex(c);
+                    Building bldg = new Building(c, game.getBoard(), Terrains.BRIDGE, BasementType.NONE);
+                    game.getBoard().getBuildingsVector().add(bldg);
+                    sendChangedBuildings(game.getBoard().getBuildingsVector());
+                    game.getBoard().updateBuildings(game.getBoard().getBuildingsVector());
+                    //game.getBoard().getBuildingsVector().add(bldg);
+                    game.getBoard().addBuildingToHash(c, bldg);
+                    // There has to be a better way
+                    // game.getBoard().addNewBuildingHash();
+                    // Reverse engineering this might help?
+                    // game.getBoard().collapseBuilding();
                 }
             }
         }


### PR DESCRIPTION
This PR still needs a lot of work, but it also has a few issues I need help with finding solutions to improve the code.

1. Need to set exits: This can easily be done manually I believe, but I would rather find a way to do it within the software that already exsists.
2. There is an NPE that pops up when you mouseover the new bridge hex (log below). I haven't looked into it yet so I may find a fix before it gets a once over.
3. Abstract the getter and setter and override in the appropriate entity class or just let entity handle everything as coded now?

Items still to do: TW p131
1. Create a second bridge terrain BRIDGE2 to use for bridges over water. Per rules bridges created using a bridgelayer have double the weight capacity of the CF listed only if placed on the water. If the land hex is higher it remains unchanged.
2. SV vehicles with bridgelayers can have the bridgelayer destroyed if the turret is hit.
3. Setup infantry bridging engineers. So far I have touched this yet.
4. Finish coding water bridging. So far only Heavy Bridgelayer is working

NOTE: when completed this will be closed, cleaned up, rewritten, and reposted.