### PR TITLE
Implement repeating TSEMPs

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -6399,13 +6399,13 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             setTsempEffect(MMConstants.TSEMP_EFFECT_NONE);
         }
 
-        // TSEMPs can fire every other round, so if we didn't fire last
-        //  round and the TSEMP isn't one-shot, reset it's fired state
+        // Standard TSEMPs can fire every other round, so if we didn't fire last
+        //  round and the TSEMP isn't one-shot or repeating, reset it's fired state
         if (hasFiredTsemp()) {
             for (Mounted m : getWeaponList()) {
                 if (m.getType().hasFlag(WeaponType.F_TSEMP)
                         && !m.getType().hasFlag(WeaponType.F_ONESHOT)) {
-                    if (m.isTSEMPDowntime()) {
+                    if (m.getType().hasFlag(WeaponType.F_REPEATING) || m.isTSEMPDowntime()) {
                         m.setFired(false);
                         m.setTSEMPDowntime(false);
                     } else if (m.isFired()) {

--- a/megamek/src/megamek/common/weapons/TSEMPHandler.java
+++ b/megamek/src/megamek/common/weapons/TSEMPHandler.java
@@ -52,6 +52,40 @@ public class TSEMPHandler extends EnergyWeaponHandler {
         return 0;
     }
     
+    // Copied from megamek.common.weapons.HVACWeaponHandler#doChecks(java.util.Vector)
+    /*
+    * (non-Javadoc)
+    *
+    * @see megamek.common.weapons.WeaponHandler#doChecks(java.util.Vector)
+    */
+    @Override
+    protected boolean doChecks(Vector<Report> vPhaseReport) {
+        if (roll == 2) {
+            Report r = new Report(3162);
+            r.subject = subjectId;
+            weapon.setHit(true);
+            int wloc = weapon.getLocation();
+            for (int i = 0; i < ae.getNumberOfCriticals(wloc); i++) {
+                CriticalSlot slot1 = ae.getCritical(wloc, i);
+                if ((slot1 == null) ||
+                    (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                        continue;
+                    }
+                Mounted mounted = slot1.getMount();
+                if (mounted.equals(weapon)) {
+                    ae.hitAllCriticals(wloc, i);
+                    break;
+                }
+            }
+            vPhaseReport.addAll(gameManager.explodeEquipment(ae, wloc, weapon));
+            r.choose(false);
+            vPhaseReport.addElement(r);
+            return true;
+        } else {
+            return super.doChecks(vPhaseReport);
+        }
+    }
+
     @Override
     public boolean handle(GamePhase phase, Vector<Report> vPhaseReport) {
         weapon.setFired(true);


### PR DESCRIPTION
Repeating TSEMPs, as the name implies, can fire every turn.

Like any self-respecting RISC project, they also explode: in this case, on a roll of 2.