### PR TITLE
Adds two new "v2" Princess Presets for the new Aggression

### DIFF
--- a/megamek/mmconf/princessBehaviors.xml
+++ b/megamek/mmconf/princessBehaviors.xml
@@ -120,6 +120,21 @@
     <strategicBuildingTargets/>
   </behavior>
   <behavior>
+    <name>BERSERK v2 ANGRY HORDE</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>false</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>2</fallShameIndex>
+    <hyperAggressionIndex>10</hyperAggressionIndex>
+    <selfPreservationIndex>3</selfPreservationIndex>
+    <herdMentalityIndex>8</herdMentalityIndex>
+    <braveryIndex>2</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets/>
+</behavior>
+  <behavior>
     <name>Brawler (pPT)</name>
     <destinationEdge>NONE</destinationEdge>
     <retreatEdge>NEAREST</retreatEdge>
@@ -161,6 +176,21 @@
     <selfPreservationIndex>5</selfPreservationIndex>
     <herdMentalityIndex>5</herdMentalityIndex>
     <braveryIndex>5</braveryIndex>
+    <verbosity>WARNING</verbosity>
+    <strategicBuildingTargets/>
+  </behavior>
+  <behavior>
+    <name>DEFAULT v2 BRAVER</name>
+    <destinationEdge>NONE</destinationEdge>
+    <retreatEdge>NEAREST</retreatEdge>
+    <forcedWithdrawal>false</forcedWithdrawal>
+    <goHome>false</goHome>
+    <autoFlee>false</autoFlee>
+    <fallShameIndex>2</fallShameIndex>
+    <hyperAggressionIndex>5</hyperAggressionIndex>
+    <selfPreservationIndex>3</selfPreservationIndex>
+    <herdMentalityIndex>5</herdMentalityIndex>
+    <braveryIndex>2</braveryIndex>
     <verbosity>WARNING</verbosity>
     <strategicBuildingTargets/>
   </behavior>


### PR DESCRIPTION
Lets see if third time is the charm?

These new presets should take advantage of the change to the highest new Aggression value. I have tested them in about 50+ bot v bot games and 2 me v bot games and they work. These are additional presets. They do not replace or change existing presets.

Because of the increased aggression on Berserker - the default BERSERK setting is foaming at the mouth damn the torpedos aggressive. This is desireable in some situations. But they will charge in depending on speed alone and faster mechs sometimes get meat-grindered.

BERSERK v2 ANGRY HORDE - adds Herding 8 to Berserker. Just as aggressive as above, but will at least attempt to maintain a formation and stay together. In tests this is the most dangerous bot setting I have found. It beats all other presets I have tested. It is still beatable by the player, but she will get in range and cause more damage. In most situations, I would reccomend this over the default Berserk setting, now. If the community decides this setting is just flat better than default Berserk, we might just replace normal Berserk with this, and remove the v2 option, just to avoid confusion.

DEFAULT v2 BRAVER - keeps default aggression, but makes Princess slightly less cautious. She will attempt to attack and kill solo and injured mechs a bit more, and wont get run over as much as regular DEFAULT.

I have attached a screen summarizing the testing leading to these two new presets.

Sorry for my clumsiness with this. Not sure why I brain farted so bad submitting it. 

![Screenshot 2023-03-29 232355](https://user-images.githubusercontent.com/23645569/228941953-a39ff2f8-50fa-448d-870a-c6dd9f7fd92d.png)
