### PR TITLE
load themes; prevent nag for disabled textboxes; npe fix

### DIFF
--- a/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
@@ -353,8 +353,9 @@ public class RandomMapDialog extends JDialog implements ActionListener {
             return;
         }
 
-        // Cache the selected boards, so we can restore them
-        List<String> selectedBoards = mapSettings.getBoardsSelectedVector();
+        // Cache the selected boards if they exist, so we can restore them
+        List<String> selectedBoards = mapSettings != null ? mapSettings.getBoardsSelectedVector() : null;
+
         // Load the file.  If there is an error, log it and return.
         try (InputStream is = new FileInputStream(selectedFile)) {
             mapSettings = MapSettings.getInstance(is);
@@ -362,9 +363,13 @@ public class RandomMapDialog extends JDialog implements ActionListener {
             LogManager.getLogger().error("", e);
             return;
         }
-        mapSettings.setBoardsSelectedVector(selectedBoards);
+
+        if(selectedBoards != null) {
+            mapSettings.setBoardsSelectedVector(selectedBoards);
+        }
 
         // Pass the loaded settings into the two different views.
+        choTheme.setSelectedItem(mapSettings.getTheme());
         basicPanel.setMapSettings(mapSettings);
         advancedPanel.setMapSettings(mapSettings);
     }

--- a/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapPanelAdvanced.java
@@ -27,6 +27,8 @@ import javax.swing.*;
 import javax.swing.border.LineBorder;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 /**
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
@@ -610,6 +612,11 @@ public class RandomMapPanelAdvanced extends JPanel {
         JLabel cityTypeLabel = new JLabel(Messages.getString("RandomMapDialog.labCity"));
         panel.add(cityTypeLabel);
         cityTypeCombo.setToolTipText(Messages.getString("RandomMapDialog.cityTypeCombo.toolTip"));
+
+        // don't nag the user about city parameters if the city is NONE
+        cityTypeCombo.addActionListener(e -> {
+            setCityPanelState();
+        });
         panel.add(cityTypeCombo);
         panel.add(new JLabel());
         panel.add(new JLabel());
@@ -660,7 +667,23 @@ public class RandomMapPanelAdvanced extends JPanel {
                                          Messages.getString("RandomMapDialog.borderCity")));
 
         RandomMapPanelBasic.makeCompactGrid(panel, 6, 4, 6, 6, 6, 6);
+        setCityPanelState();
         return panel;
+    }
+
+    /**
+     * Worker function that sets up the state of the city-related textboxes
+     */
+    private void setCityPanelState() {
+        boolean enableCityControls = cityTypeCombo.getSelectedIndex() != 0;
+
+        cityBlocks.setEnabled(enableCityControls);
+        cityCFMaxField.setEnabled(enableCityControls);
+        cityCFMinField.setEnabled(enableCityControls);
+        cityFloorsMaxField.setEnabled(enableCityControls);
+        cityFloorsMinField.setEnabled(enableCityControls);
+        cityDensityField.setEnabled(enableCityControls);
+        townSizeField.setEnabled(enableCityControls);
     }
 
     private JScrollPane setupEffectsPanel() {

--- a/megamek/src/megamek/client/ui/swing/widget/VerifiableTextField.java
+++ b/megamek/src/megamek/client/ui/swing/widget/VerifiableTextField.java
@@ -206,12 +206,12 @@ public class VerifiableTextField extends JTextField implements FocusListener {
     /**
      * Compares the text field's value to the list of {@link DataVerifier} objects to ensure the validity of the data.
      * If the text value passes all validation checks, a NULL value will be returned.  Otherwise a description of
-     * the failed validation will be returned.
+     * the failed validation will be returned. Does not verify if the field is disabled.
      *
      * @return NULL if the text in the field is valid. A description of the failure otherwise.
      */
     public String verifyTextS() {
-        if (verifiers.isEmpty()) {
+        if (verifiers.isEmpty() || !isEnabled()) {
             return null;
         }
 


### PR DESCRIPTION
A couple of fixes for the random map panel:
- the user is no longer nagged about city parameters when city is set to NONE
- theme actually loads from preset random map files
- prevent NPE when previous map settings object is null for whatever reason