### PR TITLE
Show weapon location in tooltip for multi-location entities

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1238,6 +1238,7 @@ CommonSettingsDialog.showPilotPortraitTT=Show pilot portrait in tooltip.
 CommonSettingsDialog.showReportSprites=Show Report Sprites in Report Log
 CommonSettingsDialog.showUnitId=Show each unit's unique Id next to its name.
 CommonSettingsDialog.showWpsinTT=Show unit weapons in the tooltip
+CommonSettingsDialog.showWpsLocinTT=Show weapon locations in the tooltip
 CommonSettingsDialog.showWrecks=Show wrecks.
 CommonSettingsDialog.skinFile=Skin File: 
 CommonSettingsDialog.skinFileFail.msg=Error parsing skin specification file, reverting to previous skin!

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -96,7 +96,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 if (src instanceof JList) {
                     dragSourceIndex = ((JList<?>) src).getSelectedIndex();
                     mouseDragging = true;
-                }                
+                }
             }
         }
 
@@ -143,6 +143,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private final JCheckBox soundMuteOthersTurn = new JCheckBox(Messages.getString("CommonSettingsDialog.soundMuteOthersTurn"));
     private JTextField tfSoundMuteOthersFileName;
     private final JCheckBox showWpsinTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showWpsinTT"));
+    private final JCheckBox showWpsLocinTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showWpsLocinTT"));
     private final JCheckBox showArmorMiniVisTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showArmorMiniVisTT"));
     private final JCheckBox showPilotPortraitTT = new JCheckBox(Messages.getString("CommonSettingsDialog.showPilotPortraitTT"));
     private MMComboBox<WeaponSortOrder> comboDefaultWeaponSortOrder;
@@ -230,14 +231,14 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private JCheckBox fovGrayscaleEnabled;
     private JTextField fovHighlightRingsRadii;
     private JTextField fovHighlightRingsColors;
-    
+
     // Labels (there to make it possible to disable them)
     private JLabel darkenAlphaLabel;
     private JLabel numStripesLabel;
     private JLabel fovHighlightRingsColorsLabel;
     private JLabel fovHighlightRingsRadiiLabel;
     private JLabel highlightAlphaLabel;
-    
+
     private JLabel stampFormatLabel;
     private JLabel gameLogFilenameLabel;
 
@@ -263,7 +264,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private DefaultListModel<String> unitDisplayNonTabbed = new DefaultListModel<>();
     private final StatusBarPhaseDisplay.CommandComparator cmdComp = new StatusBarPhaseDisplay.CommandComparator();
     private final PhaseCommandListMouseAdapter cmdMouseAdaptor = new PhaseCommandListMouseAdapter();
-    
+
     private JComboBox<String> tileSetChoice;
     private List<String> tileSets;
     private final MMToggleButton choiceToggle = new MMToggleButton(Messages.getString("CommonSettingsDialog.keyBinds.buttoneTabbing"));
@@ -338,9 +339,9 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
     /** Maps command strings to a JTextField for updating the key for the command. */
     private Map<String, JTextField> cmdKeyMap;
-    
+
     /** Maps command strings to a Integer for updating the key for the command. */
-    private Map<String, Integer> cmdKeyCodeMap; 
+    private Map<String, Integer> cmdKeyCodeMap;
 
     private ClientGUI clientgui = null;
 
@@ -350,10 +351,10 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private static final ButtonOrderPreferences BOP = ButtonOrderPreferences.getInstance();
 
     private static final String[] LOCALE_CHOICES = { "en", "de", "ru", "es" };
-    
+
     private static final Dimension LABEL_SPACER = new Dimension(5, 0);
     private static final Dimension DEPENDENT_INSET = new Dimension(25, 0);
-    
+
     // Save some values to restore them when the dialog is canceled
     private boolean savedFovHighlight;
     private boolean savedFovDarken;
@@ -384,7 +385,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         this(owner);
         clientgui = cg;
     }
