### PR TITLE
Print Alpha Strike cards

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/ASStatsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/ASStatsDialog.java
@@ -30,8 +30,9 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
+import java.util.*;
 
 /**
  * This non-modal dialog shows stats of one or more AlphaStrike elements in the form of a table.
@@ -41,8 +42,10 @@ public class ASStatsDialog extends AbstractDialog {
     
     private final Collection<Entity> entities;
     private final JButton clipBoardButton = new JButton("Copy to Clipboard");
+    private final JButton printButton = new JButton("Print");
     private final JScrollPane scrollPane = new JScrollPane();
     private final JPanel centerPanel = new JPanel();
+    private ASStatsTablePanel tablePanel;
     private static final String COLUMN_SEPARATOR = "\t";
     private static final String INTERNAL_DELIMITER = ",";
 
@@ -68,7 +71,9 @@ public class ASStatsDialog extends AbstractDialog {
         var optionsPanel = new UIUtil.FixedYPanel(new FlowLayout(FlowLayout.LEFT));
         optionsPanel.add(Box.createVerticalStrut(25));
         optionsPanel.add(clipBoardButton);
+        optionsPanel.add(printButton);
         clipBoardButton.addActionListener(e -> copyToClipboard());
+        printButton.addActionListener(ev -> printCards());
         
         scrollPane.getVerticalScrollBar().setUnitIncrement(16);
 
@@ -81,8 +86,8 @@ public class ASStatsDialog extends AbstractDialog {
     
     private void setupTable() {
         centerPanel.remove(scrollPane);
-        JPanel asPanel = new ASStatsTablePanel(getFrame()).add(entities, "Selected Units").getPanel();
-        scrollPane.setViewportView(asPanel);
+        tablePanel = new ASStatsTablePanel(getFrame()).add(entities, "Selected Units");
+        scrollPane.setViewportView(tablePanel.getPanel());
         centerPanel.add(scrollPane);
         adaptToGUIScale();
     }
@@ -142,5 +147,18 @@ public class ASStatsDialog extends AbstractDialog {
 
     private void adaptToGUIScale() {
         UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
+    }
+
+    private void printCards() {
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setPrintable(tablePanel);
+        boolean doPrint = job.printDialog();
+        if (doPrint) {
+            try {
+                job.print();
+            } catch (PrinterException ignored) {
+
+            }
+        }
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/ASStatsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/ASStatsDialog.java
@@ -24,15 +24,15 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.alphaStrike.AlphaStrikeHelper;
+import megamek.common.alphaStrike.cardDrawer.ASCardPrinter;
 import megamek.common.alphaStrike.conversion.ASConverter;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
-import java.awt.print.PrinterException;
-import java.awt.print.PrinterJob;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * This non-modal dialog shows stats of one or more AlphaStrike elements in the form of a table.
@@ -150,15 +150,6 @@ public class ASStatsDialog extends AbstractDialog {
     }
 
     private void printCards() {
-        PrinterJob job = PrinterJob.getPrinterJob();
-        job.setPrintable(tablePanel);
-        boolean doPrint = job.printDialog();
-        if (doPrint) {
-            try {
-                job.print();
-            } catch (PrinterException ignored) {
-
-            }
-        }
+        new ASCardPrinter(tablePanel.getElements(), getFrame()).printCards();
     }
 }

--- a/megamek/src/megamek/client/ui/swing/ASStatsTablePanel.java
+++ b/megamek/src/megamek/client/ui/swing/ASStatsTablePanel.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.dialogs.ASConversionInfoDialog;
+import megamek.client.ui.swing.alphaStrike.ASElementPrinter;
 import megamek.client.ui.swing.calculationReport.FlexibleCalculationReport;
 import megamek.client.ui.swing.util.SpringUtilities;
 import megamek.client.ui.swing.util.UIUtil;
@@ -30,10 +31,13 @@ import megamek.common.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
 import java.util.List;
 import java.util.*;
 
-public class ASStatsTablePanel {
+public class ASStatsTablePanel implements Printable {
 
     private final int COLUMNS = 15;
     private final static Color GROUP_NAME_COLOR = UIUtil.uiLightGreen();
@@ -43,6 +47,7 @@ public class ASStatsTablePanel {
     private int rows;
     private final List<EntityGroup> groups = new ArrayList<>();
     private final JFrame frame;
+    private final List<AlphaStrikeElement> elements = new ArrayList<>();
 
     /**
      * Constructs a panel with a table of AlphaStrike stats for any units that are added to it.
@@ -123,6 +128,7 @@ public class ASStatsTablePanel {
                 }
             }
         }
+        elements.addAll(elementList);
 
         // Print the elements
         rows++;
@@ -245,6 +251,11 @@ public class ASStatsTablePanel {
             spacerPanel.add(Box.createVerticalStrut(2));
             panel.add(spacerPanel);
         }
+    }
+
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        return new ASElementPrinter(elements).print(graphics, pageFormat, pageIndex);
     }
 
     /** A record to store added groups of units before constructing the panel. */

