### PR TITLE
detailed unit counts

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -958,8 +958,8 @@
 7016=<data>:
 7017=<data> / <data> BV remaining (<data>%), <data> BV fled.
 7018=<data> / <data> units remaining (<data>%).
-7019=units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> fled, <data> crew ejected, <data> crew trapped, <data> crew killed
-7020=ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
+7019=Units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> fled, <data> crew ejected, <data> crew trapped, <data> crew killed
+7020=Ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
 7023=<newline>Survivors are:
 7025=<data> (<data>)
 7030=Pilot :

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -955,7 +955,7 @@
 7005=A strange game. The only winning move is not to play.<newline>
 7010=Winner is: <data><newline>
 7015=Winner is: TEAM #<data><newline>
-7016=<data>: <data> / <data> BV remaining (<data>%), <data> BV fled. <data> / <data> units remaining (<data>%).
+7016=  <data>: <data> / <data> BV remaining (<data>%), <data> BV fled.  <data> / <data> units remaining (<data>%).  <data> units fled, <data> ejected crew, <data> ejected crew fled
 7020=<newline>Survivors are:
 7025=<data> (<data>)
 7030=Pilot :

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -957,7 +957,7 @@
 7015=Winner is: TEAM #<data><newline>
 7016=  <data>: \n&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <data> / <data> BV remaining (<data>%), <data> BV fled.\n&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <data> / <data> units remaining (<data>%).
 7017=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> crew ejected, <data> fled
-7018=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp ejected crew: <data> active, <data> killed, <data> fled
+7018=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
 7020=<newline>Survivors are:
 7025=<data> (<data>)
 7030=Pilot :

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -958,7 +958,7 @@
 7016=<data>:
 7017=<data> / <data> BV remaining (<data>%), <data> BV fled.
 7018=<data> / <data> units remaining (<data>%).
-7019=units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> crew ejected, <data> fled
+7019=units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> fled, <data> crew ejected, <data> crew killed
 7020=ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
 7023=<newline>Survivors are:
 7025=<data> (<data>)

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -958,7 +958,7 @@
 7016=<data>:
 7017=<data> / <data> BV remaining (<data>%), <data> BV fled.
 7018=<data> / <data> units remaining (<data>%).
-7019=units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> fled, <data> crew ejected, <data> crew killed
+7019=units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> fled, <data> crew ejected, <data> crew trapped, <data> crew killed
 7020=ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
 7023=<newline>Survivors are:
 7025=<data> (<data>)

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -955,10 +955,12 @@
 7005=A strange game. The only winning move is not to play.<newline>
 7010=Winner is: <data><newline>
 7015=Winner is: TEAM #<data><newline>
-7016=  <data>: \n&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <data> / <data> BV remaining (<data>%), <data> BV fled.\n&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <data> / <data> units remaining (<data>%).
-7017=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> crew ejected, <data> fled
-7018=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
-7020=<newline>Survivors are:
+7016=<data>:
+7017=<data> / <data> BV remaining (<data>%), <data> BV fled.
+7018=<data> / <data> units remaining (<data>%).
+7019=units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> crew ejected, <data> fled
+7020=ejected crew: <data> active, <data> picked up by team, <data> picked up by enemy team, <data> killed, <data> fled
+7023=<newline>Survivors are:
 7025=<data> (<data>)
 7030=Pilot :
 7035=Driver :

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -955,7 +955,9 @@
 7005=A strange game. The only winning move is not to play.<newline>
 7010=Winner is: <data><newline>
 7015=Winner is: TEAM #<data><newline>
-7016=  <data>: <data> / <data> BV remaining (<data>%), <data> BV fled.  <data> / <data> units remaining (<data>%).  <data> units fled, <data> ejected crew, <data> ejected crew fled
+7016=  <data>: \n&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <data> / <data> BV remaining (<data>%), <data> BV fled.\n&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp <data> / <data> units remaining (<data>%).
+7017=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp units: <data> light damage, <data> moderate damage, <data> heavy damage, <data> crippled, <data> destroyed, <data> crew ejected, <data> fled
+7018=&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp ejected crew: <data> active, <data> killed, <data> fled
 7020=<newline>Survivors are:
 7025=<data> (<data>)
 7030=Pilot :

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1857,6 +1857,25 @@ public class Game extends AbstractGame implements Serializable {
     }
 
     /**
+     * Get the entities for the player.
+     *
+     * @param player - the <code>Player</code> whose entities are required.
+     * @return a <code>Vector</code> of <code>Entity that have retreaded</code>s.
+     */
+    public ArrayList<Entity> getPlayerRetreatedEntities(Player player) {
+        ArrayList<Entity> output = new ArrayList<>();
+        for (Entity entity : vOutOfGame) {
+            if (player.equals(entity.getOwner()) &&
+                    ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_IN_RETREAT)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_CAPTURED)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_PUSHED))) {
+                output.add(entity);
+            }
+        }
+        return output;
+    }
+
+    /**
      * Determines if the indicated entity is stranded on a transport that can't move.
      * <p>
      * According to

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -502,6 +502,11 @@ public final class Player extends TurnOrdered {
                 .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
     }
 
+    public int getUnitCrewTrappedCount() {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> this.equals(entity.getOwner()) && entity.isDestroyed() && !entity.getCrew().isDead() && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
+    }
+
     public int getUnitCrewKilledCount() {
         return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
                 .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isDead() && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -504,7 +504,7 @@ public final class Player extends TurnOrdered {
 
     public int getUnitCrewKilledCount() {
         return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isDead() && !(entity instanceof EjectedCrew)).count());
+                .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isDead() && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
     }
 
     public int getEjectedCrewCount() {

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -467,6 +467,16 @@ public final class Player extends TurnOrdered {
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped()).count());
     }
 
+    public int getEntityCountExcludingEjectedCrew() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getCountEjectedCrewCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity instanceof EjectedCrew)).count());
+    }
+
     public int getInitialEntityCount() {
         return initialEntityCount;
     }
@@ -505,6 +515,32 @@ public final class Player extends TurnOrdered {
             }
         }
         return bv;
+    }
+
+    public int getFledEntityExcludeEjectedCrew() {
+        //TODO: I'm not sure how squadrons are treated here - see getBV()
+        Enumeration<Entity> fledUnits = game.getRetreatedEntities();
+        int count = 0;
+        while (fledUnits.hasMoreElements()) {
+            Entity entity = fledUnits.nextElement();
+            if (entity.getOwner().equals(this) && !(entity instanceof EjectedCrew)) {
+                count += 1;
+            }
+        }
+        return count;
+    }
+
+    public int getFledEjectedCrew() {
+        //TODO: I'm not sure how squadrons are treated here - see getBV()
+        Enumeration<Entity> fledUnits = game.getRetreatedEntities();
+        int count = 0;
+        while (fledUnits.hasMoreElements()) {
+            Entity entity = fledUnits.nextElement();
+            if (entity.getOwner().equals(this) && (entity instanceof EjectedCrew)) {
+                count += 1;
+            }
+        }
+        return count;
     }
 
     public int getInitialBV() {

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -472,24 +472,9 @@ public final class Player extends TurnOrdered {
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && !(entity instanceof EjectedCrew)).count());
     }
 
-    public int getUnitLightDamageCount() {
+    public int getUnitDamageCount(int damageLevel) {
         return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_LIGHT) && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitModerateDamageCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_MODERATE) && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitHeavyDamageCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_HEAVY) && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitCrippledCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_CRIPPLED) && !(entity instanceof EjectedCrew)).count());
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == damageLevel) && !(entity instanceof EjectedCrew)).count());
     }
 
     public int getUnitDestroyedCount() {
@@ -565,41 +550,23 @@ public final class Player extends TurnOrdered {
      */
     public int getFledBV() {
         //TODO: I'm not sure how squadrons are treated here - see getBV()
-        Enumeration<Entity> fledUnits = game.getRetreatedEntities();
-        int bv = 0;
-        while (fledUnits.hasMoreElements()) {
-            Entity entity = fledUnits.nextElement();
-            if (entity.getOwner().equals(this)) {
-                bv += entity.calculateBattleValue();
-            }
-        }
-        return bv;
+        return game.getPlayerRetreatedEntities(this).stream()
+                .filter(entity -> !entity.isDestroyed())
+                .mapToInt(Entity::calculateBattleValue).sum();
     }
 
     public int getFledUnitsCount() {
         //TODO: I'm not sure how squadrons are treated here - see getBV()
-        Enumeration<Entity> fledUnits = game.getRetreatedEntities();
-        int count = 0;
-        while (fledUnits.hasMoreElements()) {
-            Entity entity = fledUnits.nextElement();
-            if (entity.getOwner().equals(this) && !entity.isDestroyed() && !(entity instanceof EjectedCrew)) {
-                count += 1;
-            }
-        }
-        return count;
+        return Math.toIntExact(game.getPlayerRetreatedEntities(this).stream()
+                .filter(entity -> !entity.isDestroyed() && !(entity instanceof EjectedCrew))
+                .mapToInt(Entity::calculateBattleValue).count());
     }
 
     public int getFledEjectedCrew() {
         //TODO: I'm not sure how squadrons are treated here - see getBV()
-        Enumeration<Entity> fledUnits = game.getRetreatedEntities();
-        int count = 0;
-        while (fledUnits.hasMoreElements()) {
-            Entity entity = fledUnits.nextElement();
-            if (entity.getOwner().equals(this) && !entity.isDestroyed() && (entity instanceof EjectedCrew)) {
-                count += 1;
-            }
-        }
-        return count;
+        return Math.toIntExact(game.getPlayerRetreatedEntities(this).stream()
+                .filter(entity -> !entity.isDestroyed() && (entity instanceof EjectedCrew))
+                .mapToInt(Entity::calculateBattleValue).count());
     }
 
     public int getInitialBV() {

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -504,7 +504,21 @@ public final class Player extends TurnOrdered {
 
     public int getEjectedCrewCount() {
         return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity instanceof EjectedCrew)).count());
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
+                        (((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() == Entity.NONE) ||
+                                ((entity instanceof EjectedCrew) && !(entity instanceof MechWarrior)))).count());
+    }
+
+    public int getEjectedCrewPickedUpByTeamCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
+                        ((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() != Entity.NONE && game.getEntity(((MechWarrior) entity).getPickedUpById()).getOwner().getTeam() == this.getTeam())).count());
+    }
+
+    public int getEjectedCrewPickedUpByEnemyTeamCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
+                        ((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() != Entity.NONE && game.getEntity(((MechWarrior) entity).getPickedUpById()).getOwner().getTeam() != this.getTeam())).count());
     }
 
     public int getEjectedCrewKilledCount() {

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -467,14 +467,49 @@ public final class Player extends TurnOrdered {
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped()).count());
     }
 
