### PR TITLE
Avoid the HeadlessException in AddBotUtil

### DIFF
--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -197,8 +197,10 @@ public class AddBotUtil {
         final Player target = possible.get();
         final Princess princess = new Princess(target.getName(), host, port);
         princess.setBehaviorSettings(behavior);
-        // FIXME : I should be able to use a frame through proper channels
-        princess.getGame().addGameListener(new BotGUI(new JFrame(), princess));
+        if (!GraphicsEnvironment.isHeadless()) {
+            // FIXME : I should be able to use a frame through proper channels
+            princess.getGame().addGameListener(new BotGUI(new JFrame(), princess));
+        }
         try {
             princess.connect();
         } catch (final Exception e) {

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -25,7 +25,9 @@ import megamek.common.Player;
 import megamek.common.annotations.Nullable;
 
 import javax.swing.*;
+import java.awt.*;
 import java.util.*;
+import java.util.List;
 
 /**
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
@@ -155,8 +157,10 @@ public class AddBotUtil {
             botClient = makeNewTestBotClient(target, host, port);
         }
 
-        // FIXME : I should be able to access the JFrame by proper ways
-        botClient.getGame().addGameListener(new BotGUI(new JFrame(), botClient));
+        if (!GraphicsEnvironment.isHeadless()) {
+            // FIXME : I should be able to access the JFrame by proper ways
+            botClient.getGame().addGameListener(new BotGUI(new JFrame(), botClient));
+        }
         try {
             botClient.connect();
         } catch (final Exception e) {


### PR DESCRIPTION
Princess can conceivably run in a headless environment, therefore avoid the JFrame() constructor when headless, which - I think - throws one of the automatic PR tests. The gameListener add is only there to enable the Princess readme nag which is useless anyway when headless.