### PR TITLE
when tacops sensors is not on, show visual range in tool tip

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -534,6 +534,7 @@ BoardView1.Tooltip.Undamaged=UNDAMAGED
 BoardView1.Tooltip.UnjammingRAC=Unjamming RAC
 BoardView1.Tooltip.Unknown=UNKNOWN
 BoardView1.Tooltip.unknownOwner=Unknown owner
+BoardView1.Tooltip.Visual=Visual Range: {0}
 BoardView1.Tooltip.Weapon={3} {1}{2}
 BoardView1.Tooltip.Wreckof=Wreck of 
 BoardView1.Tooltip.X=x 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2107,7 +2107,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         if (ce == null) {
             return;
         }
-        boolean isNight = clientgui.getClient().getGame().getPlanetaryConditions().isSearchlightEffective();
+        boolean isNight = clientgui.getClient().getGame().getPlanetaryConditions().isIlluminationEffective();
         setSearchlightEnabled(isNight && ce.hasSearchlight() && !cmd.contains(MoveStepType.SEARCHLIGHT),
                 ce.isUsingSearchlight());
     }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6483,7 +6483,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         minSensorRange = 0;
 
-        if (game.getPlanetaryConditions().isSearchlightEffective()) {
+        if (game.getPlanetaryConditions().isIlluminationEffective()) {
             maxSensorRange = Compute.getMaxVisualRange(entity, true);
         } else {
             maxSensorRange = 0;

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1223,13 +1223,13 @@ public final class UnitToolTip {
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)
                 || game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)) {
             String visualRange = Compute.getMaxVisualRange(entity, false) + "";
-            if (game.getPlanetaryConditions().isSearchlightEffective()) {
+            if (game.getPlanetaryConditions().isIlluminationEffective()) {
                 visualRange += " (" + Compute.getMaxVisualRange(entity, true) + ")";
             }
             result += addToTT("Sensors", BR, getSensorDesc(entity), visualRange);
         } else {
             String visualRange = Compute.getMaxVisualRange(entity, false) + "";
-            if (game.getPlanetaryConditions().isSearchlightEffective()) {
+            if (game.getPlanetaryConditions().isIlluminationEffective()) {
                 visualRange += " (" + Compute.getMaxVisualRange(entity, true) + ")";
             }
             result += addToTT("Visual", BR, visualRange);

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1227,6 +1227,12 @@ public final class UnitToolTip {
                 visualRange += " (" + Compute.getMaxVisualRange(entity, true) + ")";
             }
             result += addToTT("Sensors", BR, getSensorDesc(entity), visualRange);
+        } else {
+            String visualRange = Compute.getMaxVisualRange(entity, false) + "";
+            if (game.getPlanetaryConditions().isSearchlightEffective()) {
+                visualRange += " (" + Compute.getMaxVisualRange(entity, true) + ")";
+            }
+            result += addToTT("Visual", BR, visualRange);
         }
 
         if (entity.hasAnyTypeNarcPodsAttached()) {

--- a/megamek/src/megamek/common/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/PlanetaryConditions.java
@@ -384,6 +384,15 @@ public class PlanetaryConditions implements Serializable {
                 || (lightConditions == L_PITCH_BLACK);
     }
 
+    /**
+     * Returns true when visual range is increased by a illumination
+     * in the light condition, i.e. in dusk/dawn, full moon,
+     * moonless and pitch black night.
+     */
+    public boolean isIlluminationEffective() {
+        return (lightConditions > L_DAY);
+    }
+
     /** Returns true when the given weather is prohibited for temperatures of 30 degC and more. */
     public static boolean requiresLowTemp(int weather) {
         return weather == WE_LIGHT_HAIL ||
@@ -776,9 +785,9 @@ public class PlanetaryConditions implements Serializable {
 
         // TO:AR v6 p189
         // Illuminated?  Flat 45 hex distance
-        if (targetIlluminated && (lightConditions > L_DAY)) {
+        if (targetIlluminated && (isIlluminationEffective())) {
             lightRange = 45;
-        } else if (Spotlight && (lightConditions > L_DAY)) {
+        } else if (Spotlight && (isIlluminationEffective())) {
             // Using a searchlight?  Flat 30 hex range
             if (isMechVee || isAero || isLargeCraft) {
                 lightRange = 30;


### PR DESCRIPTION
- when tacops sensors is not on, show visual range in tool tip
- show second range value when dusk dawn also
- allow search light to be turned on when dusk / dawn

![image](https://github.com/MegaMek/megamek/assets/116095479/9dbd2449-851c-432c-bf7d-1acf3f03bed5)


