### PR TITLE
Board Overlays: numerous problems

### DIFF
--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -372,7 +372,7 @@
     </KeyBind>
 
     <KeyBind>
-        <command>toggleTurnDetails</command> <!-- Ctrl-P -->
+         <command>toggleTurnDetails</command> <!-- Ctrl-T -->
         <keyCode>84</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>

--- a/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
@@ -29,6 +29,7 @@ import megamek.common.preference.PreferenceChangeEvent;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
+import java.util.List;
 
 import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 
@@ -137,7 +138,11 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
      * @param isDoingAction true if user has entered actions for this turn, false if not.
      */
     protected void updateDonePanelButtons(final String doneButtonLabel, final String skipButtonLabel, final boolean isDoingAction,
-                                          @Nullable java.util.List<String> turnDetails) {
+                                          @Nullable List<String> turnDetails) {
+        if (isIgnoringEvents()) {
+            return;
+        }
+
         this.isDoingAction = isDoingAction;
         if (GUIP.getNagForNoAction()) {
             butDone.setText("<html><b>" + doneButtonLabel + "</b></html>");
@@ -164,6 +169,8 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
             butSkipTurn.setEnabled(true);
         }
 
-        clientgui.getBoardView().turnDetailsOverlay.setLines(turnDetails);
+        if (clientgui.getBoardView().turnDetailsOverlay != null) {
+            clientgui.getBoardView().turnDetailsOverlay.setLines(turnDetails);
+        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -938,7 +938,6 @@ public class ClientGUI extends JPanel implements BoardViewListener,
                 break;
             case VIEW_TOGGLE_SENSOR_RANGE:
                 GUIP.setShowSensorRange(!GUIP.getShowSensorRange());
-                bv.repaint();
                 break;
             case VIEW_TOGGLE_FOV_DARKEN:
                 GUIP.setFovDarken(!GUIP.getFovDarken());

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -878,9 +878,6 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             case VIEW_MINI_MAP:
                 GUIP.toggleMinimapEnabled();
                 break;
-            case VIEW_KEYBINDS_OVERLAY:
-                GUIP.toggleKeybindsOverlay();
-                break;
             case VIEW_TOGGLE_HEXCOORDS:
                 GUIP.toggleCoords();
                 break;
@@ -961,11 +958,6 @@ public class ClientGUI extends JPanel implements BoardViewListener,
                 if (curPanel instanceof MovementDisplay) {
                     GUIP.setMoveEnvelope(!GUIP.getMoveEnvelope());
                     ((MovementDisplay) curPanel).computeMovementEnvelope(getUnitDisplay().getCurrentEntity());
-                }
-                break;
-            case VIEW_TURN_DETAILS_OVERLAY:
-                if (curPanel instanceof ActionPhaseDisplay) {
-                    GUIP.setTurnDetailsOverlay(!GUIP.getTurnDetailsOverlay());
                 }
                 break;
             case VIEW_MOVE_MOD_ENV:

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -371,6 +371,12 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         } else if (event.getActionCommand().equals(ClientGUI.VIEW_PLANETARYCONDITIONS_OVERLAY)) {
             GUIP.togglePlanetaryConditionsOverlay();
 
+        } else if (event.getActionCommand().equals(VIEW_KEYBINDS_OVERLAY)) {
+            GUIP.toggleKeybindsOverlay();
+
+        } else if (event.getActionCommand().equals(VIEW_TURN_DETAILS_OVERLAY)) {
+            GUIP.setTurnDetailsOverlay(!GUIP.getTurnDetailsOverlay());
+
         } else if (event.getActionCommand().equals(ClientGUI.VIEW_LABELS)) {
             GUIP.setUnitLabelStyle(GUIP.getUnitLabelStyle().next());
 
@@ -463,7 +469,7 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         viewZoomOut.setEnabled(isBoardView);
         toggleIsometric.setEnabled(isBoardView);
         viewKeybindsOverlay.setEnabled(isBoardView);
-        viewPlanetaryConditionsOverlay.setEnabled(isBoardView);
+        viewPlanetaryConditionsOverlay.setEnabled(isInGameBoardView);
         toggleHexCoords.setEnabled(isBoardView);
 
         viewLOSSetting.setEnabled(isInGameBoardView);
@@ -512,6 +518,8 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
             viewKeybindsOverlay.setSelected((Boolean) e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.SHOW_PLANETARYCONDITIONS_OVERLAY)) {
             viewPlanetaryConditionsOverlay.setSelected((Boolean) e.getNewValue());
+        } else if (e.getName().equals(GUIPreferences.TURN_DETAILS_OVERLAY)) {
+            viewTurnDetailsOverlay.setSelected((Boolean) e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.SHOW_UNIT_OVERVIEW)) {
             viewUnitOverview.setSelected((Boolean) e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.GUI_SCALE)) {

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -265,6 +265,8 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         viewKeybindsOverlay.setSelected(GUIP.getShowKeybindsOverlay());
         initMenuItem(viewPlanetaryConditionsOverlay, menu, VIEW_PLANETARYCONDITIONS_OVERLAY);
         viewPlanetaryConditionsOverlay.setSelected(GUIP.getShowPlanetaryConditionsOverlay());
+        initMenuItem(viewTurnDetailsOverlay, menu, VIEW_TURN_DETAILS_OVERLAY);
+        viewTurnDetailsOverlay.setSelected(GUIP.getTurnDetailsOverlay());
         initMenuItem(viewUnitOverview, menu, VIEW_UNIT_OVERVIEW);
         menu.addSeparator();
 
@@ -290,8 +292,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         toggleFovHighlight.setSelected(GUIP.getFovHighlight());
         initMenuItem(viewMovementEnvelope, menu, VIEW_MOVE_ENV);
         viewMovementEnvelope.setSelected(GUIP.getMoveEnvelope());
-        initMenuItem(viewTurnDetailsOverlay, menu, VIEW_TURN_DETAILS_OVERLAY);
-        viewTurnDetailsOverlay.setSelected(GUIP.getTurnDetailsOverlay());
         initMenuItem(viewMovModEnvelope, menu, VIEW_MOVE_MOD_ENV);
         menu.addSeparator();
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1073,7 +1073,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
     }
 
-    ArrayList<String> computeTurnDetails(){
+    private List<String> computeTurnDetails(){
         String validTextColor = AbstractBoardViewOverlay.colorToHex(AbstractBoardViewOverlay.getTextColor());
         String invalidTextColor = AbstractBoardViewOverlay.colorToHex(AbstractBoardViewOverlay.getTextColor(), 0.7f);
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -342,7 +342,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     public static final int GEAR_LONGEST_RUN = 10;
     public static final int GEAR_LONGEST_WALK = 11;
     public static final int GEAR_STRAFE = 12;
-    public static final String turnDetailsFormat = "%s%-3s %-12s %1s %2dMP%s";
+    public static final String turnDetailsFormat = "%s%-3s %-14s %1s %2dMP%s";
 
     /**
      * Creates and lays out a new movement phase display for the specified
@@ -1110,19 +1110,19 @@ public class MovementDisplay extends ActionPhaseDisplay {
             accumLegal = currentLegal;
             switch (accumType) {
                 case TURN_LEFT:
-                    unicodeIcon = "\u21B0";
+                    unicodeIcon = "↰";
                     break;
                 case TURN_RIGHT:
-                    unicodeIcon = "\u21B1";
+                    unicodeIcon = "↱";
                     break;
                 case FORWARDS:
-                    unicodeIcon = "\u2191";
+                    unicodeIcon = "↑";
                     break;
                 case BACKWARDS:
-                    unicodeIcon = "\u2193";
+                    unicodeIcon = "↓";
                     break;
                 case START_JUMP:
-                    unicodeIcon = "\u21EF";
+                    unicodeIcon = "⇯";
                     break;
                 default:
                     unicodeIcon = "";
@@ -1132,9 +1132,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // add line for last moves
         turnDetails.add(String.format(turnDetailsFormat,
-                accumLegal ?validTextColor :invalidTextColor,
-                accumTypeCount ==1?"":"x"+accumTypeCount,
-                accumType,unicodeIcon,accumMP,"*".repeat(accumDanger)));
+                accumLegal ? validTextColor : invalidTextColor,
+                accumTypeCount == 1 ? "" : "x" + accumTypeCount,
+                accumType, unicodeIcon, accumMP, "*".repeat(accumDanger)));
         return turnDetails;
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -431,21 +431,21 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         game.addGameListener(gameListener);
         game.getBoard().addBoardListener(this);
 
-        keybindOverlay = new KeyBindingsOverlay(game, clientgui);
         // Avoid showing the key binds when they can't be used (in the lobby map preview)
         if (controller != null) {
+            keybindOverlay = new KeyBindingsOverlay(game, clientgui);
             addDisplayable(keybindOverlay);
         }
 
-        planetaryConditionsOverlay = new PlanetaryConditionsOverlay(game, clientgui);
         // Avoid showing the planetary Conditions when they can't be used (in the lobby map preview)
         if (controller != null) {
+            planetaryConditionsOverlay = new PlanetaryConditionsOverlay(game, clientgui);
             addDisplayable(planetaryConditionsOverlay);
         }
 
-        turnDetailsOverlay = new TurnDetailsOverlay(game, clientgui);
         // Avoid showing the planetary Conditions when they can't be used (in the lobby map preview)
         if (controller != null) {
+            turnDetailsOverlay = new TurnDetailsOverlay(game, clientgui);
             addDisplayable(turnDetailsOverlay);
         }
 
@@ -901,12 +901,24 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 break;
 
             case GUIPreferences.SHOW_KEYBINDS_OVERLAY:
-                keybindOverlay.setVisible((boolean) e.getNewValue());
-                repaint();
+                if (keybindOverlay != null) {
+                    keybindOverlay.setVisible((boolean) e.getNewValue());
+                    repaint();
+                }
                 break;
+
             case GUIPreferences.SHOW_PLANETARYCONDITIONS_OVERLAY:
-                planetaryConditionsOverlay.setVisible((boolean) e.getNewValue());
-                repaint();
+                if (planetaryConditionsOverlay != null) {
+                    planetaryConditionsOverlay.setVisible((boolean) e.getNewValue());
+                    repaint();
+                }
+                break;
+
+            case GUIPreferences.TURN_DETAILS_OVERLAY:
+                if (turnDetailsOverlay != null) {
+                    turnDetailsOverlay.setVisible((boolean) e.getNewValue());
+                    repaint();
+                }
                 break;
 
             case GUIPreferences.AOHEXSHADOWS:
@@ -933,6 +945,14 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 break;
 
             case KeyBindParser.KEYBINDS_CHANGED:
+            case GUIPreferences.GUI_SCALE:
+                keybindOverlay.setDirty();
+                planetaryConditionsOverlay.setDirty();
+                turnDetailsOverlay.setDirty();
+                repaint();
+                break;
+
+            case GUIPreferences.SHOW_SENSOR_RANGE:
                 repaint();
                 break;
         }
@@ -5763,11 +5783,10 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
      * Appends HTML describing the buildings and minefields in a given hex
      */
     public void appendBuildingsTooltip(StringBuffer txt, @Nullable Hex mhex) {
-        if (mhex == null) {
-            return;
+        if ((mhex != null) && (clientgui != null)) {
+            String result = HexTooltip.getHexTip(mhex, clientgui.getClient());
+            txt.append(result);
         }
-        String result = HexTooltip.getHexTip(mhex, clientgui.getClient());
-        txt.append(result);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -433,19 +433,19 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         // Avoid showing the key binds when they can't be used (in the lobby map preview)
         if (controller != null) {
-            keybindOverlay = new KeyBindingsOverlay(game, clientgui);
+            keybindOverlay = new KeyBindingsOverlay(this);
             addDisplayable(keybindOverlay);
         }
 
         // Avoid showing the planetary Conditions when they can't be used (in the lobby map preview)
         if (controller != null) {
-            planetaryConditionsOverlay = new PlanetaryConditionsOverlay(game, clientgui);
+            planetaryConditionsOverlay = new PlanetaryConditionsOverlay(this);
             addDisplayable(planetaryConditionsOverlay);
         }
 
         // Avoid showing the planetary Conditions when they can't be used (in the lobby map preview)
         if (controller != null) {
-            turnDetailsOverlay = new TurnDetailsOverlay(game, clientgui);
+            turnDetailsOverlay = new TurnDetailsOverlay(this);
             addDisplayable(turnDetailsOverlay);
         }
 
@@ -900,27 +900,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 getTilesetManager().reloadUnitIcons();
                 break;
 
-            case GUIPreferences.SHOW_KEYBINDS_OVERLAY:
-                if (keybindOverlay != null) {
-                    keybindOverlay.setVisible((boolean) e.getNewValue());
-                    repaint();
-                }
-                break;
-
-            case GUIPreferences.SHOW_PLANETARYCONDITIONS_OVERLAY:
-                if (planetaryConditionsOverlay != null) {
-                    planetaryConditionsOverlay.setVisible((boolean) e.getNewValue());
-                    repaint();
-                }
-                break;
-
-            case GUIPreferences.TURN_DETAILS_OVERLAY:
-                if (turnDetailsOverlay != null) {
-                    turnDetailsOverlay.setVisible((boolean) e.getNewValue());
-                    repaint();
-                }
-                break;
-
             case GUIPreferences.AOHEXSHADOWS:
             case GUIPreferences.FLOATINGISO:
             case GUIPreferences.LEVELHIGHLIGHT:
@@ -941,14 +920,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             case GUIPreferences.INCLINES:
                 game.getBoard().initializeAllAutomaticTerrain((boolean) e.getNewValue());
                 clearHexImageCache();
-                repaint();
-                break;
-
-            case KeyBindParser.KEYBINDS_CHANGED:
-            case GUIPreferences.GUI_SCALE:
-                keybindOverlay.setDirty();
-                planetaryConditionsOverlay.setDirty();
-                turnDetailsOverlay.setDirty();
                 repaint();
                 break;
 

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -15,7 +15,6 @@ package megamek.client.ui.swing.boardview;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.common.Game;
 
@@ -137,10 +136,6 @@ public class KeyBindingsOverlay extends AbstractBoardViewOverlay {
         return result;
     }
 
-    @Override
-    protected void setVisibilityGUIPreference(boolean value) {
-        GUIP.setValue(GUIPreferences.SHOW_KEYBINDS_OVERLAY, value);
-    }
     @Override
     protected boolean getVisibilityGUIPreference() {
         return GUIP.getShowKeybindsOverlay();

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -14,9 +14,9 @@
 package megamek.client.ui.swing.boardview;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.ClientGUI;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
-import megamek.common.Game;
+import megamek.common.preference.PreferenceChangeEvent;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -82,9 +82,13 @@ public class KeyBindingsOverlay extends AbstractBoardViewOverlay {
      * An overlay for the Boardview that displays a selection of keybinds
      * for the current game situation.
      */
-    public KeyBindingsOverlay(Game game, ClientGUI cg) {
-        super(game, cg, new Font("SansSerif", Font.PLAIN, 13),
-                Messages.getString("KeyBindingsDisplay.heading", KeyCommandBind.getDesc(KeyCommandBind.KEY_BINDS)) );
+    public KeyBindingsOverlay(BoardView boardView) {
+        super(boardView, new Font("SansSerif", Font.PLAIN, 13));
+    }
+
+    @Override
+    protected String getHeaderText() {
+        return Messages.getString("KeyBindingsDisplay.heading", KeyCommandBind.getDesc(KeyCommandBind.KEY_BINDS));
     }
 
     /** @return an ArrayList of all text lines to be shown. */
@@ -149,5 +153,14 @@ public class KeyBindingsOverlay extends AbstractBoardViewOverlay {
     @Override
     protected int getDistSide(Rectangle clipBounds, int overlayWidth) {
         return 30;
+    }
+
+    @Override
+    public void preferenceChange(PreferenceChangeEvent e) {
+        if (e.getName().equals(GUIPreferences.SHOW_KEYBINDS_OVERLAY)) {
+            setVisible((boolean) e.getNewValue());
+            scheduleBoardViewRepaint();
+        }
+        super.preferenceChange(e);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
@@ -15,21 +15,17 @@ package megamek.client.ui.swing.boardview;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.common.Game;
 import megamek.common.PlanetaryConditions;
 
 import java.awt.*;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * An overlay for the Boardview that displays a selection of Planetary Conditions
  * for the current game situation
- *
- *
  */
 public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
     private static final String MSG_TEMPERATURE = Messages.getString("PlanetaryConditionsOverlay.Temperature");
@@ -69,7 +65,7 @@ public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
             if (currentGame.getPlanetaryConditions().isExtremeTemperatureHeat()) {
                 tempColor = colorToHex(colorHot);
             } else if (currentGame.getPlanetaryConditions().isExtremeTemperatureCold()) {
-                tempColor = colorToHex(colorHot);
+                tempColor = colorToHex(colorCold);
             }
 
             boolean showDefaultConditions = GUIP.getPlanetaryConditionsShowDefaults();
@@ -82,8 +78,8 @@ public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
 
             if (showDefaultConditions || (currentGame.getPlanetaryConditions().isExtremeTemperature())) {
                 tmpStr = (showLabel ? MSG_TEMPERATURE + "  " : "");
-                tmpStr = tmpStr + (showValue ? temp + "\u00B0C  " : "");
-                tmpStr = tmpStr + (showIndicator ? (!showValue ? temp + "\u00B0C   " : "" ) + currentGame.getPlanetaryConditions().getTemperatureIndicator() : "");
+                tmpStr = tmpStr + (showValue ? temp + "°C  " : "");
+                tmpStr = tmpStr + (showIndicator ? (!showValue ? temp + "°C   " : "" ) + currentGame.getPlanetaryConditions().getTemperatureIndicator() : "");
                 result.add(tempColor + tmpStr);
             }
 
@@ -152,10 +148,6 @@ public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
         return result;
     }
 
-    @Override
-    protected void setVisibilityGUIPreference(boolean value) {
-        GUIP.setValue(GUIPreferences.SHOW_PLANETARYCONDITIONS_OVERLAY, value);
-    }
     @Override
     protected boolean getVisibilityGUIPreference() {
         return GUIP.getShowPlanetaryConditionsOverlay();

--- a/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
@@ -14,10 +14,10 @@
 package megamek.client.ui.swing.boardview;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.ClientGUI;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
-import megamek.common.Game;
 import megamek.common.PlanetaryConditions;
+import megamek.common.preference.PreferenceChangeEvent;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -43,9 +43,13 @@ public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
      * An overlay for the Boardview that displays a selection of Planetary Conditions
      * for the current game situation.
      */
-    public PlanetaryConditionsOverlay(Game game, ClientGUI cg) {
-        super(game, cg, new Font("SansSerif", Font.PLAIN, 13),
-                Messages.getString("PlanetaryConditionsOverlay.heading",  KeyCommandBind.getDesc(KeyCommandBind.PLANETARY_CONDITIONS)));
+    public PlanetaryConditionsOverlay(BoardView boardView) {
+        super(boardView, new Font("SansSerif", Font.PLAIN, 13));
+    }
+
+    @Override
+    protected String getHeaderText() {
+        return Messages.getString("PlanetaryConditionsOverlay.heading",  KeyCommandBind.getDesc(KeyCommandBind.PLANETARY_CONDITIONS));
     }
 
     /** @return an ArrayList of all text lines to be shown. */
@@ -161,5 +165,14 @@ public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
     @Override
     protected int getDistSide(Rectangle clipBounds, int overlayWidth) {
         return clipBounds.width - (overlayWidth + 100);
+    }
+
+    @Override
+    public void preferenceChange(PreferenceChangeEvent e) {
+        if (e.getName().equals(GUIPreferences.SHOW_PLANETARYCONDITIONS_OVERLAY)) {
+            setVisible((boolean) e.getNewValue());
+            scheduleBoardViewRepaint();
+        }
+        super.preferenceChange(e);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/TurnDetailsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TurnDetailsOverlay.java
@@ -14,9 +14,9 @@
 package megamek.client.ui.swing.boardview;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.ClientGUI;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
-import megamek.common.Game;
+import megamek.common.preference.PreferenceChangeEvent;
 
 import java.awt.*;
 import java.util.ArrayList;
@@ -30,9 +30,13 @@ public class TurnDetailsOverlay extends AbstractBoardViewOverlay {
 
     List<String> lines = new ArrayList<>();
 
-    public TurnDetailsOverlay(Game game, ClientGUI cg) {
-        super(game, cg, new Font(Font.MONOSPACED, Font.BOLD, 12),
-                Messages.getString("TurnDetailsOverlay.heading", KeyCommandBind.getDesc(KeyCommandBind.TURN_DETAILS)) );
+    public TurnDetailsOverlay(BoardView boardView) {
+        super(boardView, new Font(Font.MONOSPACED, Font.BOLD, 12));
+    }
+
+    @Override
+    protected String getHeaderText() {
+        return Messages.getString("TurnDetailsOverlay.heading", KeyCommandBind.getDesc(KeyCommandBind.TURN_DETAILS));
     }
 
     @Override
@@ -51,7 +55,7 @@ public class TurnDetailsOverlay extends AbstractBoardViewOverlay {
 
     @Override
     protected void gameTurnOrPhaseChange() {
-        if (!clientGui.getClient().isMyTurn()) {
+        if ((clientGui == null) || !clientGui.getClient().isMyTurn()) {
             lines.clear();
         }
         super.gameTurnOrPhaseChange();
@@ -70,5 +74,14 @@ public class TurnDetailsOverlay extends AbstractBoardViewOverlay {
     @Override
     protected int getDistSide(Rectangle clipBounds, int overlayWidth) {
         return clipBounds.width - (overlayWidth + 100);
+    }
+
+    @Override
+    public void preferenceChange(PreferenceChangeEvent e) {
+        if (e.getName().equals(GUIPreferences.TURN_DETAILS_OVERLAY)) {
+            setVisible((boolean) e.getNewValue());
+            scheduleBoardViewRepaint();
+        }
+        super.preferenceChange(e);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/TurnDetailsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TurnDetailsOverlay.java
@@ -15,7 +15,6 @@ package megamek.client.ui.swing.boardview;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.common.Game;
 
@@ -26,25 +25,16 @@ import java.util.List;
 /**
  * An overlay for the Boardview that displays info about the users turn, such as list of users Move or Attack commands
  * for the current game situation
- *
- *
  */
 public class TurnDetailsOverlay extends AbstractBoardViewOverlay {
-    /**
-     * An overlay for the Boardview that shows details about a players turn
-     */
 
     List<String> lines = new ArrayList<>();
-
-    static String validTextColor, invalidTextColor;
 
     public TurnDetailsOverlay(Game game, ClientGUI cg) {
         super(game, cg, new Font(Font.MONOSPACED, Font.BOLD, 12),
                 Messages.getString("TurnDetailsOverlay.heading", KeyCommandBind.getDesc(KeyCommandBind.TURN_DETAILS)) );
     }
 
-
-    /** @return an ArrayList of all text lines to be shown. */
     @Override
     protected List<String> assembleTextLines() {
         return lines;
@@ -67,10 +57,6 @@ public class TurnDetailsOverlay extends AbstractBoardViewOverlay {
         super.gameTurnOrPhaseChange();
     }
 
-    @Override
-    protected void setVisibilityGUIPreference(boolean value) {
-        GUIP.setTurnDetailsOverlay(value);
-    }
     @Override
     protected boolean getVisibilityGUIPreference() {
         return GUIP.getTurnDetailsOverlay();


### PR DESCRIPTION
Corrects numerous problems, hopefully without introducing too many new ones
- prevents updating the done button and turn summary in phase displays that aren't active
- streamlines turning overlay visibility on/off 
- prevents adding overlays in boardviews that dont need them (it seems safer to create them but it isn't, I immediately got NPEs from listener calls for overlays that were never used, no less than three separate TurnDetailsOverlays)
- ~~removes event listening from overlays (let the boardview have control)~~
- fixes #4537 