### PR TITLE
Remove anti aliasing as a gui option; use high quality rendering

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1153,8 +1153,6 @@ CommonMenuBar.moveLAMaircraftMode=Transform to aerospace fighter mode
 #Client Settings Customization
 CommonSettingsDialog.alwaysRightClickScroll=Use the right-click to scroll also in the firing phase.
 CommonSettingsDialog.animateMove=Animate movement.
-CommonSettingsDialog.antiAliasing=Anti-aliasing
-CommonSettingsDialog.antiAliasingToolTip=Enables anti-aliasing, which will soften jagged lines but may be slower
 CommonSettingsDialog.autoDeclareSearchlight=Automatically aim searchlight at same target as first weapon; if not manually aimed before.
 CommonSettingsDialog.autoEdgeScroll=Automatically, whenever you left-click near the edge of the map.
 CommonSettingsDialog.autoEndFiring=Skip 'Done' when firing all weapons.

--- a/megamek/i18n/megamek/client/messages_ru.properties
+++ b/megamek/i18n/megamek/client/messages_ru.properties
@@ -528,8 +528,6 @@ CommonMenuBar.moveLAMaircraftMode=Трансформироваться в реж
 
 CommonSettingsDialog.alwaysRightClickScroll=Использовать правый клик для скролла и в фазу стрельбы.
 CommonSettingsDialog.animateMove=Анимировать движение.
-CommonSettingsDialog.antiAliasing=Анти-алиасинг
-CommonSettingsDialog.antiAliasingToolTip=Включает сглаживание, сгладит резкие линии, но может замедлить работу
 CommonSettingsDialog.autoDeclareSearchlight=Автоматически нацелить прожектор на ту же цель, что и первое оружие; если не нацелен вручную ранее.
 CommonSettingsDialog.autoEdgeScroll=Автоматически, при клике левой кнопкой у края карты.
 CommonSettingsDialog.autoEndFiring=Пропустить 'Готово' при стрельбе из всего оружия.

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -2305,12 +2305,8 @@ public class BoardEditor extends JPanel
                 for (final Image newVar : safeList(tm.orthoFor(curHex))) {
                     g.drawImage(newVar, 0, 0, this);
                 }
+                UIUtil.setHighQualityRendering(g);
                 // add level and INVALID if necessary
-                if (guip.getAntiAliasing()) {
-                    ((Graphics2D) g).setRenderingHint(
-                            RenderingHints.KEY_ANTIALIASING,
-                            RenderingHints.VALUE_ANTIALIAS_ON);
-                }
                 g.setColor(getForeground());
                 g.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 9));
                 g.drawString(Messages.getString("BoardEditor.LEVEL") + curHex.getLevel(), 24, 70);

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -144,7 +144,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private final JCheckBox showWpsinTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showWpsinTT"));
     private final JCheckBox showArmorMiniVisTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showArmorMiniVisTT"));
     private final JCheckBox showPilotPortraitTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showPilotPortraitTT"));
-    private final JCheckBox chkAntiAliasing = new JCheckBox(Messages.getString("CommonSettingsDialog.antiAliasing"));
     private MMComboBox<WeaponSortOrder> comboDefaultWeaponSortOrder;
     private JTextField tooltipDelay;
     private JTextField tooltipDismissDelay;
@@ -272,7 +271,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private boolean savedUnitLabelBorder;
     private boolean savedShowDamageDecal;
     private boolean savedShowDamageLabel;
-    private boolean savedAntiAlias;
     private String savedFovHighlightRingsRadii;
     private String savedFovHighlightRingsColors;
     private int savedFovHighlightAlpha;
@@ -650,7 +648,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             displayLocale.setSelectedIndex(index);
 
             showMapsheets.setSelected(GUIP.getShowMapsheets());
-            chkAntiAliasing.setSelected(GUIP.getAntiAliasing());
             showDamageLevel.setSelected(GUIP.getShowDamageLevel());
             showDamageDecal.setSelected(GUIP.getShowDamageDecal());
             aOHexShadows.setSelected(GUIP.getAOHexShadows());
@@ -744,7 +741,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             savedFovHighlightAlpha = GUIP.getFovHighlightAlpha();
             savedFovDarkenAlpha = GUIP.getFovDarkenAlpha();
             savedNumStripesSlider = GUIP.getFovStripes();
-            savedAntiAlias = GUIP.getAntiAliasing();
             savedAdvancedOpt.clear();
             
             advancedKeys.clearSelection();
