### PR TITLE
BTObject: Add several utility methods, Tripod/Quad/Aerodyne SC info

### DIFF
--- a/megamek/src/megamek/common/BTObject.java
+++ b/megamek/src/megamek/common/BTObject.java
@@ -77,7 +77,7 @@ public interface BTObject {
     }
 
     /**
-     * Returns true when this object is a Quad Mek.
+     * Returns true when this object is a Quad Mek or QuadVee, regardless of conversion state.
      * Returns false for any type of unit group even if it consists only of Quad Meks.
      *
      * @return True when this is a Quad (four-legged) Mek
@@ -160,7 +160,7 @@ public interface BTObject {
     }
 
     /**
-     * Returns true when this object is a SmallCraft (but not a DropShip).
+     * Returns true when this object is a SmallCraft (not a DropShip).
      * Returns false for any type of unit group.
      *
      * @return True when this is a SmallCraft
@@ -181,7 +181,8 @@ public interface BTObject {
 
     /**
      * Returns true when this object has the distinction between aerodyne and spheroid, i.e. if it
-     * is a DropShip or SmallCraft.
+     * is a DropShip or SmallCraft. Returns false for fighters as they are always aerodyne and do not have
+     * the distinction.
      * Returns false for any type of unit group. This method should not require overriding.
      *
      * @return True when this is object can be aerodyne or spheroid
@@ -191,20 +192,21 @@ public interface BTObject {
     }
 
     /**
-     * Returns true when this object has the distinction between aerodyne and spheroid, i.e. if it
-     * is a DropShip or SmallCraft and it is aerodyne.
-     * Returns false for any type of unit group and for any unit that does not have the distinction.
+     * Returns true when this object is aerodyne. All fighters are aerodyne. Units
+     * that have the aerodyne/spheroid distinction, i.e. DropShips and SmallCraft return true when they are
+     * aerodyne.
+     * Returns false for any type of unit group.
      * This method refers to {@link #isSpheroid()} and should not require overriding.
      *
-     * @return True when this is object is aerodyne
+     * @return True when this is object is aerodyne (fighter, aerodyne DropShip or aerodyne SmallCraft)
      */
     default boolean isAerodyne() {
-        return hasAerodyneSpheroidDistinction() && !isSpheroid();
+        return isFighter() || (hasAerodyneSpheroidDistinction() && !isSpheroid());
     }
 
     /**
      * Returns true when this object has the distinction between aerodyne and spheroid, i.e. if it
-     * is a DropShip or SmallCraft and it is spheroid.
+     * is a DropShip or SmallCraft and it is spheroid, false for any other type of object.
      * Returns false for any type of unit group and for any unit that does not have the distinction.
      *
      * @return True when this is object is spheroid

--- a/megamek/src/megamek/common/BTObject.java
+++ b/megamek/src/megamek/common/BTObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -67,6 +67,26 @@ public interface BTObject {
     }
 
     /**
+     * Returns true when this object is a Tripod Mek.
+     * Returns false for any type of unit group even if it consists only of Tripods.
+     *
+     * @return True when this is a Tripod Mek
+     */
+    default boolean isTripodMek() {
+        return false;
+    }
+
+    /**
+     * Returns true when this object is a Quad Mek.
+     * Returns false for any type of unit group even if it consists only of Quad Meks.
+     *
+     * @return True when this is a Quad (four-legged) Mek
+     */
+    default boolean isQuadMek() {
+        return false;
+    }
+
+    /**
      * Returns true when this object is an Industrial Mek or of type IM for Alpha Strike.
      * Returns false for any type of unit group even if it is of the right type.
      *
@@ -79,6 +99,7 @@ public interface BTObject {
     /**
      * Returns true when this object is a ground unit (all types of Mek, Infantry and Vehicle except aerospace
      * support vehicles such as Fixed-Wing Support). A unit is a ground unit if it is not {@link #isAerospace()}.
+     * This method should not require overriding.
      *
      * @return True when this is a ground unit or ground group (SBF)
      */