-    
+
     /** Constructs the Client Settings Dialog without a clientgui (used in the main menu and board editor). */
     public CommonSettingsDialog(JFrame owner) {
         super(owner, true, "ClientSettings", "CommonSettingsDialog.title");
@@ -863,6 +864,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         comps.add(row);
 
         comps.add(checkboxEntry(showWpsinTT, null));
+        comps.add(checkboxEntry(showWpsLocinTT, null));
         comps.add(checkboxEntry(showPilotPortraitTT, null));
 
         addLineSpacer(comps);
@@ -1223,16 +1225,16 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         JLabel displayLocaleLabel = new JLabel(Messages.getString("CommonSettingsDialog.locale"));
         displayLocale = new JComboBox<>();
-        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.English")); 
-        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Deutsch")); 
+        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.English"));
+        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Deutsch"));
         displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Russian"));
-        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Spanish")); 
+        displayLocale.addItem(Messages.getString("CommonSettingsDialog.locale.Spanish"));
         displayLocale.setMaximumSize(new Dimension(150, 40));
         row = new ArrayList<>();
         row.add(displayLocaleLabel);
         row.add(displayLocale);
         comps.add(row);
-        
+
         addLineSpacer(comps);
 
         guiScale = new JSlider();
@@ -1324,14 +1326,14 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         addLineSpacer(comps);
 
-        JLabel unitStartCharLabel = new JLabel(Messages.getString("CommonSettingsDialog.protoMechUnitCodes")); 
+        JLabel unitStartCharLabel = new JLabel(Messages.getString("CommonSettingsDialog.protoMechUnitCodes"));
         unitStartChar = new JComboBox<>();
         // Add option for "A, B, C, D..."
-        unitStartChar.addItem("\u0041, \u0042, \u0043, \u0044..."); 
+        unitStartChar.addItem("\u0041, \u0042, \u0043, \u0044...");
         // Add option for "ALPHA, BETA, GAMMA, DELTA..."
-        unitStartChar.addItem("\u0391, \u0392, \u0393, \u0394..."); 
+        unitStartChar.addItem("\u0391, \u0392, \u0393, \u0394...");
         // Add option for "alpha, beta, gamma, delta..."
-        unitStartChar.addItem("\u03B1, \u03B2, \u03B3, \u03B4..."); 
+        unitStartChar.addItem("\u03B1, \u03B2, \u03B3, \u03B4...");
         unitStartChar.setMaximumSize(new Dimension(150, 40));
         row = new ArrayList<>();
         row.add(unitStartCharLabel);
@@ -1344,7 +1346,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         addLineSpacer(comps);
         comps.add(checkboxEntry(keepGameLog, null));
 
-        gameLogFilenameLabel = new JLabel(Messages.getString("CommonSettingsDialog.logFileName")); 
+        gameLogFilenameLabel = new JLabel(Messages.getString("CommonSettingsDialog.logFileName"));
         gameLogFilename = new JTextField(15);
         gameLogFilename.setMaximumSize(new Dimension(250, 40));
         row = new ArrayList<>();
@@ -1356,7 +1358,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         addSpacer(comps, 5);
         comps.add(checkboxEntry(stampFilenames, null));
 
-        stampFormatLabel = new JLabel(Messages.getString("CommonSettingsDialog.stampFormat")); 
+        stampFormatLabel = new JLabel(Messages.getString("CommonSettingsDialog.stampFormat"));
         stampFormat = new JTextField(15);
         stampFormat.setMaximumSize(new Dimension(15*13, 40));
         row = new ArrayList<>();
@@ -1414,7 +1416,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             nagForMASC.setSelected(GUIP.getNagForMASC());
             nagForPSR.setSelected(GUIP.getNagForPSR());
             nagForWiGELanding.setSelected(GUIP.getNagForWiGELanding());
-            nagForNoAction.setSelected(GUIP.getNagForNoAction());          
+            nagForNoAction.setSelected(GUIP.getNagForNoAction());
             nagForNoUnJamRAC.setSelected(GUIP.getNagForNoUnJamRAC());
             animateMove.setSelected(GUIP.getShowMoveStep());
             showWrecks.setSelected(GUIP.getShowWrecks());
@@ -1425,6 +1427,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             tooltipDismissDelay.setText(Integer.toString(GUIP.getTooltipDismissDelay()));
             tooltipDistSupression.setText(Integer.toString(GUIP.getTooltipDistSuppression()));
             showWpsinTT.setSelected(GUIP.getShowWpsinTT());
+            showWpsLocinTT.setSelected(GUIP.getShowWpsLocinTT());
             showArmorMiniVisTT.setSelected(GUIP.getshowArmorMiniVisTT());
             showPilotPortraitTT.setSelected(GUIP.getshowPilotPortraitTT());
             comboDefaultWeaponSortOrder.setSelectedItem(GUIP.getDefaultWeaponSortOrder());
@@ -1546,7 +1549,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             gameLogFilenameLabel.setEnabled(keepGameLog.isSelected());
 
             getFocus.setSelected(GUIP.getFocus());
-            
+
             savedFovHighlight = GUIP.getFovHighlight();
             savedFovDarken = GUIP.getFovDarken();
             savedFovGrayscale = GUIP.getFovGrayscale();
@@ -1569,9 +1572,9 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             savedFovDarkenAlpha = GUIP.getFovDarkenAlpha();
             savedNumStripesSlider = GUIP.getFovStripes();
             savedAdvancedOpt.clear();
-            
+
             advancedKeys.clearSelection();
-            
+
             for (KeyCommandBind kcb : KeyCommandBind.values()) {
                 cmdModifierMap.get(kcb.cmd).setText(KeyEvent.getModifiersExText(kcb.modifiers));
                 cmdKeyMap.get(kcb.cmd).setText(KeyEvent.getKeyText(kcb.key));
@@ -1743,7 +1746,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setNagForMASC(nagForMASC.isSelected());
         GUIP.setNagForPSR(nagForPSR.isSelected());
         GUIP.setNagForWiGELanding(nagForWiGELanding.isSelected());
-        GUIP.setNagForNoAction(nagForNoAction.isSelected());      
+        GUIP.setNagForNoAction(nagForNoAction.isSelected());
         GUIP.setNagForNoUnJamRAC(nagForNoUnJamRAC.isSelected());
         GUIP.setShowMoveStep(animateMove.isSelected());
         GUIP.setShowWrecks(showWrecks.isSelected());
@@ -1751,6 +1754,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setSoundMuteMyTurn(soundMuteMyTurn.isSelected());
         GUIP.setSoundMuteOthersTurn(soundMuteOthersTurn.isSelected());
         GUIP.setShowWpsinTT(showWpsinTT.isSelected());
+        GUIP.setShowWpsLocinTT(showWpsLocinTT.isSelected());
         GUIP.setshowArmorMiniVisTT(showArmorMiniVisTT.isSelected());
         GUIP.setshowPilotPortraitTT(showPilotPortraitTT.isSelected());
 
@@ -1898,7 +1902,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 JOptionPane.showMessageDialog(getFrame(), msg, title, JOptionPane.ERROR_MESSAGE);
             } else {
                 GUIP.setSkinFile(newSkinFile);
-            }            
+            }
         }
 
         if (tileSetChoice.getSelectedIndex() >= 0) {
@@ -1920,7 +1924,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         for (KeyCommandBind kcb : KeyCommandBind.values()) {
             int modifiers = modifierCode(kcb);
             int keyCode = keyCode(kcb);
-            bindsChanged |= (kcb.modifiers != modifiers) || (kcb.key != keyCode); 
+            bindsChanged |= (kcb.modifiers != modifiers) || (kcb.key != keyCode);
             kcb.modifiers = modifiers;
             kcb.key = keyCode;
         }
@@ -1928,7 +1932,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         if (bindsChanged) {
             KeyBindParser.writeKeyBindings();
         }
-        
+
         // Button Order
         // Movement
         boolean buttonOrderChanged = false;
@@ -1940,12 +1944,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 buttonOrderChanged = true;
             }
         }
