### PR TITLE
Faction Data: Add MUL ID

### DIFF
--- a/megamek/data/forcegenerator/factions.xml
+++ b/megamek/data/forcegenerator/factions.xml
@@ -1,322 +1,322 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <factions>
-	<faction key='AML' name='Alyina Mercantile League' minor='true' clan='true' periphery='false'>
+	<faction key='AML' name='Alyina Mercantile League' mulid='102' minor='true' clan='true' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Front Line</ratingLevels>
 		<parentFaction>CJF</parentFaction>
 	</faction>
-	<faction key='ARDC' name='Arc-Royal Defense Cordon' minor='false' clan='false' periphery='false'>
+	<faction key='ARDC' name='Arc-Royal Defense Cordon' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3058-3067</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>MERC.KH</parentFaction>
 	</faction>
-	<faction key='AA' name='Augustine Alliance' minor='true' clan='false' periphery='false'>
+	<faction key='AA' name='Augustine Alliance' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3139-</years>
 		<parentFaction>ROS</parentFaction>
 	</faction>
-	<faction key='AB' name='Azami Caliphate' minor='true' clan='false' periphery='false'>
+	<faction key='AB' name='Azami Caliphate' mulid='-1' minor='true' clan='false' periphery='false'>
 		<nameChange year='3075'>Azami Brotherhood</nameChange>
 		<years>2450-2516,3075-3081</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC.AL</parentFaction>
 	</faction>
-	<faction key='BAN' name='Bandit Caste' minor='false' clan='true' periphery='false'>
+	<faction key='BAN' name='Bandit Caste' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2830-</years>
 		<ratingLevels>Solahma</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='BoS' name='Barony of Strang' minor='true' clan='false' periphery='true'>
+	<faction key='BoS' name='Barony of Strang' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2779-3049</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R,PIR</parentFaction>
 	</faction>
-	<faction key='Blessed Order' name='Blessed Order' minor='false' clan='false' periphery='false'>
+	<faction key='Blessed Order' name='Blessed Order' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3128-3141</years>
 		<parentFaction>CS</parentFaction>
 	</faction>
-	<faction key='BH' name='Butte Hold' minor='true' clan='false' periphery='true'>
+	<faction key='BH' name='Butte Hold' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>3018-3028</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R,PIR</parentFaction>
 	</faction>
-	<faction key='CDP' name='Calderon Protectorate' minor='false' clan='false' periphery='true'>
+	<faction key='CDP' name='Calderon Protectorate' mulid='78' minor='false' clan='false' periphery='true'>
 		<years>3066-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.HR</parentFaction>
 	</faction>
-	<faction key='CC' name='Capellan Confederation' minor='false' clan='false' periphery='false'>
+	<faction key='CC' name='Capellan Confederation' mulid='5' minor='false' clan='false' periphery='false'>
 		<years>2367-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='NC' name='Castillian Principalities' minor='true' clan='false' periphery='true'>
+	<faction key='NC' name='Castillian Principalities' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2392-3080</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.Deep</parentFaction>
 	</faction>
-	<faction key='CI' name='Chainelane Islands' minor='true' clan='false' periphery='true'>
+	<faction key='CI' name='Chainelane Islands' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R</parentFaction>
 	</faction>
-	<faction key='CM' name='Chaos March' minor='false' clan='false' periphery='false'>
+	<faction key='CM' name='Chaos March' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3057-3069</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='CIR' name='Circinus Federation' minor='false' clan='false' periphery='true'>
+	<faction key='CIR' name='Circinus Federation' mulid='9' minor='false' clan='false' periphery='true'>
 		<years>2785-3081</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.MW,WOB.pm</parentFaction>
 	</faction>
-	<faction key='CLAN' name='Clan - General' minor='false' clan='true' periphery='false'>
+	<faction key='CLAN' name='Clan - General' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2807-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 	</faction>
-	<faction key='CBS' name='Clan Blood Spirit' minor='false' clan='true' periphery='false'>
+	<faction key='CBS' name='Clan Blood Spirit' mulid='2' minor='false' clan='true' periphery='false'>
 		<years>2807-3082</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CB' name='Clan Burrock' minor='false' clan='true' periphery='false'>
+	<faction key='CB' name='Clan Burrock' mulid='1' minor='false' clan='true' periphery='false'>
 		<years>2807-3059,3072-3074</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CCC' name='Clan Cloud Cobra' minor='false' clan='true' periphery='false'>
+	<faction key='CCC' name='Clan Cloud Cobra' mulid='6' minor='false' clan='true' periphery='false'>
 		<years>2807-3085</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CCO' name='Clan Coyote' minor='false' clan='true' periphery='false'>
+	<faction key='CCO' name='Clan Coyote' mulid='7' minor='false' clan='true' periphery='false'>
 		<years>2807-3085</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CFM' name='Clan Fire Mandrill' minor='false' clan='true' periphery='false'>
+	<faction key='CFM' name='Clan Fire Mandrill' mulid='10' minor='false' clan='true' periphery='false'>
 		<years>2807-3073</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CGB' name='Clan Ghost Bear' minor='false' clan='true' periphery='false'>
+	<faction key='CGB' name='Clan Ghost Bear' mulid='11' minor='false' clan='true' periphery='false'>
 		<nameChange year='3060'>Ghost Bear Dominion</nameChange>
 		<years>2807-3103</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CGS' name='Clan Goliath Scorpion' minor='false' clan='true' periphery='false'>
+	<faction key='CGS' name='Clan Goliath Scorpion' mulid='12' minor='false' clan='true' periphery='false'>
 		<years>2807-3080</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CHH' name='Clan Hell&apos;s Horses' minor='false' clan='true' periphery='false'>
+	<faction key='CHH' name='Clan Hell&apos;s Horses' mulid='13' minor='false' clan='true' periphery='false'>
 		<years>2807-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CIH' name='Clan Ice Hellion' minor='false' clan='true' periphery='false'>
+	<faction key='CIH' name='Clan Ice Hellion' mulid='14' minor='false' clan='true' periphery='false'>
 		<years>2807-3074</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CJF' name='Clan Jade Falcon' minor='false' clan='true' periphery='false'>
+	<faction key='CJF' name='Clan Jade Falcon' mulid='15' minor='false' clan='true' periphery='false'>
 		<years>2807-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CMG' name='Clan Mongoose' minor='false' clan='true' periphery='false'>
+	<faction key='CMG' name='Clan Mongoose' mulid='16' minor='false' clan='true' periphery='false'>
 		<years>2807-2868</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='CNC' name='Clan Nova Cat' minor='false' clan='true' periphery='false'>
+	<faction key='CNC' name='Clan Nova Cat' mulid='17' minor='false' clan='true' periphery='false'>
 		<years>2807-3143</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CP' name='Clan Protectorate' minor='false' clan='true' periphery='false'>
+	<faction key='CP' name='Clan Protectorate' mulid='100' minor='false' clan='true' periphery='false'>
 		<years>3138-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CDS' name='Clan Sea Fox' minor='false' clan='true' periphery='false'>
+	<faction key='CDS' name='Clan Sea Fox' mulid='82' minor='false' clan='true' periphery='false'>
 		<nameChange year='2985'>Clan Diamond Shark</nameChange>
 		<nameChange year='3100'>Clan Sea Fox</nameChange>
 		<years>2807-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CSJ' name='Clan Smoke Jaguar' minor='false' clan='true' periphery='false'>
+	<faction key='CSJ' name='Clan Smoke Jaguar' mulid='20' minor='false' clan='true' periphery='false'>
 		<years>2807-3060</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CSR' name='Clan Snow Raven' minor='false' clan='true' periphery='false'>
+	<faction key='CSR' name='Clan Snow Raven' mulid='21' minor='false' clan='true' periphery='false'>
 		<years>2807-3082</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CSA' name='Clan Star Adder' minor='false' clan='true' periphery='false'>
+	<faction key='CSA' name='Clan Star Adder' mulid='19' minor='false' clan='true' periphery='false'>
 		<years>2807-3085</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CSV' name='Clan Steel Viper' minor='false' clan='true' periphery='false'>
+	<faction key='CSV' name='Clan Steel Viper' mulid='22' minor='false' clan='true' periphery='false'>
 		<years>2807-3075</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CSL' name='Clan Stone Lion' minor='false' clan='true' periphery='false'>
+	<faction key='CSL' name='Clan Stone Lion' mulid='80' minor='false' clan='true' periphery='false'>
 		<years>3075-3085</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='CWI' name='Clan Widowmaker' minor='false' clan='true' periphery='false'>
+	<faction key='CWI' name='Clan Widowmaker' mulid='25' minor='false' clan='true' periphery='false'>
 		<years>2807-2834</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='CW' name='Clan Wolf' minor='false' clan='true' periphery='false'>
+	<faction key='CW' name='Clan Wolf' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2807-3142</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CWIE' name='Clan Wolf (In Exile)' minor='false' clan='true' periphery='false'>
+	<faction key='CWIE' name='Clan Wolf (In Exile)' mulid='23' minor='false' clan='true' periphery='false'>
 		<years>3057-3151</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='CWOV' name='Clan Wolverine' minor='false' clan='true' periphery='false'>
+	<faction key='CWOV' name='Clan Wolverine' mulid='26' minor='false' clan='true' periphery='false'>
 		<years>2807-2823</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='CS' name='ComStar' minor='false' clan='false' periphery='false'>
+	<faction key='CS' name='ComStar' mulid='18' minor='true' clan='false' periphery='false'>
 		<years>2788-3081</years>
 		<ratingLevels>B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='CvW' name='Covenant Worlds' minor='true' clan='false' periphery='false'>
+	<faction key='CvW' name='Covenant Worlds' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3137-</years>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='DC' name='Draconis Combine' minor='false' clan='false' periphery='false'>
+	<faction key='DC' name='Draconis Combine' mulid='27' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='DA' name='Duchy of Andurien' minor='false' clan='false' periphery='false'>
+	<faction key='DA' name='Duchy of Andurien' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3030-3040,3079-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='DGM' name='Duchy of Graham-Marik' minor='true' clan='false' periphery='false'>
+	<faction key='DGM' name='Duchy of Graham-Marik' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3079-3082</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='DO' name='Duchy of Oriente' minor='false' clan='false' periphery='false'>
+	<faction key='DO' name='Duchy of Oriente' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3079-3086</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='DoO' name='Duchy of Orloff' minor='true' clan='false' periphery='false'>
+	<faction key='DoO' name='Duchy of Orloff' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3079-3086</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='DS' name='Duchy of Small' minor='true' clan='false' periphery='false'>
+	<faction key='DS' name='Duchy of Small' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3057-3066</years>
 		<parentFaction>CM</parentFaction>
 	</faction>
-	<faction key='DTA' name='Duchy of Tamarind' minor='false' clan='false' periphery='false'>
+	<faction key='DTA' name='Duchy of Tamarind' mulid='75' minor='false' clan='false' periphery='false'>
 		<nameChange year='3078'>Duchy of Tamarind-Abbey</nameChange>
 		<years>3071-3139</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='EF' name='Elysian Fields' minor='true' clan='false' periphery='true'>
+	<faction key='EF' name='Elysian Fields' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>-3049</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.DD</parentFaction>
 	</faction>
-	<faction key='CEI' name='Escorpión Imperio' minor='false' clan='true' periphery='true'>
+	<faction key='CEI' name='Escorpión Imperio' mulid='92' minor='false' clan='true' periphery='true'>
 		<years>3080-3141</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CGS,Periphery.Deep</parentFaction>
 	</faction>
-	<faction key='FC' name='Federated Commonwealth (Combined)' minor='false' clan='false' periphery='false'>
+	<faction key='FC' name='Federated Commonwealth (Combined)' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3028-3057</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>FS,LA</parentFaction>
 	</faction>
-	<faction key='FS' name='Federated Suns' minor='false' clan='false' periphery='false'>
+	<faction key='FS' name='Federated Suns' mulid='29' minor='false' clan='false' periphery='false'>
 		<nameChange year='3042'>Federated Commonwealth (Davion)</nameChange>
 		<nameChange year='3067'>Federated Suns</nameChange>
 		<years>2317-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='FOR' name='Fiefdom of Randis' minor='true' clan='false' periphery='true'>
+	<faction key='FOR' name='Fiefdom of Randis' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2988-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>MERC,Periphery.OS</parentFaction>
 	</faction>
-	<faction key='FVC' name='Filtvelt Coalition' minor='false' clan='false' periphery='true'>
+	<faction key='FVC' name='Filtvelt Coalition' mulid='77' minor='false' clan='false' periphery='true'>
 		<years>3072-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.HR</parentFaction>
 	</faction>
-	<faction key='FRR' name='Free Rasalhague Republic' minor='false' clan='false' periphery='false'>
+	<faction key='FRR' name='Free Rasalhague Republic' mulid='28' minor='false' clan='false' periphery='false'>
 		<years>3034-3103</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='FWL' name='Free Worlds League' minor='false' clan='false' periphery='false'>
+	<faction key='FWL' name='Free Worlds League' mulid='30' minor='false' clan='false' periphery='false'>
 		<nameChange year='3078'>Former Free Worlds Independent</nameChange>
 		<nameChange year='3138'>Free Worlds League</nameChange>
 		<years>2271-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='FR' name='Fronc Reaches' minor='true' clan='false' periphery='true'>
+	<faction key='FR' name='Fronc Reaches' mulid='95' minor='true' clan='false' periphery='true'>
 		<years>3066-</years>
 		<parentFaction>NCR</parentFaction>
 	</faction>
-	<faction key='GL' name='Galatean League' minor='true' clan='false' periphery='false'>
+	<faction key='GL' name='Galatean League' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3144-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='GV' name='Greater Valkyrate' minor='false' clan='false' periphery='true'>
+	<faction key='GV' name='Greater Valkyrate' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>3028-3049</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R,PIR</parentFaction>
 	</faction>
