### PR TITLE
Unit Selector: Check the year limit even when variable tech level is on

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
@@ -58,7 +58,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     @Override
     public void updateOptionValues() {
         gameOptions = clientGUI.getClient().getGame().getOptions();
-        enableYearLimits = gameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED);
+        enableYearLimits = true;
         allowedYear = gameOptions.intOption(OptionsConstants.ALLOWED_YEAR);
         canonOnly = gameOptions.booleanOption(OptionsConstants.ALLOWED_CANON_ONLY);
         allowInvalid = gameOptions.booleanOption(OptionsConstants.ALLOWED_ALLOW_ILLEGAL_UNITS);


### PR DESCRIPTION
The unit selector should check unit's intro years against the game year regardless of the Variable Tech Level setting.

Fixes #4262 