-        
+
         // Need to do stuff if the order changes.
         if (buttonOrderChanged && (clientgui != null)) {
             clientgui.updateButtonPanel(GamePhase.MOVEMENT);
         }
-        
+
         // Deploy
         buttonOrderChanged = false;
         for (int i = 0; i < deployPhaseCommands.getSize(); i++) {
@@ -1956,12 +1960,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 buttonOrderChanged = true;
             }
         }
-        
+
         // Need to do stuff if the order changes.
         if (buttonOrderChanged && (clientgui != null)) {
             clientgui.updateButtonPanel(GamePhase.DEPLOYMENT);
-        }        
-        
+        }
+
         // Firing
         buttonOrderChanged = false;
         for (int i = 0; i < firingPhaseCommands.getSize(); i++) {
@@ -1972,12 +1976,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 buttonOrderChanged = true;
             }
         }
-        
+
         // Need to do stuff if the order changes.
         if (buttonOrderChanged && (clientgui != null)) {
             clientgui.updateButtonPanel(GamePhase.FIRING);
         }
-        
+
         // Physical
         buttonOrderChanged = false;
         for (int i = 0; i < physicalPhaseCommands.getSize(); i++) {
@@ -1988,12 +1992,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 buttonOrderChanged = true;
             }
         }
-        
+
         // Need to do stuff if the order changes.
         if (buttonOrderChanged && (clientgui != null)) {
             clientgui.updateButtonPanel(GamePhase.PHYSICAL);
         }
-        
+
         // Targeting
         buttonOrderChanged = false;
         for (int i = 0; i < targetingPhaseCommands.getSize(); i++) {
@@ -2004,7 +2008,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 buttonOrderChanged = true;
             }
         }
-        
+
         // Need to do stuff if the order changes.
         if (buttonOrderChanged && (clientgui != null)) {
             clientgui.updateButtonPanel(GamePhase.TARGETING);
@@ -2231,19 +2235,19 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         } else if (src.equals(fovHighlightRingsColors)) {
             guip.setFovHighlightRingsColorsHsb(fovHighlightRingsColors.getText());
             return;
-        } 
+        }
         // For Advanced options
         String option = "Advanced" + advancedKeys.getModel().getElementAt(advancedKeyIndex).option;
-        savedAdvancedOpt.put(option, guip.getString(option));        
+        savedAdvancedOpt.put(option, guip.getString(option));
         guip.setValue(option, advancedValue.getText());
     }
