### PR TITLE
when tacops sensors is not on, dont show sensor rings

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6459,17 +6459,19 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         int minAirSensorRange = 0;
         int maxAirSensorRange = 0;
 
-        Compute.SensorRangeHelper srh = Compute.getSensorRanges(entity.getGame(), entity);
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)) {
+            Compute.SensorRangeHelper srh = Compute.getSensorRanges(entity.getGame(), entity);
 
-        if (srh != null) {
-            if (entity.isAirborne() && entity.getGame().getBoard().onGround()) {
-                minSensorRange = srh.minGroundSensorRange;
-                maxSensorRange = srh.maxGroundSensorRange;
-                minAirSensorRange = srh.minSensorRange;
-                maxAirSensorRange = srh.maxSensorRange;
-            } else {
-                minSensorRange = srh.minSensorRange;
-                maxSensorRange = srh.maxSensorRange;
+            if (srh != null) {
+                if (entity.isAirborne() && entity.getGame().getBoard().onGround()) {
+                    minSensorRange = srh.minGroundSensorRange;
+                    maxSensorRange = srh.maxGroundSensorRange;
+                    minAirSensorRange = srh.minSensorRange;
+                    maxAirSensorRange = srh.maxSensorRange;
+                } else {
+                    minSensorRange = srh.minSensorRange;
+                    maxSensorRange = srh.maxSensorRange;
+                }
             }
         }
 


### PR DESCRIPTION
- when tacops sensors is not on, dont show sensor rings.  it was incorrectly showing in this case

![image](https://github.com/MegaMek/megamek/assets/116095479/484bd976-2a4a-4789-9a41-da9e56df4a67)
![image](https://github.com/MegaMek/megamek/assets/116095479/63e7aad3-cd91-4b1e-8cb2-d9c9c85503fd)

