### PR TITLE
if a unit has too many bombs for a location, set then number to 0 whe…

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -105,6 +105,10 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
                 }
             }
 
+            if (bombChoices[type] > maxNumBombs) {
+                maxNumBombs = bombChoices[type];
+            }
+
             if (maxNumBombs < 0) {
                 maxNumBombs = 0;
             }

--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -168,14 +168,27 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
         for (int type = 0; type < BombType.B_NUM; type++) {
             b_choices[type].removeItemListener(this);
             b_choices[type].removeAllItems();
-            int maxNumBombs = Math.round(availBombPoints
-                    / BombType.getBombCost(type))
-                    + current[type];
+            int maxNumBombs = Math.round(availBombPoints / BombType.getBombCost(type)) + current[type];
+
             if (typeMax != null) {
                 if ((maxNumBombs > 0) && (maxNumBombs > typeMax[type])) {
                     maxNumBombs = typeMax[type];
                 }
             }
+
+            if (current[type] > maxNumBombs) {
+                maxNumBombs = current[type];
+            }
+
+            if (maxNumBombs < 0) {
+                maxNumBombs = 0;
+            }
+
+            if (maxNumBombs > maxSize) {
+                maxNumBombs = maxSize;
+            }
+
+
             for (int x = 0; x <= maxNumBombs; x++) {
                 b_choices[type].addItem(Integer.toString(x));
             }

--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -96,7 +96,7 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
 
             // somehow too many bombs were added
             if ((bombChoices[type] * BombType.getBombCost(type))  > maxSize) {
-                bombChoices[type] = 0;
+                bombChoices[type] = maxSize / BombType.getBombCost(type);
             }
             
             if (typeMax != null) {

--- a/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/BombChoicePanel.java
@@ -88,11 +88,15 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
             b_labels[type] = new JLabel();
             b_choices[type] = new JComboBox<String>();
 
-            int maxNumBombs = Math.round(availBombPoints
-                    / BombType.getBombCost(type))
-                    + bombChoices[type];
-            if (BombType.getBombCost(type) > maxSize) {
+            int maxNumBombs = Math.round(availBombPoints / BombType.getBombCost(type)) + bombChoices[type];
+
+            if (BombType.getBombCost(type) > maxSize)  {
                 maxNumBombs = 0;
+            }
+
+            // somehow too many bombs were added
+            if ((bombChoices[type] * BombType.getBombCost(type))  > maxSize) {
+                bombChoices[type] = 0;
             }
             
             if (typeMax != null) {
@@ -100,7 +104,15 @@ public class BombChoicePanel extends JPanel implements Serializable, ItemListene
                     maxNumBombs = typeMax[type];
                 }
             }
-            
+
+            if (maxNumBombs < 0) {
+                maxNumBombs = 0;
+            }
+
+            if (maxNumBombs > maxSize) {
+                maxNumBombs = maxSize;
+            }
+
             for (int x = 0; x <= maxNumBombs; x++) {
                 b_choices[type].addItem(Integer.toString(x));
             }


### PR DESCRIPTION
- if a unit has too many bombs for a location, set then the number to max / cost when loading the unit configure dialog.


a partial fix for #4261 still need to figure out how the unit got 15 bombs assigned.

here is a simple save with a unit that has too many bombs.
[Mosquito2.sav.gz](https://github.com/MegaMek/megamek/files/11043804/Mosquito2.sav.gz)

