### PR TITLE
Board Overlays: Replace unicode characters with unicode codes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1110,19 +1110,19 @@ public class MovementDisplay extends ActionPhaseDisplay {
             accumLegal = currentLegal;
             switch (accumType) {
                 case TURN_LEFT:
-                    unicodeIcon = "↰";
+                    unicodeIcon = "\u21B0";
                     break;
                 case TURN_RIGHT:
-                    unicodeIcon = "↱";
+                    unicodeIcon = "\u21B1";
                     break;
                 case FORWARDS:
-                    unicodeIcon = "↑";
+                    unicodeIcon = "\u2191";
                     break;
                 case BACKWARDS:
-                    unicodeIcon = "↓";
+                    unicodeIcon = "\u2193";
                     break;
                 case START_JUMP:
-                    unicodeIcon = "⇯";
+                    unicodeIcon = "\u21EF";
                     break;
                 default:
                     unicodeIcon = "";

--- a/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/PlanetaryConditionsOverlay.java
@@ -82,8 +82,8 @@ public class PlanetaryConditionsOverlay extends AbstractBoardViewOverlay {
 
             if (showDefaultConditions || (currentGame.getPlanetaryConditions().isExtremeTemperature())) {
                 tmpStr = (showLabel ? MSG_TEMPERATURE + "  " : "");
-                tmpStr = tmpStr + (showValue ? temp + "°C  " : "");
-                tmpStr = tmpStr + (showIndicator ? (!showValue ? temp + "°C   " : "" ) + currentGame.getPlanetaryConditions().getTemperatureIndicator() : "");
+                tmpStr = tmpStr + (showValue ? temp + "\u00B0C  " : "");
+                tmpStr = tmpStr + (showIndicator ? (!showValue ? temp + "\u00B0C   " : "" ) + currentGame.getPlanetaryConditions().getTemperatureIndicator() : "");
                 result.add(tempColor + tmpStr);
             }
 


### PR DESCRIPTION
My bad, my IDE suggested replacing the unicode codes with the actual characters but it seems that's a no-go. This reverts it and hopefully 
Fixes #4544 