### PR TITLE
Issue MHQ 3654: Add a null guard for getLinked()

### DIFF
--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1236,7 +1236,7 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
                 return 0;
             }
             if ((isHotLoaded() || hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_AMMO_FEED_PROBLEMS))
-                    && (getLinked().getUsableShotsLeft() > 0)) {
+                    && (getLinked() != null) && (getLinked().getUsableShotsLeft() > 0)) {
                 Mounted link = getLinked();
                 AmmoType atype = ((AmmoType) link.getType());
                 int damagePerShot = atype.getDamagePerShot();


### PR DESCRIPTION
This hopefully fixes MHQ#3654 (NPE when switching the engine).

From the log I assume that the problem is in Mounted, the second line (l.1239). 

            if ((isHotLoaded() || hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_AMMO_FEED_PROBLEMS))
                    && (getLinked().getUsableShotsLeft() > 0)) {

A weapon that is hot-loaded or has the neg quirk ammo feed problems (in the Issue the ENF-4R's AC/10 has the quirk) is assumed to be always be linked to ammo but apparently in this specific case it isnt (I don't know why but MHQ isn't my strong side). This PR adds a null guard. No linked ammo is the same as empty ammo, so that should be okay rules-wise.