### PR TITLE
Fix NPE when checking for infantry doomedInExtremeTemp without a game instance

### DIFF
--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1023,12 +1023,15 @@ public class Infantry extends Entity {
 
     @Override
     public boolean doomedInExtremeTemp() {
+        // If there is no game object, count any temperature protection.
         if (getArmorKit() != null) {
             if (getArmorKit().hasSubType(MiscType.S_XCT_VACUUM)) {
                 return false;
-            } else if (getArmorKit().hasSubType(MiscType.S_COLD_WEATHER) && (game.getPlanetaryConditions().getTemperature() < -30)) {
+            } else if (getArmorKit().hasSubType(MiscType.S_COLD_WEATHER)
+                    && ((game == null) || game.getPlanetaryConditions().getTemperature() < -30)) {
                 return false;
-            } else if (getArmorKit().hasSubType(MiscType.S_HOT_WEATHER) && (game.getPlanetaryConditions().getTemperature() > 50)) {
+            } else if (getArmorKit().hasSubType(MiscType.S_HOT_WEATHER)
+                    && ((game == null) || game.getPlanetaryConditions().getTemperature() > 50)) {
                 return false;
             } else {
                 return true;


### PR DESCRIPTION
The expansion of the MechSummary for advanced search purposes calls a method that fails to check for null before dereferencing game. This is only encountered with infantry armor with heat or cold protection. 

Fixes #4452