### PR TITLE
Issue 4314: Correct missing long range issue with BA Micro GL

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1738,14 +1738,15 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         if (mounted.isInBearingsOnlyMode()) {
             extremeR = RangeType.RANGE_BEARINGS_ONLY_OUT;
         }
+        // Show water ranges for submerged weapons and those that have only water ranges (torpedoes)
         if ((entity.getLocationStatus(mounted.getLocation()) == ILocationExposureStatus.WET)
-            || (longR == 0)) {
+                || ((longR == 0) && wtype.getWLongRange() > 0)) {
             shortR = wtype.getWShortRange();
             mediumR = wtype.getWMediumRange();
             longR = wtype.getWLongRange();
             extremeR = wtype.getWExtremeRange();
         } else if (wtype.hasFlag(WeaponType.F_PDBAY)) {
-        //Point Defense bays have a variable range, depending on the mode they're in
+            //Point Defense bays have a variable range, depending on the mode they're in
             if (wtype.hasModes() && mounted.curMode().equals("Point Defense")) {
                 shortR = 1;
                 wShortR.setText("1");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAGrenadeLauncherMicro.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAGrenadeLauncherMicro.java
@@ -37,8 +37,8 @@ public class ISBAGrenadeLauncherMicro extends Weapon {
         minimumRange = WEAPON_NA;
         shortRange = 1;
         mediumRange = 2;
-//        longRange = 3;
-        extremeRange = 4;
+        longRange = 2;
+        extremeRange = 2;
         tonnage = 0.075;
         criticals = 1;
         bv = 1;


### PR DESCRIPTION
Fixes #4314 
The ranges were not showing because the code treated it like a torpedo and showed its water ranges; also it seems that ranges of 1/2/0 don't work while 1/2/2 works correctly. I don't know if a weapon without a long range has an extreme range; I copied the present values from the similar BA Heavy MG.