### PR TITLE
Fatigue (Issue 894): Calculate Infantry TO fatigue from best of G/P

### DIFF
--- a/megamek/src/megamek/common/CrewType.java
+++ b/megamek/src/megamek/common/CrewType.java
@@ -35,14 +35,15 @@ public enum CrewType {
     SUPERHEAVY_TRIPOD (new String[] {"Pilot", "Gunner", "Tech Officer"}, 0, 1, 2, 2, 3),
     QUADVEE (new String[] {"Pilot", "Gunner"}, 0, 1, -1, -1, 3),
     DUAL (new String[] {"Pilot", "Gunner"}, 0, 1, -1, -1, 2),
-    COMMAND_CONSOLE (new String[] {"Pilot", "Commander"}, 0, 0, 1, -1, 1);
+    COMMAND_CONSOLE (new String[] {"Pilot", "Commander"}, 0, 0, 1, -1, 1),
+    INFANTRY_CREW (new String[] {"Commander"}, 0, 0, -1, -1, 1);
 
-    private String[] roleNames;
-    private int pilotPos;
-    private int gunnerPos;
-    private int commanderPos;
-    private int techPos;
-    private int maxPrimaryTargets;
+    private final String[] roleNames;
+    private final int pilotPos;
+    private final int gunnerPos;
+    private final int commanderPos;
+    private final int techPos;
+    private final int maxPrimaryTargets;
 
     CrewType(String[] roleNames, int pilotPos, int gunnerPos, int commanderPos, int techPos,
             int maxPrimaryTargets) {

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -166,7 +166,7 @@ public class Infantry extends Entity {
 
     @Override
     public CrewType defaultCrewType() {
-        return CrewType.CREW;
+        return CrewType.INFANTRY_CREW;
     }
 
     public static TechAdvancement getMotiveTechAdvancement(EntityMovementMode movementMode) {

--- a/megamek/unittests/megamek/common/CrewTest.java
+++ b/megamek/unittests/megamek/common/CrewTest.java
@@ -23,7 +23,7 @@ import megamek.common.battlevalue.BVCalculator;
 import megamek.common.options.GameOptions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,6 +33,90 @@ import static org.mockito.Mockito.when;
  * @since 10/30/13 9:25 AM
  */
 public class CrewTest {
+
+    @Test
+    public void testInfantryCrewFatigue() {
+        Infantry inf = mock(Infantry.class);
+        Crew crew = getInfantryCrewWithCombatTurns(17);
+        when(inf.getCrew()).thenReturn(crew);
+        inf.getCrew().setGunnery(5);
+        inf.getCrew().setPiloting(8);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+        assertTrue(inf.getCrew().isGunneryFatigued());
+
+        inf.getCrew().setGunnery(4);
+        inf.getCrew().setPiloting(2);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+        assertFalse(inf.getCrew().isGunneryFatigued());
+
+        inf.getCrew().setGunnery(1);
+        assertFalse(inf.getCrew().isPilotingFatigued());
+
+        inf.getCrew().setFatigue(15);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+
+        crew = getInfantryCrewWithCombatTurns(16);
+        when(inf.getCrew()).thenReturn(crew);
+        inf.getCrew().setGunnery(2);
+        inf.getCrew().setPiloting(8);
+        assertFalse(inf.getCrew().isPilotingFatigued());
+
+        inf.getCrew().setFatigue(4);
+        assertFalse(inf.getCrew().isPilotingFatigued());
+
+        inf.getCrew().setFatigue(5);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+    }
+
+    @Test
+    public void testMekCrewFatigue() {
+        Mech inf = mock(Mech.class);
+        Crew crew = getMekCrewWithCombatTurns(17);
+        when(inf.getCrew()).thenReturn(crew);
+        inf.getCrew().setGunnery(5);
+        inf.getCrew().setPiloting(8);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+        assertTrue(inf.getCrew().isGunneryFatigued());
+
+        inf.getCrew().setGunnery(4);
+        inf.getCrew().setPiloting(2);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+        assertFalse(inf.getCrew().isGunneryFatigued());
+
+        inf.getCrew().setGunnery(1);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+
+        inf.getCrew().setFatigue(15);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+
+        crew = getMekCrewWithCombatTurns(16);
+        when(inf.getCrew()).thenReturn(crew);
+        inf.getCrew().setGunnery(2);
+        inf.getCrew().setPiloting(8);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+
+        inf.getCrew().setFatigue(4);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+
+        inf.getCrew().setFatigue(5);
+        assertTrue(inf.getCrew().isPilotingFatigued());
+    }
+
+    Crew getInfantryCrewWithCombatTurns(int turnsActive) {
+        return getCrewWithCombatTurns(turnsActive, CrewType.INFANTRY_CREW);
+    }
+
+    Crew getMekCrewWithCombatTurns(int turnsActive) {
+        return getCrewWithCombatTurns(turnsActive, CrewType.SINGLE);
+    }
+
+    Crew getCrewWithCombatTurns(int turnsActive, CrewType crewType) {
+        Crew crew = new Crew(crewType);
+        for (int rounds = 0; rounds < turnsActive; rounds++) {
+            crew.incrementFatigueCount();
+        }
+        return crew;
+    }
 
     @Test
     public void testGetBVSkillMultiplier() {


### PR DESCRIPTION
Fixes #894

This requires making Crew aware that they're Infantry or moving out the whole thing to Entity or giving Crew an entity field. I opted for another CrewType. There doesn't seem to be anything to change across MM/MML/MHQ because of this addition.