### PR TITLE
fix logic for checking if crew blocks movement

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -503,13 +503,15 @@ public class Compute {
         int enHighEl = enLowEl + entity.getHeight();
         for (Entity inHex : game.getEntitiesVector(coords)) {
             int inHexAlt = inHex.getAltitude();
+            boolean crewOnGround = (inHex instanceof EjectedCrew) && (inHexAlt == 0);
             int inHexEnLowEl = inHex.getElevation();
             int inHexEnHighEl = inHexEnLowEl + inHex.getHeight();
             if ((!onlyMechs || (inHex instanceof Mech))
                 && !(ignoreInfantry && (inHex instanceof Infantry))
                 && inHex.isEnemyOf(entity) && !inHex.isMakingDfa()
                 && (enLowEl <= inHexEnHighEl) && (enHighEl >= inHexEnLowEl)
-                && ((entity instanceof EjectedCrew) && (inHexAlt == 0))) {
+                && (!(inHex instanceof EjectedCrew) || (crewOnGround))
+            ) {
                 return true;
             }
         }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -510,8 +510,7 @@ public class Compute {
                 && !(ignoreInfantry && (inHex instanceof Infantry))
                 && inHex.isEnemyOf(entity) && !inHex.isMakingDfa()
                 && (enLowEl <= inHexEnHighEl) && (enHighEl >= inHexEnLowEl)
-                && (!(inHex instanceof EjectedCrew) || (crewOnGround))
-            ) {
+                && (!(inHex instanceof EjectedCrew) || (crewOnGround))) {
                 return true;
             }
         }


### PR DESCRIPTION
fixes #4217

- fix logic for checking if crew blocks movement

tank with airborne pilot, dont block
![image](https://user-images.githubusercontent.com/116095479/222249649-5965851f-5d9c-4250-b3ba-9e186fdabea8.png)

tank with meck, block move out
![image](https://user-images.githubusercontent.com/116095479/222250122-6e182db3-4c5c-4121-a7cd-82869ec746d0.png)

tank with pilot on ground, block move out
![image](https://user-images.githubusercontent.com/116095479/222250405-060b758a-1d43-4ffe-a0c1-75b26068f607.png)

mech pilot on ground, dont block movement
![image](https://user-images.githubusercontent.com/116095479/222250688-7650eef5-27db-4218-a5a3-bde11590c83b.png)

mech with mech, block movement
![image](https://user-images.githubusercontent.com/116095479/222250833-b76fbb60-9998-4fea-b74a-8dfa91a9fca7.png)



