### PR TITLE
Issue 4385: Resolve overlapping F_ tags in WeaponType

### DIFF
--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -14,7 +14,6 @@
  */
 package megamek.common;
 
-import megamek.common.alphaStrike.ASRange;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.weapons.*;
 import megamek.common.weapons.artillery.*;
@@ -46,7 +45,6 @@ import megamek.common.weapons.tag.CLTAG;
 import megamek.common.weapons.tag.ISTAG;
 import megamek.common.weapons.unofficial.*;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 
 // TODO add XML support back in.
@@ -156,10 +154,6 @@ public class WeaponType extends EquipmentType {
     // C3 Master Booster System
     public static final BigInteger F_C3MBS = BigInteger.valueOf(1).shiftLeft(56);
 
-    //Used for TSEMP Weapons.
-    public static final BigInteger F_TSEMP = BigInteger.valueOf(1).shiftLeft(57);
-    public static final BigInteger F_REPEATING = BigInteger.valueOf(1).shiftLeft(61);
-
     //Naval Mass Drivers
     public static final BigInteger F_MASS_DRIVER = BigInteger.valueOf(1).shiftLeft(58);
 
@@ -192,6 +186,10 @@ public class WeaponType extends EquipmentType {
 
     /** This flag is used by mortar-type weapons that allow indirect fire without a spotter and/or with LOS. */
     public static final BigInteger F_MORTARTYPE_INDIRECT = BigInteger.valueOf(1).shiftLeft(71);
+
+    //Used for TSEMP Weapons.
+    public static final BigInteger F_TSEMP = BigInteger.valueOf(1).shiftLeft(57);
+    public static final BigInteger F_REPEATING = BigInteger.valueOf(1).shiftLeft(72);
 
     // add maximum range for AT2
     public static final int RANGE_SHORT = RangeType.RANGE_SHORT;
@@ -232,7 +230,6 @@ public class WeaponType extends EquipmentType {
     public static final int CLASS_TELE_MISSILE = 25;
     public static final int CLASS_GAUSS = 26;
     public static final int CLASS_THUNDERBOLT = 27;
-    public static final int NUM_CLASSES = 28;
 
     public static final int WEAPON_DIRECT_FIRE = 0;
     public static final int WEAPON_CLUSTER_BALLISTIC = 1;
@@ -268,12 +265,6 @@ public class WeaponType extends EquipmentType {
     public static final int BFCLASS_CAPITAL = 9;
     public static final int BFCLASS_SUBCAPITAL = 10;
     public static final int BFCLASS_CAPITAL_MISSILE = 11;
-    public static final int BFCLASS_NUM = 12;
-
-    public static final String[] BF_CLASS_NAMES = {
-            "", "LRM", "SRM", "MML", "TORP", "AC", "FLAK", "iATM",
-            "REL", "CAP", "SCAP", "CMISS"
-    };
 
     // protected RangeType rangeL;
     protected int heat;
@@ -499,9 +490,7 @@ public class WeaponType extends EquipmentType {
         if (weapon.isInBearingsOnlyMode()) {
             eRange = RangeType.RANGE_BEARINGS_ONLY_OUT;
         }
-        int[] weaponRanges =
-                { minRange, sRange, mRange, lRange, eRange };
-        return weaponRanges;
+        return new int[] { minRange, sRange, mRange, lRange, eRange };
     }
 
     public int getMinimumRange() {
@@ -750,8 +739,7 @@ public class WeaponType extends EquipmentType {
     }
 
     /**
-     * Reports the class of weapons for those that are tracked separately from standard damage
-     * @return
+     * @return The class of weapons for those that are tracked separately from standard damage (AlphaStrike)
      */
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;

--- a/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/EnergyWeapon.java
@@ -23,7 +23,6 @@ import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.EnergyWeaponHandler;
 import megamek.common.weapons.Weapon;
 import megamek.server.GameManager;
-import megamek.server.Server;
 
 /**
  * @author Andrew Hunter
@@ -33,21 +32,11 @@ public abstract class EnergyWeapon extends Weapon {
     private static final long serialVersionUID = 3128205629152612073L;
 
     public EnergyWeapon() {
-        flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON).or(F_PROTO_WEAPON)
-                .or(F_ENERGY);
+        flags = flags.or(F_MECH_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON).or(F_PROTO_WEAPON).or(F_ENERGY);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, Game game, GameManager manager) {
+    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, GameManager manager) {
         return new EnergyWeaponHandler(toHit, waa, game, manager);
     }
     

--- a/megamek/src/megamek/common/weapons/other/ISTSEMPCannon.java
+++ b/megamek/src/megamek/common/weapons/other/ISTSEMPCannon.java
@@ -16,6 +16,7 @@ package megamek.common.weapons.other;
 import megamek.common.SimpleTechLevel;
 
 public class ISTSEMPCannon extends TSEMPWeapon {
+
     private static final long serialVersionUID = -4861067053206502295L;
 
     public ISTSEMPCannon() {
@@ -23,10 +24,10 @@ public class ISTSEMPCannon extends TSEMPWeapon {
         bv = 488;
         name = "TSEMP Cannon";
         setInternalName(name);
-        this.addLookupName("ISTSEMP");
+        addLookupName("ISTSEMP");
         tonnage = 6;
         criticals  = 5;
-		rulesRefs = "91, IO";
+		rulesRefs = "84, IO:AE";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
 		techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false).setUnofficial(false)
@@ -38,19 +39,4 @@ public class ISTSEMPCannon extends TSEMPWeapon {
                 .setProductionFactions(F_RS)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED);
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
-    /*@Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, Server server) {
-        return new TSEMPCannonHandler(toHit, waa, game, server);
-    }
-    */
-
 }

--- a/megamek/src/megamek/common/weapons/other/ISTSEMPOneShot.java
+++ b/megamek/src/megamek/common/weapons/other/ISTSEMPOneShot.java
@@ -16,6 +16,7 @@ package megamek.common.weapons.other;
 import megamek.common.SimpleTechLevel;
 
 public class ISTSEMPOneShot extends TSEMPWeapon {
+
     private static final long serialVersionUID = 2945503963826543215L;
 
     public ISTSEMPOneShot() {
@@ -25,10 +26,10 @@ public class ISTSEMPOneShot extends TSEMPWeapon {
         bv = 98;
         name = "TSEMP One-Shot";
         setInternalName(name);
-        this.addLookupName("ISTSEMPOS");
+        addLookupName("ISTSEMPOS");
         tonnage = 4;
         criticals = 3;
-		rulesRefs = "90, IO";
+		rulesRefs = "84, IO:AE";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
 		techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false).setUnofficial(false)
@@ -40,18 +41,4 @@ public class ISTSEMPOneShot extends TSEMPWeapon {
                 .setProductionFactions(F_RS)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED);
     }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
-    /*@Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, Server server) {
-        return new TSEMPOneShotHandler(toHit, waa, game, server);
-    }
-    */
 }

--- a/megamek/src/megamek/common/weapons/other/ISTSEMPRepeatingCannon.java
+++ b/megamek/src/megamek/common/weapons/other/ISTSEMPRepeatingCannon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2016-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -15,10 +15,8 @@ package megamek.common.weapons.other;
 
 import megamek.common.SimpleTechLevel;
 
-/**
- * TODO : Implement Game Rules. See IO pg 94 for specifics.
- */
 public class ISTSEMPRepeatingCannon extends TSEMPWeapon {
+
     private static final long serialVersionUID = -4861067053206502295L;
 
     public ISTSEMPRepeatingCannon() {
@@ -26,12 +24,12 @@ public class ISTSEMPRepeatingCannon extends TSEMPWeapon {
         bv = 600;
         name = "TSEMP Repeating Cannon";
         setInternalName(name);
-        this.addLookupName("ISTSEMPREPEATING");
-        flags = flags.or(F_TSEMP).or(F_DIRECT_FIRE).or(F_REPEATING);
+        addLookupName("ISTSEMPREPEATING");
+        flags = flags.or(F_REPEATING);
         tonnage = 8;
         criticals  = 7;
         tankslots = 1;
-        rulesRefs = "92, IO";
+        rulesRefs = "88, IO:AE";
         techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_F)
                 .setAvailability(RATING_X, RATING_X, RATING_X, RATING_F)
                 .setISAdvancement(3133, DATE_NONE, DATE_NONE, 3138, DATE_NONE)

--- a/megamek/src/megamek/common/weapons/other/TSEMPWeapon.java
+++ b/megamek/src/megamek/common/weapons/other/TSEMPWeapon.java
@@ -43,17 +43,8 @@ public class TSEMPWeapon extends EnergyWeapon {
         explosionDamage = 10;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
-                                              GameManager manager) {
+    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, GameManager manager) {
         return new TSEMPHandler(toHit, waa, game, manager);
     }
 }


### PR DESCRIPTION
This will show Repeating TSEMP on Aeros. The problem was that F_REPEATING and F_BOMB in WeaponType had the same value. I updated some rules refs to IO:AE pages. All other changes are cosmetic.

Fixes #4385 