### PR TITLE
add placeholder in chat input

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -733,6 +733,7 @@ ChatLounge.colPlayer=Player
 ChatLounge.colForce=
 ChatLounge.colTon=Tons
 ChatLounge.ChangeOwner=Change Owner
+ChatLounge.ChatPlaceholder=Type to chat...
 ChatLounge.ChooseBotName=Choose Bot Name
 ChatLounge.Command=Command: 
 ChatLounge.CustomMapSize=Custom board size

--- a/megamek/src/megamek/client/ui/swing/ChatterBox.java
+++ b/megamek/src/megamek/client/ui/swing/ChatterBox.java
@@ -23,6 +23,8 @@ import megamek.common.preference.PreferenceManager;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.util.LinkedList;
@@ -124,8 +126,24 @@ public class ChatterBox implements KeyListener, IPreferenceChangeListener {
         playerList.setVisibleRowCount(GUIPreferences.getInstance().getInt(CB_KEY_ADVANCED_CHATBOXSIZE));
         scrPlayers = new JScrollPane(playerList);
         scrPlayers.setPreferredSize(new Dimension(250, chatArea.getHeight()));
-        inputField = new JTextField();
+        inputField = new JTextField(Messages.getString("ChatLounge.ChatPlaceholder"));
         inputField.addKeyListener(this);
+        inputField.addFocusListener(new FocusListener() {
+            private final String chatPlaceholder = Messages.getString("ChatLounge.ChatPlaceholder");
+            @Override
+            public void focusGained(FocusEvent e) {
+                if (inputField.getText().equals(chatPlaceholder)) {
+                    inputField.setText("");
+                }
+            }
+
+            @Override
+            public void focusLost(FocusEvent e) {
+                if (inputField.getText().equals("")) {
+                    inputField.setText(chatPlaceholder);
+                }
+            }
+        });
         butDone = new JButton(Messages.getString("ChatterBox.ImDone"));
         butDone.setEnabled(false);
 


### PR DESCRIPTION
This pull request adds a place holder "Type to chat..." in the input text field (in the game lobby), so it is more obvious this is a chat box and easier to see it.