### PR TITLE
MTF Files: fix system model fluff entries

### DIFF
--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) A.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) A.mtf
@@ -162,12 +162,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
-
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) B.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) B.mtf
@@ -162,12 +162,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
-
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) C.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) C.mtf
@@ -162,12 +162,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
-
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) D.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) D.mtf
@@ -163,11 +163,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) E.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) E.mtf
@@ -165,11 +165,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) H.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) H.mtf
@@ -160,11 +160,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) J.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) J.mtf
@@ -163,11 +163,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/3050U/Puma (Adder) Prime.mtf
+++ b/megamek/data/mechfiles/mechs/3050U/Puma (Adder) Prime.mtf
@@ -161,8 +161,11 @@ manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech 
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 notes:Codenamed Puma by Inner Sphere forces who first engaged it.
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
 systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
+systemmode:COMMUNICATIONS:945B
 systemmanufacturer:TARGETING:Adder Special
-
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/RS Succession Wars/Thunderbolt TDR-5D.mtf
+++ b/megamek/data/mechfiles/mechs/RS Succession Wars/Thunderbolt TDR-5D.mtf
@@ -150,11 +150,10 @@ Heat Sink
 manufacturer:Earthwerks Incorporated
 primaryFactory:Keystone
 systemmanufacturer:CHASSIS:Earthwerks
-systemmodel:CHASSIS:TDR Standard
+systemmode:CHASSIS:TDR Standard
 systemmanufacturer:ENGINE:Magna
-systemmodel:ENGINE:260
+systemmode:ENGINE:260
 systemmanufacturer:COMMUNICATIONS:Neil
-systemmodel:COMMUNICATIONS:8000
+systemmode:COMMUNICATIONS:8000
 systemmanufacturer:TARGETING:RCA
-systemmodel:TARGETING:Instatrac Mark X
-
+systemmode:TARGETING:Instatrac Mark X

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) I.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) I.mtf
@@ -166,11 +166,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) K.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) K.mtf
@@ -161,11 +161,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) L.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) L.mtf
@@ -164,11 +164,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) S.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) S.mtf
@@ -178,11 +178,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) T.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 3/Puma (Adder) T.mtf
@@ -160,12 +160,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
-
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6

--- a/megamek/data/mechfiles/mechs/Tukayyid/Puma (Adder) TC.mtf
+++ b/megamek/data/mechfiles/mechs/Tukayyid/Puma (Adder) TC.mtf
@@ -171,12 +171,11 @@ history:The Adder was designed by Clan Star Adder in preparation for the invasio
 manufacturer:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 primaryfactory:Sheridan LM-TA 8-10, W-7 Facilities,Wolf Clan Site 3, Assault Tech Industries
 systemmanufacturer:CHASSIS:Hooded Endo-Lite
-systemmodel:CHASSIS:Endo Steel
+systemmode:CHASSIS:Endo Steel
 systemmanufacturer:ENGINE:Great Father 210 XL
-systemmanufacturer:ARMOR:Star Lite 
-systemmodel:ARMOR:Ferro-Fibrous
+systemmanufacturer:ARMOR:Star Lite
+systemmode:ARMOR:Ferro-Fibrous
 systemmanufacturer:COMMUNICATIONS:Trueborn Ultra
-systemmodel:COMMUNICATIONS:945B
-systemmanufacturer:TARGETING:Adder Special 
-systemmodel:TARGETING:V8.6
-
+systemmode:COMMUNICATIONS:945B
+systemmanufacturer:TARGETING:Adder Special
+systemmode:TARGETING:V8.6


### PR DESCRIPTION
Several MTF files specify system model fluff using 'systemmodel:' entries.

However, the MtfFile loader expects 'systemmode:' for these entries instead: 
https://github.com/MegaMek/megamek/blob/c7dad145036c6a54cf39fe785af2924574b07bb4/megamek/src/megamek/common/loaders/MtfFile.java#L116

so these entries are ignored.

The PR replaces 'systemmodel:' with 'systemmode:'. I also added the system model info to the Puma Prime config.

Note: Probably a copy & paste error, since 13 of the 14 affected files are Puma alt configs.