@@ -135,6 +156,60 @@ public interface BTObject {
      * @return True when this is an aerospace Support Vehicle
      */
     default boolean isAerospaceSV() {
+        return false;
+    }
+
+    /**
+     * Returns true when this object is a SmallCraft (but not a DropShip).
+     * Returns false for any type of unit group.
+     *
+     * @return True when this is a SmallCraft
+     */
+    default boolean isSmallCraft() {
+        return false;
+    }
+
+    /**
+     * Returns true when this object is a DropShip.
+     * Returns false for any type of unit group.
+     *
+     * @return True when this is a DropShip
+     */
+    default boolean isDropShip() {
+        return false;
+    }
+
+    /**
+     * Returns true when this object has the distinction between aerodyne and spheroid, i.e. if it
+     * is a DropShip or SmallCraft.
+     * Returns false for any type of unit group. This method should not require overriding.
+     *
+     * @return True when this is object can be aerodyne or spheroid
+     */
+    default boolean hasAerodyneSpheroidDistinction() {
+        return isDropShip() || isSmallCraft();
+    }
+
+    /**
+     * Returns true when this object has the distinction between aerodyne and spheroid, i.e. if it
+     * is a DropShip or SmallCraft and it is aerodyne.
+     * Returns false for any type of unit group and for any unit that does not have the distinction.
+     * This method refers to {@link #isSpheroid()} and should not require overriding.
+     *
+     * @return True when this is object is aerodyne
+     */
+    default boolean isAerodyne() {
+        return hasAerodyneSpheroidDistinction() && !isSpheroid();
+    }
+
+    /**
+     * Returns true when this object has the distinction between aerodyne and spheroid, i.e. if it
+     * is a DropShip or SmallCraft and it is spheroid.
+     * Returns false for any type of unit group and for any unit that does not have the distinction.
+     *
+     * @return True when this is object is spheroid
+     */
+    default boolean isSpheroid() {
         return false;
     }
 
@@ -226,6 +301,7 @@ public interface BTObject {
     /**
      * Returns true when this is a single unit such as a TW Entity or AlphaStrikeElement, false when it is a
      * group unit type, see {@link #isUnitGroup()}
+     * This method fowards to {@link #isUnitGroup()} and should not require overriding.
      *
      * @return True when this is a single unit or element.
      */

--- a/megamek/src/megamek/common/BuildingTarget.java
+++ b/megamek/src/megamek/common/BuildingTarget.java
@@ -234,11 +234,6 @@ public class BuildingTarget implements Targetable {
         return false;
     }
 
-    @Override
-    public boolean isAero() {
-        return false;
-    }
-
     /*
      * (non-Javadoc)
      * @see megamek.common.Targetable#isAirborne()

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -89,6 +89,16 @@ public class Dropship extends SmallCraft {
     }
 
     @Override
+    public boolean isSmallCraft() {
+        return false;
+    }
+
+    @Override
+    public boolean isDropShip() {
+        return true;
+    }
+
+    @Override
     public CrewType defaultCrewType() {
         return CrewType.VESSEL;
     }

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -868,4 +868,8 @@ public class FighterSquadron extends Aero {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public boolean isUnitGroup() {
+        return true;
+    }
 }

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -273,6 +273,11 @@ public class QuadMech extends Mech {
         }
     }
 
+    @Override
+    public boolean isQuadMek() {
+        return true;
+    }
+
     /**
      * Sets the internal structure for the mech.
      *

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -86,7 +86,12 @@ public class SmallCraft extends Aero {
     public boolean isPrimitive() {
         return getArmorType(LOC_NOSE) == EquipmentType.T_ARMOR_PRIMITIVE_AERO;
     }
-    
+
+    @Override
+    public boolean isSmallCraft() {
+        return true;
+    }
+
     @Override
     public void setNCrew(int crew) {
         nCrew = crew;

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -95,6 +95,11 @@ public class TripodMech extends Mech {
         return Entity.ETYPE_MECH | Entity.ETYPE_TRIPOD_MECH;
     }
 
+    @Override
+    public boolean isTripodMek() {
+        return true;
+    }
+
     /**
      * Returns true if the entity can flip its arms
      */

--- a/megamek/src/megamek/common/alphaStrike/ASCardDisplayable.java
+++ b/megamek/src/megamek/common/alphaStrike/ASCardDisplayable.java
@@ -227,6 +227,31 @@ public interface ASCardDisplayable extends BattleForceSUAFormatter, BTObject {
         return isAerospace();
     }
 
+    @Override
+    default boolean isTripodMek() {
+        return getSpecialAbilities().hasSUA(BattleForceSUA.TRI);
+    }
+
+    @Override
+    default boolean isQuadMek() {
+        return getSpecialAbilities().hasSUA(BattleForceSUA.QUAD);
+    }
+
+    @Override
+    default boolean isSmallCraft() {
+        return isType(SC);
+    }
+
+    @Override
+    default boolean isDropShip() {
+        return isType(DS, DA);
+    }
+
+    @Override
+    default boolean isSpheroid() {
+        return isType(ASUnitType.DS) || (isType(ASUnitType.SC) && !getSpecialAbilities().hasSUA(BattleForceSUA.AERODYNESC));
+    }
+
     /**
      * Returns true if this unit uses the 4 firing arcs of Warships, Dropships and other units.
      * When this is the case, {@link #getStandardDamage()} will return zero damage and the actual

--- a/megamek/src/megamek/common/alphaStrike/AlphaStrikeHelper.java
+++ b/megamek/src/megamek/common/alphaStrike/AlphaStrikeHelper.java
@@ -136,7 +136,7 @@ public class AlphaStrikeHelper {
      * @return True when the given Special Unit Ability should be listed on the element's card
      */
     public static boolean hideSpecial(BattleForceSUA sua, ASCardDisplayable element) {
-        return sua.isDoor()
+        return sua.isDoor() || sua.isAnyOf(TRI, QUAD, AERODYNESC)
                 || (element.isLargeAerospace() && (sua == STD))
                 || (element.usesCapitalWeapons() && sua.isAnyOf(MSL, SCAP, CAP))
                 || (element.isType(BM, PM) && (sua == SOA))

--- a/megamek/src/megamek/common/alphaStrike/BattleForceSUA.java
+++ b/megamek/src/megamek/common/alphaStrike/BattleForceSUA.java
@@ -50,7 +50,9 @@ public enum BattleForceSUA {
     // SBF
     AC3, COM, SBF_OMNI,
     // Placeholder for STD (Standard) damage on large AS elements with firing arcs:
-    STD
+    STD,
+    // Placeholders for additional unit info not otherwise present in the AS element
+    TRI, QUAD, AERODYNESC
     ;
     
     private static final EnumMap<BattleForceSUA, BattleForceSUA> transportBayDoors = new EnumMap<>(BattleForceSUA.class);

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASConverter.java
@@ -24,6 +24,7 @@ import megamek.common.*;
 import megamek.common.alphaStrike.ASArcs;
 import megamek.common.alphaStrike.ASUnitType;
 import megamek.common.alphaStrike.AlphaStrikeElement;
+import megamek.common.alphaStrike.BattleForceSUA;
 import megamek.common.annotations.Nullable;
 import org.apache.logging.log4j.LogManager;
 
@@ -142,6 +143,13 @@ public final class ASConverter {
         element.setThreshold(ASArmStrConverter.convertThreshold(conversionData));
         ASDamageConverter.getASDamageConverter(entity, element, conversionReport).convert();
         ASSpecialAbilityConverter.getConverter(entity, element, conversionReport).processAbilities();
+        if (entity instanceof TripodMech) {
+            element.getSpecialAbilities().setSUA(BattleForceSUA.TRI);
+        } else if (entity instanceof QuadMech) {
+            element.getSpecialAbilities().setSUA(BattleForceSUA.QUAD);
+        } else if ((entity instanceof SmallCraft) && !(entity instanceof Dropship) && !((IAero) entity).isSpheroid()) {
+            element.getSpecialAbilities().setSUA(BattleForceSUA.AERODYNESC);
+        }
         ASPointValueConverter pvConverter = ASPointValueConverter.getPointValueConverter(element, conversionReport);
         element.setPointValue(pvConverter.getSkillAdjustedPointValue());
         element.setConversionReport(conversionReport);


### PR DESCRIPTION
This PR adds several general utility methods for all BTObjects. For AS Elements, info that they are Tripods, QuadMeks or aerodyne SC which is necessary for some AS rules is stored in new special abilities that are kept invisible.