-	<faction key='HL' name='Hanseatic League' minor='true' clan='false' periphery='true'>
+	<faction key='HL' name='Hanseatic League' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2891-3141</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.Deep</parentFaction>
 	</faction>
-	<faction key='IP' name='Illyrian Palatinate' minor='true' clan='false' periphery='true'>
+	<faction key='IP' name='Illyrian Palatinate' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2350-3063</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.MW</parentFaction>
 	</faction>
-	<faction key='IS' name='Inner Sphere - General' minor='false' clan='false' periphery='false'>
+	<faction key='IS' name='Inner Sphere - General' mulid='55' minor='false' clan='false' periphery='false'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 	</faction>
-	<faction key='KP' name='Kittery Prefecture' minor='true' clan='false' periphery='false'>
+	<faction key='KP' name='Kittery Prefecture' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3072-3081</years>
 		<parentFaction>CM</parentFaction>
 	</faction>
-	<faction key='LL' name='Lothian League' minor='true' clan='false' periphery='true'>
+	<faction key='LL' name='Lothian League' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2815-3055,3087-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.MW</parentFaction>
 	</faction>
-	<faction key='LA' name='Lyran Commonwealth' minor='false' clan='false' periphery='false'>
+	<faction key='LA' name='Lyran Commonwealth' mulid='60' minor='false' clan='false' periphery='false'>
 		<nameChange year='3042'>Federated Commonwealth (Steiner)</nameChange>
 		<nameChange year='3057'>Lyran Alliance</nameChange>
 		<nameChange year='3084'>Lyran Commonwealth</nameChange>
@@ -324,1137 +324,1137 @@
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='MOC' name='Magistracy of Canopus' minor='false' clan='false' periphery='true'>
+	<faction key='MOC' name='Magistracy of Canopus' mulid='33' minor='false' clan='false' periphery='true'>
 		<years>2530-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.CM</parentFaction>
 	</faction>
-	<faction key='MC' name='Malagrotta Cooperative' minor='true' clan='false' periphery='false'>
+	<faction key='MC' name='Malagrotta Cooperative' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3073-3079</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>FS.CrMM</parentFaction>
 	</faction>
-	<faction key='MalCon' name='Malthus Confederation' minor='true' clan='false' periphery='false'>
+	<faction key='MalCon' name='Malthus Confederation' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>F,D,C</ratingLevels>
 		<parentFaction>MERC</parentFaction>
 	</faction>
-	<faction key='MH' name='Marian Hegemony' minor='false' clan='false' periphery='true'>
+	<faction key='MH' name='Marian Hegemony' mulid='35' minor='false' clan='false' periphery='true'>
 		<years>2920-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.ME</parentFaction>
 	</faction>
-	<faction key='MCM' name='Marik Commonwealth' minor='false' clan='false' periphery='false'>
+	<faction key='MCM' name='Marik Commonwealth' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3079-3082</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='MSC' name='Marik-Stewart Commonwealth' minor='false' clan='false' periphery='false'>
+	<faction key='MSC' name='Marik-Stewart Commonwealth' mulid='74' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='MERC' name='Mercenary' minor='false' clan='false' periphery='false'>
+	<faction key='MERC' name='Mercenary' mulid='34' minor='false' clan='false' periphery='false'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='MM' name='Mica Majority' minor='true' clan='false' periphery='true'>
+	<faction key='MM' name='Mica Majority' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2855-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.OS</parentFaction>
 	</faction>
-	<faction key='MiC' name='Milton Combine' minor='true' clan='false' periphery='false'>
+	<faction key='MiC' name='Milton Combine' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3137-3139</years>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='MV' name='Morgraine&apos;s Valkyrate' minor='true' clan='false' periphery='true'>
+	<faction key='MV' name='Morgraine&apos;s Valkyrate' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>3021-3028</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R,PIR</parentFaction>
 	</faction>
-	<faction key='NCR' name='New Colony Region' minor='true' clan='false' periphery='true'>
+	<faction key='NCR' name='New Colony Region' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>3060-3066</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.CM</parentFaction>
 	</faction>
-	<faction key='NIOPS' name='Niops Association' minor='true' clan='false' periphery='true'>
+	<faction key='NIOPS' name='Niops Association' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2760-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.CM</parentFaction>
 	</faction>
-	<faction key='OC' name='Oberon Confederation' minor='true' clan='false' periphery='true'>
+	<faction key='OC' name='Oberon Confederation' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2775-2795,3012-3049</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.DD</parentFaction>
 	</faction>
-	<faction key='OZP' name='Ohrensen-Zion Province' minor='true' clan='false' periphery='false'>
+	<faction key='OZP' name='Ohrensen-Zion Province' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3078-3081</years>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='OP' name='Oriente Protectorate' minor='false' clan='false' periphery='false'>
+	<faction key='OP' name='Oriente Protectorate' mulid='67' minor='false' clan='false' periphery='false'>
 		<years>3086-3139</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='OA' name='Outworlds Alliance' minor='false' clan='false' periphery='true'>
+	<faction key='OA' name='Outworlds Alliance' mulid='36' minor='false' clan='false' periphery='true'>
 		<years>2413-3082</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.OS</parentFaction>
 	</faction>
-	<faction key='PP' name='Pentagon Powers' minor='false' clan='false' periphery='false'>
+	<faction key='PP' name='Pentagon Powers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2801-2822</years>
 		<parentFaction>SL</parentFaction>
 	</faction>
-	<faction key='Periphery' name='Periphery' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery' name='Periphery' mulid='57' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 	</faction>
-	<faction key='PIR' name='Pirates' minor='false' clan='false' periphery='true'>
+	<faction key='PIR' name='Pirates' mulid='38' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='PG' name='Principality of Gibson' minor='true' clan='false' periphery='false'>
+	<faction key='PG' name='Principality of Gibson' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3079-3086</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='PoR' name='Principality of Rasalhague' minor='false' clan='false' periphery='false'>
+	<faction key='PoR' name='Principality of Rasalhague' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2260-2510</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='PR' name='Principality of Regulus' minor='false' clan='false' periphery='false'>
+	<faction key='PR' name='Principality of Regulus' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3079-3086</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='PC' name='Protectorate Coalition' minor='true' clan='false' periphery='false'>
+	<faction key='PC' name='Protectorate Coalition' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3136-3144</years>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='RD' name='Rasalhague Dominion' minor='false' clan='true' periphery='false'>
+	<faction key='RD' name='Rasalhague Dominion' mulid='40' minor='false' clan='true' periphery='false'>
 		<years>3103-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='RA' name='Raven Alliance' minor='false' clan='true' periphery='false'>
+	<faction key='RA' name='Raven Alliance' mulid='39' minor='false' clan='true' periphery='false'>
 		<years>3083-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
-	<faction key='RF' name='Regulan Fiefs' minor='false' clan='false' periphery='false'>
+	<faction key='RF' name='Regulan Fiefs' mulid='72' minor='false' clan='false' periphery='false'>
 		<years>3086-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='RFS' name='Regulan Free States' minor='true' clan='false' periphery='false'>
+	<faction key='RFS' name='Regulan Free States' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3079-3086</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='RR' name='Republic Remnant' minor='false' clan='false' periphery='false'>
+	<faction key='RR' name='Republic Remnant' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3135-3151</years>
 		<ratingLevels>Triarii Protectors,Principes Guards,Hastati Sentinels,Stone&apos;s Brigade</ratingLevels>
 		<parentFaction>ROS</parentFaction>
 	</faction>
-	<faction key='ROS' name='Republic of the Sphere' minor='false' clan='false' periphery='false'>
+	<faction key='ROS' name='Republic of the Sphere' mulid='41' minor='false' clan='false' periphery='false'>
 		<years>3081-3151</years>
 		<ratingLevels>Triarii Protectors,Principes Guards,Hastati Sentinels,Stone&apos;s Brigade</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='RIM' name='Rim Collection' minor='true' clan='false' periphery='true'>
+	<faction key='RIM' name='Rim Collection' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>3048-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R</parentFaction>
 	</faction>
-	<faction key='RCM' name='Rim Commonality' minor='false' clan='false' periphery='false'>
+	<faction key='RCM' name='Rim Commonality' mulid='76' minor='false' clan='false' periphery='false'>
 		<years>3075-3139</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
 	</faction>
-	<faction key='RT' name='Rim Territories' minor='true' clan='false' periphery='true'>
+	<faction key='RT' name='Rim Territories' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>3087-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R</parentFaction>
 	</faction>
-	<faction key='RWR' name='Rim Worlds Republic' minor='false' clan='false' periphery='true'>
+	<faction key='RWR' name='Rim Worlds Republic' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2250-2769</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R</parentFaction>
 	</faction>
-	<faction key='ST' name='Saiph Triumvirate' minor='true' clan='false' periphery='false'>
+	<faction key='ST' name='Saiph Triumvirate' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3057-3068</years>
 		<parentFaction>CM</parentFaction>
 	</faction>
-	<faction key='SE' name='Scorpion Empire' minor='false' clan='true' periphery='true'>
+	<faction key='SE' name='Scorpion Empire' mulid='91' minor='false' clan='true' periphery='true'>
 		<years>3141-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CEI,Periphery</parentFaction>
 	</faction>
-	<faction key='SA' name='Senatorial Alliance' minor='true' clan='false' periphery='false'>
+	<faction key='SA' name='Senatorial Alliance' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3135-3138</years>
 		<parentFaction>ROS</parentFaction>
 	</faction>
-	<faction key='ShA' name='Shiloh Alliance' minor='true' clan='false' periphery='false'>
+	<faction key='ShA' name='Shiloh Alliance' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3135-3144</years>
 		<parentFaction>ROS</parentFaction>
 	</faction>
-	<faction key='SHC' name='Silver Hawk Coalition' minor='true' clan='false' periphery='false'>
+	<faction key='SHC' name='Silver Hawk Coalition' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3079-3084</years>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='SIC' name='St Ives Compact' minor='false' clan='false' periphery='false'>
+	<faction key='SIC' name='St Ives Compact' mulid='83' minor='false' clan='false' periphery='false'>
 		<years>3029-3063</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='SL' name='Star League' minor='false' clan='false' periphery='false'>
+	<faction key='SL' name='Star League' mulid='90' minor='false' clan='false' periphery='false'>
 		<years>2571-2780</years>
 		<ratingLevels>C,B,A</ratingLevels>
 	</faction>
-	<faction key='SL3' name='Star League (Clan Wolf)' minor='false' clan='false' periphery='false'>
+	<faction key='SL3' name='Star League (Clan Wolf)' mulid='96' minor='false' clan='false' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>C,B,A</ratingLevels>
 		<parentFaction>CWE,ROS</parentFaction>
 	</faction>
-	<faction key='SLIE' name='Star League in Exile' minor='false' clan='false' periphery='false'>
+	<faction key='SLIE' name='Star League in Exile' mulid='94' minor='false' clan='false' periphery='false'>
 		<years>2786-2801</years>
 		<parentFaction>SL</parentFaction>
 	</faction>
-	<faction key='SC' name='Stewart Commonality' minor='true' clan='false' periphery='false'>
+	<faction key='SC' name='Stewart Commonality' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3079-3082</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='Stone' name='Stone&apos;s Coalition' minor='false' clan='false' periphery='true'>
+	<faction key='Stone' name='Stone&apos;s Coalition' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>3073-3081</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>ROS</parentFaction>
 	</faction>
-	<faction key='SKC' name='Styk Commonality' minor='true' clan='false' periphery='false'>
+	<faction key='SKC' name='Styk Commonality' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3057-3063</years>
 		<parentFaction>CM</parentFaction>
 	</faction>
-	<faction key='TTU' name='Tall Trees Union' minor='true' clan='false' periphery='false'>
+	<faction key='TTU' name='Tall Trees Union' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3136-3144</years>
 		<parentFaction>ROS</parentFaction>
 	</faction>
-	<faction key='TamPact' name='Tamar Pact' minor='true' clan='false' periphery='false'>
+	<faction key='TamPact' name='Tamar Pact' mulid='104' minor='true' clan='false' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>F,D,A</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='TC' name='Taurian Concordat' minor='false' clan='false' periphery='true'>
+	<faction key='TC' name='Taurian Concordat' mulid='47' minor='false' clan='false' periphery='true'>
 		<years>2335-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.HR</parentFaction>
 	</faction>
-	<faction key='TCC' name='Terracap Confederation' minor='true' clan='false' periphery='false'>
+	<faction key='TCC' name='Terracap Confederation' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3057-3068</years>
 		<parentFaction>CM</parentFaction>
 	</faction>
-	<faction key='TA' name='Terran Alliance' minor='false' clan='false' periphery='false'>
+	<faction key='TA' name='Terran Alliance' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2086-2315</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='TH' name='Terran Hegemony' minor='false' clan='true' periphery='false'>
+	<faction key='TH' name='Terran Hegemony' mulid='87' minor='false' clan='true' periphery='false'>
 		<nameChange year='2767'>Amaris Empire</nameChange>
 		<nameChange year='2779'>Terran Hegemony</nameChange>
 		<years>2315-2788</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,SL,SL.R</parentFaction>
 	</faction>
-	<faction key='TB' name='The Barrens' minor='false' clan='false' periphery='false'>
+	<faction key='TB' name='The Barrens' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3100-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.DD</parentFaction>
 	</faction>
-	<faction key='TP' name='The Protectorate' minor='true' clan='false' periphery='false'>
+	<faction key='TP' name='The Protectorate' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3078-3086</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='SOC' name='The Society' minor='false' clan='true' periphery='false'>
+	<faction key='SOC' name='The Society' mulid='86' minor='false' clan='true' periphery='false'>
 		<years>3072-3075</years>
 		<ratingLevels>PG</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='TFR' name='Tikonov Free Republic' minor='true' clan='false' periphery='false'>
