### PR TITLE
delete PilotToolTip cache on client start and when portrait is set

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -32,6 +32,7 @@ import megamek.client.ui.swing.dialog.MainMenuUnitBrowserDialog;
 import megamek.client.ui.swing.gameConnectionDialogs.ConnectDialog;
 import megamek.client.ui.swing.gameConnectionDialogs.HostDialog;
 import megamek.client.ui.swing.skinEditor.SkinEditorMainGUI;
+import megamek.client.ui.swing.tooltip.PilotToolTip;
 import megamek.client.ui.swing.util.MegaMekController;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.widget.MegamekButton;
@@ -73,10 +74,6 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
@@ -462,18 +459,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         }
 
         // delete PilotToolTip cache
-        String tempPath = Configuration.imagesDir() + "/temp/";
-        String filter = "TT_Portrait_*.png";
-        try {
-            DirectoryStream<Path> ds = Files.newDirectoryStream(Paths.get(tempPath), filter);
-            for (Path p: ds) {
-                try {
-                    Files.delete(p);
-                } catch (Exception ex) {
-                }
-            }
-        } catch (Exception ex) {
-        }
+        PilotToolTip.deleteImageCache();
 
         client = new Client(playerName, serverAddress, port);
         ClientGUI gui = new ClientGUI(client, controller);

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -73,6 +73,10 @@ import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.*;
 import java.util.zip.GZIPInputStream;
@@ -455,6 +459,20 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                     Messages.getString("MegaMek.LoadGameAlert.title"), JOptionPane.ERROR_MESSAGE);
             frame.setVisible(true);
             return;
+        }
+
+        // delete PilotToolTip cache
+        String tempPath = Configuration.imagesDir() + "/temp/";
+        String filter = "TT_Portrait_*.png";
+        try {
+            DirectoryStream<Path> ds = Files.newDirectoryStream(Paths.get(tempPath), filter);
+            for (Path p: ds) {
+                try {
+                    Files.delete(p);
+                } catch (Exception ex) {
+                }
+            }
+        } catch (Exception ex) {
         }
 
         client = new Client(playerName, serverAddress, port);

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -26,6 +26,10 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static megamek.client.ui.swing.tooltip.TipUtil.getOptionList;
 import static megamek.client.ui.swing.tooltip.TipUtil.scaledHTMLSpacer;
@@ -187,4 +191,29 @@ public final class PilotToolTip {
     }
 
     private PilotToolTip() { }
+
+    public static void deleteImageCache() {
+        String tempPath = Configuration.imagesDir() + "/temp/";
+        String filter = "TT_Portrait_*.png";
+        try {
+            DirectoryStream<Path> ds = Files.newDirectoryStream(Paths.get(tempPath), filter);
+            for (Path p: ds) {
+                try {
+                    Files.delete(p);
+                } catch (Exception ex) {
+                }
+            }
+        } catch (Exception ex) {
+        }
+    }
+
+    public static void deleteImageCache(Crew crew, int pos) {
+        // delete PilotToolTip cache for this portrait
+        String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + crew.getExternalIdAsString() + "_" + pos + ".png";
+        File tempFile = new File(tempPath);
+        try {
+            Files.deleteIfExists(tempFile.toPath());
+        } catch (Exception ex) {
+        }
+    }
 }

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -30,6 +30,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.stream.StreamSupport;
 
 import static megamek.client.ui.swing.tooltip.TipUtil.getOptionList;
 import static megamek.client.ui.swing.tooltip.TipUtil.scaledHTMLSpacer;
