### PR TITLE
Issue #3914: LAM fuel tanks

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -922,7 +922,7 @@ public final class UnitToolTip {
         if (entity.isAero()) {
             // Velocity, Altitude, Elevation, Fuel
             IAero aero = (IAero) entity;
-            sAeroInfo = addToTT("AeroVelAltFuel", BR, aero.getCurrentVelocity(), aero.getAltitude(), aero.getFuel()).toString();
+            sAeroInfo = addToTT("AeroVelAltFuel", BR, aero.getCurrentVelocity(), aero.getAltitude(), aero.getCurrentFuel()).toString();
         } else if (entity.getElevation() != 0) {
             // Elevation only
             sAeroInfo = addToTT("Elev", BR, entity.getElevation()).toString();

--- a/megamek/src/megamek/common/LandAirMech.java
+++ b/megamek/src/megamek/common/LandAirMech.java
@@ -157,8 +157,6 @@ public class LandAirMech extends BipedMech implements IAero, IBomber {
         }
 
         previousMovementMode = movementMode;
-        setFuel(80);
-
         setCrew(new LAMPilot(this));
     }
 

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -1898,7 +1898,7 @@ public class MoveStep implements Serializable {
             // check the fuel requirements
             if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_FUEL_CONSUMPTION)) {
                 int fuelUsed = mpUsed + Math.max(mpUsed - cachedEntityState.getWalkMP(), 0);
-                if (fuelUsed > a.getFuel()) {
+                if (fuelUsed > a.getCurrentFuel()) {
                     return;
                 }
             }

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -437,12 +437,6 @@ public class MtfFile implements IMechLoader {
                 mech.initializeRearArmor(Integer.parseInt(armorValues[x + locationOrder.length].substring(10)), rearLocationOrder[x]);
             }
             
-            // Set capital fighter stats for LAMs
-            if (mech instanceof LandAirMech) {
-                ((LandAirMech) mech).autoSetCapArmor();
-                ((LandAirMech) mech).autoSetFatalThresh();
-            }
-
             // oog, crits.
             compactCriticals(mech);
             // we do these in reverse order to get the outermost
@@ -453,6 +447,14 @@ public class MtfFile implements IMechLoader {
 
             for (String equipment : noCritEquipment) {
                 parseNoCritEquipment(mech, equipment);
+            }
+
+            if (mech instanceof LandAirMech) {
+                // Set capital fighter stats for LAMs
+                ((LandAirMech) mech).autoSetCapArmor();
+                ((LandAirMech) mech).autoSetFatalThresh();
+                int fuelTankCount = (int) mech.getEquipment().stream().filter(e -> e.is(EquipmentTypeLookup.LAM_FUEL_TANK)).count();
+                ((LandAirMech) mech).setFuel(80 * (1 + fuelTankCount));
             }
 
             // add any heat sinks not allocated


### PR DESCRIPTION
- Includes LAM fuel tanks in fuel count
- shows the current fuel in the tooltip and unit display (instead of the full fuel)
- corrects a remaining fuel comparison in MoveStep
Fixes #3914 