### PR TITLE
Ignore .run subdir created by custom local IntelliJ tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ out/
 .classpath
 .project
 .classpath
+.run
 settings_local.gradle
 properties_local.gradle
 


### PR DESCRIPTION
 Ignore .run subdir created by custom local IntelliJ tasks.