### PR TITLE
Minimap updates

### DIFF
--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1861,6 +1861,7 @@ public class BoardEditor extends JPanel
             setExitsState(texTerrExits.getNumber() != 0);
             updateWhenSelected();
         } else if (ae.getActionCommand().equals(ClientGUI.VIEW_MINI_MAP)) {
+            guip.toggleMinimapEnabled();
             minimapW.setVisible(guip.getMinimapEnabled());
         } else if (ae.getActionCommand().equals(ClientGUI.HELP_ABOUT)) {
             showAbout();

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -605,6 +605,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                     newX = scrollpane.getViewport().getViewPosition().x;
                 }
                 scrollpane.getViewport().setViewPosition(new Point(newX, newY));
+                pingMinimap();
             }
         };
         addMouseMotionListener(mouseMotionListener);

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2002-2005 Ben Mazur (bmazur@sev.org)
  * Copyright (c) 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (c) 2021-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2021-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -263,12 +263,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     }
 
     @Override
-    public synchronized void update(Graphics g) {
-        paint(g);
-    }
-
-    @Override
-    public void paint(Graphics g) {
+    protected void paintComponent(Graphics g) {
         if (mapImage != null) {
             g.drawImage(mapImage, 0, 0, this);
             paintVisibleSection(g);
@@ -474,7 +469,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     };
 
     /** Call this to schedule a minimap redraw. */
-    public synchronized void refreshMap() {
+    public void refreshMap() {
         lastDrawMapReq = System.currentTimeMillis();
         SwingUtilities.invokeLater(drawMapable);
     }
@@ -488,12 +483,12 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     }
 
     /** 
-     * Draws the minimap to the backbuffer. When ignoreVisible is true,
+     * Draws the minimap to the backbuffer. When forceDraw is true,
      * the map will be drawn even if it is minimized or not visible.
      * This can be used to draw the minimap for saving it as an image regardless
      * of its visual status onscreen.
      */
-    private synchronized void drawMap(boolean forceDraw) {
+    private void drawMap(boolean forceDraw) {
         if ((lastDrawStarted > lastDrawMapReq) && !forceDraw) {
             return;
         }
@@ -629,7 +624,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
 
         // thin less translucent rectangle
         g.setColor(new Color(255, 255, 255, 180));
-        ((Graphics2D) g).setStroke(new BasicStroke(zoom / 2));
+        ((Graphics2D) g).setStroke(new BasicStroke(zoom / 2f));
         g.drawRect(x1, y1, x2, y2);
     }
 
@@ -664,7 +659,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
 
         int[] xTriangle = new int[3];
         int[] yTriangle = new int[3];
-        xTriangle[0] = Math.round((w - 11) / 2);
+        xTriangle[0] = Math.round((w - 11) / 2f);
         xTriangle[1] = xTriangle[0] + 11;
         if (minimized) {
             yTriangle[0] = h - 10;
@@ -815,6 +810,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
 
     private void paintSingleCoordBorder(Graphics g, int x, int y, Color c) {
         g.setColor(c);
+        ((Graphics2D) g).setStroke(new BasicStroke(Math.max(1, zoom / 2f)));
         g.drawPolygon(xPoints(x), yPoints(x, y), 6);
     }
 
@@ -1472,7 +1468,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         
         @Override
         public void hexMoused(BoardViewEvent b) {
-            update();
+            repaint();
         }
 
         @Override


### PR DESCRIPTION
- makes it possible again to show the minimap in the board editor
- makes specific hex borders on the minimap thicker on high zoom (big minimap) to improve visibility (e.g. deployment borders)
- makes the minimap repaint continuously when the board is dragged in the main boardview window to show updates to the visible section (this does not do a full minimap redraw, only blits the image again and draws the visible section rectangle, so should be very fast)
- removes the paint() and update() overrides from the minimap in favor of paintComponent which should be the method to override. This seems to remove a slight lag when starting a drag in the main boardview window in deployment although I couldn't find out why this lagged except that it came from drawing the deployment borders in the minimap.
- removes a few synchronized as the minimap is only accessed from the EDT.