### PR TITLE
issue4117 allow mini map and unit display to come to front when clicked

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/UnitDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/UnitDisplayDialog.java
@@ -51,8 +51,6 @@ public class UnitDisplayDialog extends JDialog {
 
         UIUtil.updateWindowBounds(this);
         this.setResizable(true);
-        this.setFocusable(false);
-        this.setFocusableWindowState(false);
 
         addWindowListener(new WindowAdapter() {
             @Override

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -150,9 +150,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
      */
     public static JDialog createMinimap(JFrame parent, @Nullable BoardView bv, Game game, @Nullable ClientGUI cg) {
         var result = new JDialog(parent, Messages.getString("ClientGUI.Minimap"), false);
-        result.setAutoRequestFocus(false);
-        result.setFocusable(false);
-        result.setFocusableWindowState(false);
+
         result.setLocation(GUIP.getMinimapPosX(), GUIP.getMinimapPosY());
         result.setResizable(false);
         result.addWindowListener(new WindowAdapter() {


### PR DESCRIPTION
- allow mini map and unit display to come to front when clicked

fixes #4117