+	<faction key='TFR' name='Tikonov Free Republic' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3029-3031</years>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='TD' name='Tortuga Dominions' minor='false' clan='false' periphery='true'>
+	<faction key='TD' name='Tortuga Dominions' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2785-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.HR,PIR</parentFaction>
 	</faction>
-	<faction key='UC' name='Umayyad Caliphate' minor='true' clan='false' periphery='true'>
+	<faction key='UC' name='Umayyad Caliphate' mulid='-1' minor='true' clan='false' periphery='true'>
 		<years>2830-3080</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>NC,Periphery.Deep</parentFaction>
 	</faction>
-	<faction key='UHC' name='United Hindu Collective' minor='false' clan='false' periphery='false'>
+	<faction key='UHC' name='United Hindu Collective' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2240-2540</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='VesMar' name='Vesper Marches' minor='true' clan='false' periphery='false'>
+	<faction key='VesMar' name='Vesper Marches' mulid='105' minor='true' clan='false' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>F,D,A</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='CWE' name='Wolf Empire' minor='false' clan='true' periphery='false'>
+	<faction key='CWE' name='Wolf Empire' mulid='101' minor='false' clan='true' periphery='false'>
 		<years>3143-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CW</parentFaction>
 	</faction>
-	<faction key='WOB' name='Word of Blake' minor='false' clan='false' periphery='false'>
+	<faction key='WOB' name='Word of Blake' mulid='48' minor='false' clan='false' periphery='false'>
 		<years>3052-3081</years>
 		<ratingLevels>B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='FS.ACAD' name='Academy and Training Units' minor='false' clan='false' periphery='false'>
+	<faction key='FS.ACAD' name='Academy and Training Units' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2317-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='LA.AlG' name='Alliance Guards' minor='false' clan='false' periphery='false'>
+	<faction key='LA.AlG' name='Alliance Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3058-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='LA.AlJ' name='Alliance Jaegers' minor='false' clan='false' periphery='false'>
+	<faction key='LA.AlJ' name='Alliance Jaegers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<nameChange year='3084'>Lyran Reserves</nameChange>
 		<years>3057-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='RA.OA' name='Alliance Military Corps' minor='false' clan='false' periphery='true'>
+	<faction key='RA.OA' name='Alliance Military Corps' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>3083-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>OA</parentFaction>
 	</faction>
-	<faction key='DC.AR' name='Alshain Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.AR' name='Alshain Regulars' mulid='-1' minor='true' clan='false' periphery='false'>
 		<nameChange year='3052'>Alshain Avengers</nameChange>
 		<years>3034-3064</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.ALAG' name='Amphigean Light Assault Group' minor='false' clan='false' periphery='false'>
+	<faction key='DC.ALAG' name='Amphigean Light Assault Group' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.ATL' name='An Ting Legion' minor='false' clan='false' periphery='false'>
+	<faction key='DC.ATL' name='An Ting Legion' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2823-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='CC.AH' name='Andurien Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='CC.AH' name='Andurien Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2556-3000</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FS.AC' name='Arcadian Cuirassiers' minor='false' clan='false' periphery='false'>
+	<faction key='FS.AC' name='Arcadian Cuirassiers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2317-2830</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='LA.AG' name='Arcturan Guards' minor='false' clan='false' periphery='false'>
+	<faction key='LA.AG' name='Arcturan Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='DC.AL' name='Arkab Legions' minor='false' clan='false' periphery='false'>
+	<faction key='DC.AL' name='Arkab Legions' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2479-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='MSC.AD' name='Atrean Dragoons' minor='false' clan='false' periphery='false'>
+	<faction key='MSC.AD' name='Atrean Dragoons' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>MSC</parentFaction>
 	</faction>
-	<faction key='FWL.AD' name='Atrean Dragoons' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.AD' name='Atrean Dragoons' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2271-3079,3138-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='MSC.AH' name='Atrean Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='MSC.AH' name='Atrean Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>MSC</parentFaction>
 	</faction>
-	<faction key='FWL.AH' name='Atrean Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.AH' name='Atrean Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2923-3079</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FS.AH' name='Avalon Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='FS.AH' name='Avalon Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2317-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='DC.BR' name='Benjamin Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.BR' name='Benjamin Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='FWL.BD' name='Bolan Defenders' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.BD' name='Bolan Defenders' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2558-2950</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='MOC.CF' name='Canopian Fusiliers' minor='false' clan='false' periphery='true'>
+	<faction key='MOC.CF' name='Canopian Fusiliers' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2530-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>MOC</parentFaction>
 	</faction>
-	<faction key='CC.CB' name='Capellan Brigade' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CB' name='Capellan Brigade' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3061-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.CC' name='Capellan Chargers' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CC' name='Capellan Chargers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-2835,3135-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.CDF' name='Capellan Defense Force' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CDF' name='Capellan Defense Force' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3057-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.CHG' name='Capellan Home Guard' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CHG' name='Capellan Home Guard' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.CH' name='Capellan Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CH' name='Capellan Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FS.CMB' name='Capellan March Brigade' minor='false' clan='false' periphery='false'>
+	<faction key='FS.CMB' name='Capellan March Brigade' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3079-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.CMM' name='Capellan March Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FS.CMM' name='Capellan March Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2754-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='Periphery.CM' name='Capellan Marches' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.CM' name='Capellan Marches' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='FS.CH' name='Ceti Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='FS.CH' name='Ceti Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2730-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='MOC.CC' name='Chasseurs à Cheval' minor='false' clan='false' periphery='true'>
+	<faction key='MOC.CC' name='Chasseurs à Cheval' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2530-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>MOC</parentFaction>
 	</faction>
-	<faction key='CC.CR' name='Chesterton Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CR' name='Chesterton Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<nameChange year='2832'>Chesteron Reserves</nameChange>
 		<years>2832-3060</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FS.CR' name='Chisholm&apos;s Raiders' minor='false' clan='false' periphery='false'>
+	<faction key='FS.CR' name='Chisholm&apos;s Raiders' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2897-3067</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='CC.CHO' name='Citizens&apos; Honored' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CHO' name='Citizens&apos; Honored' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3060-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CLAN.HW' name='Clan - Homeworld' minor='false' clan='true' periphery='false'>
+	<faction key='CLAN.HW' name='Clan - Homeworld' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>3050-3085</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='CLAN.IS' name='Clan - Inner Sphere' minor='false' clan='true' periphery='false'>
+	<faction key='CLAN.IS' name='Clan - Inner Sphere' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>3050-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='FWL.CP' name='Clan Protectorate' minor='false' clan='true' periphery='false'>
+	<faction key='FWL.CP' name='Clan Protectorate' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>3139-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CP</parentFaction>
 	</faction>
-	<faction key='CC.CRC' name='Confederation Reserve Cavalry' minor='false' clan='false' periphery='false'>
+	<faction key='CC.CRC' name='Confederation Reserve Cavalry' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2650-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FWL.CG' name='Covenant Guards' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.CG' name='Covenant Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3139-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FS.CL' name='Crucis Lancers' minor='false' clan='false' periphery='false'>
+	<faction key='FS.CL' name='Crucis Lancers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2780-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.CrMM' name='Crucis March Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FS.CrMM' name='Crucis March Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2754-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.DBG' name='Davion Brigade of Guards' minor='false' clan='false' periphery='false'>
+	<faction key='FS.DBG' name='Davion Brigade of Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2418-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='CC.DC' name='Death Commandos' minor='false' clan='false' periphery='false'>
+	<faction key='CC.DC' name='Death Commandos' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2988-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='Periphery.Deep' name='Deep Periphery' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.Deep' name='Deep Periphery' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='FWL.DA' name='Defenders of Andurien' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.DA' name='Defenders of Andurien' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2514-3039</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FS.DLC' name='Deneb Light Cavalry' minor='false' clan='false' periphery='false'>
+	<faction key='FS.DLC' name='Deneb Light Cavalry' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2780-3081</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='DC.DR' name='Dieron Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.DR' name='Dieron Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-3081,3135-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='LA.DG' name='Donegal Guards' minor='false' clan='false' periphery='false'>
+	<faction key='LA.DG' name='Donegal Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='Periphery.DD' name='Draconian Drift' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.DD' name='Draconian Drift' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='FS.DMM' name='Draconis March Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FS.DMM' name='Draconis March Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2754-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.DL' name='Dragonlords' minor='false' clan='false' periphery='false'>
+	<faction key='FS.DL' name='Dragonlords' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2572-2870</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='MERC.ELH' name='Eridani Light Horse' minor='false' clan='false' periphery='false'>
+	<faction key='MERC.ELH' name='Eridani Light Horse' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2780-3081</years>
 		<parentFaction>MERC</parentFaction>
 	</faction>
-	<faction key='CS.EC' name='Explorer Corps' minor='false' clan='false' periphery='false'>
+	<faction key='CS.EC' name='Explorer Corps' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2959-</years>
 		<ratingLevels>B,A</ratingLevels>
 		<parentFaction>CS</parentFaction>
 	</faction>
-	<faction key='FC.FCC' name='Federated Commonwealth Corps' minor='false' clan='false' periphery='false'>
+	<faction key='FC.FCC' name='Federated Commonwealth Corps' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3028-3057</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FC</parentFaction>
 	</faction>
-	<faction key='MSC.FWG' name='Free Worlds Guards' minor='false' clan='false' periphery='false'>
+	<faction key='MSC.FWG' name='Free Worlds Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>MSC</parentFaction>
 	</faction>
-	<faction key='FWL.FWG' name='Free Worlds Guards' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.FWG' name='Free Worlds Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2426-3079,3138-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='MSC.FWL' name='Free Worlds Legionnaires' minor='false' clan='false' periphery='false'>
+	<faction key='MSC.FWL' name='Free Worlds Legionnaires' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>MSC</parentFaction>
 	</faction>
-	<faction key='FWL.FWL' name='Free Worlds Legionnaires' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.FWL' name='Free Worlds Legionnaires' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3042-3079</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='OP.FO' name='Fusiliers of Oriente' minor='false' clan='false' periphery='false'>
+	<faction key='OP.FO' name='Fusiliers of Oriente' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3086-3139</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>OP</parentFaction>
 	</faction>
-	<faction key='FWL.FO' name='Fusiliers of Oriente' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.FO' name='Fusiliers of Oriente' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2485-3079,3139-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='DC.GR' name='Galedon Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.GR' name='Galedon Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.GEN' name='Genyosha' minor='false' clan='false' periphery='false'>
+	<faction key='DC.GEN' name='Genyosha' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3027-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.GHO' name='Ghost Regiments' minor='false' clan='false' periphery='false'>
+	<faction key='DC.GHO' name='Ghost Regiments' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3033-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='CLAN.GC' name='Grand Council (Ebon Keshik)' minor='false' clan='true' periphery='false'>
+	<faction key='CLAN.GC' name='Grand Council (Ebon Keshik)' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2820-</years>
 		<ratingLevels>Keshik</ratingLevels>
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
-	<faction key='MERC.GDL' name='Gray Death Legion' minor='false' clan='false' periphery='false'>
+	<faction key='MERC.GDL' name='Gray Death Legion' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3024-3065</years>
 		<parentFaction>MERC</parentFaction>
 	</faction>
-	<faction key='LA.HG' name='Hesperus Guards' minor='false' clan='false' periphery='false'>
+	<faction key='LA.HG' name='Hesperus Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2755-2950</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='Periphery.HR' name='Hyades Rim' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.HR' name='Hyades Rim' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='DC.I' name='Izanagi Warriors' minor='false' clan='false' periphery='false'>
+	<faction key='DC.I' name='Izanagi Warriors' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3030-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='MERC.KH' name='Kell Hounds' minor='false' clan='false' periphery='false'>
+	<faction key='MERC.KH' name='Kell Hounds' mulid='31' minor='false' clan='false' periphery='false'>
 		<years>3010-</years>
 		<parentFaction>MERC,LA</parentFaction>
 	</faction>
-	<faction key='CFM.BG' name='Kindraa Beyl-Grant' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.BG' name='Kindraa Beyl-Grant' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3066</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.FT' name='Kindraa Faraday-Tanaga' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.FT' name='Kindraa Faraday-Tanaga' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3073</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.Kl' name='Kindraa Kline' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.Kl' name='Kindraa Kline' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3067</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.MaC' name='Kindraa Mattila-Carrol' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.MaC' name='Kindraa Mattila-Carrol' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3073</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.MiKr' name='Kindraa Mick-Kreese' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.MiKr' name='Kindraa Mick-Kreese' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3067</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.MiKrKl' name='Kindraa Mick-Kreese-Kline' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.MiKrKl' name='Kindraa Mick-Kreese-Kline' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>3067-3073</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.P' name='Kindraa Payne' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.P' name='Kindraa Payne' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3066</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.PBG' name='Kindraa Payne-Beyl-Grant' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.PBG' name='Kindraa Payne-Beyl-Grant' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>3066-3073</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.S' name='Kindraa Sainze' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.S' name='Kindraa Sainze' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-3073</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='CFM.SmJ' name='Kindraa Smythe-Jewel' minor='false' clan='true' periphery='false'>
+	<faction key='CFM.SmJ' name='Kindraa Smythe-Jewel' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2823-2872</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CFM</parentFaction>
 	</faction>
-	<faction key='FWL.KIS' name='Knights of the Inner Sphere' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.KIS' name='Knights of the Inner Sphere' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3055-3079</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='CGB.FRR' name='Kungsarmé' minor='false' clan='false' periphery='false'>
+	<faction key='CGB.FRR' name='Kungsarmé' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3079-3103</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FRR</parentFaction>
 	</faction>