@@ -199,14 +200,16 @@ public final class PilotToolTip {
     public static void deleteImageCache() {
         String tempPath = Configuration.imagesDir() + TEMP_DIR;
         String filter = PORTRAIT_PREFIX + "*" + PNG_EXT;
+
         try {
-            DirectoryStream<Path> ds = Files.newDirectoryStream(Paths.get(tempPath), filter);
-            for (Path p: ds) {
-                try {
-                    Files.delete(p);
-                } catch (Exception ex) {
-                }
-            }
+            StreamSupport.stream(Files.newDirectoryStream(Paths.get(tempPath), filter).spliterator(), true)
+                    .forEach(p -> {
+                                try {
+                                    Files.delete(p);
+                                } catch (Exception ex) {
+                                }
+                            }
+                    );
         } catch (Exception ex) {
         }
     }

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -42,6 +42,10 @@ public final class PilotToolTip {
     private final static int PORTRAIT_BASESIZE = 72;
     final static String BG_COLOR = "#313131";
 
+    final static String TEMP_DIR = "/temp/";
+    final static String PORTRAIT_PREFIX = "TT_Portrait_";
+    final static String PNG_EXT = ".png";
+
     public static StringBuilder lobbyTip(InGameObject unit) {
         if (unit instanceof Entity) {
             return getPilotTipDetailed((Entity) unit, true);
@@ -158,7 +162,7 @@ public final class PilotToolTip {
                 // Write the scaled portrait to file
                 // This is done to avoid using HTML rescaling on the portrait which does
                 // not do any smoothing and has extremely ugly results
-                String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + crew.getExternalIdAsString() + "_" + i + ".png";
+                String tempPath = Configuration.imagesDir() + TEMP_DIR + PORTRAIT_PREFIX + crew.getExternalIdAsString() + "_" + i + PNG_EXT;
                 File tempFile = new File(tempPath);
                 if (!tempFile.exists()) {
                     BufferedImage bufferedImage = new BufferedImage(portrait.getWidth(null), portrait.getHeight(null), BufferedImage.TYPE_INT_RGB);
@@ -193,8 +197,8 @@ public final class PilotToolTip {
     private PilotToolTip() { }
 
     public static void deleteImageCache() {
-        String tempPath = Configuration.imagesDir() + "/temp/";
-        String filter = "TT_Portrait_*.png";
+        String tempPath = Configuration.imagesDir() + TEMP_DIR;
+        String filter = PORTRAIT_PREFIX + "*" + PNG_EXT;
         try {
             DirectoryStream<Path> ds = Files.newDirectoryStream(Paths.get(tempPath), filter);
             for (Path p: ds) {
@@ -208,8 +212,7 @@ public final class PilotToolTip {
     }
 
     public static void deleteImageCache(Crew crew, int pos) {
-        // delete PilotToolTip cache for this portrait
-        String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + crew.getExternalIdAsString() + "_" + pos + ".png";
+        String tempPath = Configuration.imagesDir() + TEMP_DIR + PORTRAIT_PREFIX + crew.getExternalIdAsString() + "_" + pos + PNG_EXT;
         File tempFile = new File(tempPath);
         try {
             Files.deleteIfExists(tempFile.toPath());

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -154,7 +154,7 @@ public final class PilotToolTip {
                 // Write the scaled portrait to file
                 // This is done to avoid using HTML rescaling on the portrait which does
                 // not do any smoothing and has extremely ugly results
-                String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + entity.getExternalIdAsString() + "_" + i + ".png";
+                String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + crew.getExternalIdAsString() + "_" + i + ".png";
                 File tempFile = new File(tempPath);
                 if (!tempFile.exists()) {
                     BufferedImage bufferedImage = new BufferedImage(portrait.getWidth(null), portrait.getHeight(null), BufferedImage.TYPE_INT_RGB);

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -16,6 +16,7 @@
 package megamek.common;
 
 import megamek.client.generator.RandomGenderGenerator;
+import megamek.client.ui.swing.tooltip.PilotToolTip;
 import megamek.common.enums.Gender;
 import megamek.common.icons.Portrait;
 import megamek.common.options.IOption;
@@ -24,9 +25,7 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import megamek.common.util.CrewSkillSummaryUtil;
 
-import java.io.File;
 import java.io.Serializable;
-import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -380,14 +379,7 @@ public class Crew implements Serializable {
 
     public void setPortrait(final Portrait portrait, final int pos) {
         getPortraits()[pos] = portrait;
-
-        // delete PilotToolTip cache for this portrait
-        String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + getExternalIdAsString() + "_" + pos + ".png";
-        File tempFile = new File(tempPath);
-        try {
-           Files.deleteIfExists(tempFile.toPath());
-        } catch (Exception ex) {
-        }
+        PilotToolTip.deleteImageCache(this, pos);
     }
 
     /**

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -24,7 +24,9 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import megamek.common.util.CrewSkillSummaryUtil;
 
+import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Files;
 import java.util.*;
 
 /**
@@ -378,6 +380,14 @@ public class Crew implements Serializable {
 
     public void setPortrait(final Portrait portrait, final int pos) {
         getPortraits()[pos] = portrait;
+
+        // delete PilotToolTip cache for this portrait
+        String tempPath = Configuration.imagesDir() + "/temp/TT_Portrait_" + getExternalIdAsString() + "_" + pos + ".png";
+        File tempFile = new File(tempPath);
+        try {
+           Files.deleteIfExists(tempFile.toPath());
+        } catch (Exception ex) {
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -1111,7 +1111,7 @@ public class Crew implements Serializable {
      */
     public String getExternalIdAsString() {
         for (int i = 0; i < getSlotCount(); i++) {
-            if (!externalId[i].equals("-1")) {
+            if (externalId != null && !externalId[i].equals("-1")) {
                 return externalId[i];
             }
         }

--- a/megamek/src/megamek/common/Crew.java
+++ b/megamek/src/megamek/common/Crew.java
@@ -379,6 +379,8 @@ public class Crew implements Serializable {
 
     public void setPortrait(final Portrait portrait, final int pos) {
         getPortraits()[pos] = portrait;
+
+        // delete PilotToolTip cache for this portrait
         PilotToolTip.deleteImageCache(this, pos);
     }
 


### PR DESCRIPTION
- delete PilotToolTip portrait  cache on client start and when portrait is set, so that it is reloaded with any updated images.

![image](https://github.com/MegaMek/megamek/assets/116095479/caa1c51e-7aa6-4757-b8eb-c86567c31851)


fixes #4449