### PR TITLE
Add Sneede's Hybrid Rifleman variants from the Snord's Irregulars focepack

### DIFF
--- a/megamek/data/mechfiles/mechs/ForcePacks/Snords Irregulars/Hybrid Rifleman RFL-3N (Sneede II).mtf
+++ b/megamek/data/mechfiles/mechs/ForcePacks/Snords Irregulars/Hybrid Rifleman RFL-3N (Sneede II).mtf
@@ -1,0 +1,154 @@
+Version:1.3
+Hybrid Rifleman
+RFL-3N (Sneede II)
+mul id:9497
+Config:Biped
+techbase:Mixed (IS Chassis)
+era:3147
+source:Force Pack Snords Irregulars - Dark Age
+rules level:4
+
+mass:60
+engine:240 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+
+heat sinks:15 Clan Double
+walk mp:4
+jump mp:0
+
+armor:Ferro-Fibrous(Clan)
+LA armor:15
+RA armor:19
+LT armor:20
+RT armor:21
+CT armor:28
+HD armor:9
+LL armor:24
+RL armor:24
+RTL armor:6
+RTR armor:7
+RTC armor:9
+
+Weapons:6
+ER Medium Laser, Left Arm
+ER PPC, Right Arm
+LRM 20, Left Torso
+Improved Heavy Medium Laser, Left Torso
+Small X-Pulse Laser, Right Torso
+ER Medium Laser, Center Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+CLERMediumLaser
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+Clan Ferro-Fibrous
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+CLERPPC
+CLERPPC
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+CLLRM20
+CLLRM20
+CLLRM20
+CLLRM20
+Clan Ammo LRM-20 (Clan) Artemis V-capable
+Clan Ammo LRM-20 (Clan) Artemis V-capable
+CLArtemisV
+CLArtemisV
+CLImprovedMediumHeavyLaser
+CLImprovedMediumHeavyLaser
+CLCASEII
+-Empty-
+
+Right Torso:
+ISSmallXPulseLaser
+CLTargeting Computer
+CLTargeting Computer
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+ISERMediumLaser (R)
+-Empty-
+
+Head:
+Life Support
+Sensors
+Cockpit
+CLECMSuite
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+CLDoubleHeatSink
+CLDoubleHeatSink
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+notes:Upgrade of Hybrid Rifleman RFL-3N (Sneede)  
+

--- a/megamek/data/mechfiles/mechs/ForcePacks/Snords Irregulars/Hybrid Rifleman RFL-3N (Sneede).mtf
+++ b/megamek/data/mechfiles/mechs/ForcePacks/Snords Irregulars/Hybrid Rifleman RFL-3N (Sneede).mtf
@@ -1,48 +1,49 @@
-Version:1.0
-Rifleman
-Sneede-FLU
-
+Version:1.3
+Hybrid Rifleman
+RFL-3N (Sneede)
+mul id:4920
 Config:Biped
-TechBase:Inner Sphere
-Era:3025
-Rules Level:5
+techbase:Inner Sphere
+era:3024
+source:Force Pack Snords Irregulars - Late Succession War - Renaissance
+rules level:4
 
-Mass:60
-Engine:240 Fusion Engine
-Structure:Standard
-Myomer:Standard
+mass:60
+engine:240 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
 
-Heat Sinks:14 Single
-Walk MP:4
-Jump MP:0
+heat sinks:14 Single
+walk mp:4
+jump mp:0
 
-Armor:Standard Armor
-LA Armor:22
-RA Armor:20
-LT Armor:22
-RT Armor:15
-CT Armor:22
-HD Armor:8
-LL Armor:15
-RL Armor:15
-RTL Armor:6
-RTR Armor:3
-RTC Armor:4
+armor:Standard(Inner Sphere)
+LA armor:20
+RA armor:20
+LT armor:22
+RT armor:15
+CT armor:22
+HD armor:9
+LL armor:16
+RL armor:16
+RTL armor:6
+RTR armor:2
+RTC armor:4
 
 Weapons:6
-1 ISPPC, Right Arm
-1 ISMediumLaser, Left Arm
-1 ISMediumLaser, Right Torso
-1 ISMediumLaser, Left Torso
-1 ISLRM20, Left Torso, Ammo:12
-1 ISMediumLaser, Center Torso (R)
+Medium Laser, Left Arm
+PPC, Right Arm
+Medium Laser, Left Torso
+LRM 20, Left Torso
+Medium Laser, Right Torso
+Medium Laser, Center Torso
 
 Left Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-ISMediumLaser
+Medium Laser
 -Empty-
 -Empty-
 -Empty-
@@ -55,9 +56,9 @@ Right Arm:
 Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
-ISPPC
-ISPPC
-ISPPC
+PPC
+PPC
+PPC
 Heat Sink
 -Empty-
 -Empty-
@@ -66,21 +67,21 @@ Heat Sink
 -Empty-
 
 Left Torso:
-ISMediumLaser
-ISLRM20
-ISLRM20
-ISLRM20
-ISLRM20
-ISLRM20
-ISLRM20 Ammo
-ISLRM20 Ammo
+Medium Laser
+LRM 20
+LRM 20
+LRM 20
+LRM 20
+LRM 20
+IS Ammo LRM-20
+IS Ammo LRM-20
 -Empty-
 -Empty-
 -Empty-
 -Empty-
 
 Right Torso:
-ISMediumLaser
+Medium Laser
 -Empty-
 -Empty-
 -Empty-
@@ -104,7 +105,7 @@ Gyro
 Fusion Engine
 Fusion Engine
 Fusion Engine
-ISMediumLaser (R)
+Medium Laser (R)
 Heat Sink
 
 Head:
@@ -148,4 +149,5 @@ Heat Sink
 -Empty-
 -Empty-
 -Empty-
+
 

--- a/megamek/data/unit_roles.txt
+++ b/megamek/data/unit_roles.txt
@@ -5390,6 +5390,8 @@ Rifleman RFL-2N:SNIPER
 Rifleman RFL-3C:BRAWLER
 Rifleman RFL-3Cr:BRAWLER
 Rifleman RFL-3N:SNIPER
+Rifleman RFL-3N (Sneede):SNIPER
+Rifleman RFL-3N (Sneede II):SNIPER
 Rifleman RFL-4D:SNIPER
 Rifleman RFL-5CS:SNIPER
 Rifleman RFL-5D:BRAWLER


### PR DESCRIPTION
I followed the record sheets for the forcepacks, here: https://bg.battletech.com/download/ForcePack%20Record%20Sheets%20Snords%20Irregulars.pdf

The existing unofficial Rifleman Sneede-FLU is almost identical to the newly official Hybrid Rifleman RFL-3N (Sneede), but the Sneede-FLU was created with FrankenMech construction rules while the new one is an approximation under standard construction rules.