### PR TITLE
calculate heat capacity correctly in the unit tool tip

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -960,7 +960,7 @@ public final class UnitToolTip {
             } else {
                 sHeat += addToTT("Heat", BR, heat).toString();
             }
-            sHeat += " / "+entity.getHeatCapacity();
+            sHeat += " / "+ entity.getHeatCapacityForDisplay();
             result += guiScaledFontHTML(GUIP.getColorForHeat(heat)) + sHeat + "</FONT>";
         }
 

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1125,36 +1125,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             currentHeatBuildup++;
         }
 
-        // This code block copied from the MovementPanel class,
-        // bad coding practice (duplicate code).
-        int heatCap;
-        if (en instanceof Mech) {
-            heatCap = ((Mech) en).getHeatCapacity(true, false);
-        } else if (en instanceof Aero) {
-            heatCap = en.getHeatCapacity(false);
-        } else {
-            heatCap = en.getHeatCapacity();
-        }
-        int heatCapWater = en.getHeatCapacityWithWater();
-        if (en.getCoolantFailureAmount() > 0) {
-            heatCap -= en.getCoolantFailureAmount();
-            heatCapWater -= en.getCoolantFailureAmount();
-        }
-        if (en.hasActivatedRadicalHS()) {
-            if (en instanceof Mech) {
-                heatCap += ((Mech) en).getActiveSinks();
-                heatCapWater += ((Mech) en).getActiveSinks();
-            } else if (en instanceof Aero) {
-                heatCap += ((Aero) en).getHeatSinks();
-                heatCapWater += ((Aero) en).getHeatSinks();
-            }
-        }
-        String heatCapacityStr = Integer.toString(heatCap);
-
-        if (heatCap < heatCapWater) {
-            heatCapacityStr = heatCap + " [" + heatCapWater + ']';
-        }
-
         // check for negative values due to extreme temp
         if (currentHeatBuildup < 0) {
             currentHeatBuildup = 0;
@@ -1168,6 +1138,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             String msg_over = Messages.getString("MechDisplay.over");
             sheatOverCapacity = " " + heatOverCapacity + " " + msg_over;
         }
+
+        String heatCapacityStr = en.getHeatCapacityForDisplay();
 
         currentHeatBuildupR.setForeground(GUIP.getColorForHeat(heatOverCapacity, Color.WHITE));
         currentHeatBuildupR.setText(heatText + " (" + heatCapacityStr + ')' + sheatOverCapacity);

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4656,6 +4656,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             heatCap = this.getHeatCapacity();
         }
 
+        int heatCapOrg = heatCap;
+
         int heatCapWater = this.getHeatCapacityWithWater();
 
         if (this instanceof Mech) {
@@ -4678,10 +4680,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             }
         }
 
-        String heatCapacityStr = Integer.toString(heatCap);
+        String heatCapacityStr = Integer.toString(heatCap) ;
+
+        if (heatCap < heatCapOrg) {
+            heatCapacityStr += "*";
+        }
 
         if (heatCap < heatCapWater) {
-            heatCapacityStr = heatCap + " [" + heatCapWater + ']';
+            heatCapacityStr += " [" + heatCapWater + ']';
         }
 
         return heatCapacityStr;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4642,7 +4642,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * returns total heat capacity factoring in normal capacity, water and radical HS
      *
-     * @param en Entity to check
      */
     public String getHeatCapacityForDisplay() {
         int heatCap;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4640,6 +4640,55 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public abstract int getEngineCritHeat();
 
     /**
+     * returns total heat capacity factoring in normal capacity, water and radical HS
+     *
+     * @param en Entity to check
+     */
+    public String getHeatCapacityForDisplay() {
+        int heatCap;
+
+        if (this instanceof Mech) {
+            Mech m = (Mech) this;
+            heatCap = m.getHeatCapacity(true, false);
+        } else if (this instanceof Aero) {
+            Aero a = (Aero) this;
+            heatCap = a.getHeatCapacity(false);
+        } else {
+            heatCap = this.getHeatCapacity();
+        }
+
+        int heatCapWater = this.getHeatCapacityWithWater();
+
+        if (this instanceof Mech) {
+            Mech m = (Mech) this;
+            if (m.getCoolantFailureAmount() > 0) {
+                heatCap -= m.getCoolantFailureAmount();
+                heatCapWater -= m.getCoolantFailureAmount();
+            }
+        }
+
+        if (this.hasActivatedRadicalHS()) {
+            if (this instanceof Mech) {
+                Mech m = (Mech) this;
+                heatCap += m.getActiveSinks();
+                heatCapWater += m.getActiveSinks();
+            } else if (this instanceof Aero) {
+                Aero a = (Aero) this;
+                heatCap += a.getHeatSinks();
+                heatCapWater += a.getHeatSinks();
+            }
+        }
+
+        String heatCapacityStr = Integer.toString(heatCap);
+
+        if (heatCap < heatCapWater) {
+            heatCapacityStr = heatCap + " [" + heatCapWater + ']';
+        }
+
+        return heatCapacityStr;
+    }
+
+    /**
      * Returns a critical hit slot
      */
     public @Nullable CriticalSlot getCritical(int loc, int slot) {


### PR DESCRIPTION
- calculate heat capacity correctly in the unit tool tip
- add a * if heat capacity has been lowered

![image](https://user-images.githubusercontent.com/116095479/232563747-5b560d36-4d4d-4b85-a3de-1e925403d3be.png)
![image](https://user-images.githubusercontent.com/116095479/232911811-4056807f-dcff-4e52-b1c3-12e13bd1fa5e.png)
![image](https://user-images.githubusercontent.com/116095479/232911861-6c3b03c1-9000-4869-a1b1-c5b6c8234832.png)


fixes #4325
