### PR TITLE
allow entity images to show on reports when using double blind

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -27,7 +27,6 @@ import megamek.client.generator.skillGenerators.ModifiedTotalWarfareSkillGenerat
 import megamek.client.ui.IClientCommandHandler;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.boardview.BoardView;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.Building.DemolitionCharge;
 import megamek.common.actions.*;
@@ -974,8 +973,7 @@ public class Client implements IClientCommandHandler {
         graphics.setComposite(AlphaComposite.Clear);
         graphics.fillRect(0, 0, 56, 48);
         graphics.setComposite(AlphaComposite.Src);
-        graphics.setStroke(new BasicStroke(4f));
-        graphics.setColor(Color.WHITE);
+        graphics.setColor(UIManager.getColor("Label.foreground"));
         graphics.setFont(new Font(MMConstants.FONT_DIALOG, Font.PLAIN, 26));
         graphics.drawString("?", 20, 40);
         try {

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -27,7 +27,6 @@ import megamek.client.generator.skillGenerators.ModifiedTotalWarfareSkillGenerat
 import megamek.client.ui.IClientCommandHandler;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.boardview.BoardView;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.Building.DemolitionCharge;
 import megamek.common.actions.*;
@@ -966,22 +965,6 @@ public class Client implements IClientCommandHandler {
         game.setBoard(newBoard);
     }
 
-    private void createDoubleBlindHiddenImage() {
-        BufferedImage image = new BufferedImage(56, 48, BufferedImage.TYPE_INT_ARGB);
-        Graphics2D graphics = image.createGraphics();
-        UIUtil.setHighQualityRendering(graphics);
-        graphics.setComposite(AlphaComposite.Clear);
-        graphics.fillRect(0, 0, 56, 48);
-        graphics.setComposite(AlphaComposite.Src);
-        graphics.setColor(UIManager.getColor("Label.foreground"));
-        graphics.setFont(new Font(MMConstants.FONT_DIALOG, Font.BOLD, 26));
-        graphics.drawString("?", 20, 40);
-
-        String base64Text = ImageUtil.base64TextEncodeImage(image);
-        String img = "<img src='data:image/png;base64," + base64Text + "'>";
-        imgCache.put(Report.HIDDEN_ENTITY_NUM, img);
-    }
-
     /**
      * Loads the entities from the data in the net command.
      */
@@ -1009,7 +992,7 @@ public class Client implements IClientCommandHandler {
         if (GUIP.getMiniReportShowSprites() &&
                 game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND) &&
                 imgCache != null && !imgCache.containsKey(Report.HIDDEN_ENTITY_NUM)) {
-            createDoubleBlindHiddenImage();
+            ImageUtil.createDoubleBlindHiddenImage(imgCache);
         }
     }
     

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -27,6 +27,7 @@ import megamek.client.generator.skillGenerators.ModifiedTotalWarfareSkillGenerat
 import megamek.client.ui.IClientCommandHandler;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.boardview.BoardView;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.Building.DemolitionCharge;
 import megamek.common.actions.*;
@@ -51,11 +52,9 @@ import megamek.common.util.StringUtil;
 import megamek.server.SmokeCloud;
 import org.apache.logging.log4j.LogManager;
 
-import javax.imageio.ImageIO;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.awt.image.RenderedImage;
 import java.io.*;
 import java.util.List;
 import java.util.*;
@@ -967,27 +966,20 @@ public class Client implements IClientCommandHandler {
         game.setBoard(newBoard);
     }
 
-    private void createDoubleBlindHiddenImg() {
+    private void createDoubleBlindHiddenImage() {
         BufferedImage image = new BufferedImage(56, 48, BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();
+        UIUtil.setHighQualityRendering(graphics);
         graphics.setComposite(AlphaComposite.Clear);
         graphics.fillRect(0, 0, 56, 48);
         graphics.setComposite(AlphaComposite.Src);
         graphics.setColor(UIManager.getColor("Label.foreground"));
-        graphics.setFont(new Font(MMConstants.FONT_DIALOG, Font.PLAIN, 26));
+        graphics.setFont(new Font(MMConstants.FONT_DIALOG, Font.BOLD, 26));
         graphics.drawString("?", 20, 40);
-        try {
-            String base64Text;
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ImageIO.write((RenderedImage) image, "png", baos);
-            baos.flush();
-            base64Text = Base64.getEncoder().encodeToString(baos.toByteArray());
-            baos.close();
-            String img = "<img src='data:image/png;base64," + base64Text + "'>";
-            imgCache.put(Report.HIDDEN_ENTITY_NUM, img);
-        } catch (final IOException ioe) {
-            throw new UncheckedIOException(ioe);
-        }
+
+        String base64Text = ImageUtil.base64TextEncodeImage(image);
+        String img = "<img src='data:image/png;base64," + base64Text + "'>";
+        imgCache.put(Report.HIDDEN_ENTITY_NUM, img);
     }
 
     /**
@@ -1017,7 +1009,7 @@ public class Client implements IClientCommandHandler {
         if (GUIP.getMiniReportShowSprites() &&
                 game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND) &&
                 imgCache != null && !imgCache.containsKey(Report.HIDDEN_ENTITY_NUM)) {
-            createDoubleBlindHiddenImg();
+            createDoubleBlindHiddenImage();
         }
     }
     
@@ -1285,19 +1277,10 @@ public class Client implements IClientCommandHandler {
 
         if (getTargetImage(entity) != null) {
             // convert image to base64, add to the <img> tag and store in cache
-            Image image = ImageUtil.getScaledImage(getTargetImage(entity), 56, 48);
-            try {
-                String base64Text;
-                ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                ImageIO.write((RenderedImage) image, "png", baos);
-                baos.flush();
-                base64Text = Base64.getEncoder().encodeToString(baos.toByteArray());
-                baos.close();
-                String img = "<img src='data:image/png;base64," + base64Text + "'>";
-                imgCache.put(entity.getId(), img);
-            } catch (final IOException ioe) {
-                throw new UncheckedIOException(ioe);
-            }
+            BufferedImage image = ImageUtil.getScaledImage(getTargetImage(entity), 56, 48);
+            String base64Text = ImageUtil.base64TextEncodeImage(image);
+            String img = "<img src='data:image/png;base64," + base64Text + "'>";
+            imgCache.put(entity.getId(), img);
         }
     }
 

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -175,6 +175,8 @@ public class Report implements Serializable {
      */
     public transient int player = Player.PLAYER_NONE;
 
+    public static int HIDDEN_ENTITY_NUM = -1;
+
     /**
      * This hash table will store the tagData Vector indexes that are supposed
      * to be obscured before sending to clients. This only applies when the
@@ -250,6 +252,7 @@ public class Report implements Serializable {
         obscuredIndexes = (Hashtable<Integer, Boolean>) r.obscuredIndexes.clone();
         obscuredRecipients = (Vector<String>) r.obscuredRecipients.clone();
         tagCounter = r.tagCounter;
+        imageCode = r.imageCode;
     }
 
     /**
@@ -470,6 +473,10 @@ public class Report implements Serializable {
      */
     public void setShowImage(boolean showImage) {
         this.showImage = showImage;
+    }
+
+    public void obsureImg() {
+        imageCode = "<span id='" + HIDDEN_ENTITY_NUM +  "'></span>";
     }
 
     /**

--- a/megamek/src/megamek/common/util/ImageUtil.java
+++ b/megamek/src/megamek/common/util/ImageUtil.java
@@ -23,17 +23,16 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
 import java.awt.Image;
-import java.awt.RenderingHints;
 import java.awt.Toolkit;
 import java.awt.Transparency;
-import java.awt.image.BufferedImage;
-import java.awt.image.FilteredImageSource;
-import java.awt.image.ImageFilter;
-import java.awt.image.ImageObserver;
-import java.awt.image.ImageProducer;
+import java.awt.image.*;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import megamek.client.ui.swing.util.ImageAtlasMap;
@@ -42,6 +41,8 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
 import megamek.common.annotations.Nullable;
 import org.apache.logging.log4j.LogManager;
+
+import javax.imageio.ImageIO;
 
 /**
  * Generic utility methods for image data
@@ -425,5 +426,24 @@ public final class ImageUtil {
         public boolean isAnimated() {
             return animated;
         }
+    }
+
+    /**
+     * takes an image and converts it to text in the Base64 encoding.
+     */
+    public static String base64TextEncodeImage(BufferedImage img) {
+        String base64Text = "";
+
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write((RenderedImage) img, "png", baos);
+            baos.flush();
+            base64Text = Base64.getEncoder().encodeToString(baos.toByteArray());
+            baos.close();
+        } catch (final IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+
+        return base64Text;
     }
 }

--- a/megamek/src/megamek/common/util/ImageUtil.java
+++ b/megamek/src/megamek/common/util/ImageUtil.java
@@ -15,16 +15,7 @@
 */
 package megamek.common.util;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.HeadlessException;
-import java.awt.Image;
-import java.awt.Toolkit;
-import java.awt.Transparency;
+import java.awt.*;
 import java.awt.image.*;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -33,16 +24,20 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Hashtable;
 import java.util.List;
 
+import megamek.MMConstants;
 import megamek.client.ui.swing.util.ImageAtlasMap;
 import megamek.client.ui.swing.util.ImprovedAveragingScaleFilter;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
+import megamek.common.Report;
 import megamek.common.annotations.Nullable;
 import org.apache.logging.log4j.LogManager;
 
 import javax.imageio.ImageIO;
+import javax.swing.*;
 
 /**
  * Generic utility methods for image data
@@ -445,5 +440,24 @@ public final class ImageUtil {
         }
 
         return base64Text;
+    }
+
+    /**
+     * creates a ? image, used when units are hidden in double blind
+     */
+    public static void createDoubleBlindHiddenImage(Hashtable<Integer, String> imgCache) {
+        BufferedImage image = new BufferedImage(56, 48, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        UIUtil.setHighQualityRendering(graphics);
+        graphics.setComposite(AlphaComposite.Clear);
+        graphics.fillRect(0, 0, 56, 48);
+        graphics.setComposite(AlphaComposite.Src);
+        graphics.setColor(UIManager.getColor("Label.foreground"));
+        graphics.setFont(new Font(MMConstants.FONT_DIALOG, Font.BOLD, 26));
+        graphics.drawString("?", 20, 40);
+
+        String base64Text = base64TextEncodeImage(image);
+        String img = "<img src='data:image/png;base64," + base64Text + "'>";
+        imgCache.put(Report.HIDDEN_ENTITY_NUM, img);
     }
 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -13,7 +13,6 @@
  */
 package megamek.server;
 
-import com.thoughtworks.xstream.XStream;
 import megamek.MMConstants;
 import megamek.MegaMek;
 import megamek.client.bot.princess.BehaviorSettings;

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -28797,6 +28797,11 @@ public class GameManager implements IGameManager {
                 }
             }
         }
+
+        if (shouldObscure) {
+            copy.obsureImg();
+        }
+
         return copy;
     }
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3247,6 +3247,8 @@ public class GameManager implements IGameManager {
             }
         }
 
+        addNewLines();
+
         if (!abbreviatedReport) {
             // remaining deployments
             Comparator<Entity> comp = Comparator.comparingInt(Entity::getDeployRound);


### PR DESCRIPTION
- allow entity images to show on reports when using double blind
- show ? image when entity is hidden

![image](https://user-images.githubusercontent.com/116095479/235462342-0e2812d7-d8c6-43be-b272-2916afc36df6.png)

fixes #2981