-    
+
     /** Creates a panel with a box for all of the commands that can be bound to keys. */
     private JPanel getKeyBindPanel() {
         // The first column is for labels, the second column for modifiers, the third column for keys
         JPanel outer = new JPanel();
         outer.setLayout(new BoxLayout(outer, BoxLayout.PAGE_AXIS));
-        
+
         var tabChoice = new JPanel();
         tabChoice.setLayout(new BoxLayout(tabChoice, BoxLayout.PAGE_AXIS));
         tabChoice.setBorder(new EmptyBorder(15, 15, 15, 15));
@@ -2272,7 +2276,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = gbc.gridy = 0;
         gbc.insets = new Insets(0, 10, 5, 10);
-        
+
         // Create header: labels for describing what each column does
         JLabel headers = new JLabel("Name");
         String msg_tooltipName = Messages.getString("CommonSettingsDialog.keyBinds.tooltipName");
@@ -2291,14 +2295,14 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         gbc.gridy++;
         gbc.gridx = 0;
         gbc.gridwidth = 4;
-        
+
         gbc.fill = GridBagConstraints.BOTH;
         keyBinds.add(new JSeparator(SwingConstants.HORIZONTAL), gbc);
-        
+
         gbc.fill = GridBagConstraints.NONE;
         gbc.gridy++;
         gbc.gridwidth = 1;
-        
+
 
         // Create maps to retrieve the text fields for saving
         int numBinds = KeyCommandBind.values().length;
@@ -2387,7 +2391,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             keyBinds.add(key, gbc);
             gbc.gridx = 0;
             gbc.gridy++;
-            
+
             // deactivate TABbing through fields here so TAB can be caught as a keybind
             modifiers.setFocusTraversalKeysEnabled(false);
             key.setFocusTraversalKeysEnabled(false);
@@ -2524,7 +2528,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         return createSettingsPanel(comps);
     }
-    
+
     private void updateKeybindsFocusTraversal() {
         for (KeyCommandBind kcb : KeyCommandBind.values()) {
             cmdModifierMap.get(kcb.cmd).setFocusTraversalKeysEnabled(choiceToggle.isSelected());
@@ -2545,12 +2549,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         markDuplicateBinds();
     }
 
-    /** 
+    /**
      * Marks the text fields when duplicate keybinds occur. Two commands may share a keybind if none
      * of them is a Menubar or exclusive keybind (although that only works well if they're used in different
-     * phases such as turn and twist). 
+     * phases such as turn and twist).
      * Also checks for Ctrl-C and Ctrl-V. These are coded into JTables and JTrees and making them
-     * configurable would be unproportional effort to the gain. 
+     * configurable would be unproportional effort to the gain.
      */
     private void markDuplicateBinds() {
         Map<KeyStroke, KeyCommandBind> duplicates = new HashMap<>();
@@ -2562,14 +2566,14 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 duplicates.put(keyStroke, kcb);
             }
         }
-                    
+
         // Now traverse the commands again. When a duplicate keybind is found and this KeyCommandBind is exclusive or Menubar
         // or the other one (the first one found with the same keybind) is exclusive or Menubar, both are marked.
         // Also, Ctrl-C and Ctrl-V are marked as these are hard-mapped to Copy/Paste and cannot be used otherwise.
         for (KeyCommandBind kcb : KeyCommandBind.values()) {
             boolean isCorrect = true;
             KeyStroke keyStroke = KeyStroke.getKeyStroke(keyCode(kcb), modifierCode(kcb));
-            if (duplicates.containsKey(keyStroke) && 
+            if (duplicates.containsKey(keyStroke) &&
                     (kcb.isMenuBar || kcb.isExclusive || duplicates.get(keyStroke).isExclusive || duplicates.get(keyStroke).isMenuBar)) {
                 // Mark the current kcb and the one that was already in the keyMap as duplicate
                 markTextfield(cmdModifierMap.get(kcb.cmd), "This keybind is a duplicate and will not work correctly.");
@@ -2591,17 +2595,17 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             }
         }
     }
-    
+
     private void markTextfield(JTextField field, String errorMsg) {
         field.setForeground(errorMsg != null ? GUIP.getWarningColor() : null);
         field.setToolTipText(errorMsg);
     }
-    
+
     /** Returns the keycode for the character part of a user-entered keybind (The "V" in CTRL-V). */
     private int keyCode(KeyCommandBind kcb) {
         return cmdKeyCodeMap.get(kcb.cmd);
     }
-    
+
     /** Returns the keycode for the modifier part of a user-entered keybind (The "CTRL" in CTRL-V). */
     private int modifierCode(KeyCommandBind kcb) {
         int modifiers = 0;
@@ -2617,44 +2621,44 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         }
         return modifiers;
     }
-    
+
     /** Creates a panel with a list boxes that allow the button order to be changed. */
     private JPanel getButtonOrderPanel() {
         JPanel buttonOrderPanel = new JPanel();
         buttonOrderPanel.setLayout(new BoxLayout(buttonOrderPanel, BoxLayout.Y_AXIS));
         JTabbedPane phasePane = new JTabbedPane();
         buttonOrderPanel.add(phasePane);
-        
-        // MovementPhaseDisplay        
+
+        // MovementPhaseDisplay
         movePhaseCommands = new DefaultListModel<>();
         phasePane.add("Movement", getButtonOrderPane(movePhaseCommands,
                 MovementDisplay.MoveCommand.values()));
-        
+
         // DeploymentPhaseDisplay
         deployPhaseCommands = new DefaultListModel<>();
         phasePane.add("Deployment", getButtonOrderPane(deployPhaseCommands,
                 DeploymentDisplay.DeployCommand.values()));
-        
+
         // FiringPhaseDisplay
         firingPhaseCommands = new DefaultListModel<>();
         phasePane.add("Firing", getButtonOrderPane(firingPhaseCommands,
                 FiringDisplay.FiringCommand.values()));
-        
+
         // PhysicalPhaseDisplay
         physicalPhaseCommands = new DefaultListModel<>();
         phasePane.add("Physical", getButtonOrderPane(physicalPhaseCommands,
-                PhysicalDisplay.PhysicalCommand.values()));          
-        
+                PhysicalDisplay.PhysicalCommand.values()));
+
         // TargetingPhaseDisplay
         targetingPhaseCommands = new DefaultListModel<>();
         phasePane.add("Targeting", getButtonOrderPane(targetingPhaseCommands,
                 TargetingPhaseDisplay.TargetingCommand.values()));