@@ -782,8 +778,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setFovHighlightAlpha(savedFovHighlightAlpha);
         GUIP.setFovDarkenAlpha(savedFovDarkenAlpha);
         GUIP.setFovStripes(savedNumStripesSlider);
-        GUIP.setAntiAliasing(savedAntiAlias);
-         
+
         for (String option: savedAdvancedOpt.keySet()) {
             GUIP.setValue(option, savedAdvancedOpt.get(option));
         }
@@ -1117,8 +1112,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             GUIP.setShowDamageDecal(showDamageDecal.isSelected());
         } else if (source.equals(showDamageLevel)) {
             GUIP.setShowDamageLevel(showDamageLevel.isSelected());
-        } else if (source.equals(chkAntiAliasing)) {
-            GUIP.setAntiAliasing(chkAntiAliasing.isSelected());
         }
     }
 
@@ -1148,7 +1141,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         List<List<Component>> comps = new ArrayList<>();
         ArrayList<Component> row;
 
-        comps.add(checkboxEntry(chkAntiAliasing, Messages.getString("CommonSettingsDialog.antiAliasingToolTip")));
         comps.add(checkboxEntry(animateMove, null));
         comps.add(checkboxEntry(showWrecks, null));
         comps.add(checkboxEntry(showMapsheets, null));

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -120,7 +120,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
     /* --End advanced settings-- */
 
     public static final String SHOW_COORDS = "showCoords";
-    public static final String ANTIALIASING = "AntiAliasing";
     public static final String SHADOWMAP = "ShadowMap";
     public static final String INCLINES = "Inclines";
     public static final String AOHEXSHADOWS = "AoHexShadows";
@@ -452,7 +451,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(FOV_STRIPES, 35);
         store.setDefault(FOV_GRAYSCALE, false);
 
-        store.setDefault(ANTIALIASING, true);
         store.setDefault(AOHEXSHADOWS, false);
         store.setDefault(SHADOWMAP, true);
         store.setDefault(INCLINES, true);
@@ -639,10 +637,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
     @Override
     public String[] getAdvancedProperties() {
         return store.getAdvancedProperties();
-    }
-
-    public boolean getAntiAliasing() {
-        return store.getBoolean(ANTIALIASING);
     }
 
     public boolean getAOHexShadows() {
@@ -1267,10 +1261,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public boolean getBoardEdRndStart() {
         return store.getBoolean(BOARDEDIT_RNDDIALOG_START);
-    }
-
-    public void setAntiAliasing(boolean state) {
-        store.setValue(ANTIALIASING, state);
     }
 
     public void setShadowMap(boolean state) {
@@ -2250,19 +2240,4 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return Color.BLUE;
     }
     //endregion Colours
-
-    /**
-     * Activates AntiAliasing for the <code>Graphics</code> graph
-     * if AA is activated in the Client settings.
-     *
-     * @param graph Graphics context to activate AA for
-     */
-    public static void AntiAliasifSet(Graphics graph) {
-        if (getInstance().getAntiAliasing()) {
-            ((Graphics2D) graph).setRenderingHint(
-                    RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON);
-        }
-    }
-
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -916,7 +916,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             case GUIPreferences.FOV_HIGHLIGHT_RINGS_COLORS_HSB:
             case GUIPreferences.FOV_HIGHLIGHT_RINGS_RADII:
             case GUIPreferences.SHADOWMAP:
-            case GUIPreferences.ANTIALIASING:
                 clearHexImageCache();
                 repaint();
                 break;
@@ -1027,10 +1026,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             paintCompsStartTime = System.nanoTime();
         }
 
-        if (GUIP.getAntiAliasing()) {
-            ((Graphics2D) g).setRenderingHint(RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON);
-        }
+        UIUtil.setHighQualityRendering(g);
 
         Rectangle viewRect = scrollpane.getVisibleRect();
 
@@ -2159,9 +2155,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         Image entireBoard = createImage(boardSize.width, boardSize.height);
         Graphics2D boardGraph = (Graphics2D) entireBoard.getGraphics();
         boardGraph.setClip(0, 0, boardSize.width, boardSize.height);
-        if (GUIP.getAntiAliasing()) {
-            boardGraph.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        }
+        UIUtil.setHighQualityRendering(boardGraph);
 
         if (shadowMap == null) {
             updateShadowMap();
@@ -2423,7 +2417,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 BufferedImage.TYPE_INT_ARGB);
 
         Graphics2D g = (Graphics2D) (hexImage.getGraphics());
