### PR TITLE
issue3703 allow loading an uncompressed save

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -914,9 +914,17 @@ public class Client implements IClientCommandHandler {
      * sends a load game file to the server
      */
     public void sendLoadGame(File f) {
-        try (InputStream fis = new FileInputStream(f); InputStream is = new GZIPInputStream(fis)) {
+        try (InputStream is = new FileInputStream(f)) {
+            InputStream gzi;
+
+            if (f.getName().toLowerCase().endsWith(".gz")) {
+                gzi = new GZIPInputStream(is);
+            } else {
+                gzi = is;
+            }
+
             game.reset();
-            send(new Packet(PacketCommand.LOAD_GAME, SerializationHelper.getLoadSaveGameXStream().fromXML(is)));
+            send(new Packet(PacketCommand.LOAD_GAME, SerializationHelper.getLoadSaveGameXStream().fromXML(gzi)));
         } catch (Exception ex) {
             LogManager.getLogger().error("Can't find the local savegame " + f, ex);
         }

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -511,8 +511,15 @@ public class MegaMekGUI implements IPreferenceChangeListener {
 
         // Handrolled extraction, as we require Server initialization to use XStream and don't need
         // the additional overhead of initializing everything twice
-        try (InputStream is = new FileInputStream(fc.getSelectedFile());
-             InputStream gzi = new GZIPInputStream(is)) {
+        try (InputStream is = new FileInputStream(fc.getSelectedFile())) {
+            InputStream gzi;
+
+            if (fc.getSelectedFile().getName().toLowerCase().endsWith(".gz")) {
+                gzi = new GZIPInputStream(is);
+            } else {
+                gzi = is;
+            }
+
             // Using factory get an instance of document builder
             final DocumentBuilder documentBuilder = MMXMLUtility.newSafeDocumentBuilder();
             // Parse using builder to get DOM representation of the XML file

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -866,7 +866,15 @@ public class Server implements Runnable {
         LogManager.getLogger().info("s: loading saved game file '" + f + '\'');
 
         Game newGame;
-        try (InputStream is = new FileInputStream(f); InputStream gzi = new GZIPInputStream(is)) {
+        try (InputStream is = new FileInputStream(f)) {
+            InputStream gzi;
+
+            if (f.getName().toLowerCase().endsWith(".gz")) {
+                gzi = new GZIPInputStream(is);
+            } else {
+                gzi = is;
+            }
+
             XStream xstream = SerializationHelper.getLoadSaveGameXStream();
             newGame = (Game) xstream.fromXML(gzi);
         } catch (Exception e) {


### PR DESCRIPTION
- allow loading an uncompressed save
- if file ends in .gz uncompress the file else load file without uncompressing it.

fixes #3703 