-        
+
         return buttonOrderPanel;
     }
 
-    /** Constructs the button ordering panel for one phase. */ 
-    private JScrollPane getButtonOrderPane(DefaultListModel<PhaseCommand> list, 
+    /** Constructs the button ordering panel for one phase. */
+    private JScrollPane getButtonOrderPane(DefaultListModel<PhaseCommand> list,
             StatusBarPhaseDisplay.PhaseCommand[] commands) {
         JPanel panel = new JPanel();
         Arrays.sort(commands, cmdComp);
@@ -2694,7 +2698,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                     subPanel.add(c);
                     subPanel.add(Box.createRigidArea(LABEL_SPACER));
                 } else {
-                    subPanel.add(c);    
+                    subPanel.add(c);
                 }
             }
             subPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -2739,7 +2743,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         return p;
     }
 
-    /** Used to note which advanced setting is currently clicked. */  
+    /** Used to note which advanced setting is currently clicked. */
     @Override
     public void valueChanged(ListSelectionEvent event) {
         if (event.getValueIsAdjusting()) {

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -271,6 +271,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String SHOW_FIELD_OF_FIRE = "ShowFieldOfFire";
     public static final String SHOW_MAPHEX_POPUP = "ShowMapHexPopup";
     public static final String SHOW_WPS_IN_TT = "ShowWpsinTT";
+    public static final String SHOW_WPS_LOC_IN_TT = "ShowWpsLocinTT";
     public static final String SHOW_ARMOR_MINIVIS_TT = "showArmorMiniVisTT";
     public static final String SHOW_PILOT_PORTRAIT_TT = "showPilotPortraitTT";
     public static final String SHOW_MOVE_STEP = "ShowMoveStep";
@@ -628,6 +629,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(TOOLTIP_DISMISS_DELAY, -1);
         store.setDefault(TOOLTIP_DIST_SUPRESSION, BoardView.HEX_DIAG);
         store.setDefault(SHOW_WPS_IN_TT, true);
+        store.setDefault(SHOW_WPS_LOC_IN_TT, true);
         store.setDefault(SHOW_ARMOR_MINIVIS_TT, true);
         store.setDefault(SHOW_PILOT_PORTRAIT_TT, true);
 
@@ -1275,6 +1277,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public boolean getShowWpsinTT() {
         return store.getBoolean(SHOW_WPS_IN_TT);
+    }
+
+    public boolean getShowWpsLocinTT() {
+        return store.getBoolean(SHOW_WPS_LOC_IN_TT);
     }
 
     public boolean getshowArmorMiniVisTT() {
@@ -2018,6 +2024,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setShowWpsinTT(boolean state) {
         store.setValue(SHOW_WPS_IN_TT, state);
+    }
+
+    public void setShowWpsLocinTT(boolean state) {
+        store.setValue(SHOW_WPS_LOC_IN_TT, state);
     }
 
     public void setshowArmorMiniVisTT(boolean state) {

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -479,10 +479,10 @@ public final class UnitToolTip {
             if (isNotTTRelevant(wtype)) {
                 continue;
             }
+
             String weapDesc = curWp.getDesc();
 
-            // location info is only useful units with more than one location
-            if (entity.locations() > 1) {
+            if (GUIP.getShowWpsLocinTT() && (entity.locations() > 1)) {
                 weapDesc += " ["+entity.getLocationAbbr(curWp.getLocation()) + ']';
             }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1,16 +1,16 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
-*/  
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
+*/
 package megamek.client.ui.swing.tooltip;
 
 import megamek.client.ui.Messages;
@@ -63,7 +63,7 @@ public final class UnitToolTip {
             MapSettings mapSettings) {
         return getEntityTipTable(entity, localPlayer, true, false, mapSettings);
     }
-    
+
     /** Returns the unit tooltip with values that are relevant in-game. */
     public static StringBuilder getEntityTipGame(Entity entity, Player localPlayer) {
         return getEntityTipTable(entity, localPlayer, false, true, null);
@@ -75,11 +75,11 @@ public final class UnitToolTip {
     }
 
     // PRIVATE
-    
+
     /** Assembles the whole unit tooltip. */
     private static StringBuilder getEntityTipTable(Entity entity, Player localPlayer,
            boolean details, boolean pilotInfo, @Nullable MapSettings mapSettings) {
-        
+
         // Tooltip info for a sensor blip
         if (EntityVisibilityUtils.onlyDetectedBySensors(localPlayer, entity)) {
             String msg_senorreturn = Messages.getString("BoardView1.sensorReturn");
@@ -139,7 +139,7 @@ public final class UnitToolTip {
         String sEntityInfo = entityValues(entity).toString();
         result += guiScaledFontHTML() + sEntityInfo + "</FONT>";
 
-        // Status bar visual representation of armor and IS 
+        // Status bar visual representation of armor and IS
         if (GUIP.getshowArmorMiniVisTT()) {
             result += addArmorMiniVisToTT(entity);
         }
@@ -162,7 +162,7 @@ public final class UnitToolTip {
                 sQuirks += quirksList;
             }
             for (Mounted weapon: entity.getWeaponList()) {
-                String wpQuirksList = getOptionList(weapon.getQuirks().getGroups(), 
+                String wpQuirksList = getOptionList(weapon.getQuirks().getGroups(),
                         grp -> weapon.countQuirks(), (e) -> weapon.getDesc(), details);
                 if (!wpQuirksList.isEmpty()) {
                     // Line break after weapon name not useful here
@@ -173,16 +173,16 @@ public final class UnitToolTip {
         }
 
         // Partial repairs
-        String partialList = getOptionList(entity.getPartialRepairs().getGroups(), 
+        String partialList = getOptionList(entity.getPartialRepairs().getGroups(),
                 grp -> entity.countPartialRepairs(), details);
         if (!partialList.isEmpty()) {
             result += guiScaledFontHTML(uiPartialRepairColor(), TT_SMALLFONT_DELTA) + partialList + "</FONT>";
         }
-        
+
         if (!entity.getLoadedUnits().isEmpty()) {
             result += carriedUnits(entity);
         }
-        
+
         if (details && entity.hasAnyC3System()) {
             result += c3Info(entity);
         }
@@ -256,7 +256,7 @@ public final class UnitToolTip {
                     col1 += intactLocBar(entity.getOArmor(loc, true), entity.getArmor(loc, true), armorChar).toString();
                 } else {
                     // No rear armor: empty table cells instead
-                    // At small font sizes, writing one character at the correct font size is 
+                    // At small font sizes, writing one character at the correct font size is
                     // necessary to prevent the table rows from being spaced non-beautifully
                     col1 = guiScaledFontHTML(TT_SMALLFONT_DELTA) + "&nbsp;" + "</FONT>";
                 }
@@ -308,7 +308,7 @@ public final class UnitToolTip {
                     col3 += sysCrits(entity, CriticalSlot.TYPE_SYSTEM, Mech.ACTUATOR_FOOT, loc, msg_abbr_foot).toString();
                     break;
                 case 6:
-                case 7:                
+                case 7:
                 case 8:
                     col3 = sysCrits(entity, CriticalSlot.TYPE_SYSTEM, Mech.ACTUATOR_HIP, loc, msg_abbr_hip).toString();
                     col3 += sysCrits(entity, CriticalSlot.TYPE_SYSTEM, Mech.ACTUATOR_UPPER_LEG, loc, msg_abbr_upperleg).toString();
@@ -329,32 +329,32 @@ public final class UnitToolTip {
 
         return new StringBuilder().append(table);
     }
-    
-    /** 
+
+    /**
      * Used for destroyed locations.
      * Returns a string representing armor or internal structure of the location.
-     * The location has the given orig original Armor/IS. 
+     * The location has the given orig original Armor/IS.
      */
     private static StringBuilder destroyedLocBar(int orig) {
         String destroyedChar = GUIP.getUnitToolTipArmorMiniDestoryedChar();
         return locBar(orig, orig, destroyedChar, true);
     }
 
-    /** 
+    /**
      * Used for intact locations.
      * Returns a string representing armor or internal structure of the location.
-     * The location has the given orig original Armor/IS. 
+     * The location has the given orig original Armor/IS.
      */
     private static StringBuilder intactLocBar(int orig, int curr, String dChar) {
         return locBar(orig, curr, dChar, false);
     }
-    
-    /** 
+
+    /**
      * Returns a string representing armor or internal structure of one location.
      * The location has the given orig original Armor/IS and the given curr current
      * Armor/IS. The character dChar will be repeated at appropriate colors depending
-     * on the value of curr, orig and the static visUnit which gives the amount of 
-     * Armor/IS per single character. 
+     * on the value of curr, orig and the static visUnit which gives the amount of
+     * Armor/IS per single character.
      */
     private static StringBuilder locBar(int orig, int curr, String dChar, boolean destroyed) {
         // Internal Structure can be zero, e.g. in Aero
@@ -367,12 +367,12 @@ public final class UnitToolTip {
         Color colorPartialDmg = GUIP.getColor(GUIPreferences.UNIT_TOOLTIP_ARMORMINI_COLOR_PARTIAL_DMG);
         Color colorDamaged = GUIP.getColor(GUIPreferences.UNIT_TOOLTIP_ARMORMINI_COLOR_DAMAGED);
         int visUnit = GUIP.getInt(GUIPreferences.UNIT_TOOLTIP_ARMORMINI_UNITS_PER_BLOCK);
-        
+
         if (destroyed) {
             colorIntact = colorDamaged;
             colorPartialDmg = colorDamaged;
         }
-        
+
         int numPartial = ((curr != orig) && (curr % visUnit) > 0) ? 1 : 0;
         int numIntact = (curr - 1) / visUnit + 1 - numPartial;
         int numDmgd = (orig - 1) / visUnit + 1 - numPartial - numIntact;
@@ -382,7 +382,7 @@ public final class UnitToolTip {
             numIntact = 0;
             numDmgd = (orig - 1) / visUnit + 1;
         }
-        
+
         if (numIntact > 0) {
             if (numIntact > 15 && numIntact + numDmgd > 30) {
                 int tensIntact = (numIntact - 1) / 10;
@@ -441,7 +441,7 @@ public final class UnitToolTip {
         }
         return new StringBuilder().append(result);
     }
-    
+
     private static class WeaponInfo {
         String name;
         String sortString;
@@ -453,18 +453,18 @@ public final class UnitToolTip {
         HashMap<String, Integer> ammos = new HashMap<>();
         int ammoActiveWeaponCount;
     }
-    
-    /** 
-     * Returns true if the weapontype should be excluded from the Tooltip. 
-     * This is true for C3 computers (only Masters are weapons) and 
+
+    /**
+     * Returns true if the weapontype should be excluded from the Tooltip.
+     * This is true for C3 computers (only Masters are weapons) and
      * special Infantry attacks (Swarm Attacks and the like).
-     */ 
+     */
     private static boolean isNotTTRelevant(WeaponType wtype) {
         return wtype.hasFlag(WeaponType.F_C3M) || wtype.hasFlag(WeaponType.F_C3MBS)
                 || wtype instanceof LegAttack || wtype instanceof SwarmAttack
                 || wtype instanceof StopSwarmAttack || wtype instanceof SwarmWeaponAttack;
     }
-    
+
     private static final String RAPIDFIRE = "|RF|";
     private static final String CLANWP = "|CL|";
 
@@ -480,6 +480,12 @@ public final class UnitToolTip {
                 continue;
             }
             String weapDesc = curWp.getDesc();
+
+            // location info is only useful units with more than one location
+            if (entity.locations() > 1) {
+                weapDesc += " ["+entity.getLocationAbbr(curWp.getLocation()) + ']';
+            }
+
             // Distinguish equal weapons with and without rapid fire
             if (isRapidFireActive(entity.getGame()) && curWp.isRapidfire() && !curWp.isDestroyed()) {
                 weapDesc += RAPIDFIRE;
@@ -502,7 +508,7 @@ public final class UnitToolTip {
                 if (!curWp.isDestroyed() && wpInfos.containsKey(curWp.getName() + msg_ammo)) {
                     WeaponInfo currAmmo = wpInfos.get(curWp.getName() + msg_ammo);
                     currAmmo.ammoActiveWeaponCount++;
-                } 
+                }
             } else {
                 currentWp = new WeaponInfo();
                 currentWp.name = weapDesc;
@@ -544,8 +550,8 @@ public final class UnitToolTip {
                 currentWp.isClan = wpT.isClan();
                 wpInfos.put(weapDesc, currentWp);
 
-                // Add ammo info if the weapon has ammo 
-                // Check wpInfos for dual entries to avoid displaying ammo twice for non/rapid-fire  
+                // Add ammo info if the weapon has ammo
+                // Check wpInfos for dual entries to avoid displaying ammo twice for non/rapid-fire
                 if ((wtype.getAmmoType() != AmmoType.T_NA)
                         && (!wtype.hasFlag(WeaponType.F_ONESHOT) || wtype.hasFlag(WeaponType.F_BA_INDIVIDUAL))
                         && (wtype.getAmmoType() != AmmoType.T_INFANTRY)) {
@@ -594,13 +600,13 @@ public final class UnitToolTip {
                 }
             }
         }
-        
+
         // Print to Tooltip
         String col1 = "";
         String col2 = "";
         String row = "";
         String rows = "";
-        boolean subsequentLine = false; 
+        boolean subsequentLine = false;
         // Display sorted by weapon name
         var wps = new ArrayList<>(wpInfos.values());
         wps.sort(Comparator.comparing(w -> w.sortString));
@@ -749,7 +755,7 @@ public final class UnitToolTip {
         }
         return "";
     }
-    
+
     /** Returns the ammo line(s) for the ammo of one weapon type. */
     private static StringBuilder createAmmoEntry(WeaponInfo ammoInfo) {
         String col1 = "";
@@ -777,13 +783,13 @@ public final class UnitToolTip {
                 col1 = "";
                 col2 = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;";
                 String msg_shots = Messages.getString("BoardView1.Tooltip.Shots");
-                if (ammoInfo.ammoActiveWeaponCount > 1) { 
+                if (ammoInfo.ammoActiveWeaponCount > 1) {
                     // Remaining ammo and multiple weapons using it
                     col2 += ammoName;
                     String msg_turns = Messages.getString("BoardView1.Tooltip.Turns");
                     col2 += ammo.getValue() / ammoInfo.ammoActiveWeaponCount + " " + msg_turns;
                     col2 += " (" + ammo.getValue() + " " + msg_shots + ")";
-                } else { 
+                } else {
                     // Remaining ammo and only one weapon using it
                     col2 += ammoName + ammo.getValue() + " " + msg_shots;
                 }
@@ -822,7 +828,7 @@ public final class UnitToolTip {
         Game game = entity.getGame();
         boolean isGunEmplacement = entity instanceof GunEmplacement;
         String result = "";
-        
+
         // BV Info
         // Hidden for invisible units when in double blind and hide enemy bv is selected
         // Also not shown in the lobby as BV is shown there outside the tooltip
@@ -970,7 +976,7 @@ public final class UnitToolTip {
 
         // Gun Emplacement Status
         if (isGunEmplacement) {
-            GunEmplacement emp = (GunEmplacement) entity; 
+            GunEmplacement emp = (GunEmplacement) entity;
             if (emp.isTurret() && emp.isTurretLocked(emp.getLocTurret())) {
                 String sTurretLocked = addToTT("TurretLocked", BR).toString();
                 sTurretLocked = "<I>" + sTurretLocked + "</I>";
@@ -1062,7 +1068,7 @@ public final class UnitToolTip {
                 tempList.delete(tempList.length() - 2, tempList.length());
                 String sSeenBy = addToTT("SeenBy", BR, tempList.toString()).toString();
                 result += guiScaledFontHTML() + sSeenBy + "</FONT>";
-            }            
+            }
         }
 
         // If sensors, display what sensors this unit is using
@@ -1075,7 +1081,7 @@ public final class UnitToolTip {
             String sNarced = addToTT(entity.hasNarcPodsAttached() ? "Narced" : "INarced", BR).toString();
             result += guiScaledFontHTML(uiLightRed()) + sNarced + "</FONT>";
         }
-        
+
         // Towing
         if (!entity.getAllTowedUnits().isEmpty()) {
             String unitList = entity.getAllTowedUnits().stream()
@@ -1092,7 +1098,7 @@ public final class UnitToolTip {
 
         return new StringBuilder().append(result);
     }
-    
+
     /** Returns unit values that are relevant in-game and in the lobby such as movement ability. */
     private static StringBuilder entityValues(Entity entity) {
         boolean isGunEmplacement = entity instanceof GunEmplacement;
@@ -1279,7 +1285,7 @@ public final class UnitToolTip {
                 l2 = "<Li style=\"list-style-type: none; list-style-image: none; margin: 0; padding: 0;\">" + jj + "</Li>";
             }
         }
-        
+
         // Infantry specialization like SCUBA
         if (entity instanceof Infantry) {
             Infantry inf = (Infantry) entity;
@@ -1309,7 +1315,7 @@ public final class UnitToolTip {
 
         return new StringBuilder().append(result);
     }
-    
+
     /** Returns warnings about problems that should be solved before deploying. */
     private static StringBuilder deploymentWarnings(Entity entity, Player localPlayer,
                                                     MapSettings mapSettings) {
@@ -1342,7 +1348,7 @@ public final class UnitToolTip {
             String msg_unconnectedc3computer = Messages.getString("BoardView1.Tooltip.UnconnectedC3Computer");
             sNoncritial += "<BR>" + msg_unconnectedc3computer;
         }
-        
+
         // Non-critical (yellow) warnings
         if (entity instanceof FighterSquadron && entity.getLoadedUnits().isEmpty()) {
             String msg_fightersquadronempty = Messages.getString("BoardView1.Tooltip.FighterSquadronEmpty");
@@ -1353,7 +1359,7 @@ public final class UnitToolTip {
 
         return new StringBuilder().append(result);
     }
-    
+
     /** Returns a list of units loaded onto this unit. */
     private static StringBuilder carriedUnits(Entity entity) {
         String result = "";
@@ -1402,7 +1408,7 @@ public final class UnitToolTip {
 
         return new StringBuilder().append(result);
     }
-    
+
     /** Returns an overview of the C3 system the unit is in. */
     private static StringBuilder c3Info(Entity entity) {
         String result = "";
@@ -1457,7 +1463,7 @@ public final class UnitToolTip {
 
         return result;
     }
-    
+
     /** Helper method to shorten repetitive calls. */
     private static StringBuilder addToTT(String tipName, boolean startBR, Object... ttO) {
         StringBuilder result = new StringBuilder();
@@ -1471,12 +1477,12 @@ public final class UnitToolTip {
         }
         return result;
     }
-    
+
     /** Returns true when Hot-Loading LRMs is on. */
     static boolean isHotLoadActive(Game game) {
         return game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HOTLOAD);
     }
-    
+
     /** Returns true when Hot-Loading LRMs is on. */
     static boolean isRapidFireActive(Game game) {
         return game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_BURST);


### PR DESCRIPTION
This adds the weapon location to the tooltips. I find this very useful info to know. Without this change,  I had to select and view a unit in the UnitDisplay.
![weaponlocations](https://user-images.githubusercontent.com/1423800/233751865-3841ce96-56d4-49d7-803e-53d712b55541.png)

This is optional, and can be toggle in the client settings UI:
![Capture](https://user-images.githubusercontent.com/1423800/233797164-30243972-b4df-4e63-98c4-adedb0f1d7a7.PNG)
