### PR TITLE
MTF Files: various chassis fixes

### DIFF
--- a/megamek/data/mechfiles/mechs/3055U/Prometheus.mtf
+++ b/megamek/data/mechfiles/mechs/3055U/Prometheus.mtf
@@ -4,14 +4,14 @@ Prometheus
 mul id:4871
 
 Config:Biped
-TechBase:Mixed (Clan Chassis)
+TechBase:Mixed (IS Chassis)
 Era:3053
 Source:Unbound - Clan Invasion
 Rules Level:4
 
 Mass:75
 Engine:375 XL Fusion Engine (Inner Sphere)
-Structure:Endo-Steel
+Structure:Clan Endo Steel
 Cockpit:Torso-Mounted Cockpit
 Myomer:Standard
 
@@ -121,22 +121,22 @@ Head:
 Sensors
 Sensors
 CLMG Ammo (100)
-Endo-Steel
-Endo-Steel
-Endo-Steel
+Clan Endo Steel
+Clan Endo Steel
+Clan Endo Steel
 
 Left Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
 Foot Actuator
-Endo-Steel
-Endo-Steel
+Clan Endo Steel
+Clan Endo Steel
 
 Right Leg:
 Hip
 Upper Leg Actuator
 Lower Leg Actuator
 Foot Actuator
-Endo-Steel
-Endo-Steel
+Clan Endo Steel
+Clan Endo Steel

--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Cougar X 2.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Cougar X 2.mtf
@@ -4,7 +4,7 @@ X 2
 mul id:6952
 
 Config:Biped
-TechBase:Mixed (IS Chassis)
+TechBase:Mixed (Clan Chassis)
 Era:3089
 Source:RS 3145 NT NU
 Rules Level:3
@@ -86,8 +86,8 @@ Clan Improved Jump Jet
 Clan Improved Jump Jet
 Clan Improved Jump Jet
 Clan Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
 Clan Ferro-Fibrous
 Clan Ferro-Fibrous
 

--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Cougar X 3.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Cougar X 3.mtf
@@ -4,7 +4,7 @@ X 3
 mul id:6953
 
 Config:Biped
-TechBase:Mixed (IS Chassis)
+TechBase:Mixed (Clan Chassis)
 Era:3093
 Source:RS 3145 NT NU
 Rules Level:3
@@ -43,13 +43,13 @@ Shoulder
 Upper Arm Actuator
 Lower Arm Actuator
 Hand Actuator
-ISDoubleHeatSink
-ISDoubleHeatSink
-ISDoubleHeatSink
-ISDoubleHeatSink
-ISDoubleHeatSink
-ISDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
+CLDoubleHeatSink
 Clan Ferro-Fibrous
+-Empty-
+-Empty-
 -Empty-
 
 Right Arm:

--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Cougar X.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Cougar X.mtf
@@ -4,7 +4,7 @@ X
 mul id:6951
 
 Config:Biped
-TechBase:Mixed (IS Chassis)
+TechBase:Mixed (Clan Chassis)
 Era:3132
 Source:RS 3145 NT NU
 Rules Level:3

--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Dasher II 4.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Dasher II 4.mtf
@@ -4,7 +4,7 @@ Dasher II
 mul id:6919
 
 Config:Biped
-TechBase:Mixed (IS Chassis)
+TechBase:Mixed (Clan Chassis)
 Era:3136
 Source:RS 3145 NT NU
 Rules Level:3
@@ -74,12 +74,12 @@ Fusion Engine
 Fusion Engine
 Fusion Engine
 Fusion Engine
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
 CLLRM5
 Clan Endo Steel
 
@@ -88,12 +88,12 @@ Fusion Engine
 Fusion Engine
 Fusion Engine
 Fusion Engine
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
-IS Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
 CLLRM5
 Clan Ammo LRM-5
 
@@ -130,8 +130,8 @@ Hip
 Upper Leg Actuator
 Lower Leg Actuator
 Foot Actuator
-IS Improved Jump Jet
-IS Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
 -Empty-
 -Empty-
 -Empty-
@@ -144,8 +144,8 @@ Hip
 Upper Leg Actuator
 Lower Leg Actuator
 Foot Actuator
-IS Improved Jump Jet
-IS Improved Jump Jet
+Clan Improved Jump Jet
+Clan Improved Jump Jet
 -Empty-
 -Empty-
 -Empty-

--- a/megamek/data/mechfiles/mechs/XTRs/Republic III/Parash 3.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Republic III/Parash 3.mtf
@@ -4,7 +4,7 @@ Parash
 mul id:7375
 
 Config:Biped
-TechBase:Mixed (IS Chassis)
+TechBase:Mixed (Clan Chassis)
 Era:3083
 Source:XTR Republic III - Jihad
 Rules Level:4


### PR DESCRIPTION
Cougar X, Cougar X 2, Cougar X 3: tech base should be "Mixed (Clan chassis)
  - ref: RS 3145 NTNU p.95, p.96, p.97

Dasher II 4: tech base should be "Mixed (Clan chassis)
  - ref: RS 3145 NTNU p.106

Parash 3: tech base should be "Mixed (Clan chassis)
  - ref: XTRO Republic III p.24

Prometheus (Standard): tech base should be "Mixed (IS chassis)
  - ref: RS 3055U Unabridged - Mechs and Omnifighters p.279