-    public int getEntityCountExcludingEjectedCrew() {
+    public int getUnitCount() {
         return Math.toIntExact(game.getPlayerEntities(this, false).stream()
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && !(entity instanceof EjectedCrew)).count());
     }
 
-    public int getCountEjectedCrewCount() {
+    public int getUnitLightDamageCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_LIGHT) && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getUnitModerateDamageCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_MODERATE) && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getUnitHeavyDamageCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_HEAVY) && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getEUnitCrippledCount() {
+        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_CRIPPLED) && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getUnitDestroyedCount() {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> this.equals(entity.getOwner()) && entity.isDestroyed() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getUnitCrewEjectedCount() {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public int getEjectedCrewCount() {
         return Math.toIntExact(game.getPlayerEntities(this, false).stream()
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity instanceof EjectedCrew)).count());
+    }
+
+    public int getEjectedCrewKilledCount() {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> entity.isDestroyed() && (entity instanceof EjectedCrew)).count());
     }
 
     public int getInitialEntityCount() {
@@ -517,7 +552,7 @@ public final class Player extends TurnOrdered {
         return bv;
     }
 
-    public int getFledEntityExcludeEjectedCrew() {
+    public int getFledUnitsCount() {
         //TODO: I'm not sure how squadrons are treated here - see getBV()
         Enumeration<Entity> fledUnits = game.getRetreatedEntities();
         int count = 0;

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -487,7 +487,7 @@ public final class Player extends TurnOrdered {
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_HEAVY) && !(entity instanceof EjectedCrew)).count());
     }
 
-    public int getEUnitCrippledCount() {
+    public int getUnitCrippledCount() {
         return Math.toIntExact(game.getPlayerEntities(this, false).stream()
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == Entity.DMG_CRIPPLED) && !(entity instanceof EjectedCrew)).count());
     }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -533,7 +533,7 @@ public final class Player extends TurnOrdered {
 
     public int getEjectedCrewKilledCount() {
         return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> entity.isDestroyed() && (entity instanceof EjectedCrew)).count());