-	<faction key='DC.LV' name='Legion of Vega' minor='false' clan='false' periphery='false'>
+	<faction key='DC.LV' name='Legion of Vega' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3011-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='CC.LCC' name='Liao Cháng-Chéng' minor='false' clan='false' periphery='false'>
+	<faction key='CC.LCC' name='Liao Cháng-Chéng' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3061-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.LG' name='Liao Guards' minor='false' clan='false' periphery='false'>
+	<faction key='CC.LG' name='Liao Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-2823,3113-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.LL' name='Liao Lancers' minor='false' clan='false' periphery='false'>
+	<faction key='CC.LL' name='Liao Lancers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2529-3000</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='LA.LG' name='Lyran Guards' minor='false' clan='false' periphery='false'>
+	<faction key='LA.LG' name='Lyran Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='LA.LR' name='Lyran Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='LA.LR' name='Lyran Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='MOC.MH' name='Magistracy Highlanders' minor='false' clan='false' periphery='true'>
+	<faction key='MOC.MH' name='Magistracy Highlanders' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2755-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>MOC</parentFaction>
 	</faction>
-	<faction key='MOC.MRG' name='Magristracy Royal Guard' minor='false' clan='false' periphery='true'>
+	<faction key='MOC.MRG' name='Magristracy Royal Guard' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2530-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>MOC</parentFaction>
 	</faction>
-	<faction key='Periphery.MW' name='March Worlds' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.MW' name='March Worlds' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='Periphery.ME' name='Marik Expanses' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.ME' name='Marik Expanses' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='FWL.MG' name='Marik Guard' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.MG' name='Marik Guard' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2246-3079</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FWL.MM' name='Marik Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.MM' name='Marik Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2238-3079,3139-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='MSC.MM' name='Marik Militia' minor='false' clan='false' periphery='false'>
+	<faction key='MSC.MM' name='Marik Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>MSC</parentFaction>
 	</faction>
-	<faction key='CC.MAC' name='McCarron&apos;s Armored Cavalry' minor='false' clan='false' periphery='false'>
+	<faction key='CC.MAC' name='McCarron&apos;s Armored Cavalry' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3060-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FS.NIC' name='New Ivaarsen Chasseurs' minor='false' clan='false' periphery='false'>
+	<faction key='FS.NIC' name='New Ivaarsen Chasseurs' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3020-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='DC.NSR' name='New Samarkand Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.NSR' name='New Samarkand Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.NS' name='Night Stalkers' minor='false' clan='false' periphery='false'>
+	<faction key='DC.NS' name='Night Stalkers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3020-3076</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='MERC.NH' name='Northwind Highlanders' minor='false' clan='false' periphery='false'>
+	<faction key='MERC.NH' name='Northwind Highlanders' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>-3081</years>
 		<parentFaction>MERC</parentFaction>
 	</faction>
-	<faction key='LA.OR' name='Odessa Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='LA.OR' name='Odessa Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2755-2950</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='FWL.OH' name='Oriente Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.OH' name='Oriente Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2245-3079,3139-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='OP.OH' name='Oriente Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='OP.OH' name='Oriente Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3086-3139</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>OP</parentFaction>
 	</faction>
-	<faction key='FWL.OG' name='Orloff Grenadiers' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.OG' name='Orloff Grenadiers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2691-3079,3139-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='OP.OG' name='Orloff Grenadiers' minor='false' clan='false' periphery='false'>
+	<faction key='OP.OG' name='Orloff Grenadiers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3086-3139</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>OP</parentFaction>
 	</faction>
-	<faction key='DC.O' name='Otomo' minor='false' clan='false' periphery='false'>
+	<faction key='DC.O' name='Otomo' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2571-2900,3050-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='Periphery.OS' name='Outer Sphere' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.OS' name='Outer Sphere' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='FS.PMG' name='Periphery March Guard' minor='false' clan='false' periphery='false'>
+	<faction key='FS.PMG' name='Periphery March Guard' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3080-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.PMM' name='Periphery March Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FS.PMM' name='Periphery March Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3080-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='DC.PR' name='Pesht Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.PR' name='Pesht Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='DC.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>DC,IS.pm</parentFaction>
 	</faction>
-	<faction key='MSC.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='MSC.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3082-3138</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>MSC,IS.pm</parentFaction>
 	</faction>
-	<faction key='FS.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FS.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2317-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FS,IS.pm</parentFaction>
 	</faction>
-	<faction key='DA.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='DA.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3079-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>DA,IS.pm</parentFaction>
 	</faction>
-	<faction key='RCM.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='RCM.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3075-3139</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>RCM,IS.pm</parentFaction>
 	</faction>
-	<faction key='FC.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FC.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3028-3057</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FS.pm,LA.pm</parentFaction>
 	</faction>
-	<faction key='FWL.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2271-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>FWL,IS.pm</parentFaction>
 	</faction>
-	<faction key='RF.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='RF.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3086-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>RF,IS.pm</parentFaction>
 	</faction>
-	<faction key='ROS.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='ROS.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3081-</years>
 		<ratingLevels>PG</ratingLevels>
 		<parentFaction>ROS,IS.pm</parentFaction>
 	</faction>
-	<faction key='LA.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='LA.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>LA,IS.pm</parentFaction>
 	</faction>
-	<faction key='TC.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='TC.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2335-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>TC</parentFaction>
 	</faction>
-	<faction key='IS.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='IS.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='TH.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='TH.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2315-2767</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>TH,IS.pm</parentFaction>
 	</faction>
-	<faction key='CC.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='CC.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>CC,IS.pm</parentFaction>
 	</faction>
-	<faction key='DTA.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='DTA.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3071-3139</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>DTA,IS.pm</parentFaction>
 	</faction>
-	<faction key='MOC.pm' name='Planetary Militia' minor='false' clan='false' periphery='false'>
+	<faction key='MOC.pm' name='Planetary Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2530-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>MOC</parentFaction>
 	</faction>
-	<faction key='TC.PL' name='Pleiades Lancers' minor='false' clan='false' periphery='true'>
+	<faction key='TC.PL' name='Pleiades Lancers' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>2335-</years>
 		<parentFaction>TC</parentFaction>
 	</faction>
-	<faction key='DC.PH' name='Proserpina Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.PH' name='Proserpina Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-3082</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='FWL.PG' name='Protectorate Guard' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.PG' name='Protectorate Guard' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3000-3079,3138-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='WOB.PM' name='Protectorate Militia' minor='false' clan='false' periphery='false'>
+	<faction key='WOB.PM' name='Protectorate Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3066-3078</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>WOB</parentFaction>
 	</faction>
-	<faction key='DC.RR' name='Rasalhague Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='DC.RR' name='Rasalhague Regulars' mulid='-1' minor='false' clan='true' periphery='false'>
 		<years>2730-3034</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='MOC.RC' name='Raventhir Footmen' minor='false' clan='false' periphery='true'>
+	<faction key='MOC.RC' name='Raventhir Footmen' mulid='-1' minor='false' clan='false' periphery='true'>
 		<nameChange year='3063'>Raventhir Cuirassiers</nameChange>
 		<years>3055-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>MOC</parentFaction>
 	</faction>
-	<faction key='LA.M' name='Regional Militia' minor='false' clan='false' periphery='false'>
+	<faction key='LA.M' name='Regional Militia' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='FWL.RH' name='Regulan Hussars' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.RH' name='Regulan Hussars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2478-3079</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FS.RG' name='Republican Guards' minor='false' clan='false' periphery='false'>
+	<faction key='FS.RG' name='Republican Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3029-3067</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FWL.RCG' name='Rim Commonality Guards' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.RCG' name='Rim Commonality Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3139-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='RWR.HG' name='Rim Worlds Republic - Home Guard' minor='false' clan='false' periphery='true'>
+	<faction key='RWR.HG' name='Rim Worlds Republic - Home Guard' mulid='42' minor='false' clan='false' periphery='true'>
 		<years>2250-2769</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.R</parentFaction>
 	</faction>
-	<faction key='RWR.TC' name='Rim Worlds Republic - Terran Corps' minor='false' clan='false' periphery='true'>
+	<faction key='RWR.TC' name='Rim Worlds Republic - Terran Corps' mulid='88' minor='false' clan='false' periphery='true'>
 		<years>2765-2779</years>
 		<ratingLevels>B,A</ratingLevels>
 		<parentFaction>SL.R,Periphery.R</parentFaction>
 	</faction>
-	<faction key='FS.RC' name='Robinson Chevaliers' minor='false' clan='false' periphery='false'>
+	<faction key='FS.RC' name='Robinson Chevaliers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2540-2950</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.RMB' name='Robinson March Brigade' minor='false' clan='false' periphery='false'>
+	<faction key='FS.RMB' name='Robinson March Brigade' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3080-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FS.RR' name='Robinson Rangers' minor='false' clan='false' periphery='false'>
+	<faction key='FS.RR' name='Robinson Rangers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2780-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='LA.RG' name='Royal Guards' minor='false' clan='false' periphery='false'>
+	<faction key='LA.RG' name='Royal Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='DC.RYU' name='Ryuken' minor='false' clan='false' periphery='false'>
+	<faction key='DC.RYU' name='Ryuken' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3026-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='CC.SSB' name='Sarna Sabres Brigade' minor='false' clan='false' periphery='false'>
+	<faction key='CC.SSB' name='Sarna Sabres Brigade' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-2529</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='SL.2' name='Second Star League' minor='false' clan='false' periphery='false'>
+	<faction key='SL.2' name='Second Star League' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3058-3067</years>
 		<ratingLevels>C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='MERC.pm' name='Security Forces' minor='false' clan='false' periphery='false'>
+	<faction key='MERC.pm' name='Security Forces' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>-</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>MERC,IS.pm</parentFaction>
 	</faction>
-	<faction key='WOB.SD' name='Shadow Divisions' minor='false' clan='false' periphery='false'>
+	<faction key='WOB.SD' name='Shadow Divisions' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3067-3081</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>WOB</parentFaction>
 	</faction>
-	<faction key='DC.SHIN' name='Shin Legion' minor='false' clan='false' periphery='false'>
+	<faction key='DC.SHIN' name='Shin Legion' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3036-3061</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='CC.SD' name='Sian Lancers' minor='false' clan='false' periphery='false'>
+	<faction key='CC.SD' name='Sian Lancers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<nameChange year='2485'>Sian Dragoons</nameChange>
 		<years>2367-3000</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='FWL.SHI' name='Silver Hawk Irregulars ' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.SHI' name='Silver Hawk Irregulars ' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3000-3081,3138-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FWL.SL' name='Sirian Lancers' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.SL' name='Sirian Lancers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2950-3079</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='LA.SR' name='Skye Rangers' minor='false' clan='false' periphery='false'>
+	<faction key='LA.SR' name='Skye Rangers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-3081</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='CC.SIAC' name='St Ives Armored Cavalry' minor='false' clan='false' periphery='false'>
+	<faction key='CC.SIAC' name='St Ives Armored Cavalry' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.SIJ' name='St Ives Janissaries' minor='false' clan='false' periphery='false'>
+	<faction key='CC.SIJ' name='St Ives Janissaries' mulid='-1' minor='true' clan='false' periphery='false'>
 		<years>3055-3079</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.SIS' name='St Ives Sentinels' minor='false' clan='false' periphery='false'>
+	<faction key='CC.SIS' name='St Ives Sentinels' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3062-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='SL3.CJF' name='Star League (Clan Jade Falcon)' minor='true' clan='true' periphery='false'>
+	<faction key='SL3.CJF' name='Star League (Clan Jade Falcon)' mulid='-1' minor='true' clan='true' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>Front Line,Keshik</ratingLevels>
 		<parentFaction>CJF,CLAN.IS</parentFaction>
 	</faction>
-	<faction key='SL.R' name='Star League Royal' minor='false' clan='false' periphery='false'>
+	<faction key='SL.R' name='Star League Royal' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2571-2780</years>
 		<parentFaction>SL</parentFaction>
 	</faction>
-	<faction key='FWL.SD' name='Stewart Dragoons' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.SD' name='Stewart Dragoons' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2293-3079</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='DC.SZC' name='Sun Zhang Academy' minor='false' clan='false' periphery='false'>
+	<faction key='DC.SZC' name='Sun Zhang Academy' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='DC.SL' name='Sword of Light' minor='false' clan='false' periphery='false'>
+	<faction key='DC.SL' name='Sword of Light' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2319-</years>
 		<ratingLevels>A</ratingLevels>
 		<parentFaction>DC</parentFaction>
 	</faction>
-	<faction key='FS.SF' name='Syrtis Fusiliers' minor='false' clan='false' periphery='false'>
+	<faction key='FS.SF' name='Syrtis Fusiliers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2418-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='FWL.TR' name='Tamarind Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='FWL.TR' name='Tamarind Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3139-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FWL</parentFaction>
 	</faction>
-	<faction key='FS.TL' name='Tancredi Loyalists' minor='false' clan='false' periphery='false'>
+	<faction key='FS.TL' name='Tancredi Loyalists' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2540-3000</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>FS</parentFaction>
 	</faction>
-	<faction key='Periphery.R' name='The Rift' minor='false' clan='false' periphery='true'>
+	<faction key='Periphery.R' name='The Rift' mulid='-1' minor='false' clan='false' periphery='true'>
 		<years>-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery</parentFaction>
 	</faction>
-	<faction key='CC.TG' name='Tikonov Guards' minor='false' clan='false' periphery='false'>
+	<faction key='CC.TG' name='Tikonov Guards' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3134-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.TL' name='Tikonov Lancers' minor='false' clan='false' periphery='false'>
+	<faction key='CC.TL' name='Tikonov Lancers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2367-3000</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='LA.T' name='Training Units' minor='false' clan='false' periphery='false'>
+	<faction key='LA.T' name='Training Units' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2341-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>LA</parentFaction>
 	</faction>
-	<faction key='CJF.TA' name='Turkina Ascendancy' minor='true' clan='true' periphery='false'>
+	<faction key='CJF.TA' name='Turkina Ascendancy' mulid='-1' minor='true' clan='true' periphery='false'>
 		<years>3150-3152</years>
 		<ratingLevels>Provisional Garrison,Solahma</ratingLevels>
 		<parentFaction>CJF</parentFaction>
 	</faction>
