### PR TITLE
Fix: #4424 type of Stingray Ammo

### DIFF
--- a/megamek/data/mechfiles/dropships/TRO3085/Cutting Edge/Clan/Vanir Assault Dropship (Standard).blk
+++ b/megamek/data/mechfiles/dropships/TRO3085/Cutting Edge/Clan/Vanir Assault Dropship (Standard).blk
@@ -116,7 +116,7 @@ Ammo Piranha:45
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:30
+Ammo Stingray:30
 (B) CLHAG40
 CLHAG40
 Hyper-Assault Gauss Rifle/40 Ammo:42
@@ -144,7 +144,7 @@ CLAMS Ammo:216
 (R) (B) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
-(R) Ammo Stringray:30
+(R) Ammo Stingray:30
 (R) (B) CLERLargeLaser
 (R) CLERLargeLaser
 (R) CLERLargeLaser
@@ -172,7 +172,7 @@ Ammo Piranha:45
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:30
+Ammo Stingray:30
 (B) CLHAG40
 CLHAG40
 Hyper-Assault Gauss Rifle/40 Ammo:42
@@ -200,7 +200,7 @@ CLAMS Ammo:216
 (R) (B) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
 (R) Sub-Capital Missile Launcher (Stingray)
-(R) Ammo Stringray:30
+(R) Ammo Stingray:30
 (R) (B) CLERLargeLaser
 (R) CLERLargeLaser
 (R) CLERLargeLaser

--- a/megamek/data/mechfiles/warship/XTR/Republic III/Leviathan III Battleship.blk
+++ b/megamek/data/mechfiles/warship/XTR/Republic III/Leviathan III Battleship.blk
@@ -616,11 +616,11 @@ Naval Laser 55
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) CLERPPC
 CLERPPC
 CLERPPC
@@ -708,11 +708,11 @@ Naval Laser 55
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
 Sub-Capital Missile Launcher (Stingray)
-Ammo Stringray:150
+Ammo Stingray:150
 (B) CLERPPC
 CLERPPC
 CLERPPC

--- a/megamek/docs/equipment.txt
+++ b/megamek/docs/equipment.txt
@@ -1398,7 +1398,7 @@ A,3091-Inner Sphere3063-Inner Sphere3085-Inner Sphere,3091-IS_TW_Non_Box3063-IS_
 A,3091-Inner Sphere3063-Inner Sphere3085-Inner Sphere,3091-IS_TW_Non_Box3063-IS_Advanced3085-IS_TW_Non_Box,Ammo Heavy SCC,Heavy SCC Ammo,HeavySCC Ammo,
 A,3072-Inner Sphere3065-Inner Sphere3055-Inner Sphere,3072-IS_TW_Non_Box3065-IS_Advanced3055-IS_Advanced,Ammo Manta Ray,MantaRay Ammo,Manta Ray Ammo,
 A,3072-Inner Sphere3065-Inner Sphere3055-Inner Sphere,3072-IS_TW_Non_Box3065-IS_Advanced3055-IS_Advanced,Ammo Swordfish,Swordfish Ammo,
-A,3072-Inner Sphere3065-Inner Sphere3055-Inner Sphere,3072-IS_TW_Non_Box3065-IS_Advanced3055-IS_Advanced,Ammo Stringray,Stingray Ammo,ClStingray Ammo,
+A,3072-Inner Sphere3065-Inner Sphere3055-Inner Sphere,3072-IS_TW_Non_Box3065-IS_Advanced3055-IS_Advanced,Ammo Stingray,Stingray Ammo,ClStingray Ammo,
 A,3072-Inner Sphere3065-Inner Sphere3055-Inner Sphere,3072-IS_TW_Non_Box3065-IS_Advanced3055-IS_Advanced,Ammo Piranha,Piranha Ammo,PiranhaAmmo,
 A,-1-Inner Sphere,-1-IS_Unofficial,Ammo Kraken,Kraken Ammo,
 A,2710-Inner Sphere,2710-IS_Experimental,Ammo Heavy Mass Driver,HeavyMassDriver Ammo,

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -10246,8 +10246,8 @@ public class AmmoType extends EquipmentType {
     private static AmmoType createStingrayAmmo() {
         AmmoType ammo = new AmmoType();
 
-        ammo.name = "Stringray Ammo";
-        ammo.setInternalName("Ammo Stringray");
+        ammo.name = "Stingray Ammo";
+        ammo.setInternalName("Ammo Stingray");
         ammo.addLookupName("Stingray Ammo");
         ammo.addLookupName("ClStingray Ammo");
         ammo.damagePerShot = 3;


### PR DESCRIPTION
Fixed an ammo spelling mistake:  Stringray -> Stingray.