+                .filter(entity -> entity.getOwner().equals(this) && entity.isDestroyed() && (entity instanceof EjectedCrew)).count());
     }
 
     public int getInitialEntityCount() {
@@ -582,7 +582,7 @@ public final class Player extends TurnOrdered {
         int count = 0;
         while (fledUnits.hasMoreElements()) {
             Entity entity = fledUnits.nextElement();
-            if (entity.getOwner().equals(this) && !(entity instanceof EjectedCrew)) {
+            if (entity.getOwner().equals(this) && !entity.isDestroyed() && !(entity instanceof EjectedCrew)) {
                 count += 1;
             }
         }
@@ -595,7 +595,7 @@ public final class Player extends TurnOrdered {
         int count = 0;
         while (fledUnits.hasMoreElements()) {
             Entity entity = fledUnits.nextElement();
-            if (entity.getOwner().equals(this) && (entity instanceof EjectedCrew)) {
+            if (entity.getOwner().equals(this) && !entity.isDestroyed() && (entity instanceof EjectedCrew)) {
                 count += 1;
             }
         }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -502,6 +502,11 @@ public final class Player extends TurnOrdered {
                 .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
     }
 
+    public int getUnitCrewKilledCount() {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isDead() && !(entity instanceof EjectedCrew)).count());
+    }
+
     public int getEjectedCrewCount() {
         return Math.toIntExact(game.getPlayerEntities(this, false).stream()
                 .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1587,21 +1587,35 @@ public class GameManager implements IGameManager {
         int bv;
         int initialBV;
         int fledBV;
-        int entityCount;
-        int initialEntityCount;
-        int fledEntityCount;
-        int ejectedCrew;
-        int fledEjectedCrewCount;
+        int unitCount;
+        int unitsInitialCount;
+        int unitsLightDamageCount;
+        int unitsModerateDamageCount;
+        int unitsHeavyDamageCount;
+        int unitsCrippledCount;
+        int unitsDestoryedCount;
+        int unitsCrewEjectedCount;
+        int unitsFledCount;
+        int ejectedCrewActiveCount;
+        int ejectedCrewKilledCount;
+        int ejectedCrewFledCount;
 
         public TeamHelper() {
             this.bv = bv;
             this.initialBV = 0;
             this.fledBV = 0;
-            this.entityCount = 0;
-            this.initialEntityCount = 0;
-            this.fledEntityCount = 0;
-            this.ejectedCrew = 0;
-            this.fledEjectedCrewCount = 0;
+            this.unitCount = 0;
+            this.unitsInitialCount = 0;
+            this.unitsLightDamageCount = 0;
+            this.unitsModerateDamageCount = 0;
+            this.unitsHeavyDamageCount = 0;
+            this.unitsCrippledCount = 0;
+            this.unitsDestoryedCount = 0;
+            this.unitsCrewEjectedCount = 0;
+            this.unitsFledCount = 0;
+            this.ejectedCrewActiveCount = 0;
+            this.ejectedCrewKilledCount = 0;
+            this.ejectedCrewFledCount = 0;
         }
     }
 
@@ -1630,38 +1644,72 @@ public class GameManager implements IGameManager {
             int bv = player.getBV();
             int initialBV = player.getInitialBV();
             int fledBV = player.getFledBV();
-            int entityCount = player.getEntityCountExcludingEjectedCrew();
-            int initialEntityCount = player.getInitialEntityCount();
-            int fledEntityCount = player.getFledEntityExcludeEjectedCrew();
-            int ejectedCrewCount = player.getCountEjectedCrewCount();
-            int fledEjectedCrewCount = player.getFledEjectedCrew();
+            int unitsCount = player.getUnitCount();
+            int initialUnitsCount = player.getInitialEntityCount();
+            int unitsLightDamageCount = player.getUnitLightDamageCount();
+            int unitsModerateDamageCount = player.getUnitModerateDamageCount();
+            int unitsHeavyDamageCount = player.getUnitHeavyDamageCount();
+            int unitsCrippledCount = player.getEUnitCrippledCount();
+            int unitsDestroyedCount = player.getUnitDestroyedCount();
+            int unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
+            int unitsFledCount = player.getFledUnitsCount();
+            int ejectedCrewActiveCount = player.getEjectedCrewCount();
+            int ejectedCrewKilledCount = player.getEjectedCrewKilledCount();
+            int ejectedCrewFledCount = player.getFledEjectedCrew();
 
             r.add(player.getColorForPlayer());
             r.add(bv);
             r.add(initialBV);
             r.add(Double.toString(Math.round(((double) bv /initialBV) * 10000.0) / 100.0));
             r.add(fledBV);
-            r.add(entityCount);
-            r.add(initialEntityCount);
-            r.add(Double.toString(Math.round(((double) entityCount / initialEntityCount) * 10000.0) / 100.0));
-            r.add(fledEntityCount);
-            r.add(ejectedCrewCount);
-            r.add(fledEjectedCrewCount);
+            r.add(unitsCount);
+            r.add(initialUnitsCount);
+            r.add(Double.toString(Math.round(((double) unitsCount / initialUnitsCount) * 10000.0) / 100.0));
             addReport(r);
+
+            r = new Report(7017, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = player.getId();
+            }
+            r.add(unitsLightDamageCount);
+            r.add(unitsModerateDamageCount);
+            r.add(unitsHeavyDamageCount);
+            r.add(unitsCrippledCount);
+            r.add(unitsDestroyedCount);
+            r.add(unitsCrewEjectedCount);
+            r.add(unitsFledCount);
+            addReport(r);
+
+            r = new Report(7018, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = player.getId();
+            }
+            r.add(ejectedCrewActiveCount);
+            r.add(ejectedCrewKilledCount);
+            r.add(ejectedCrewFledCount);
+            addReport(r);
+
+            // blank line
+            addReport(new Report(1210, Report.PUBLIC));
 
             TeamHelper th = teamsInfo.get(player.getTeam());
             th.bv += bv;
             th.initialBV += initialBV;
             th.fledBV += fledBV;
-            th.entityCount += entityCount;
-            th.initialEntityCount += initialEntityCount;
-            th.fledEntityCount += fledEntityCount;
-            th.ejectedCrew += ejectedCrewCount;
-            th.fledEjectedCrewCount += fledEjectedCrewCount;
+            th.unitCount += unitsCount;
+            th.unitsInitialCount += initialUnitsCount;
+            th.unitsLightDamageCount += unitsLightDamageCount;
+            th.unitsModerateDamageCount += unitsModerateDamageCount;
+            th.unitsHeavyDamageCount += unitsHeavyDamageCount;
+            th.unitsCrippledCount += unitsCrippledCount;
+            th.unitsDestoryedCount += unitsDestroyedCount;
+            th.unitsCrewEjectedCount += unitsCrewEjectedCount;
+            th.unitsFledCount += unitsFledCount;
+            th.ejectedCrewActiveCount += ejectedCrewActiveCount;
+            th.ejectedCrewFledCount += ejectedCrewFledCount;
         }
-
-        // blank line
-        addReport(new Report(1210, Report.PUBLIC));
 
         // Show teams BVs
         for (Map.Entry<Integer, TeamHelper> e : teamsInfo.entrySet()) {
@@ -1672,17 +1720,30 @@ public class GameManager implements IGameManager {
             r.add(th.initialBV);
             r.add(Double.toString(Math.round(((double) th.bv / th.initialBV) * 10000.0) / 100.0));
             r.add(th.fledBV);
-            r.add(th.entityCount);
-            r.add(th.initialEntityCount);
-            r.add(Double.toString(Math.round(((double) th.entityCount / th.initialEntityCount) * 10000.0) / 100.0));
-            r.add(th.fledEntityCount);
-            r.add(th.ejectedCrew);
-            r.add(th.fledEjectedCrewCount);
+            r.add(th.unitCount);
+            r.add(th.unitsInitialCount);
+            r.add(Double.toString(Math.round(((double) th.unitCount / th.unitsInitialCount) * 10000.0) / 100.0));
             addReport(r);
-        }
 
-        // blank line
-        addReport(new Report(1210, Report.PUBLIC));
+            r = new Report(7017, Report.PUBLIC);
+            r.add(th.unitsLightDamageCount);
+            r.add(th.unitsModerateDamageCount);
+            r.add(th.unitsHeavyDamageCount);
+            r.add(th.unitsCrippledCount);
+            r.add(th.unitsDestoryedCount);
+            r.add(th.unitsCrewEjectedCount);
+            r.add(th.unitsFledCount);
+            addReport(r);
+
+            r = new Report(7018, Report.PUBLIC);
+            r.add(th.ejectedCrewActiveCount);
+            r.add(th.ejectedCrewKilledCount);
+            r.add(th.ejectedCrewFledCount);
+            addReport(r);
+
+            // blank line
+            addReport(new Report(1210, Report.PUBLIC));
+        }
     }
 
     /**

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1595,6 +1595,7 @@ public class GameManager implements IGameManager {
         int unitsCrippledCount;
         int unitsDestroyedCount;
         int unitsCrewEjectedCount;
+        int unitsCrewKilledCount;
         int unitsFledCount;
         int ejectedCrewActiveCount;
         int ejectedCrewPickedUpByTeamCount;
@@ -1614,6 +1615,7 @@ public class GameManager implements IGameManager {
             this.unitsCrippledCount = 0;
             this.unitsDestroyedCount = 0;
             this.unitsCrewEjectedCount = 0;
+            this.unitsCrewKilledCount = 0;
             this.unitsFledCount = 0;
             this.ejectedCrewActiveCount = 0;
             this.ejectedCrewPickedUpByTeamCount = 0;
@@ -1652,6 +1654,7 @@ public class GameManager implements IGameManager {
             bvcPlayer.unitsCrippledCount = player.getUnitCrippledCount();
             bvcPlayer.unitsDestroyedCount =  player.getUnitDestroyedCount();
             bvcPlayer.unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
+            bvcPlayer.unitsCrewKilledCount = player.getUnitCrewKilledCount();
             bvcPlayer.unitsFledCount = player.getFledUnitsCount();
             bvcPlayer.ejectedCrewActiveCount = player.getEjectedCrewCount();
             bvcPlayer.ejectedCrewPickedUpByTeamCount =  player.getEjectedCrewPickedUpByTeamCount();
@@ -1673,6 +1676,7 @@ public class GameManager implements IGameManager {
             bvcTeam.unitsCrippledCount += bvcPlayer.unitsCrippledCount;
             bvcTeam.unitsDestroyedCount += bvcPlayer.unitsDestroyedCount;
             bvcTeam.unitsCrewEjectedCount += bvcPlayer.unitsCrewEjectedCount;
+            bvcTeam.unitsCrewKilledCount += bvcPlayer.unitsCrewKilledCount;
             bvcTeam.unitsFledCount += bvcPlayer.unitsFledCount;
             bvcTeam.ejectedCrewActiveCount += bvcPlayer.ejectedCrewActiveCount;
             bvcTeam.ejectedCrewPickedUpByTeamCount += bvcPlayer.ejectedCrewPickedUpByTeamCount;
@@ -1725,8 +1729,9 @@ public class GameManager implements IGameManager {
         r.add(bvc.unitsHeavyDamageCount);
         r.add(bvc.unitsCrippledCount);
         r.add(bvc.unitsDestroyedCount);
-        r.add(bvc.unitsCrewEjectedCount);
         r.add(bvc.unitsFledCount);
+        r.add(bvc.unitsCrewEjectedCount);;
+        r.add(bvc.unitsCrewKilledCount);
         r.indent(2);
         addReport(r);
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1650,10 +1650,10 @@ public class GameManager implements IGameManager {
             bvcPlayer.bvFled = player.getFledBV();
             bvcPlayer.unitsCount = player.getUnitCount();
             bvcPlayer.unitsInitialCount = player.getInitialEntityCount();
-            bvcPlayer.unitsLightDamageCount = player.getUnitLightDamageCount();
-            bvcPlayer.unitsModerateDamageCount = player.getUnitModerateDamageCount();
-            bvcPlayer.unitsHeavyDamageCount = player.getUnitHeavyDamageCount();
-            bvcPlayer.unitsCrippledCount = player.getUnitCrippledCount();
+            bvcPlayer.unitsLightDamageCount = player.getUnitDamageCount(Entity.DMG_LIGHT);
+            bvcPlayer.unitsModerateDamageCount = player.getUnitDamageCount(Entity.DMG_MODERATE);
+            bvcPlayer.unitsHeavyDamageCount = player.getUnitDamageCount(Entity.DMG_HEAVY);
+            bvcPlayer.unitsCrippledCount = player.getUnitDamageCount(Entity.DMG_CRIPPLED);
             bvcPlayer.unitsDestroyedCount =  player.getUnitDestroyedCount();
             bvcPlayer.unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
             bvcPlayer.unitsCrewTrappedCount = player.getUnitCrewTrappedCount();

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1690,9 +1690,11 @@ public class GameManager implements IGameManager {
         }
 
         // Show teams BVs
-        for (Map.Entry<Integer, BVCountHelper> e : teamsInfo.entrySet()) {
-            BVCountHelper bvc = e.getValue();
-            bvReport(Player.TEAM_NAMES[e.getKey()], Player.PLAYER_NONE, bvc, false);
+        if (!(checkBlind && doBlind() && suppressBlindBV())) {
+            for (Map.Entry<Integer, BVCountHelper> e : teamsInfo.entrySet()) {
+                BVCountHelper bvc = e.getValue();
+                bvReport(Player.TEAM_NAMES[e.getKey()], Player.PLAYER_NONE, bvc, false);
+            }
         }
     }
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1194,7 +1194,7 @@ public class GameManager implements IGameManager {
         // List the survivors
         Iterator<Entity> survivors = game.getEntities();
         if (survivors.hasNext()) {
-            addReport(new Report(7020, Report.PUBLIC));
+            addReport(new Report(7023, Report.PUBLIC));
             while (survivors.hasNext()) {
                 Entity entity = survivors.next();
 
@@ -1639,11 +1639,6 @@ public class GameManager implements IGameManager {
             if (player.isObserver() && (player.getInitialEntityCount() == 0)) {
                 continue;
             }
-            Report r = new Report(7016, Report.PUBLIC);
-            if (checkBlind && doBlind() && suppressBlindBV()) {
-                r.type = Report.PLAYER;
-                r.player = player.getId();
-            }
 
             int bv = player.getBV();
             int initialBV = player.getInitialBV();
@@ -1663,17 +1658,38 @@ public class GameManager implements IGameManager {
             int ejectedCrewKilledCount = player.getEjectedCrewKilledCount();
             int ejectedCrewFledCount = player.getFledEjectedCrew();
 
+            Report r = new Report(7016, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = player.getId();
+            }
             r.add(player.getColorForPlayer());
+            addReport(r);
+
+            r = new Report(7017, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = player.getId();
+            }
             r.add(bv);
             r.add(initialBV);
             r.add(Double.toString(Math.round(((double) bv /initialBV) * 10000.0) / 100.0));
             r.add(fledBV);
+            r.indent(2);
+            addReport(r);
+
+            r = new Report(7018, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = player.getId();
+            }
             r.add(unitsCount);
             r.add(initialUnitsCount);
             r.add(Double.toString(Math.round(((double) unitsCount / initialUnitsCount) * 10000.0) / 100.0));
+            r.indent(2);
             addReport(r);
 
-            r = new Report(7017, Report.PUBLIC);
+            r = new Report(7019, Report.PUBLIC);
             if (checkBlind && doBlind() && suppressBlindBV()) {
                 r.type = Report.PLAYER;
                 r.player = player.getId();
@@ -1685,9 +1701,10 @@ public class GameManager implements IGameManager {
             r.add(unitsDestroyedCount);
             r.add(unitsCrewEjectedCount);
             r.add(unitsFledCount);
+            r.indent(2);
             addReport(r);
 
-            r = new Report(7018, Report.PUBLIC);
+            r = new Report(7020, Report.PUBLIC);
             if (checkBlind && doBlind() && suppressBlindBV()) {
                 r.type = Report.PLAYER;
                 r.player = player.getId();
@@ -1697,6 +1714,7 @@ public class GameManager implements IGameManager {
             r.add(ejectedCrewPickedUpByEnemyTeamCount);
             r.add(ejectedCrewKilledCount);
             r.add(ejectedCrewFledCount);
+            r.indent(2);
             addReport(r);
 
             // blank line
@@ -1724,18 +1742,27 @@ public class GameManager implements IGameManager {
         // Show teams BVs
         for (Map.Entry<Integer, TeamHelper> e : teamsInfo.entrySet()) {
             TeamHelper th = e.getValue();
+
             Report r = new Report(7016, Report.PUBLIC);
             r.add(Player.TEAM_NAMES[e.getKey()]);
+            addReport(r);
+
+            r = new Report(7017, Report.PUBLIC);
             r.add(th.bv);
             r.add(th.initialBV);
             r.add(Double.toString(Math.round(((double) th.bv / th.initialBV) * 10000.0) / 100.0));
             r.add(th.fledBV);
+            r.indent(2);
+            addReport(r);
+
+            r = new Report(7018, Report.PUBLIC);
             r.add(th.unitCount);
             r.add(th.unitsInitialCount);
             r.add(Double.toString(Math.round(((double) th.unitCount / th.unitsInitialCount) * 10000.0) / 100.0));
+            r.indent(2);
             addReport(r);
 
-            r = new Report(7017, Report.PUBLIC);
+            r = new Report(7019, Report.PUBLIC);
             r.add(th.unitsLightDamageCount);
             r.add(th.unitsModerateDamageCount);
             r.add(th.unitsHeavyDamageCount);
@@ -1743,14 +1770,16 @@ public class GameManager implements IGameManager {
             r.add(th.unitsDestoryedCount);
             r.add(th.unitsCrewEjectedCount);
             r.add(th.unitsFledCount);
+            r.indent(2);
             addReport(r);
 
-            r = new Report(7018, Report.PUBLIC);
+            r = new Report(7020, Report.PUBLIC);
             r.add(th.ejectedCrewActiveCount);
             r.add(th.ejectedCrewPickedUpByTeamCount);
             r.add(th.ejectedCrewPickedUpByEnemyTeamCount);
             r.add(th.ejectedCrewKilledCount);
             r.add(th.ejectedCrewFledCount);
+            r.indent(2);
             addReport(r);
 
             // blank line

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1624,7 +1624,7 @@ public class GameManager implements IGameManager {
             this.ejectedCrewFledCount = 0;
         }
     }
-
+    
     private void bvReports(boolean checkBlind) {
         HashMap<Integer, BVCountHelper> teamsInfo = new HashMap<>();
 
@@ -1719,34 +1719,40 @@ public class GameManager implements IGameManager {
         r.indent(2);
         addReport(r);
 
-        r = new Report(7019, Report.PUBLIC);
-        if (checkBlind && doBlind() && suppressBlindBV()) {
-            r.type = Report.PLAYER;
-            r.player = playerID;
+        if (bvc.unitsLightDamageCount + bvc.unitsModerateDamageCount + bvc.unitsHeavyDamageCount +
+                bvc.unitsCrippledCount + bvc.unitsDestroyedCount + bvc.unitsFledCount + bvc.unitsCrewEjectedCount +
+                bvc.unitsCrewKilledCount > 0) {
+            r = new Report(7019, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = playerID;
+            }
+            r.add(bvc.unitsLightDamageCount > 0 ? r.warning(bvc.unitsLightDamageCount + "") : bvc.unitsLightDamageCount + "");
+            r.add(bvc.unitsModerateDamageCount > 0 ? r.warning(bvc.unitsModerateDamageCount + "") : bvc.unitsModerateDamageCount + "");
+            r.add(bvc.unitsHeavyDamageCount > 0 ? r.warning(bvc.unitsHeavyDamageCount + "") : bvc.unitsHeavyDamageCount + "");
+            r.add(bvc.unitsCrippledCount > 0 ? r.warning(bvc.unitsCrippledCount + "") : bvc.unitsCrippledCount + "");
+            r.add(bvc.unitsDestroyedCount > 0 ? r.warning(bvc.unitsDestroyedCount + "") : bvc.unitsDestroyedCount + "");
+            r.add(bvc.unitsFledCount > 0 ? r.warning(bvc.unitsFledCount + "") : bvc.unitsFledCount + "");
+            r.add(bvc.unitsCrewEjectedCount > 0 ? r.warning(bvc.unitsCrewEjectedCount + "") : bvc.unitsCrewEjectedCount + "");
+            r.add(bvc.unitsCrewKilledCount > 0 ? r.warning(bvc.unitsCrewKilledCount + "") : bvc.unitsCrewKilledCount + "");
+            r.indent(2);
+            addReport(r);
         }
-        r.add(bvc.unitsLightDamageCount);
-        r.add(bvc.unitsModerateDamageCount);
-        r.add(bvc.unitsHeavyDamageCount);
-        r.add(bvc.unitsCrippledCount);
-        r.add(bvc.unitsDestroyedCount);
-        r.add(bvc.unitsFledCount);
-        r.add(bvc.unitsCrewEjectedCount);;
-        r.add(bvc.unitsCrewKilledCount);
-        r.indent(2);
-        addReport(r);
 
-        r = new Report(7020, Report.PUBLIC);
-        if (checkBlind && doBlind() && suppressBlindBV()) {
-            r.type = Report.PLAYER;
-            r.player = playerID;
+        if (bvc.unitsCrewEjectedCount > 0) {
+            r = new Report(7020, Report.PUBLIC);
+            if (checkBlind && doBlind() && suppressBlindBV()) {
+                r.type = Report.PLAYER;
+                r.player = playerID;
+            }
+            r.add(bvc.ejectedCrewActiveCount > 0 ? r.warning(bvc.ejectedCrewActiveCount + "") : bvc.ejectedCrewActiveCount + "");
+            r.add(bvc.ejectedCrewPickedUpByTeamCount > 0 ? r.warning(bvc.ejectedCrewPickedUpByTeamCount + "") : bvc.ejectedCrewPickedUpByTeamCount + "");
+            r.add(bvc.ejectedCrewPickedUpByEnemyTeamCount > 0 ? r.warning(bvc.ejectedCrewPickedUpByEnemyTeamCount + "") : bvc.ejectedCrewPickedUpByEnemyTeamCount + "");
+            r.add(bvc.ejectedCrewKilledCount > 0 ? r.warning(bvc.ejectedCrewKilledCount + "") : bvc.ejectedCrewKilledCount + "");
+            r.add(bvc.ejectedCrewFledCount > 0 ? r.warning(bvc.ejectedCrewFledCount + "") : bvc.ejectedCrewFledCount + "");
+            r.indent(2);
+            addReport(r);
         }
-        r.add(bvc.ejectedCrewActiveCount);
-        r.add(bvc.ejectedCrewPickedUpByTeamCount);
-        r.add(bvc.ejectedCrewPickedUpByEnemyTeamCount);
-        r.add(bvc.ejectedCrewKilledCount);
-        r.add(bvc.ejectedCrewFledCount);
-        r.indent(2);
-        addReport(r);
 
         // blank line
         addReport(new Report(1210, Report.PUBLIC));

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1189,7 +1189,7 @@ public class GameManager implements IGameManager {
         }
         addReport(r);
 
-        bvReport(false);
+        bvReports(false);
 
         // List the survivors
         Iterator<Entity> survivors = game.getEntities();
@@ -1583,17 +1583,17 @@ public class GameManager implements IGameManager {
         }
     }
 
-    private static class TeamHelper {
+    private static class BVCountHelper {
         int bv;
-        int initialBV;
-        int fledBV;
-        int unitCount;
+        int bvInitial;
+        int bvFled;
+        int unitsCount;
         int unitsInitialCount;
         int unitsLightDamageCount;
         int unitsModerateDamageCount;
         int unitsHeavyDamageCount;
         int unitsCrippledCount;
-        int unitsDestoryedCount;
+        int unitsDestroyedCount;
         int unitsCrewEjectedCount;
         int unitsFledCount;
         int ejectedCrewActiveCount;
@@ -1602,17 +1602,17 @@ public class GameManager implements IGameManager {
         int ejectedCrewKilledCount;
         int ejectedCrewFledCount;
 
-        public TeamHelper() {
-            this.bv = bv;
-            this.initialBV = 0;
-            this.fledBV = 0;
-            this.unitCount = 0;
+        public BVCountHelper() {
+            this.bv = 0;
+            this.bvInitial = 0;
+            this.bvFled = 0;
+            this.unitsCount = 0;
             this.unitsInitialCount = 0;
             this.unitsLightDamageCount = 0;
             this.unitsModerateDamageCount = 0;
             this.unitsHeavyDamageCount = 0;
             this.unitsCrippledCount = 0;
-            this.unitsDestoryedCount = 0;
+            this.unitsDestroyedCount = 0;
             this.unitsCrewEjectedCount = 0;
             this.unitsFledCount = 0;
             this.ejectedCrewActiveCount = 0;
@@ -1623,11 +1623,11 @@ public class GameManager implements IGameManager {
         }
     }
 
-    private void bvReport(boolean checkBlind) {
-        HashMap<Integer, TeamHelper> teamsInfo = new HashMap<>();
+    private void bvReports(boolean checkBlind) {
+        HashMap<Integer, BVCountHelper> teamsInfo = new HashMap<>();
 
         for (Team team : game.getTeams()) {
-            teamsInfo.put(team.getId(), new TeamHelper());
+            teamsInfo.put(team.getId(), new BVCountHelper());
         }
 
         // blank line
@@ -1640,151 +1640,111 @@ public class GameManager implements IGameManager {
                 continue;
             }
 
-            int bv = player.getBV();
-            int initialBV = player.getInitialBV();
-            int fledBV = player.getFledBV();
-            int unitsCount = player.getUnitCount();
-            int initialUnitsCount = player.getInitialEntityCount();
-            int unitsLightDamageCount = player.getUnitLightDamageCount();
-            int unitsModerateDamageCount = player.getUnitModerateDamageCount();
-            int unitsHeavyDamageCount = player.getUnitHeavyDamageCount();
-            int unitsCrippledCount = player.getEUnitCrippledCount();
-            int unitsDestroyedCount = player.getUnitDestroyedCount();
-            int unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
-            int unitsFledCount = player.getFledUnitsCount();
-            int ejectedCrewActiveCount = player.getEjectedCrewCount();
-            int ejectedCrewPickedUpByTeamCount = player.getEjectedCrewPickedUpByTeamCount();
-            int ejectedCrewPickedUpByEnemyTeamCount = player.getEjectedCrewPickedUpByEnemyTeamCount();
-            int ejectedCrewKilledCount = player.getEjectedCrewKilledCount();
-            int ejectedCrewFledCount = player.getFledEjectedCrew();
+            BVCountHelper bvcPlayer = new BVCountHelper();
+            bvcPlayer.bv = player.getBV();
+            bvcPlayer.bvInitial = player.getInitialBV();
+            bvcPlayer.bvFled = player.getFledBV();
+            bvcPlayer.unitsCount = player.getUnitCount();
+            bvcPlayer.unitsInitialCount = player.getInitialEntityCount();
+            bvcPlayer.unitsLightDamageCount = player.getUnitLightDamageCount();
+            bvcPlayer.unitsModerateDamageCount = player.getUnitModerateDamageCount();
+            bvcPlayer.unitsHeavyDamageCount = player.getUnitHeavyDamageCount();
+            bvcPlayer.unitsCrippledCount = player.getUnitCrippledCount();
+            bvcPlayer.unitsDestroyedCount =  player.getUnitDestroyedCount();
+            bvcPlayer.unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
+            bvcPlayer.unitsFledCount = player.getFledUnitsCount();
+            bvcPlayer.ejectedCrewActiveCount = player.getEjectedCrewCount();
+            bvcPlayer.ejectedCrewPickedUpByTeamCount =  player.getEjectedCrewPickedUpByTeamCount();
+            bvcPlayer.ejectedCrewPickedUpByEnemyTeamCount = player.getEjectedCrewPickedUpByEnemyTeamCount();
+            bvcPlayer.ejectedCrewKilledCount = player.getEjectedCrewKilledCount();
+            bvcPlayer.ejectedCrewFledCount = player.getFledEjectedCrew();
 
-            Report r = new Report(7016, Report.PUBLIC);
-            if (checkBlind && doBlind() && suppressBlindBV()) {
-                r.type = Report.PLAYER;
-                r.player = player.getId();
-            }
-            r.add(player.getColorForPlayer());
-            addReport(r);
+            bvReport(player.getColorForPlayer(), player.getId(), bvcPlayer, checkBlind);
 
-            r = new Report(7017, Report.PUBLIC);
-            if (checkBlind && doBlind() && suppressBlindBV()) {
-                r.type = Report.PLAYER;
-                r.player = player.getId();
-            }
-            r.add(bv);
-            r.add(initialBV);
-            r.add(Double.toString(Math.round(((double) bv /initialBV) * 10000.0) / 100.0));
-            r.add(fledBV);
-            r.indent(2);
-            addReport(r);
-
-            r = new Report(7018, Report.PUBLIC);
-            if (checkBlind && doBlind() && suppressBlindBV()) {
-                r.type = Report.PLAYER;
-                r.player = player.getId();
-            }
-            r.add(unitsCount);
-            r.add(initialUnitsCount);
-            r.add(Double.toString(Math.round(((double) unitsCount / initialUnitsCount) * 10000.0) / 100.0));
-            r.indent(2);
-            addReport(r);
-
-            r = new Report(7019, Report.PUBLIC);
-            if (checkBlind && doBlind() && suppressBlindBV()) {
-                r.type = Report.PLAYER;
-                r.player = player.getId();
-            }
-            r.add(unitsLightDamageCount);
-            r.add(unitsModerateDamageCount);
-            r.add(unitsHeavyDamageCount);
-            r.add(unitsCrippledCount);
-            r.add(unitsDestroyedCount);
-            r.add(unitsCrewEjectedCount);
-            r.add(unitsFledCount);
-            r.indent(2);
-            addReport(r);
-
-            r = new Report(7020, Report.PUBLIC);
-            if (checkBlind && doBlind() && suppressBlindBV()) {
-                r.type = Report.PLAYER;
-                r.player = player.getId();
-            }
-            r.add(ejectedCrewActiveCount);
-            r.add(ejectedCrewPickedUpByTeamCount);
-            r.add(ejectedCrewPickedUpByEnemyTeamCount);
-            r.add(ejectedCrewKilledCount);
-            r.add(ejectedCrewFledCount);
-            r.indent(2);
-            addReport(r);
-
-            // blank line
-            addReport(new Report(1210, Report.PUBLIC));
-
-            TeamHelper th = teamsInfo.get(player.getTeam());
-            th.bv += bv;
-            th.initialBV += initialBV;
-            th.fledBV += fledBV;
-            th.unitCount += unitsCount;
-            th.unitsInitialCount += initialUnitsCount;
-            th.unitsLightDamageCount += unitsLightDamageCount;
-            th.unitsModerateDamageCount += unitsModerateDamageCount;
-            th.unitsHeavyDamageCount += unitsHeavyDamageCount;
-            th.unitsCrippledCount += unitsCrippledCount;
-            th.unitsDestoryedCount += unitsDestroyedCount;
-            th.unitsCrewEjectedCount += unitsCrewEjectedCount;
-            th.unitsFledCount += unitsFledCount;
-            th.ejectedCrewActiveCount += ejectedCrewActiveCount;
-            th.ejectedCrewPickedUpByTeamCount += ejectedCrewPickedUpByTeamCount;
-            th.ejectedCrewPickedUpByEnemyTeamCount += ejectedCrewPickedUpByEnemyTeamCount;
-            th.ejectedCrewFledCount += ejectedCrewFledCount;
+            BVCountHelper bvcTeam = teamsInfo.get(player.getTeam());
+            bvcTeam.bv += bvcPlayer.bv;
+            bvcTeam.bvInitial += bvcPlayer.bvInitial;
+            bvcTeam.bvFled += bvcPlayer.bvFled;
+            bvcTeam.unitsCount += bvcPlayer.unitsCount;
+            bvcTeam.unitsInitialCount += bvcPlayer.unitsInitialCount;
+            bvcTeam.unitsLightDamageCount += bvcPlayer.unitsLightDamageCount;
+            bvcTeam.unitsModerateDamageCount += bvcPlayer.unitsModerateDamageCount;
+            bvcTeam.unitsHeavyDamageCount += bvcPlayer.unitsHeavyDamageCount;
+            bvcTeam.unitsCrippledCount += bvcPlayer.unitsCrippledCount;
+            bvcTeam.unitsDestroyedCount += bvcPlayer.unitsDestroyedCount;
+            bvcTeam.unitsCrewEjectedCount += bvcPlayer.unitsCrewEjectedCount;
+            bvcTeam.unitsFledCount += bvcPlayer.unitsFledCount;
+            bvcTeam.ejectedCrewActiveCount += bvcPlayer.ejectedCrewActiveCount;
+            bvcTeam.ejectedCrewPickedUpByTeamCount += bvcPlayer.ejectedCrewPickedUpByTeamCount;
+            bvcTeam.ejectedCrewPickedUpByEnemyTeamCount += bvcPlayer.ejectedCrewPickedUpByEnemyTeamCount;
+            bvcTeam.ejectedCrewKilledCount += bvcPlayer.ejectedCrewKilledCount;
+            bvcTeam.ejectedCrewFledCount += bvcPlayer.ejectedCrewFledCount;
         }
 
         // Show teams BVs
-        for (Map.Entry<Integer, TeamHelper> e : teamsInfo.entrySet()) {
-            TeamHelper th = e.getValue();
-
-            Report r = new Report(7016, Report.PUBLIC);
-            r.add(Player.TEAM_NAMES[e.getKey()]);
-            addReport(r);
-
-            r = new Report(7017, Report.PUBLIC);
-            r.add(th.bv);
-            r.add(th.initialBV);
-            r.add(Double.toString(Math.round(((double) th.bv / th.initialBV) * 10000.0) / 100.0));
-            r.add(th.fledBV);
-            r.indent(2);
-            addReport(r);
-
-            r = new Report(7018, Report.PUBLIC);
-            r.add(th.unitCount);
-            r.add(th.unitsInitialCount);
-            r.add(Double.toString(Math.round(((double) th.unitCount / th.unitsInitialCount) * 10000.0) / 100.0));
-            r.indent(2);
-            addReport(r);
-
-            r = new Report(7019, Report.PUBLIC);
-            r.add(th.unitsLightDamageCount);
-            r.add(th.unitsModerateDamageCount);
-            r.add(th.unitsHeavyDamageCount);
-            r.add(th.unitsCrippledCount);
-            r.add(th.unitsDestoryedCount);
-            r.add(th.unitsCrewEjectedCount);
-            r.add(th.unitsFledCount);
-            r.indent(2);
-            addReport(r);
-
-            r = new Report(7020, Report.PUBLIC);
-            r.add(th.ejectedCrewActiveCount);
-            r.add(th.ejectedCrewPickedUpByTeamCount);
-            r.add(th.ejectedCrewPickedUpByEnemyTeamCount);
-            r.add(th.ejectedCrewKilledCount);
-            r.add(th.ejectedCrewFledCount);
-            r.indent(2);
-            addReport(r);
-
-            // blank line
-            addReport(new Report(1210, Report.PUBLIC));
+        for (Map.Entry<Integer, BVCountHelper> e : teamsInfo.entrySet()) {
+            BVCountHelper bvc = e.getValue();
+            bvReport(Player.TEAM_NAMES[e.getKey()], Player.PLAYER_NONE, bvc, false);
         }
+    }
+
+    private void bvReport(String name, int playerID, BVCountHelper bvc, boolean checkBlind) {
+        Report r = new Report(7016, Report.PUBLIC);
+        r.add(name);
+        addReport(r);
+
+        r = new Report(7017, Report.PUBLIC);
+        if (checkBlind && doBlind() && suppressBlindBV()) {
+            r.type = Report.PLAYER;
+            r.player = playerID;
+        }
+        r.add(bvc.bv);
+        r.add(bvc.bvInitial);
+        r.add(Double.toString(Math.round(((double) bvc.bv / bvc.bvInitial) * 10000.0) / 100.0));
+        r.add(bvc.bvFled);
+        r.indent(2);
+        addReport(r);
+
+        r = new Report(7018, Report.PUBLIC);
+        if (checkBlind && doBlind() && suppressBlindBV()) {
+            r.type = Report.PLAYER;
+        }
+        r.add(bvc.unitsCount);
+        r.add(bvc.unitsInitialCount);
+        r.add(Double.toString(Math.round(((double) bvc.unitsCount / bvc.unitsInitialCount) * 10000.0) / 100.0));
+        r.indent(2);
+        addReport(r);
+
+        r = new Report(7019, Report.PUBLIC);
+        if (checkBlind && doBlind() && suppressBlindBV()) {
+            r.type = Report.PLAYER;
+            r.player = playerID;
+        }
+        r.add(bvc.unitsLightDamageCount);
+        r.add(bvc.unitsModerateDamageCount);
+        r.add(bvc.unitsHeavyDamageCount);
+        r.add(bvc.unitsCrippledCount);
+        r.add(bvc.unitsDestroyedCount);
+        r.add(bvc.unitsCrewEjectedCount);
+        r.add(bvc.unitsFledCount);
+        r.indent(2);
+        addReport(r);
+
+        r = new Report(7020, Report.PUBLIC);
+        if (checkBlind && doBlind() && suppressBlindBV()) {
+            r.type = Report.PLAYER;
+            r.player = playerID;
+        }
+        r.add(bvc.ejectedCrewActiveCount);
+        r.add(bvc.ejectedCrewPickedUpByTeamCount);
+        r.add(bvc.ejectedCrewPickedUpByEnemyTeamCount);
+        r.add(bvc.ejectedCrewKilledCount);
+        r.add(bvc.ejectedCrewFledCount);
+        r.indent(2);
+        addReport(r);
+
+        // blank line
+        addReport(new Report(1210, Report.PUBLIC));
     }
 
     /**
@@ -1987,7 +1947,7 @@ public class GameManager implements IGameManager {
             case INITIATIVE_REPORT: {
                 autoSave();
 
-                bvReport(true);
+                bvReports(true);
             }
             case TARGETING_REPORT:
             case MOVEMENT_REPORT:

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1595,6 +1595,7 @@ public class GameManager implements IGameManager {
         int unitsCrippledCount;
         int unitsDestroyedCount;
         int unitsCrewEjectedCount;
+        int unitsCrewTrappedCount;
         int unitsCrewKilledCount;
         int unitsFledCount;
         int ejectedCrewActiveCount;
@@ -1615,6 +1616,7 @@ public class GameManager implements IGameManager {
             this.unitsCrippledCount = 0;
             this.unitsDestroyedCount = 0;
             this.unitsCrewEjectedCount = 0;
+            this.unitsCrewTrappedCount = 0;
             this.unitsCrewKilledCount = 0;
             this.unitsFledCount = 0;
             this.ejectedCrewActiveCount = 0;
@@ -1624,7 +1626,7 @@ public class GameManager implements IGameManager {
             this.ejectedCrewFledCount = 0;
         }
     }
-    
+
     private void bvReports(boolean checkBlind) {
         HashMap<Integer, BVCountHelper> teamsInfo = new HashMap<>();
 
@@ -1654,6 +1656,7 @@ public class GameManager implements IGameManager {
             bvcPlayer.unitsCrippledCount = player.getUnitCrippledCount();
             bvcPlayer.unitsDestroyedCount =  player.getUnitDestroyedCount();
             bvcPlayer.unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
+            bvcPlayer.unitsCrewTrappedCount = player.getUnitCrewTrappedCount();
             bvcPlayer.unitsCrewKilledCount = player.getUnitCrewKilledCount();
             bvcPlayer.unitsFledCount = player.getFledUnitsCount();
             bvcPlayer.ejectedCrewActiveCount = player.getEjectedCrewCount();
@@ -1676,6 +1679,7 @@ public class GameManager implements IGameManager {
             bvcTeam.unitsCrippledCount += bvcPlayer.unitsCrippledCount;
             bvcTeam.unitsDestroyedCount += bvcPlayer.unitsDestroyedCount;
             bvcTeam.unitsCrewEjectedCount += bvcPlayer.unitsCrewEjectedCount;
+            bvcTeam.unitsCrewTrappedCount += bvcPlayer.unitsCrewTrappedCount;
             bvcTeam.unitsCrewKilledCount += bvcPlayer.unitsCrewKilledCount;
             bvcTeam.unitsFledCount += bvcPlayer.unitsFledCount;
             bvcTeam.ejectedCrewActiveCount += bvcPlayer.ejectedCrewActiveCount;
@@ -1734,6 +1738,7 @@ public class GameManager implements IGameManager {
             r.add(bvc.unitsDestroyedCount > 0 ? r.warning(bvc.unitsDestroyedCount + "") : bvc.unitsDestroyedCount + "");
             r.add(bvc.unitsFledCount > 0 ? r.warning(bvc.unitsFledCount + "") : bvc.unitsFledCount + "");
             r.add(bvc.unitsCrewEjectedCount > 0 ? r.warning(bvc.unitsCrewEjectedCount + "") : bvc.unitsCrewEjectedCount + "");
+            r.add(bvc.unitsCrewTrappedCount > 0 ? r.warning(bvc.unitsCrewTrappedCount + "") : bvc.unitsCrewTrappedCount + "");
             r.add(bvc.unitsCrewKilledCount > 0 ? r.warning(bvc.unitsCrewKilledCount + "") : bvc.unitsCrewKilledCount + "");
             r.indent(2);
             addReport(r);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1589,13 +1589,19 @@ public class GameManager implements IGameManager {
         int fledBV;
         int entityCount;
         int initialEntityCount;
+        int fledEntityCount;
+        int ejectedCrew;
+        int fledEjectedCrewCount;
 
-        public TeamHelper(int bv, int initialBV, int fledBV, int entityCount, int initialEntityCount) {
+        public TeamHelper() {
             this.bv = bv;
-            this.initialBV = initialBV;
-            this.fledBV = fledBV;
-            this.entityCount = entityCount;
-            this.initialEntityCount = initialEntityCount;
+            this.initialBV = 0;
+            this.fledBV = 0;
+            this.entityCount = 0;
+            this.initialEntityCount = 0;
+            this.fledEntityCount = 0;
+            this.ejectedCrew = 0;
+            this.fledEjectedCrewCount = 0;
         }
     }
 
@@ -1603,7 +1609,7 @@ public class GameManager implements IGameManager {
         HashMap<Integer, TeamHelper> teamsInfo = new HashMap<>();
 
         for (Team team : game.getTeams()) {
-            teamsInfo.put(team.getId(), new TeamHelper(0, 0, 0, 0, 0));
+            teamsInfo.put(team.getId(), new TeamHelper());
         }
 
         // blank line
@@ -1620,22 +1626,38 @@ public class GameManager implements IGameManager {
                 r.type = Report.PLAYER;
                 r.player = player.getId();
             }
+
+            int bv = player.getBV();
+            int initialBV = player.getInitialBV();
+            int fledBV = player.getFledBV();
+            int entityCount = player.getEntityCountExcludingEjectedCrew();
+            int initialEntityCount = player.getInitialEntityCount();
+            int fledEntityCount = player.getFledEntityExcludeEjectedCrew();
+            int ejectedCrewCount = player.getCountEjectedCrewCount();
+            int fledEjectedCrewCount = player.getFledEjectedCrew();
+
             r.add(player.getColorForPlayer());
-            r.add(player.getBV());
-            r.add(player.getInitialBV());
-            r.add(Double.toString(Math.round(((double) player.getBV() / player.getInitialBV()) * 10000.0) / 100.0));
-            r.add(player.getFledBV());
-            r.add(player.getEntityCount());
-            r.add(player.getInitialEntityCount());
-            r.add(Double.toString(Math.round(((double) player.getEntityCount() / player.getInitialEntityCount()) * 10000.0) / 100.0));
+            r.add(bv);
+            r.add(initialBV);
+            r.add(Double.toString(Math.round(((double) bv /initialBV) * 10000.0) / 100.0));
+            r.add(fledBV);
+            r.add(entityCount);
+            r.add(initialEntityCount);
+            r.add(Double.toString(Math.round(((double) entityCount / initialEntityCount) * 10000.0) / 100.0));
+            r.add(fledEntityCount);
+            r.add(ejectedCrewCount);
+            r.add(fledEjectedCrewCount);
             addReport(r);
 
             TeamHelper th = teamsInfo.get(player.getTeam());
-            th.bv += player.getBV();
-            th.initialBV += player.getInitialBV();
-            th.fledBV += player.getFledBV();
-            th.entityCount += player.getEntityCount();
-            th.initialEntityCount += player.getInitialEntityCount();
+            th.bv += bv;
+            th.initialBV += initialBV;
+            th.fledBV += fledBV;
+            th.entityCount += entityCount;
+            th.initialEntityCount += initialEntityCount;
+            th.fledEntityCount += fledEntityCount;
+            th.ejectedCrew += ejectedCrewCount;
+            th.fledEjectedCrewCount += fledEjectedCrewCount;
         }
 
         // blank line
@@ -1653,6 +1675,9 @@ public class GameManager implements IGameManager {
             r.add(th.entityCount);
             r.add(th.initialEntityCount);
             r.add(Double.toString(Math.round(((double) th.entityCount / th.initialEntityCount) * 10000.0) / 100.0));
+            r.add(th.fledEntityCount);
+            r.add(th.ejectedCrew);
+            r.add(th.fledEjectedCrewCount);
             addReport(r);
         }
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1716,6 +1716,7 @@ public class GameManager implements IGameManager {
         r = new Report(7018, Report.PUBLIC);
         if (checkBlind && doBlind() && suppressBlindBV()) {
             r.type = Report.PLAYER;
+            r.player = playerID;
         }
         r.add(bvc.unitsCount);
         r.add(bvc.unitsInitialCount);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1597,6 +1597,8 @@ public class GameManager implements IGameManager {
         int unitsCrewEjectedCount;
         int unitsFledCount;
         int ejectedCrewActiveCount;
+        int ejectedCrewPickedUpByTeamCount;
+        int ejectedCrewPickedUpByEnemyTeamCount;
         int ejectedCrewKilledCount;
         int ejectedCrewFledCount;
 
@@ -1614,6 +1616,8 @@ public class GameManager implements IGameManager {
             this.unitsCrewEjectedCount = 0;
             this.unitsFledCount = 0;
             this.ejectedCrewActiveCount = 0;
+            this.ejectedCrewPickedUpByTeamCount = 0;
+            this.ejectedCrewPickedUpByEnemyTeamCount = 0;
             this.ejectedCrewKilledCount = 0;
             this.ejectedCrewFledCount = 0;
         }
@@ -1654,6 +1658,8 @@ public class GameManager implements IGameManager {
             int unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
             int unitsFledCount = player.getFledUnitsCount();
             int ejectedCrewActiveCount = player.getEjectedCrewCount();
+            int ejectedCrewPickedUpByTeamCount = player.getEjectedCrewPickedUpByTeamCount();
+            int ejectedCrewPickedUpByEnemyTeamCount = player.getEjectedCrewPickedUpByEnemyTeamCount();
             int ejectedCrewKilledCount = player.getEjectedCrewKilledCount();
             int ejectedCrewFledCount = player.getFledEjectedCrew();
 
@@ -1687,6 +1693,8 @@ public class GameManager implements IGameManager {
                 r.player = player.getId();
             }
             r.add(ejectedCrewActiveCount);
+            r.add(ejectedCrewPickedUpByTeamCount);
+            r.add(ejectedCrewPickedUpByEnemyTeamCount);
             r.add(ejectedCrewKilledCount);
             r.add(ejectedCrewFledCount);
             addReport(r);
@@ -1708,6 +1716,8 @@ public class GameManager implements IGameManager {
             th.unitsCrewEjectedCount += unitsCrewEjectedCount;
             th.unitsFledCount += unitsFledCount;
             th.ejectedCrewActiveCount += ejectedCrewActiveCount;
+            th.ejectedCrewPickedUpByTeamCount += ejectedCrewPickedUpByTeamCount;
+            th.ejectedCrewPickedUpByEnemyTeamCount += ejectedCrewPickedUpByEnemyTeamCount;
             th.ejectedCrewFledCount += ejectedCrewFledCount;
         }
 
@@ -1737,6 +1747,8 @@ public class GameManager implements IGameManager {
 
             r = new Report(7018, Report.PUBLIC);
             r.add(th.ejectedCrewActiveCount);
+            r.add(th.ejectedCrewPickedUpByTeamCount);
+            r.add(th.ejectedCrewPickedUpByEnemyTeamCount);
             r.add(th.ejectedCrewKilledCount);
             r.add(th.ejectedCrewFledCount);
             addReport(r);


### PR DESCRIPTION
- "units remaining" only count units, exclude ejected crew in the count and percentage
- display counts for units : light damage, moderate damage, heavy damage, crippled, destroyed, fled, crew ejected, crew trapped, and crew killed
- display counts for ejected crew: active, picked up by team, picked up by enemy team, killed, and fled

![image](https://user-images.githubusercontent.com/116095479/235310061-e359db7e-ed8f-44ae-8d7b-ca35d925473c.png)


