### PR TITLE
Issue #3696: Prevent altitude values from influencing space combat

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1738,7 +1738,7 @@ public class Compute {
         }
 
         // air-to-air attacks add one for altitude differences
-        if (Compute.isAirToAir(attacker, target)) {
+        if (Compute.isAirToAir(attacker, target) && !attacker.isSpaceborne()) {
             int aAlt = attacker.getAltitude();
             int tAlt = target.getAltitude();
             if (target.isAirborneVTOLorWIGE()) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -13061,7 +13061,12 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     @Override
     public int getAltitude() {
-        return altitude;
+        if (isSpaceborne()) {
+            LogManager.getLogger().warn("Altitude retrieved for a spaceborne unit!");
+            return 0;
+        } else {
+            return altitude;
+        }
     }
 
     public void setAltitude(int a) {


### PR DESCRIPTION
I wasn't able to reproduce the issue. I think all Aeros keep their starting altitude of 5 in space but it seems possible to lose altitude and then air to air attacks get increased effective ranges and incorrect hit tables due to altitude difference. This PR
- adds a spaceborne check to prevent effective range from being influences by altitude in space 
- makes Entity return altitude 0 when in space (which should prevent all those issues) and give a log warning when altitude is retrieved for a spaceborne unit (since that shouldn't be done).

Fixes #3696 