-        GUIPreferences.AntiAliasifSet(g);
+        UIUtil.setHighQualityRendering(g);
 
         if (standardTile) { // is the image hex-sized, 84*72?
             g.drawImage(scaledImage, 0, 0, this);

--- a/megamek/src/megamek/client/ui/swing/boardview/CursorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/CursorSprite.java
@@ -9,6 +9,7 @@ import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 
 import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
 
 /**
@@ -37,12 +38,7 @@ class CursorSprite extends Sprite {
         Image tempImage = new BufferedImage(bounds.width, bounds.height,
                 BufferedImage.TYPE_INT_ARGB);
         Graphics graph = tempImage.getGraphics();
-        
-        if (GUIPreferences.getInstance().getAntiAliasing()) {
-            ((Graphics2D) graph).setRenderingHint(
-                    RenderingHints.KEY_ANTIALIASING,
-                    RenderingHints.VALUE_ANTIALIAS_ON);
-        }
+        UIUtil.setHighQualityRendering(graph);
 
         // fill with key color
         graph.setColor(new Color(0, 0, 0, 0));

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -22,6 +22,7 @@ import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.EntityWreckHelper;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 
@@ -403,7 +404,7 @@ class EntitySprite extends Sprite {
         image = config.createCompatibleImage(bounds.width, bounds.height,
                 Transparency.TRANSLUCENT);
         Graphics2D graph = (Graphics2D) image.getGraphics();
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
 
         // translate everything (=correction for label placement)
         graph.translate(-hexOrigin.x, -hexOrigin.y);

--- a/megamek/src/megamek/client/ui/swing/boardview/FieldofFireSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FieldofFireSprite.java
@@ -11,7 +11,7 @@ import java.awt.Stroke;
 import java.awt.image.ImageObserver;
 import static megamek.client.ui.swing.boardview.HexDrawUtilities.*;
 
-import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
 
 /**
@@ -97,7 +97,7 @@ public class FieldofFireSprite extends MovementEnvelopeSprite {
         // create image for buffer
         images[borders][rangeBracket] = createNewHexImage();
         Graphics2D graph = (Graphics2D) images[borders][rangeBracket].getGraphics();
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
 
         // scale the following draws according to board zoom
         graph.scale(bv.scale, bv.scale);

--- a/megamek/src/megamek/client/ui/swing/boardview/FiringSolutionSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FiringSolutionSprite.java
@@ -10,6 +10,7 @@ import java.awt.Stroke;
 import java.awt.geom.AffineTransform;
 
 import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.TargetRoll;
 import megamek.common.util.FiringSolution;
 
@@ -91,7 +92,7 @@ class FiringSolutionSprite extends HexSprite {
         // create image for buffer
         image = createNewHexImage();
         Graphics2D graph = (Graphics2D) image.getGraphics();
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
         
         // scale the following draws according to board zoom
         graph.scale(bv.scale, bv.scale);

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -19,6 +19,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Game;
 import megamek.common.KeyBindParser;
 import megamek.common.enums.GamePhase;
@@ -32,7 +33,6 @@ import megamek.common.util.ImageUtil;
 import org.apache.logging.log4j.LogManager;
 
 import java.awt.*;
-import java.awt.event.KeyEvent;
 import java.awt.font.TextAttribute;
 import java.text.AttributedString;
 import java.util.ArrayList;
@@ -154,7 +154,7 @@ public class KeyBindingsOverlay implements IDisplayable, IPreferenceChangeListen
 
             displayImage = ImageUtil.createAcceleratedImage(r.width, r.height);
             Graphics intGraph = displayImage.getGraphics();
-            GUIPreferences.AntiAliasifSet(intGraph);
+            UIUtil.setHighQualityRendering(intGraph);
 
             // draw a semi-transparent background rectangle 
             intGraph.setColor(BG_COLOR);

--- a/megamek/src/megamek/client/ui/swing/boardview/MovementEnvelopeSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/MovementEnvelopeSprite.java
@@ -6,7 +6,7 @@ import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Graphics2D;
 
-import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
 
 /**
@@ -37,7 +37,7 @@ class MovementEnvelopeSprite extends HexSprite {
         // create image for buffer
         image = createNewHexImage();
         Graphics2D graph = (Graphics2D) image.getGraphics();
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
 
         // scale the following draws according to board zoom
         graph.scale(bv.scale, bv.scale);

--- a/megamek/src/megamek/client/ui/swing/boardview/MovementModifierEnvelopeSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/MovementModifierEnvelopeSprite.java
@@ -6,7 +6,7 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.geom.Point2D;
 
-import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Compute;
 import megamek.common.CrewType;
 import megamek.common.Facing;
@@ -69,7 +69,7 @@ public class MovementModifierEnvelopeSprite extends HexSprite {
         // create image for buffer
         image = createNewHexImage();
         Graphics2D graph = (Graphics2D) image.getGraphics();
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
 
         // scale the following draws according to board zoom
         graph.scale(bv.scale, bv.scale);

--- a/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
@@ -18,6 +18,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Game;
 import megamek.common.KeyBindParser;
 import megamek.common.PlanetaryConditions;
@@ -31,7 +32,6 @@ import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.util.ImageUtil;
 import org.apache.logging.log4j.LogManager;
 
-import java.awt.event.KeyEvent;
 import java.awt.font.TextAttribute;
 import java.text.AttributedString;
 import java.text.MessageFormat;
@@ -135,7 +135,7 @@ public class PlanetaryConditionsOverlay implements IDisplayable, IPreferenceChan
 
             displayImage = ImageUtil.createAcceleratedImage(r.width, r.height);
             Graphics intGraph = displayImage.getGraphics();
-            GUIPreferences.AntiAliasifSet(intGraph);
+            UIUtil.setHighQualityRendering(intGraph);
 
             // draw a semi-transparent background rectangle
             Color colorBG = GUIP.getPlanetaryConditionsColorBackground();

--- a/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
@@ -16,6 +16,7 @@ package megamek.client.ui.swing.boardview;
 import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.MovePath.MoveStepType;
 
@@ -76,7 +77,7 @@ class StepSprite extends Sprite {
         Graphics graph = tempImage.getGraphics();
         Graphics2D g2D = (Graphics2D) graph;
 
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
 
         // fill with key color
         graph.setColor(new Color(0, 0, 0, 0));

--- a/megamek/src/megamek/client/ui/swing/boardview/TextMarkerSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TextMarkerSprite.java
@@ -1,7 +1,7 @@
 package megamek.client.ui.swing.boardview;
 
 import megamek.MMConstants;
-import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
 
 import java.awt.*;
@@ -25,7 +25,7 @@ public class TextMarkerSprite extends HexSprite {
         // create image for buffer
         image = createNewHexImage();
         Graphics2D graph = (Graphics2D) image.getGraphics();
-        GUIPreferences.AntiAliasifSet(graph);
+        UIUtil.setHighQualityRendering(graph);
 
         // get a big font and test to see which font size will fit
         // the hex shape

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -84,7 +84,6 @@ import java.awt.image.FilteredImageSource;
 import java.awt.image.ImageFilter;
 import java.awt.image.ImageProducer;
 import java.io.*;
-import java.text.MessageFormat;
 import java.text.NumberFormat;
 import java.util.List;
 import java.util.*;
@@ -1117,7 +1116,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
     
     private void markServerSideBoard(BufferedImage image) {
         Graphics g = image.getGraphics();
-        GUIPreferences.AntiAliasifSet(g);
+        setHighQualityRendering(g);
         int w = image.getWidth();
         int h = image.getHeight();
         String text = Messages.getString("ChatLounge.board.serverSide");

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
@@ -142,7 +142,7 @@ public class LobbyUtility {
         if (text.isBlank()) {
             return;
         }
-        GUIPreferences.AntiAliasifSet(g);
+        UIUtil.setHighQualityRendering(g);
         // The text size may grow with the width of the image, but no bigger than 16*guiscale
         // to avoid huge text
         int fontSize = Math.min(w / 10, UIUtil.scaleForGUI(16));

--- a/megamek/src/megamek/client/ui/swing/lobby/MapPreviewButton.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MapPreviewButton.java
@@ -19,7 +19,6 @@
 package megamek.client.ui.swing.lobby;
 
 import megamek.MMConstants;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.MapSettings;
 import megamek.common.util.ImageUtil;
@@ -156,7 +155,7 @@ public class MapPreviewButton extends JButton {
             // Add the labels (index, name, example)
             BufferedImage drawableImage = ImageUtil.createAcceleratedImage(scaledImage);
             Graphics g = drawableImage.getGraphics();
-            GUIPreferences.AntiAliasifSet(g);
+            UIUtil.setHighQualityRendering(g);
             if (lobby.isMultipleBoards()) {
                 drawIndex(g, w, h);
             }

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -29,6 +29,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.boardview.BoardView;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.actions.AttackAction;
 import megamek.common.actions.EntityAction;
@@ -487,12 +488,12 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         }
         
         Graphics g = mapImage.getGraphics();
-        GUIPreferences.AntiAliasifSet(g);
+        UIUtil.setHighQualityRendering(g);
         
         if (!minimized || forceDraw) {
             roadHexes.clear();
             Graphics gg = terrainBuffer.getGraphics();
-            GUIPreferences.AntiAliasifSet(gg);
+            UIUtil.setHighQualityRendering(gg);
             for (int j = 0; j < board.getWidth(); j++) {
                 for (int k = 0; k < board.getHeight(); k++) {
                     Hex h = board.getHex(j, k);

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -643,6 +643,20 @@ public final class UIUtil {
             component.setLocationRelativeTo(null);
         }
     }
+
+    /**
+     * Activates anti-aliasing and other high-quality settings for the given Graphics.
+     *
+     * @param graph Graphics context to use hq rendering for
+     */
+    public static void setHighQualityRendering(Graphics graph) {
+        ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+        ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+        ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+    }
+
     /** A specialized panel for the header of a section. */
     public static class Header extends JPanel {
         private static final long serialVersionUID = -6235772150005269143L;

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
@@ -19,9 +19,9 @@
 package megamek.common.alphaStrike.cardDrawer;
 
 import megamek.MMConstants;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.FluffImageHelper;
 import megamek.client.ui.swing.util.StringDrawer;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Configuration;
 import megamek.common.alphaStrike.ASCardDisplayable;
 import megamek.common.alphaStrike.ASDamageVector;
@@ -226,11 +226,7 @@ public class ASCard {
     public final void drawCard(Graphics g) {
         initializeFonts(lightFont, boldFont, blackFont);
         Graphics2D g2D = (Graphics2D) g;
-        GUIPreferences.AntiAliasifSet(g);
-        g2D.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-        g2D.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-        g2D.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        g2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        UIUtil.setHighQualityRendering(g);
 
         paintCardBackground(g2D, false);
 

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASLargeAeroCard.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASLargeAeroCard.java
@@ -18,8 +18,8 @@
  */
 package megamek.common.alphaStrike.cardDrawer;
 
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.StringDrawer;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.alphaStrike.*;
 import megamek.common.util.ImageUtil;
 
@@ -104,11 +104,7 @@ public class ASLargeAeroCard extends ASCard {
 
     public void drawFlipside(Graphics2D g) {
         initializeFonts(lightFont, boldFont, blackFont);
-        GUIPreferences.AntiAliasifSet(g);
-        g.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-        g.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-        g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        UIUtil.setHighQualityRendering(g);
         paintCardBackground(g, true);
         new StringDrawer("WEAPON CRITICALS").at(33, 629).font(arcTitleFont).maxWidth(220)
                 .outline(Color.BLACK, 0.4f).centerY().draw(g);

--- a/megamek/src/megamek/common/strategicBattleSystems/SBFRecordSheet.java
+++ b/megamek/src/megamek/common/strategicBattleSystems/SBFRecordSheet.java
@@ -19,8 +19,8 @@
 package megamek.common.strategicBattleSystems;
 
 import megamek.MMConstants;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.StringDrawer;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Configuration;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.annotations.Nullable;
@@ -84,11 +84,7 @@ public class SBFRecordSheet implements Printable {
     /** Draws the sheet to the given Graphics2D. When the formation is null, an empty sheet is drawn. */
     public final void drawSheet(Graphics g) {
         Graphics2D g2D = (Graphics2D) g;
-        GUIPreferences.AntiAliasifSet(g);
-        g2D.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
-        g2D.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-        g2D.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-        g2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        UIUtil.setHighQualityRendering(g);
 
         drawFormationBackground(g2D);
         drawUnitOverviewBackground(g2D);

--- a/megamek/src/megamek/common/util/ImageUtil.java
+++ b/megamek/src/megamek/common/util/ImageUtil.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import megamek.client.ui.swing.util.ImageAtlasMap;
 import megamek.client.ui.swing.util.ImprovedAveragingScaleFilter;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
 import megamek.common.annotations.Nullable;
 import org.apache.logging.log4j.LogManager;
@@ -134,8 +135,7 @@ public final class ImageUtil {
         if (scaleType == IMAGE_SCALE_BICUBIC) {
             BufferedImage scaled = createAcceleratedImage(newWidth, newHeight);
             Graphics2D g2 = (Graphics2D) scaled.getGraphics();
-            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                    RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            UIUtil.setHighQualityRendering(g2);
             g2.drawImage(img, 0, 0, newWidth, newHeight, null);
             return scaled;
         } else {


### PR DESCRIPTION
As the title says. Having AA as an option seems very outdated and the option was not even checked consistently and not at all in MML/MHQ. So this PR removes it in favor of general high quality rendering.