### PR TITLE
issue 4234 mini round report allow copy text

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/MiniReportDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/MiniReportDisplayDialog.java
@@ -44,8 +44,6 @@ public class MiniReportDisplayDialog extends JDialog {
 
         UIUtil.updateWindowBounds(this);
         this.setResizable(true);
-        this.setFocusable(false);
-        this.setFocusableWindowState(false);
 
         addWindowListener(new WindowAdapter() {
             @Override


### PR DESCRIPTION
allow mini round report to copy text while in the window state.

![image](https://user-images.githubusercontent.com/116095479/224376748-5aeedf6c-7b7c-4b8f-86e3-0c72602da57b.png)

fixes #4234 