-	<faction key='CC.VCR' name='Victoria Commonality Rangers' minor='false' clan='false' periphery='false'>
+	<faction key='CC.VCR' name='Victoria Commonality Rangers' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>3060-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CC.WHO' name='Warrior House Orders' minor='false' clan='false' periphery='false'>
+	<faction key='CC.WHO' name='Warrior House Orders' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2864-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='MERC.WD' name='Wolf&apos;s Dragoons' minor='false' clan='false' periphery='false'>
+	<faction key='MERC.WD' name='Wolf&apos;s Dragoons' mulid='49' minor='false' clan='false' periphery='false'>
 		<years>3005-</years>
 		<parentFaction>MERC</parentFaction>
 	</faction>
-	<faction key='LA.YR' name='York Regulars' minor='false' clan='false' periphery='false'>
+	<faction key='LA.YR' name='York Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
 		<years>2700-2950</years>
 		<ratingLevels>F</ratingLevels>
 		<parentFaction>LA</parentFaction>

--- a/megamek/data/forcegenerator/factions.xml
+++ b/megamek/data/forcegenerator/factions.xml
@@ -176,7 +176,7 @@
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='CW' name='Clan Wolf' mulid='-1' minor='false' clan='true' periphery='false'>
+	<faction key='CW' name='Clan Wolf' mulid='24' minor='false' clan='true' periphery='false'>
 		<years>2807-3142</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
@@ -205,7 +205,7 @@
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='DA' name='Duchy of Andurien' mulid='-1' minor='false' clan='false' periphery='false'>
+	<faction key='DA' name='Duchy of Andurien' mulid='59' minor='false' clan='false' periphery='false'>
 		<years>3030-3040,3079-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
@@ -245,7 +245,7 @@
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CGS,Periphery.Deep</parentFaction>
 	</faction>
-	<faction key='FC' name='Federated Commonwealth (Combined)' mulid='-1' minor='false' clan='false' periphery='false'>
+	<faction key='FC' name='Federated Commonwealth (Combined)' mulid='84' minor='false' clan='false' periphery='false'>
 		<years>3028-3057</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>FS,LA</parentFaction>
@@ -316,7 +316,7 @@
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>Periphery.MW</parentFaction>
 	</faction>
-	<faction key='LA' name='Lyran Commonwealth' mulid='60' minor='false' clan='false' periphery='false'>
+	<faction key='LA' name='Lyran Commonwealth' mulid='32' minor='false' clan='false' periphery='false'>
 		<nameChange year='3042'>Federated Commonwealth (Steiner)</nameChange>
 		<nameChange year='3057'>Lyran Alliance</nameChange>
 		<nameChange year='3084'>Lyran Commonwealth</nameChange>
@@ -510,7 +510,7 @@
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
 	</faction>
-	<faction key='SL' name='Star League' mulid='90' minor='false' clan='false' periphery='false'>
+	<faction key='SL' name='Star League' mulid='45' minor='false' clan='false' periphery='false'>
 		<years>2571-2780</years>
 		<ratingLevels>C,B,A</ratingLevels>
 	</faction>
@@ -779,12 +779,12 @@
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='CLAN.HW' name='Clan - Homeworld' mulid='-1' minor='false' clan='true' periphery='false'>
+	<faction key='CLAN.HW' name='Clan - Homeworld' mulid='85' minor='false' clan='true' periphery='false'>
 		<years>3050-3085</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
 	</faction>
-	<faction key='CLAN.IS' name='Clan - Inner Sphere' mulid='-1' minor='false' clan='true' periphery='false'>
+	<faction key='CLAN.IS' name='Clan - Inner Sphere' mulid='56' minor='false' clan='true' periphery='false'>
 		<years>3050-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN</parentFaction>
@@ -1320,7 +1320,7 @@
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='SL.2' name='Second Star League' mulid='-1' minor='false' clan='false' periphery='false'>
+	<faction key='SL.2' name='Second Star League' mulid='46' minor='false' clan='false' periphery='false'>
 		<years>3058-3067</years>
 		<ratingLevels>C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
@@ -1376,12 +1376,12 @@
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>CC</parentFaction>
 	</faction>
-	<faction key='SL3.CJF' name='Star League (Clan Jade Falcon)' mulid='-1' minor='true' clan='true' periphery='false'>
+	<faction key='SL3.CJF' name='Star League (Clan Jade Falcon)' mulid='97' minor='true' clan='true' periphery='false'>
 		<years>3151-</years>
 		<ratingLevels>Front Line,Keshik</ratingLevels>
 		<parentFaction>CJF,CLAN.IS</parentFaction>
 	</faction>
-	<faction key='SL.R' name='Star League Royal' mulid='-1' minor='false' clan='false' periphery='false'>
+	<faction key='SL.R' name='Star League Royal' mulid='43' minor='false' clan='false' periphery='false'>
 		<years>2571-2780</years>
 		<parentFaction>SL</parentFaction>
 	</faction>

--- a/megamek/data/forcegenerator/factions.xml
+++ b/megamek/data/forcegenerator/factions.xml
@@ -15,7 +15,7 @@
 		<parentFaction>ROS</parentFaction>
 	</faction>
 	<faction key='AB' name='Azami Caliphate' mulid='-1' minor='true' clan='false' periphery='false'>
-		<nameChange year='3075'>Azami Brotherhood</nameChange>
+		<nameChange year='3075' mulid='-1'>Azami Brotherhood</nameChange>
 		<years>2450-2516,3075-3081</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC.AL</parentFaction>
@@ -99,7 +99,7 @@
 		<parentFaction>CLAN.HW</parentFaction>
 	</faction>
 	<faction key='CGB' name='Clan Ghost Bear' mulid='11' minor='false' clan='true' periphery='false'>
-		<nameChange year='3060'>Ghost Bear Dominion</nameChange>
+		<nameChange year='3060' mulid='11'>Ghost Bear Dominion</nameChange>
 		<years>2807-3103</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
@@ -140,8 +140,8 @@
 		<parentFaction>CLAN.IS</parentFaction>
 	</faction>
 	<faction key='CDS' name='Clan Sea Fox' mulid='82' minor='false' clan='true' periphery='false'>
-		<nameChange year='2985'>Clan Diamond Shark</nameChange>
-		<nameChange year='3100'>Clan Sea Fox</nameChange>
+		<nameChange year='2985' mulid='8'>Clan Diamond Shark</nameChange>
+		<nameChange year='3100' mulid='82'>Clan Sea Fox</nameChange>
 		<years>2807-</years>
 		<ratingLevels>Provisional Garrison,Solahma,Second Line,Front Line,Keshik</ratingLevels>
 		<parentFaction>CLAN.IS</parentFaction>
@@ -230,7 +230,7 @@
 		<parentFaction>CM</parentFaction>
 	</faction>
 	<faction key='DTA' name='Duchy of Tamarind' mulid='75' minor='false' clan='false' periphery='false'>
-		<nameChange year='3078'>Duchy of Tamarind-Abbey</nameChange>
+		<nameChange year='3078' mulid='75'>Duchy of Tamarind-Abbey</nameChange>
 		<years>3071-3139</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,FWL</parentFaction>
@@ -251,8 +251,8 @@
 		<parentFaction>FS,LA</parentFaction>
 	</faction>
 	<faction key='FS' name='Federated Suns' mulid='29' minor='false' clan='false' periphery='false'>
-		<nameChange year='3042'>Federated Commonwealth (Davion)</nameChange>
-		<nameChange year='3067'>Federated Suns</nameChange>
+		<nameChange year='3042' mulid='29'>Federated Commonwealth (Davion)</nameChange>
+		<nameChange year='3067' mulid='29'>Federated Suns</nameChange>
 		<years>2317-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
@@ -273,8 +273,8 @@
 		<parentFaction>IS</parentFaction>
 	</faction>
 	<faction key='FWL' name='Free Worlds League' mulid='30' minor='false' clan='false' periphery='false'>
-		<nameChange year='3078'>Former Free Worlds Independent</nameChange>
-		<nameChange year='3138'>Free Worlds League</nameChange>
+		<nameChange year='3078' mulid='30'>Former Free Worlds Independent</nameChange>
+		<nameChange year='3138' mulid='30'>Free Worlds League</nameChange>
 		<years>2271-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
@@ -317,9 +317,9 @@
 		<parentFaction>Periphery.MW</parentFaction>
 	</faction>
 	<faction key='LA' name='Lyran Commonwealth' mulid='32' minor='false' clan='false' periphery='false'>
-		<nameChange year='3042'>Federated Commonwealth (Steiner)</nameChange>
-		<nameChange year='3057'>Lyran Alliance</nameChange>
-		<nameChange year='3084'>Lyran Commonwealth</nameChange>
+		<nameChange year='3042' mulid='32'>Federated Commonwealth (Steiner)</nameChange>
+		<nameChange year='3057' mulid='32'>Lyran Alliance</nameChange>
+		<nameChange year='3084' mulid='32'>Lyran Commonwealth</nameChange>
 		<years>2341-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS</parentFaction>
@@ -561,8 +561,8 @@
 		<parentFaction>IS</parentFaction>
 	</faction>
 	<faction key='TH' name='Terran Hegemony' mulid='87' minor='false' clan='true' periphery='false'>
-		<nameChange year='2767'>Amaris Empire</nameChange>
-		<nameChange year='2779'>Terran Hegemony</nameChange>
+		<nameChange year='2767' mulid='87'>Amaris Empire</nameChange>
+		<nameChange year='2779' mulid='87'>Terran Hegemony</nameChange>
 		<years>2315-2788</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
 		<parentFaction>IS,SL,SL.R</parentFaction>
@@ -627,7 +627,7 @@
 		<parentFaction>LA</parentFaction>
 	</faction>
 	<faction key='LA.AlJ' name='Alliance Jaegers' mulid='-1' minor='false' clan='false' periphery='false'>
-		<nameChange year='3084'>Lyran Reserves</nameChange>
+		<nameChange year='3084' mulid='-1'>Lyran Reserves</nameChange>
 		<years>3057-</years>
 		<ratingLevels>B</ratingLevels>
 		<parentFaction>LA</parentFaction>
@@ -638,7 +638,7 @@
 		<parentFaction>OA</parentFaction>
 	</faction>
 	<faction key='DC.AR' name='Alshain Regulars' mulid='-1' minor='true' clan='false' periphery='false'>
-		<nameChange year='3052'>Alshain Avengers</nameChange>
+		<nameChange year='3052' mulid='-1'>Alshain Avengers</nameChange>
 		<years>3034-3064</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>DC</parentFaction>
@@ -764,7 +764,7 @@
 		<parentFaction>MOC</parentFaction>
 	</faction>
 	<faction key='CC.CR' name='Chesterton Regulars' mulid='-1' minor='false' clan='false' periphery='false'>
-		<nameChange year='2832'>Chesteron Reserves</nameChange>
+		<nameChange year='2832' mulid='-1'>Chesteron Reserves</nameChange>
 		<years>2832-3060</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>CC</parentFaction>
@@ -1255,7 +1255,7 @@
 		<parentFaction>DC</parentFaction>
 	</faction>
 	<faction key='MOC.RC' name='Raventhir Footmen' mulid='-1' minor='false' clan='false' periphery='true'>
-		<nameChange year='3063'>Raventhir Cuirassiers</nameChange>
+		<nameChange year='3063' mulid='-1'>Raventhir Cuirassiers</nameChange>
 		<years>3055-</years>
 		<ratingLevels>C</ratingLevels>
 		<parentFaction>MOC</parentFaction>
@@ -1341,7 +1341,7 @@
 		<parentFaction>DC</parentFaction>
 	</faction>
 	<faction key='CC.SD' name='Sian Lancers' mulid='-1' minor='false' clan='false' periphery='false'>
-		<nameChange year='2485'>Sian Dragoons</nameChange>
+		<nameChange year='2485' mulid='-1'>Sian Dragoons</nameChange>
 		<years>2367-3000</years>
 		<ratingLevels>D</ratingLevels>
 		<parentFaction>CC</parentFaction>

