### PR TITLE
Issue 4480: Prevent exception in the Weapon panel

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1978,7 +1978,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         ranges[0] = wtype.getRanges(mounted);
 
         AmmoType atype = null;
-        if (mounted.getLinked() != null) {
+        if ((mounted.getLinked() != null) && (mounted.getLinked().getType() instanceof AmmoType)) {
             atype = (AmmoType) mounted.getLinked().getType();
         }
 


### PR DESCRIPTION
The BA AP weapon exception was due to the linked() thing not being ammo but the armored glove or AP mount.
Fixes #4480 
Fixes #3494 