--- a/megamek/src/megamek/client/ui/swing/ASStatsTablePanel.java
+++ b/megamek/src/megamek/client/ui/swing/ASStatsTablePanel.java
@@ -19,7 +19,6 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.dialogs.ASConversionInfoDialog;
-import megamek.client.ui.swing.alphaStrike.ASElementPrinter;
 import megamek.client.ui.swing.calculationReport.FlexibleCalculationReport;
 import megamek.client.ui.swing.util.SpringUtilities;
 import megamek.client.ui.swing.util.UIUtil;
@@ -31,13 +30,10 @@ import megamek.common.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.print.PageFormat;
-import java.awt.print.Printable;
-import java.awt.print.PrinterException;
 import java.util.List;
 import java.util.*;
 
-public class ASStatsTablePanel implements Printable {
+public class ASStatsTablePanel {
 
     private final int COLUMNS = 15;
     private final static Color GROUP_NAME_COLOR = UIUtil.uiLightGreen();
@@ -98,6 +94,10 @@ public class ASStatsTablePanel implements Printable {
     public JPanel getPanel() {
         constructPanel();
         return panel;
+    }
+
+    public List<AlphaStrikeElement> getElements() {
+        return elements;
     }
 
     /** Assembles the JPanel. It is empty before calling this method. */
@@ -251,11 +251,6 @@ public class ASStatsTablePanel implements Printable {
             spacerPanel.add(Box.createVerticalStrut(2));
             panel.add(spacerPanel);
         }
-    }
-
-    @Override
-    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
-        return new ASElementPrinter(elements).print(graphics, pageFormat, pageIndex);
     }
 
     /** A record to store added groups of units before constructing the panel. */

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ASCardPanel.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ASCardPanel.java
@@ -116,4 +116,8 @@ public final class ASCardPanel extends JComponent {
         super.paintComponent(g);
         g.drawImage(cardImage, 0, 0, this);
     }
+
+    public ASCard getCard() {
+        return card;
+    }
 }

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ASElementPrinter.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ASElementPrinter.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.alphaStrike;
+
+import megamek.MMConstants;
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.codeUtilities.StringUtility;
+import megamek.common.alphaStrike.ASCardDisplayable;
+import megamek.common.alphaStrike.cardDrawer.ASCard;
+import megamek.common.alphaStrike.cardDrawer.ASLargeAeroCard;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ASElementPrinter {
+
+    private final List<CardSlot> cardSlots = new ArrayList<>();
+    private int row;
+    private int column;
+    private AffineTransform baseTransform;
+    private int columnCount = 2;
+    private int rowCount = 4;
+
+    public ASElementPrinter(Collection<? extends ASCardDisplayable> elements) {
+        Font userSelectedFont = userSelectedFont();
+        for (ASCardDisplayable element : elements) {
+            ASCard card = ASCard.createCard(element);
+            card.setFont(userSelectedFont);
+            cardSlots.add(new CardSlot(card, false));
+            if (element.usesArcs()) {
+                cardSlots.add(new CardSlot(card, true));
+            }
+        }
+    }
+
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)
+            throws PrinterException {
+        double height = 2.5 * 72;
+        rowCount = (int) (pageFormat.getImageableHeight() / height);
+        columnCount = (int) (pageFormat.getImageableWidth() / (3.5 * 72));
+        if (isPageIndexValid(pageIndex)) {
+            double fullHeight = rowCount * height;
+            Graphics2D g2D = (Graphics2D) graphics;
+            double topCardY = pageFormat.getHeight() / 2 - fullHeight / 2;
+            g2D.translate(pageFormat.getWidth() / 2, topCardY);
+            g2D.scale(ASCard.PRINT_SCALE, ASCard.PRINT_SCALE);
+            baseTransform = g2D.getTransform();
+
+            int elementIndex = pageStartSlotIndex(pageIndex);
+            while ((elementIndex < pageStartSlotIndex(pageIndex + 1)) && (elementIndex < cardSlots.size())) {
+                goToPrintSlot(elementIndex - pageStartSlotIndex(pageIndex), g2D);
+                CardSlot cardSlot = cardSlots.get(elementIndex);
+                if (cardSlot.flipSide) {
+                    ((ASLargeAeroCard) (cardSlot.card)).drawFlipside(g2D);
+                } else {
+                    cardSlot.card.drawCard(g2D);
+                }
+                elementIndex++;
+            }
+
+            return Printable.PAGE_EXISTS;
+        } else {
+            return Printable.NO_SUCH_PAGE;
+        }
+    }
+
+    private Font userSelectedFont() {
+        String fontName = GUIPreferences.getInstance().getAsCardFont();
+        return (StringUtility.isNullOrBlank(fontName)
+                ? new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 14)
+                : Font.decode(fontName));
+    }
+
+    private int pageStartSlotIndex(int pageIndex) {
+        return columnCount * rowCount * pageIndex;
+    }
+
+    private boolean isPageIndexValid(int pageIndex) {
+        return cardSlots.size() > pageStartSlotIndex(pageIndex);
+    }
+
+    private void goToPrintSlot(int slot, Graphics2D g2D) {
+        g2D.setTransform(baseTransform);
+        column = slot / rowCount;
+        row = slot - column * rowCount;
+        g2D.translate(-ASCard.WIDTH * columnCount / 2 + ASCard.WIDTH * column, ASCard.HEIGHT * row);
+    }
+
+    private static class CardSlot {
+        ASCard card;
+        boolean flipSide;
+
+        CardSlot(ASCard card, boolean flipSide) {
+            this.card = card;
+            this.flipSide = flipSide;
+        }
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
@@ -24,6 +24,7 @@ import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.alphaStrike.ASCardDisplayable;
 import megamek.common.alphaStrike.AlphaStrikeElement;
+import megamek.common.alphaStrike.cardDrawer.ASCardPrinter;
 import megamek.common.annotations.Nullable;
 import org.apache.logging.log4j.LogManager;
 
@@ -36,6 +37,7 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 import java.net.URL;
+import java.util.List;
 
 /**
  * This is a JPanel that displays an AlphaStrike unit card and elements to configure the display of
@@ -173,16 +175,7 @@ public class ConfigurableASCardPanel extends JPanel {
     }
 
     private void printCard() {
-        PrinterJob job = PrinterJob.getPrinterJob();
-        job.setPrintable(cardPanel.getCard());
-        boolean doPrint = job.printDialog();
-        if (doPrint) {
-            try {
-                job.print();
-            } catch (PrinterException ex) {
-                JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
-            }
-        }
+        new ASCardPrinter(List.of(element), parent).printCards();
     }
 
     // Taken from https://alvinalexander.com/java/java-copy-image-to-clipboard-example/

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
@@ -33,6 +33,8 @@ import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 import java.net.URL;
 
 /**
@@ -45,6 +47,7 @@ public class ConfigurableASCardPanel extends JPanel {
     private final JComboBox<String> fontChooser = new JComboBox<>();
     private final JComboBox<Float> sizeChooser = new JComboBox<>();
     private final JButton copyButton = new JButton("Copy to Clipboard");
+    private final JButton printButton = new JButton("Print");
     private final JButton mulButton = new JButton("MUL");
     private final JButton conversionButton = new JButton("Conversion Report");
     private final ASCardPanel cardPanel = new ASCardPanel();
@@ -79,6 +82,7 @@ public class ConfigurableASCardPanel extends JPanel {
         sizeChooser.setRenderer((list, value, index, isSelected, cellHasFocus) -> new JLabel(Float.toString(value)));
 
         copyButton.addActionListener(ev -> copyCardToClipboard());
+        printButton.addActionListener(ev -> printCard());
 
         mulButton.addActionListener(ev -> showMUL());
         mulButton.setToolTipText("Show the Master Unit List entry for this unit. Opens a browser window.");
@@ -95,6 +99,8 @@ public class ConfigurableASCardPanel extends JPanel {
         chooserLine.add(sizeChooser);
         chooserLine.add(Box.createHorizontalStrut(15));
         chooserLine.add(copyButton);
+        chooserLine.add(Box.createHorizontalStrut(15));
+        chooserLine.add(printButton);
         chooserLine.add(Box.createHorizontalStrut(15));
         chooserLine.add(mulButton);
         chooserLine.add(Box.createHorizontalStrut(15));
@@ -163,6 +169,19 @@ public class ConfigurableASCardPanel extends JPanel {
             var dialog = new ASConversionInfoDialog(parent, ((AlphaStrikeElement) element).getConversionReport(), element);
             dialog.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
             dialog.setVisible(true);
+        }
+    }
+
+    private void printCard() {
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setPrintable(cardPanel.getCard());
+        boolean doPrint = job.printDialog();
+        if (doPrint) {
+            try {
+                job.print();
+            } catch (PrinterException ex) {
+                JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
+            }
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -34,8 +34,6 @@ import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.print.PrinterException;
-import java.awt.print.PrinterJob;
 import java.net.URL;
 import java.util.List;
 

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -416,7 +416,7 @@ public final class UIUtil {
             if ((comp instanceof JButton) || (comp instanceof JLabel)
                     || (comp instanceof JComboBox<?>) || (comp instanceof JTextField) || (comp instanceof JSlider)
                     || (comp instanceof JSpinner) || (comp instanceof JTextArea) || (comp instanceof JToggleButton)
-                    || (comp instanceof JTable) || (comp instanceof JList)
+                    || (comp instanceof JTable) || (comp instanceof JList) || (comp instanceof JProgressBar)
                     || (comp instanceof JEditorPane) || (comp instanceof JTree)) {
                 if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
                     comp.setFont(comp.getFont().deriveFont((float) sf));

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
@@ -33,6 +33,9 @@ import megamek.common.util.fileUtils.MegaMekFile;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
 import java.time.LocalDate;
 import java.util.Locale;
 
@@ -50,10 +53,11 @@ import static java.awt.Color.WHITE;
  * for Large Aerospace units the specific class can be used to have additional functionality for the two
  * card faces of these cards.
  */
-public class ASCard {
+public class ASCard implements Printable {
 
-    protected final static int WIDTH = 1050;
-    protected final static int HEIGHT = 750;
+    public final static int WIDTH = 1050;
+    public final static int HEIGHT = 750;
+    public final static double PRINT_SCALE = 3.5 * 72 / WIDTH; // 3.5" wide, 1/72 dots per inch
     protected final static int BORDER = 21;
     protected final static int ARMOR_PIP_SIZE = 22;
     protected final static int DAMAGE_PIP_SIZE = 18;
@@ -222,7 +226,7 @@ public class ASCard {
     }
 
     /** This method controls drawing the card. */
-    protected final void drawCard(Graphics g) {
+    public final void drawCard(Graphics g) {
         initializeFonts(lightFont, boldFont, blackFont);
         Graphics2D g2D = (Graphics2D) g;
         GUIPreferences.AntiAliasifSet(g);
@@ -553,6 +557,21 @@ public class ASCard {
             return FluffImageHelper.loadFluffImageHeuristic(element);
         } else {
             return null;
+        }
+    }
+
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+        if (pageIndex == 0) {
+            Graphics2D g2D = (Graphics2D) graphics;
+            double height = 2.5 * 72;
+            g2D.translate(pageFormat.getWidth() / 2, pageFormat.getHeight() / 2 - height / 2);
+            g2D.scale(ASCard.PRINT_SCALE, ASCard.PRINT_SCALE);
+            g2D.translate(-WIDTH / 2, 0);
+            drawCard(graphics);
+            return PAGE_EXISTS;
+        } else {
+            return NO_SUCH_PAGE;
         }
     }
 }

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
@@ -33,9 +33,6 @@ import megamek.common.util.fileUtils.MegaMekFile;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.awt.print.PageFormat;
-import java.awt.print.Printable;
-import java.awt.print.PrinterException;
 import java.time.LocalDate;
 import java.util.Locale;
 
@@ -53,7 +50,7 @@ import static java.awt.Color.WHITE;
  * for Large Aerospace units the specific class can be used to have additional functionality for the two
  * card faces of these cards.
  */
-public class ASCard implements Printable {
+public class ASCard {
 
     public final static int WIDTH = 1050;
     public final static int HEIGHT = 750;
@@ -557,21 +554,6 @@ public class ASCard implements Printable {
             return FluffImageHelper.loadFluffImageHeuristic(element);
         } else {
             return null;
-        }
-    }
-
-    @Override
-    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
-        if (pageIndex == 0) {
-            Graphics2D g2D = (Graphics2D) graphics;
-            double height = 2.5 * 72;
-            g2D.translate(pageFormat.getWidth() / 2, pageFormat.getHeight() / 2 - height / 2);
-            g2D.scale(ASCard.PRINT_SCALE, ASCard.PRINT_SCALE);
-            g2D.translate(-WIDTH / 2, 0);
-            drawCard(graphics);
-            return PAGE_EXISTS;
-        } else {
-            return NO_SUCH_PAGE;
         }
     }
 }

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCardPrinter.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCardPrinter.java
@@ -49,6 +49,8 @@ public class ASCardPrinter implements Printable {
     private int row;
     private int column;
     private AffineTransform baseTransform;
+
+    // The column and row count depend on the page format of a given print job and are set anew for each print call
     private int columnCount = 2;
     private int rowCount = 4;
 
@@ -129,8 +131,8 @@ public class ASCardPrinter implements Printable {
         }
     }
 
-    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex)
-            throws PrinterException {
+    @Override
+    public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
         double height = 2.5 * 72;
         rowCount = (int) (pageFormat.getImageableHeight() / height);
         columnCount = (int) (pageFormat.getImageableWidth() / (3.5 * 72));
@@ -178,6 +180,7 @@ public class ASCardPrinter implements Printable {
         return cardSlots.size() > pageStartSlotIndex(pageIndex);
     }
 
+    /** Sets the translate in the given g2D to the given card slot, going down the first column, then the second... */
     private void goToPrintSlot(int slot, Graphics2D g2D) {
         g2D.setTransform(baseTransform);
         column = slot / rowCount;
@@ -185,6 +188,7 @@ public class ASCardPrinter implements Printable {
         g2D.translate(-ASCard.WIDTH * columnCount / 2 + ASCard.WIDTH * column, ASCard.HEIGHT * row);
     }
 
+    /** Holds the card for a card slot on the page together with the info if this is the front or back side. */
     private static class CardSlot {
         ASCard card;
         boolean flipSide;

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCardPrinter.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCardPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -36,6 +36,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * This class prints a collection of one or more Alpha Strike cards. The cards to be printed can be created
+ * from either an {@link megamek.common.alphaStrike.AlphaStrikeElement} or a {@link megamek.common.MechSummary}.
+ * It shows a progress bar dialog but the printing happens in the background and the calling window is not blocked.
+ */
 public class ASCardPrinter implements Printable {
 
     private final JFrame parent;
@@ -47,6 +52,11 @@ public class ASCardPrinter implements Printable {
     private int columnCount = 2;
     private int rowCount = 4;
 
+    /**
+     * Creates a new ASCardPrinter object for the given ASCardDisplayable elements (either
+     * {@link megamek.common.alphaStrike.AlphaStrikeElement} or {@link megamek.common.MechSummary}.
+     * The parent is used for the progress dialog. Print the cards by calling {@link #printCards()}.
+     */
     public ASCardPrinter(Collection<? extends ASCardDisplayable> elements, JFrame parent) {
         Font userSelectedFont = userSelectedFont();
         this.parent = parent;
@@ -60,6 +70,11 @@ public class ASCardPrinter implements Printable {
         }
     }
 
+    /**
+     * Starts a printing process for the carsd of this ASCardPrinter. This will display the usual printer
+     * selection dialog and a progress dialog. Printing itself happens in the background and the progress
+     * dialog can be closed.
+     */
     public void printCards() {
         PrinterJob job = PrinterJob.getPrinterJob();
         job.setPrintable(this);

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASLargeAeroCard.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASLargeAeroCard.java
@@ -18,6 +18,7 @@
  */
 package megamek.common.alphaStrike.cardDrawer;
 
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.StringDrawer;
 import megamek.common.alphaStrike.*;
 import megamek.common.util.ImageUtil;
@@ -48,8 +49,7 @@ public class ASLargeAeroCard extends ASCard {
     private Font arcSpecialsFont;
     private Font critTextFont;
 
-    private final StringDrawer.StringDrawerConfig damageValueConfig = new StringDrawer.StringDrawerConfig().centerX()
-            .scaleX(0.9f).color(Color.BLACK).font(damageFont);
+    private StringDrawer.StringDrawerConfig damageValueConfig;
 
     public ASLargeAeroCard(ASCardDisplayable element) {
         super(element);
@@ -89,6 +89,9 @@ public class ASLargeAeroCard extends ASCard {
 
         specialsHeaderConfig = new StringDrawer.StringDrawerConfig().color(Color.BLACK)
                 .font(blackFont.deriveFont((float)largeAeroSpecialFont.getSize()));
+
+        damageValueConfig = new StringDrawer.StringDrawerConfig().centerX()
+                .scaleX(0.9f).color(Color.BLACK).font(damageFont);
     }
 
     @Override
@@ -99,7 +102,13 @@ public class ASLargeAeroCard extends ASCard {
         fluffYCenter = 366;
     }
 
-    private void drawFlipside(Graphics2D g) {
+    public void drawFlipside(Graphics2D g) {
+        initializeFonts(lightFont, boldFont, blackFont);
+        GUIPreferences.AntiAliasifSet(g);
+        g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+        g.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+        g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
         paintCardBackground(g, true);
         new StringDrawer("WEAPON CRITICALS").at(33, 629).font(arcTitleFont).maxWidth(220)
                 .outline(Color.BLACK, 0.4f).centerY().draw(g);


### PR DESCRIPTION
This PR allows printing AS Cards from the conversion stats dialog in MM as well as the unit selector and wherever the standard AS card panel is used.