### PR TITLE
Issue 4283: Write the correct enum constant name to xml

### DIFF
--- a/megamek/src/megamek/common/WeaponOrderHandler.java
+++ b/megamek/src/megamek/common/WeaponOrderHandler.java
@@ -129,7 +129,7 @@ public class WeaponOrderHandler {
             output.write("</" + ID +">");
             output.write("\n\t\t");
             output.write("<" + ORDER_TYPE +">");
-            output.write(weapOrder.orderType.toString());
+            output.write(weapOrder.orderType.name());
             output.write("</" + ORDER_TYPE +">");
             output.write("\n\t\t");
             output.write("<" + WEAPON_LIST +">");


### PR DESCRIPTION
Fixes #4283 

toString() wrote a i18n text as xml tag that couldnt be parsed correctly. Now writes the enum name itself.