--- a/megamek/src/megamek/MMConstants.java
+++ b/megamek/src/megamek/MMConstants.java
@@ -24,7 +24,6 @@ package megamek;
 public final class MMConstants extends SuiteConstants {
     //region General Constants
     public static final String PROJECT_NAME = "MegaMek";
-    public static final String MUL_URL_PREFIX = "http://www.masterunitlist.info/Unit/Details/";
     //endregion General Constants
 
     //region GUI Constants

--- a/megamek/src/megamek/SuiteConstants.java
+++ b/megamek/src/megamek/SuiteConstants.java
@@ -59,4 +59,7 @@ public abstract class SuiteConstants {
     public static final String MM_PREFERENCES_FILE = "mmconf/mm.preferences";
     public static final String MML_PREFERENCES_FILE = "mmconf/mml.preferences";
     //endregion File Paths
+
+    public static final String MUL_URL_UNIT_PREFIX = "http://www.masterunitlist.info/Unit/Details/";
+    public static final String MUL_URL_FACTION_PREFIX = "http://www.masterunitlist.info/Faction/Details/";
 }

--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -67,6 +67,7 @@ public class FactionRecord {
     }
 
     private String key;
+    private int mulId = -1;
     private boolean minor;
     private boolean clan;
     private boolean periphery;
@@ -131,6 +132,14 @@ public class FactionRecord {
 
     public String getKey() {
         return key;
+    }
+
+    public int getMulId() {
+        return mulId;
+    }
+
+    public void setMulId(int newId) {
+        mulId = newId;
     }
 
     public boolean isMinor() {
@@ -479,6 +488,7 @@ public class FactionRecord {
         FactionRecord retVal = new FactionRecord();
         retVal.key = node.getAttributes().getNamedItem("key").getTextContent();
         retVal.name = node.getAttributes().getNamedItem("name").getTextContent();
+        retVal.mulId = Integer.parseInt(node.getAttributes().getNamedItem("mulid").getTextContent());
         if (node.getAttributes().getNamedItem("minor") != null) {
             retVal.minor = Boolean.parseBoolean(node.getAttributes().getNamedItem("minor").getTextContent());
         } else {
@@ -586,10 +596,8 @@ public class FactionRecord {
     }
 
     public void writeToXml(PrintWriter pw) {
-        pw.println("\t<faction key='" + key + "' name='"
-                + StringEscapeUtils.escapeXml10(name) + "' minor='" + minor
-                + "' clan='" + clan
-                + "' periphery='" + periphery + "'>");
+        pw.println("\t<faction key='" + key + "' name='" + StringEscapeUtils.escapeXml10(name)
+                + "' mulid='" + mulId + "' minor='" + minor + "' clan='" + clan + "' periphery='" + periphery + "'>");
         for (Integer year : altNames.keySet()) {
             pw.println("\t\t<nameChange year='" + year + "'>"
                     + altNames.get(year) + "</nameChange>");

--- a/megamek/src/megamek/client/ratgenerator/RATDataCSVExporter.java
+++ b/megamek/src/megamek/client/ratgenerator/RATDataCSVExporter.java
@@ -95,6 +95,7 @@ public class RATDataCSVExporter {
             }
         } catch (Exception ex) {
             LogManager.getLogger().error("", ex);
+            JOptionPane.showMessageDialog(null, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
         }
     }
 
@@ -143,7 +144,7 @@ public class RATDataCSVExporter {
         csvLine.append(record.getMechSummary().getMulId()).append(DELIMITER);
         csvLine.append(UnitType.getTypeName(record.getUnitType())).append(DELIMITER);
         csvLine.append(record.getMechSummary().getYear()).append(DELIMITER);
-        csvLine.append("TBD").append(DELIMITER);
+        csvLine.append(mulId(faction)).append(DELIMITER);
         csvLine.append(faction).append(DELIMITER);
     }
 
@@ -154,8 +155,13 @@ public class RATDataCSVExporter {
         csvLine.append(DELIMITER);
         csvLine.append(UnitType.getTypeName(record.getUnitType())).append(DELIMITER);
         csvLine.append(DELIMITER);
-        csvLine.append("TBD").append(DELIMITER);
+        csvLine.append(mulId(faction)).append(DELIMITER);
         csvLine.append(faction).append(DELIMITER);
+    }
+
+    private static int mulId(String faction) {
+        FactionRecord factionRecord = RATGenerator.getInstance().getFaction(faction);
+        return factionRecord != null ? factionRecord.getMulId() : -2;
     }
 
     private static RATGenerator initializeRatGenerator() {

--- a/megamek/src/megamek/client/ui/swing/MechViewPanel.java
+++ b/megamek/src/megamek/client/ui/swing/MechViewPanel.java
@@ -20,12 +20,12 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.swing.util.FluffImageHelper;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.util.UIUtil.FixedXPanel;
 import megamek.common.Entity;
 import megamek.common.MechView;
 import megamek.common.Report;
 import megamek.common.templates.TROView;
-import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
@@ -60,15 +60,8 @@ public class MechViewPanel extends JPanel {
         txtMek.setMinimumSize(new Dimension(width, height));
         txtMek.setPreferredSize(new Dimension(width, height));
         txtMek.addHyperlinkListener(e -> {
-            try {
-                if (HyperlinkEvent.EventType.ACTIVATED == e.getEventType()) {
-                    if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                        Desktop.getDesktop().browse(e.getURL().toURI());
-                    }
-                }
-            } catch (Exception ex) {
-                LogManager.getLogger().error("", ex);
-                JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
+            if (HyperlinkEvent.EventType.ACTIVATED == e.getEventType()) {
+                UIUtil.openInBrowser(e.getURL().toString(), null);
             }
         });
         scrMek = new JScrollPane(txtMek);

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
@@ -19,22 +19,20 @@
 package megamek.client.ui.swing.alphaStrike;
 
 import megamek.MMConstants;
+import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.ASConversionInfoDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.UIUtil;
-import megamek.client.ui.Messages;
 import megamek.common.alphaStrike.ASCardDisplayable;
 import megamek.common.alphaStrike.ASStatsExporter;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.alphaStrike.cardDrawer.ASCardPrinter;
 import megamek.common.annotations.Nullable;
-import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.datatransfer.*;
-import java.net.URL;
 import java.util.List;
 
 /**
@@ -86,7 +84,7 @@ public class ConfigurableASCardPanel extends JPanel {
         copyStatsButton.addActionListener(ev -> copyStats());
         printButton.addActionListener(ev -> printCard());
 
-        mulButton.addActionListener(ev -> showMUL());
+        mulButton.addActionListener(ev -> UIUtil.showUnitInMul(mulId, parent));
         mulButton.setToolTipText("Show the Master Unit List entry for this unit. Opens a browser window.");
 
         conversionButton.addActionListener(e -> showConversionReport());
@@ -157,17 +155,6 @@ public class ConfigurableASCardPanel extends JPanel {
         if (sizeChooser.getSelectedItem() != null) {
             cardPanel.setScale((Float) sizeChooser.getSelectedItem());
             GUIPreferences.getInstance().setAsCardSize((Float) sizeChooser.getSelectedItem());
-        }
-    }
-
-    private void showMUL() {
-        try {
-            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                Desktop.getDesktop().browse(new URL(MMConstants.MUL_URL_PREFIX + mulId).toURI());
-            }
-        } catch (Exception ex) {
-            LogManager.getLogger().error("", ex);
-            JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -22,6 +22,7 @@ import megamek.client.ui.swing.MMToggleButton;
 import megamek.common.Player;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.ImageUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -35,6 +36,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.MouseEvent;
 import java.awt.image.ImageObserver;
+import java.net.URL;
 import java.util.List;
 import java.util.*;
 import java.util.stream.Stream;
@@ -44,10 +46,14 @@ public final class UIUtil {
     // The standard pixels-per-inch to compare against for display scaling
     private static final int DEFAULT_DISPLAY_PPI = 96;
 
-    /** The width for a tooltip displayed to the side of a dialog using one of TipXX classes. */
+    /**
+     * The width for a tooltip displayed to the side of a dialog using one of TipXX classes.
+     */
     private static final int TOOLTIP_WIDTH = 300;
-    
-    /** The style = font-size: xx value corresponding to a GUI scale of 1 */
+
+    /**
+     * The style = font-size: xx value corresponding to a GUI scale of 1
+     */
     public final static int FONT_SCALE1 = 14;
     public final static int FONT_SCALE2 = 17;
     public final static String ECM_SIGN = " \u24BA ";
@@ -64,68 +70,72 @@ public final class UIUtil {
         return String.valueOf(str).repeat(Math.max(0, count));
     }
 
-    /** 
-     * Returns an HTML FONT tag setting the font face to Dialog 
-     * and the font size according to GUIScale. 
+    /**
+     * Returns an HTML FONT tag setting the font face to Dialog
+     * and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML() {
         return "<FONT FACE=Dialog " + sizeString() + ">";
     }
-    
-    /** 
+
+    /**
      * Returns an HTML FONT tag setting the color to the given col,
-     * the font face to Dialog and the font size according to GUIScale. 
+     * the font face to Dialog and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML(Color col) {
         return "<FONT FACE=Dialog " + sizeString() + colorString(col) + ">";
     }
-    
-    /** 
-     * Returns an HTML FONT tag setting the font face to Dialog 
-     * and the font size according to GUIScale. 
+
+    /**
+     * Returns an HTML FONT tag setting the font face to Dialog
+     * and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML(float deltaScale) {
         return "<FONT FACE=Dialog " + sizeString(deltaScale) + ">";
     }
-    
-    /** 
+
+    /**
      * Returns an HTML FONT tag setting the color to the given col,
-     * the font face to Dialog and the font size according to GUIScale. 
+     * the font face to Dialog and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML(Color col, float deltaScale) {
         return "<FONT FACE=Dialog " + sizeString(deltaScale) + colorString(col) + ">";
     }
-    
-    /** Returns the yellow and gui-scaled warning sign. */
+
+    /**
+     * Returns the yellow and gui-scaled warning sign.
+     */
     public static String warningSign() {
         return guiScaledFontHTML(uiYellow()) + WARNING_SIGN + "</FONT>";
     }
-    
-    /** Returns the (usually) red and gui-scaled warning sign. */
+
+    /**
+     * Returns the (usually) red and gui-scaled warning sign.
+     */
     public static String criticalSign() {
         return guiScaledFontHTML(GUIPreferences.getInstance().getWarningColor()) + WARNING_SIGN + "</FONT>";
     }
-    
-    /** 
+
+    /**
      * Helper method to place Strings in lines according to length. The Strings
-     * in origList will be added to one line with separator sep between them as 
-     * long as the total length does not exceed maxLength. If it exceeds maxLength, 
-     * a new line is begun. All lines but the last will end with sep if sepAtEnd is true. 
+     * in origList will be added to one line with separator sep between them as
+     * long as the total length does not exceed maxLength. If it exceeds maxLength,
+     * a new line is begun. All lines but the last will end with sep if sepAtEnd is true.
      */
-    public static ArrayList<String> arrangeInLines(List<String> origList, int maxLength, 
-            String sep, boolean sepAtEnd) {
-        
+    public static ArrayList<String> arrangeInLines(List<String> origList, int maxLength,
+                                                   String sep, boolean sepAtEnd) {
+
         ArrayList<String> result = new ArrayList<>();
         if (origList == null || origList.isEmpty()) {
             return result;
         }
         String currLine = "";
-        for (String curr: origList) {
+        for (String curr : origList) {
             // Skip empty strings to avoid double separators
             if (curr.isEmpty()) {
                 continue;
             }
-            
+
             if (currLine.isEmpty()) {
                 // No entry in this line yet
                 currLine = curr;
@@ -151,14 +161,14 @@ public final class UIUtil {
         }
         return result;
     }
-    
-    public static ArrayList<String> arrangeInLines(int maxLength, 
-            String sep, boolean sepAtEnd, String... origList) {
-        
+
+    public static ArrayList<String> arrangeInLines(int maxLength,
+                                                   String sep, boolean sepAtEnd, String... origList) {
+
         return arrangeInLines(Arrays.asList(origList), maxLength, sep, sepAtEnd);
     }
-    
-    /** 
+
+    /**
      * Returns a UIManager Color that can be used as an alternate row color in a table
      * to offset each other row.
      */
@@ -178,11 +188,11 @@ public final class UIUtil {
         // The really last fallback position
         return uiGray();
     }
-    
-    /** 
-     * Returns the Color associated with either enemies, allies or 
+
+    /**
+     * Returns the Color associated with either enemies, allies or
      * oneself from the GUIPreferences depending on the relation
-     * of the given player1 and player2. 
+     * of the given player1 and player2.
      */
     public static Color teamColor(Player player1, Player player2) {
         if (player1.getId() == player2.getId()) {
@@ -193,64 +203,64 @@ public final class UIUtil {
             return GUIPreferences.getInstance().getAllyUnitColor();
         }
     }
-    
-    /** 
+
+    /**
      * Returns a green color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiGreen() {
         return uiBgBrightness() > 130 ? LIGHTUI_GREEN : DARKUI_GREEN;
     }
-    
-    /** 
+
+    /**
      * Returns a gray color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiGray() {
         return uiBgBrightness() > 130 ? LIGHTUI_GRAY : DARKUI_GRAY;
     }
-    
-    /** 
+
+    /**
      * Returns a light blue color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiLightBlue() {
         return uiBgBrightness() > 130 ? LIGHTUI_LIGHTBLUE : DARKUI_LIGHTBLUE;
     }
-    
-    /** 
+
+    /**
      * Returns a light red color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiLightRed() {
         return uiBgBrightness() > 130 ? LIGHTUI_LIGHTRED : DARKUI_LIGHTRED;
     }
 
-    /** 
+    /**
      * Returns a light violet color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiLightViolet() {
         return uiBgBrightness() > 130 ? LIGHTUI_LIGHTVIOLET : DARKUI_LIGHTVIOLET;
     }
-    
-    /** 
+
+    /**
      * Returns a light green color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiLightGreen() {
         return uiBgBrightness() > 130 ? LIGHTUI_LIGHTGREEN : DARKUI_LIGHTGREEN;
     }
-    
-    /** 
+
+    /**
      * Returns a yellow color suitable as a text color. The supplied
-     * color depends on the UI look and feel and will be lighter for a 
+     * color depends on the UI look and feel and will be lighter for a
      * dark UI LAF than for a light UI LAF.
      */
     public static Color uiYellow() {
@@ -274,41 +284,41 @@ public final class UIUtil {
     public static Color uiWhite() {
         return uiBgBrightness() > 130 ? LIGHTUI_WHITE : DARKUI_WHITE;
     }
-    
-    /** 
-     * Returns a color for the UI display of Quirks/Advantages. Different 
+
+    /**
+     * Returns a color for the UI display of Quirks/Advantages. Different
      * colors will be supplied for a dark and for a light UI look-and-feel.
      */
     public static Color uiQuirksColor() {
         return uiBgBrightness() > 130 ? LIGHTUI_LIGHTCYAN : DARKUI_LIGHTCYAN;
     }
-    
-    /** 
-     * Returns a color for the UI display of Partial Repairs. Different 
+
+    /**
+     * Returns a color for the UI display of Partial Repairs. Different
      * colors will be supplied for a dark and for a light UI look-and-feel.
      */
     public static Color uiPartialRepairColor() {
         return uiLightRed();
     }
-    
-    /** 
-     * Returns a color for the UI display of C3 Info. Different 
+
+    /**
+     * Returns a color for the UI display of C3 Info. Different
      * colors will be supplied for a dark and for a light UI look-and-feel.
      */
     public static Color uiC3Color() {
         return uiLightViolet();
     }
-    
-    /** 
-     * Returns a color for the UI display of C3 Info. Different 
+
+    /**
+     * Returns a color for the UI display of C3 Info. Different
      * colors will be supplied for a dark and for a light UI look-and-feel.
      */
     public static Color uiNickColor() {
         return uiLightGreen();
     }
-    
-    /** 
-     * Returns a color for the UI display of C3 Info. Different 
+
+    /**
+     * Returns a color for the UI display of C3 Info. Different
      * colors will be supplied for a dark and for a light UI look-and-feel.
      */
     public static Color uiTTWeaponColor() {
@@ -327,19 +337,19 @@ public final class UIUtil {
     public static int scaleForGUI(int value) {
         return Math.round(scaleForGUI((float) value));
     }
-    
+
     public static float scaleForGUI(float value) {
         return GUIPreferences.getInstance().getGUIScale() * value;
     }
-    
+
     public static Dimension scaleForGUI(Dimension dim) {
         float scale = GUIPreferences.getInstance().getGUIScale();
         return new Dimension((int) (scale * dim.width), (int) (scale * dim.height));
     }
-    
-    /** 
+
+    /**
      * Returns the provided color with its alpha value set to the provided alpha.
-     * alpha should be from 0 to 255 with 0 meaning transparent. 
+     * alpha should be from 0 to 255 with 0 meaning transparent.
      */
     public static Color addAlpha(Color color, int alpha) {
         Objects.requireNonNull(color);
@@ -348,10 +358,10 @@ public final class UIUtil {
         }
         return new Color(color.getRed(), color.getGreen(), color.getBlue(), alpha);
     }
-    
-    /** 
+
+    /**
      * Returns a grayed-out version of the given color. gray should be from 0 to 255
-     * with 255 meaning completely gray. Does not change the brightness, nor alpha. 
+     * with 255 meaning completely gray. Does not change the brightness, nor alpha.
      */
     public static Color addGray(Color color, int gray) {
         Objects.requireNonNull(color);
@@ -364,27 +374,34 @@ public final class UIUtil {
         int blue = (color.getBlue() * (255 - gray) + mid) / 255;
         return new Color(red, green, blue, color.getAlpha());
     }
-    
-    /** Returns the given String str enclosed in HTML tags and with a font tag according to the guiScale. */ 
+
+    /**
+     * Returns the given String str enclosed in HTML tags and with a font tag according to the guiScale.
+     */
     public static String scaleStringForGUI(String str) {
         return "<HTML>" + UIUtil.guiScaledFontHTML() + str + "</FONT></HTML>";
     }
-    
-    /** Returns the given String str enclosed in HTML tags and with a font tag according to the guiScale. */ 
+
+    /**
+     * Returns the given String str enclosed in HTML tags and with a font tag according to the guiScale.
+     */
     public static String scaleMessageForGUI(String str) {
         return "<HTML>" + UIUtil.guiScaledFontHTML() + Messages.getString(str) + "</FONT></HTML>";
     }
-    
-    /** Call this for {@link #adjustContainer(Container, int)} with a dialog as parameter. */
+
+    /**
+     * Call this for {@link #adjustContainer(Container, int)} with a dialog as parameter.
+     */
     public static void adjustDialog(JDialog dialog, int fontSize) {
         adjustContainer(dialog.getContentPane(), fontSize);
     }
 
-    /** calculate the max row height in a table + pad */
-    public static int calRowHeights(JTable table, int sf, int pad)
-    {
+    /**
+     * calculate the max row height in a table + pad
+     */
+    public static int calRowHeights(JTable table, int sf, int pad) {
         int rowHeight = sf;
-        for (int row = 0; row < table.getRowCount(); row++)         {
+        for (int row = 0; row < table.getRowCount(); row++) {
             for (int col = 0; col < table.getColumnCount(); col++) {
                 // Consider the preferred height of the column
                 TableCellRenderer renderer = table.getCellRenderer(row, col);
@@ -396,24 +413,26 @@ public final class UIUtil {
         return rowHeight + pad;
     }
 
-    /** set font size for the TitledBorder */
-     public static void setTitledBorder(Border border, int sf) {
+    /**
+     * set font size for the TitledBorder
+     */
+    public static void setTitledBorder(Border border, int sf) {
         if ((border instanceof TitledBorder)) {
             ((TitledBorder) border).setTitleFont(((TitledBorder) border).getTitleFont().deriveFont((float) sf));
         }
     }
 
-    /** 
+    /**
      * Applies the current gui scale to a given Container.
      * For a dialog, pass getContentPane(). This can work well for simple dialogs,
-     * but it is of course "experimental". Complex dialogs must be hand-adapted to the 
+     * but it is of course "experimental". Complex dialogs must be hand-adapted to the
      * gui scale.
      */
     public static void adjustContainer(Container parentCon, int fontSize) {
         int sf = scaleForGUI(fontSize);
         int pad = 3;
 
-        for (Component comp: parentCon.getComponents()) {
+        for (Component comp : parentCon.getComponents()) {
             if ((comp instanceof JButton) || (comp instanceof JLabel)
                     || (comp instanceof JComboBox<?>) || (comp instanceof JTextField) || (comp instanceof JSlider)
                     || (comp instanceof JSpinner) || (comp instanceof JTextArea) || (comp instanceof JToggleButton)
@@ -423,7 +442,7 @@ public final class UIUtil {
                     comp.setFont(comp.getFont().deriveFont((float) sf));
                 }
             }
-            if (comp instanceof JScrollPane 
+            if (comp instanceof JScrollPane
                     && ((JScrollPane) comp).getViewport().getView() instanceof JComponent) {
                 JScrollPane scrollPane = (JScrollPane) comp;
                 Border border = scrollPane.getBorder();
@@ -439,7 +458,7 @@ public final class UIUtil {
                     comp.setFont(comp.getFont().deriveFont((float) sf));
                 }
                 JTabbedPane tabbedPane = (JTabbedPane) comp;
-                for (int i=0; i < tabbedPane.getTabCount();i++) {
+                for (int i = 0; i < tabbedPane.getTabCount(); i++) {
                     Component subComp = tabbedPane.getTabComponentAt(i);
                     if (subComp instanceof JPanel) {
                         adjustContainer((JPanel) subComp, fontSize);
@@ -460,9 +479,11 @@ public final class UIUtil {
         }
     }
 
-    /** Adapt a JPopupMenu to the GUI scaling. Use after all menu items have been added. */
+    /**
+     * Adapt a JPopupMenu to the GUI scaling. Use after all menu items have been added.
+     */
     public static void scaleMenu(final JComponent popup) {
-        for (Component comp: popup.getComponents()) {
+        for (Component comp : popup.getComponents()) {
             if ((comp instanceof JMenuItem)) {
                 comp.setFont(getScaledFont());
                 scaleJMenuItem((JMenuItem) comp);
@@ -481,7 +502,6 @@ public final class UIUtil {
     }
 
     /**
-     *
      * @param currentMonitor The DisplayMode of the current monitor
      * @return the width of the screen taking into account display scaling
      */
@@ -492,7 +512,6 @@ public final class UIUtil {
     }
 
     /**
-     *
      * @param currentMonitor The DisplayMode of the current monitor
      * @return The height of the screen taking into account display scaling
      */
@@ -503,7 +522,6 @@ public final class UIUtil {
     }
 
     /**
-     *
      * @return The height of the screen taking into account display scaling
      */
     public static Dimension getScaledScreenSize(Component component) {
@@ -511,7 +529,6 @@ public final class UIUtil {
     }
 
     /**
-     *
      * @param currentMonitor The DisplayMode of the current monitor
      * @return The height of the screen taking into account display scaling
      */
@@ -525,7 +542,6 @@ public final class UIUtil {
     }
 
     /**
-     *
      * @return an image with the same aspect ratio that fits within the given bounds, or the existing image if it already does
      */
     public static Image constrainImageSize(Image image, ImageObserver observer, int maxWidth, int maxHeight) {
@@ -537,25 +553,24 @@ public final class UIUtil {
         }
 
         //choose resize that fits in bounds
-        double scaleW = maxWidth / (double)w;
-        double scaleH = maxHeight / (double)h;
-        if (scaleW < scaleH ) {
-            return ImageUtil.getScaledImage(image, maxWidth, (int)(h*scaleW));
+        double scaleW = maxWidth / (double) w;
+        double scaleH = maxHeight / (double) h;
+        if (scaleW < scaleH) {
+            return ImageUtil.getScaledImage(image, maxWidth, (int) (h * scaleW));
         } else {
-            return ImageUtil.getScaledImage(image, (int)(w*scaleH), maxHeight);
+            return ImageUtil.getScaledImage(image, (int) (w * scaleH), maxHeight);
         }
     }
 
     /**
-     *
      * @param multiResImageMap a collection of widths matched with corresponding image file path
-     * @param parent component
+     * @param parent           component
      * @return a JLabel setup to the correct size to act as a splash screen
      */
     public static JLabel createSplashComponent(TreeMap<Integer, String> multiResImageMap, Component parent) {
         // Use the current monitor so we don't "overflow" computers whose primary
         // displays aren't as large as their secondary displays.
-        Dimension scaledMonitorSize = getScaledScreenSize( parent.getGraphicsConfiguration().getDevice().getDisplayMode());
+        Dimension scaledMonitorSize = getScaledScreenSize(parent.getGraphicsConfiguration().getDevice().getDisplayMode());
         Image imgSplash = parent.getToolkit().getImage(multiResImageMap.floorEntry(scaledMonitorSize.width).getValue());
 
         // wait for splash image to load completely
@@ -571,9 +586,8 @@ public final class UIUtil {
     }
 
     /**
-     *
      * @param imgSplashFile path to an image on disk
-     * @param parent component
+     * @param parent        component
      * @return a JLabel setup to the correct size to act as a splash screen
      */
     public static JLabel createSplashComponent(String imgSplashFile, Component parent) {
@@ -596,9 +610,8 @@ public final class UIUtil {
     }
 
     /**
-     *
-     * @param imgSplash an image
-     * @param observer An imageObserver
+     * @param imgSplash         an image
+     * @param observer          An imageObserver
      * @param scaledMonitorSize the dimensions of the monitor taking into account display scaling
      * @return a JLabel setup to the correct size to act as a splash screen
      */
@@ -638,7 +651,7 @@ public final class UIUtil {
         Rectangle r = new Rectangle(scaledScreenSize);
 
         // center and size if out of bounds
-        if ( (pos.x < 0) || (pos.y < 0) ||
+        if ((pos.x < 0) || (pos.y < 0) ||
                 (pos.x + size.width > scaledScreenSize.width) ||
                 (pos.y + size.height > scaledScreenSize.getHeight())) {
             component.setLocationRelativeTo(null);
@@ -658,10 +671,12 @@ public final class UIUtil {
         ((Graphics2D) graph).setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
     }
 
-    /** A specialized panel for the header of a section. */
+    /**
+     * A specialized panel for the header of a section.
+     */
     public static class Header extends JPanel {
         private static final long serialVersionUID = -6235772150005269143L;
-        
+
         public Header(String text) {
             super();
             setLayout(new GridLayout(1, 1, 0, 0));
@@ -671,8 +686,10 @@ public final class UIUtil {
             setBackground(alternateTableBGColor());
         }
     }
-    
-    /** A panel for the content of a subsection of the dialog. */
+
+    /**
+     * A panel for the content of a subsection of the dialog.
+     */
     public static class Content extends JPanel {
         private static final long serialVersionUID = -6605053283642217306L;
 
@@ -680,15 +697,17 @@ public final class UIUtil {
             this();
             setLayout(layout);
         }
-        
+
         public Content() {
             super();
             setBorder(BorderFactory.createEmptyBorder(8, 25, 5, 25));
             setAlignmentX(Component.LEFT_ALIGNMENT);
         }
     }
-    
-    /** A panel for a subsection of the dialog, e.g. Minefields. */
+
+    /**
+     * A panel for a subsection of the dialog, e.g. Minefields.
+     */
     public static class OptionPanel extends FixedYPanel {
         private static final long serialVersionUID = -7168700339882132428L;
 
@@ -700,14 +719,16 @@ public final class UIUtil {
         }
     }
 
-    /** A JPanel that does not stretch vertically beyond its preferred height. */
+    /**
+     * A JPanel that does not stretch vertically beyond its preferred height.
+     */
     public static class FixedYPanel extends JPanel {
         private static final long serialVersionUID = -8805710112708937089L;
-        
+
         public FixedYPanel(LayoutManager layout) {
             super(layout);
         }
-        
+
         public FixedYPanel() {
             super();
         }
@@ -717,15 +738,17 @@ public final class UIUtil {
             return new Dimension(super.getMaximumSize().width, getPreferredSize().height);
         }
     }
-    
-    /** A JPanel that does not stretch horizontally beyond its preferred width. */
+
+    /**
+     * A JPanel that does not stretch horizontally beyond its preferred width.
+     */
     public static class FixedXPanel extends JPanel {
         private static final long serialVersionUID = -4634244641653743910L;
 
         public FixedXPanel(LayoutManager layout) {
             super(layout);
         }
-        
+
         public FixedXPanel() {
             super();
         }
@@ -735,10 +758,10 @@ public final class UIUtil {
             return new Dimension(getPreferredSize().width, super.getMaximumSize().height);
         }
     }
-    
-    /** 
+
+    /**
      * A JLabel with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent dialog, not following the mouse. 
+     * of the parent dialog, not following the mouse.
      * Used in the player settings and planetary settings dialogs.
      */
     public static class TipLabel extends JLabel {
@@ -757,7 +780,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -771,10 +794,10 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
+
+    /**
      * A JButton with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent dialog, not following the mouse. 
+     * of the parent dialog, not following the mouse.
      * Used in the player settings and planetary settings dialogs.
      */
     public static class TipButton extends JButton {
@@ -789,7 +812,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -803,11 +826,11 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
-     * A MMComboBox with a specialized tooltip display. Displays the tooltip to the right side
 
-     * of the parent dialog, not following the mouse. 
+    /**
+     * A MMComboBox with a specialized tooltip display. Displays the tooltip to the right side
+     * <p>
+     * of the parent dialog, not following the mouse.
      * Used in the player settings dialog.
      */
     public static class TipCombo<E> extends MMComboBox<E> {
@@ -815,7 +838,7 @@ public final class UIUtil {
         public TipCombo(String name) {
             super(name);
         }
-        
+
         public TipCombo(String name, E[] items) {
             super(name, items);
         }
@@ -830,7 +853,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -844,28 +867,28 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
+
+    /**
      * A JList with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent dialog, not following the mouse. 
+     * of the parent dialog, not following the mouse.
      */
     public static class TipList<E> extends JList<E> {
-        
+
         public TipList() {
             super();
         }
-        
+
         public TipList(ListModel<E> dataModel) {
             super(dataModel);
         }
-        
+
         @Override
         public Point getToolTipLocation(MouseEvent event) {
             Window win = SwingUtilities.getWindowAncestor(this);
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -879,42 +902,42 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
+
+    /**
      * A JTextField with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent dialog, not following the mouse. Can also display a hint text 
+     * of the parent dialog, not following the mouse. Can also display a hint text
      * such as "..., ..." when empty.
      * Used in the player settings and planetary settings dialogs.
      */
     public static class TipTextField extends JTextField {
 
         String hintText;
-        
+
         public TipTextField(int n) {
             super(n);
         }
-        
+
         public TipTextField(String text, int n) {
             super(text, n);
         }
-        
+
         public TipTextField(int n, String hint) {
             this(n);
             prepareForHint(hint);
-            
+
         }
-        
+
         public TipTextField(String text, int n, String hint) {
             this(text, n);
             prepareForHint(hint);
         }
-        
+
         private void prepareForHint(String hint) {
             hintText = hint;
             addFocusListener(l);
             updateHint();
         }
-        
+
         private void updateHint() {
             if (getText().isEmpty()) {
                 setText(hintText);
@@ -922,7 +945,7 @@ public final class UIUtil {
                 setCaretPosition(0);
             }
         }
-        
+
         @Override
         public void setText(String t) {
             if ((t != null) && !t.isBlank()) {
@@ -930,13 +953,13 @@ public final class UIUtil {
             }
             super.setText(t);
         }
-        
+
         FocusListener l = new FocusListener() {
             @Override
             public void focusLost(FocusEvent e) {
                 updateHint();
             }
-            
+
             @Override
             public void focusGained(FocusEvent e) {
                 if (getText().equals(hintText)) {
@@ -952,7 +975,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -966,17 +989,17 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
+
+    /**
      * A JPanel with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent dialog, not following the mouse. 
+     * of the parent dialog, not following the mouse.
      */
     public static class TipPanel extends JPanel {
-        
+
         public TipPanel() {
             super();
         }
-        
+
         public TipPanel(LayoutManager lm) {
             super(lm);
         }
@@ -987,7 +1010,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -1001,14 +1024,14 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
+
+    /**
      * A JSlider with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent window (dialog), not following the mouse. 
+     * of the parent window (dialog), not following the mouse.
      * Implement the missing super constructors as necessary.
      */
     public static class TipSlider extends JSlider {
-        
+
         public TipSlider(int orientation, int min, int max, int value) {
             super(orientation, min, max, value);
         }
@@ -1019,7 +1042,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -1033,13 +1056,13 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
+
+    /**
      * A MMToggleButton with a specialized tooltip display. Displays the tooltip to the right side
-     * of the parent window (dialog), not following the mouse. 
+     * of the parent window (dialog), not following the mouse.
      */
     public static class TipMMToggleButton extends MMToggleButton {
-        
+
         public TipMMToggleButton(String text) {
             super(text);
         }
@@ -1050,7 +1073,7 @@ public final class UIUtil {
             Point origin = SwingUtilities.convertPoint(this, 0, 0, win);
             return new Point(win.getWidth() - origin.x, 0);
         }
-        
+
         @Override
         public JToolTip createToolTip() {
             JToolTip tip = super.createToolTip();
@@ -1064,55 +1087,55 @@ public final class UIUtil {
             super.setToolTipText(formatSideTooltip(text));
         }
     }
-    
-    /** 
-     * Completes the tooltip for a dialog using one of the TipXXX clasess, setting 
-     * its width and adding HTML tags. 
+
+    /**
+     * Completes the tooltip for a dialog using one of the TipXXX clasess, setting
+     * its width and adding HTML tags.
      */
     public static String formatSideTooltip(String text) {
         String result = "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
         return scaleStringForGUI(result);
     }
-    
+
     /**
      * This is a specialized JPanel for use with a button bar at the bottom
      * of a dialog for when it's possible that the button bar has to wrap (is
      * wider than the dialog and needs to use two or more rows for the buttons).
-     * With a normal JPanel the wrapped buttons just disappear. 
+     * With a normal JPanel the wrapped buttons just disappear.
      * This Panel tries to detect when wrapping occurs and then extends vertically.
-     * Note that it will only extend to two rows, not more. But if three rows of 
+     * Note that it will only extend to two rows, not more. But if three rows of
      * buttons are used, this will be very obvious.
-     * The native FlowLayout should be kept for the buttons. 
+     * The native FlowLayout should be kept for the buttons.
      */
     public static class WrappingButtonPanel extends JPanel {
         private static final long serialVersionUID = -6966176665047676553L;
 
         @Override
         public Dimension getPreferredSize() {
-            int height = super.getPreferredSize().height; 
+            int height = super.getPreferredSize().height;
             if (getSize().width < super.getPreferredSize().width) {
                 height = height * 2;
             }
             return new Dimension(super.getPreferredSize().width, height);
         }
-        
+
         @Override
         public Dimension getMinimumSize() {
             return new Dimension(super.getMinimumSize().width, getPreferredSize().height);
         }
-        
+
         @Override
         public Dimension getMaximumSize() {
             return new Dimension(super.getMaximumSize().width, getPreferredSize().height);
         }
     }
-    
+
     /**
      * Returns a single menu item with the given text, the given command string
      * cmd, the given enabled state, and assigned the given listener.
      */
-    public static JMenuItem menuItem(String text, String cmd, boolean enabled, 
-            ActionListener listener) {
+    public static JMenuItem menuItem(String text, String cmd, boolean enabled,
+                                     ActionListener listener) {
 
         return menuItem(text, cmd, enabled, listener, Integer.MIN_VALUE);
     }
@@ -1122,8 +1145,8 @@ public final class UIUtil {
      * cmd, the given enabled state, and assigned the given listener. Also assigns
      * the given key mnemonic.
      */
-    public static JMenuItem menuItem(String text, String cmd, boolean enabled, 
-            ActionListener listener, int mnemonic) {
+    public static JMenuItem menuItem(String text, String cmd, boolean enabled,
+                                     ActionListener listener, int mnemonic) {
 
         JMenuItem result = new JMenuItem(text);
         result.setActionCommand(cmd);
@@ -1134,10 +1157,10 @@ public final class UIUtil {
         }
         return result;
     }
-    
-    /** 
-     * Returns a Font object using the "Dialog" logic font. The font size is based on 
-     * size 14 and scaled with the current gui scaling. 
+
+    /**
+     * Returns a Font object using the "Dialog" logic font. The font size is based on
+     * size 14 and scaled with the current gui scaling.
      */
     public static Font getScaledFont() {
         return new Font(MMConstants.FONT_DIALOG, Font.PLAIN, scaleForGUI(FONT_SCALE1));
@@ -1165,10 +1188,80 @@ public final class UIUtil {
         }
     }
 
-    /** Returns true when a modal dialog such as the Camo Chooser or a Load Force dialog is currently shown. */
+    /**
+     * Returns true when a modal dialog such as the Camo Chooser or a Load Force dialog is currently shown.
+     */
     public static boolean isModalDialogDisplayed() {
         return Stream.of(Window.getWindows())
                 .anyMatch(w -> w.isShowing() && (w instanceof JDialog) && ((JDialog) w).isModal());
+    }
+
+    /**
+     * Opens a browser window if the OS supports it and shows the MUL unit entry for the given MUL ID. When
+     * mulid is 0 or less, this method does nothing. Other errors are logged.
+     *
+     * @param mulid The MUL ID to show; should be 1 or more
+     */
+    public static void showUnitInMul(int mulid) {
+        showUnitInMul(mulid, null);
+    }
+
+    /**
+     * Opens a browser window if the OS supports it and shows the MUL unit entry for the given MUL ID. When
+     * mulid is 0 or less, this method does nothing. When an exception occurs, an error dialog is shown with
+     * the given parentFrame as parent.
+     *
+     * @param mulid The MUL ID to show; should be 1 or more
+     * @param parentFrame The parent Component; used only for an error dialog
+     */
+    public static void showUnitInMul(int mulid, JFrame parentFrame) {
+        if (mulid > 0) {
+            openInBrowser(MMConstants.MUL_URL_UNIT_PREFIX + mulid, parentFrame);
+        }
+    }
+
+    /**
+     * Opens a browser window if the OS supports it and shows the MUL faction entry for the given MUL ID. When
+     * mulid is 0 or less, this method does nothing. Other errors are logged.
+     *
+     * @param mulid The MUL ID to show; should be 1 or more
+     */
+    public static void showFactionInMul(int mulid) {
+        showFactionInMul(mulid, null);
+    }
+
+    /**
+     * Opens a browser window if the OS supports it and shows the MUL faction entry for the given MUL ID. When
+     * mulid is 0 or less, this method does nothing. When an exception occurs, an error dialog is shown with
+     * the given parentFrame as parent.
+     *
+     * @param mulid The MUL ID to show; should be 1 or more
+     * @param parentFrame The parent Component; used only for an error dialog
+     */
+    public static void showFactionInMul(int mulid, @Nullable JFrame parentFrame) {
+        if (mulid > 0) {
+            openInBrowser(MMConstants.MUL_URL_FACTION_PREFIX + mulid, parentFrame);
+        }
+    }
+
+    /**
+     * Opens a browser window if the OS supports it and shows the given link. When an exception occurs and
+     * the given parentFrame is not null, an error dialog is shown.
+     *
+     * @param link The full link to show
+     * @param parentFrame The parent Component; used only for an error dialog
+     */
+    public static void openInBrowser(String link, @Nullable JFrame parentFrame) {
+        try {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                Desktop.getDesktop().browse(new URL(link).toURI());
+            }
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+            if (parentFrame != null) {
+                JOptionPane.showMessageDialog(parentFrame, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
+            }
+        }
     }
 
     // PRIVATE

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -251,7 +251,7 @@ public class MechView {
         sHead.add(new LabeledElement(Messages.getString("MechView.Cost"),
                 dFormatter.format(cost) + " C-bills"));
         if (entity.hasMulId()) {
-            sHead.add(new HyperLinkElement(MMConstants.MUL_URL_PREFIX + entity.getMulId(),
+            sHead.add(new HyperLinkElement(MMConstants.MUL_URL_UNIT_PREFIX + entity.getMulId(),
                     Messages.getString("MechView.Source")));
             if (!entity.getSource().isEmpty()) {
                 sHead.add(new LabeledElement("", entity.getSource()));

--- a/megamek/src/megamek/utilities/RATGeneratorEditor.java
+++ b/megamek/src/megamek/utilities/RATGeneratorEditor.java
@@ -13,7 +13,6 @@
  */
 package megamek.utilities;
 
-import megamek.MMConstants;
 import megamek.client.ratgenerator.*;
 import megamek.client.ratgenerator.FactionRecord.TechCategory;
 import megamek.client.ui.swing.util.UIUtil;
@@ -35,7 +34,6 @@ import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableRowSorter;
 import java.awt.*;
 import java.io.File;
-import java.net.URL;
 import java.util.List;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -1147,7 +1145,7 @@ public class RATGeneratorEditor extends JFrame {
             if (col == COL_MINOR || col == COL_CLAN || col == COL_PERIPHERY) {
                 return Boolean.class;
             } else if (col == COL_MULID) {
-                return Integer.class;
+                return String.class;
             } else {
                 return String.class;
             }
@@ -1161,7 +1159,7 @@ public class RATGeneratorEditor extends JFrame {
                 case COL_NAME:
                     return data.get(row).getNamesAsString();
                 case COL_MULID:
-                    return data.get(row).getMulId();
+                    return data.get(row).getMulIdsAsString();
                 case COL_YEARS:
                     return data.get(row).getYearsAsString();
                 case COL_MINOR:
@@ -1192,8 +1190,8 @@ public class RATGeneratorEditor extends JFrame {
                     data.get(row).setNames((String) val);
                     break;
                 case COL_MULID:
-                    data.get(row).setMulId((Integer) val);
-                    currentFactionMulId = (Integer) val;
+                    data.get(row).setMulIds((String) val);
+                    currentFactionMulId = data.get(row).getMulId();
                     break;
                 case COL_YEARS:
                     try {

--- a/megamek/src/megamek/utilities/RATGeneratorEditor.java
+++ b/megamek/src/megamek/utilities/RATGeneratorEditor.java
@@ -1239,10 +1239,6 @@ public class RATGeneratorEditor extends JFrame {
                 UnitType.MEK, UnitType.TANK, UnitType.AERO
         };
 
-        private static final String[] WEIGHT_DIST_UNIT_NAME = {
-                "Mek", "Tank", "Aero"
-        };
-        
         private FactionRecord factionRec;
         
         public FactionEditorTableModel(FactionRecord rec) {


### PR DESCRIPTION
As the title says, this adds the faction ID from the MUL to the FactionRecord data, editable in the RATGeneratorEditor. I added faction IDs as far as I could match them.

Since the MUL is called from a few places, I unified the calling code. The whitespace changes in UIUtil weren't intentional.

Fixes #4286 