### PR TITLE
Allow -quick flag to combine with the other flags

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -323,9 +323,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         launch(editor.getFrame());
         editor.boardNew(GUIPreferences.getInstance().getBoardEdRndStart());
     }
-    
+
     void showSkinEditor() {
-        int response = JOptionPane.showConfirmDialog(frame, 
+        int response = JOptionPane.showConfirmDialog(frame,
                 "The skin editor is currently "
                 + "in beta and is a work in progress.  There are likely to "
                 + "be issues. \nContinue?", "Continue?",
@@ -336,7 +336,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         SkinEditorMainGUI skinEditor = new SkinEditorMainGUI();
         skinEditor.initialize();
         skinEditor.switchPanel(GamePhase.MOVEMENT);
-        launch(skinEditor.getFrame());        
+        launch(skinEditor.getFrame());
     }
 
     /**
@@ -651,10 +651,10 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             }
         }
     }
-    
+
     /** Developer Utility: Loads "quicksave.sav.gz" with the last used connection settings. */
     public void quickLoadGame() {
-        File file = new File(MMConstants.QUICKSAVE_PATH, MMConstants.QUICKSAVE_FILE + MMConstants.SAVE_FILE_GZ_EXT);
+        File file = MegaMek.getQuickSaveFile();
         if (!file.exists() || !file.canRead()) {
             JOptionPane.showMessageDialog(frame,
                     Messages.getFormattedString("MegaMek.LoadGameAlert.message", file.getAbsolutePath()),
@@ -744,7 +744,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             pcd.setVisible(true);
             g.setPlanetaryConditions(pcd.getConditions());
         }
-        
+
         String playerName;
         int port;
         String serverPW;
@@ -800,7 +800,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             return;
         }
         server.setGame(g);
-        
+
         // apply any scenario damage
         sl.applyDamage(gameManager);
 
@@ -810,14 +810,14 @@ public class MegaMekGUI implements IPreferenceChangeListener {
 
         // calculate initial BV
         gameManager.calculatePlayerInitialCounts();
-        
+
         // setup any bots
         for (int x = 0; x < pa.length; x++) {
             if (playerTypes[x] == ScenarioDialog.T_BOT) {
                 LogManager.getLogger().info("Adding bot "  + pa[x].getName() + " as Princess");
                 BotClient c = new Princess(pa[x].getName(), MMConstants.LOCALHOST, port);
                 c.getGame().addGameListener(new BotGUI(frame, c));
-                c.connect();                
+                c.connect();
             } else if (playerTypes[x] == ScenarioDialog.T_OBOT) {
                 LogManager.getLogger().info("Adding bot "  + pa[x].getName() + " as TestBot");
                 BotClient c = new TestBot(pa[x].getName(), MMConstants.LOCALHOST, port);
@@ -864,7 +864,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         var bcd = new BotConfigDialog(frame, cd.getPlayerName());
         bcd.setVisible(true);
         if (bcd.getResult() == DialogResult.CANCELLED) {
-            return; 
+            return;
         }
         client = Princess.createPrincess(bcd.getBotName(), cd.getServerAddress(), cd.getPort(), bcd.getBehaviorSettings());
         client.getGame().addGameListener(new BotGUI(frame, (BotClient) client));
@@ -982,7 +982,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         System.gc();
         System.runFinalization();
     }
-    
+
     private final ActionListener actionListener = ev -> {
         switch (ev.getActionCommand()) {
             case ClientGUI.BOARD_NEW:
@@ -1066,9 +1066,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     }
 
     /**
-     * Method used to determine the appropriate splash screen to use. This method looks 
+     * Method used to determine the appropriate splash screen to use. This method looks
      * at both the height and the width of the main monitor.
-     * 
+     *
      * @param splashScreens List of available splash screens.
      * @param screenWidth Width of the current monitor.
      * @param screenHeight Height of the current monitor.


### PR DESCRIPTION
Allows the -quick command line flag to be used in combination with other flags such as -playername, or fallback to defaults if they are not provided. Previously it always used the defaults.