### PR TITLE
Connections package inner classes extraction

### DIFF
--- a/megamek/src/megamek/common/net/connections/AbstractConnection.java
+++ b/megamek/src/megamek/common/net/connections/AbstractConnection.java
@@ -15,8 +15,6 @@
 */
 package megamek.common.net.connections;
 
-import megamek.common.annotations.Nullable;
-import megamek.common.net.enums.PacketCommand;
 import megamek.common.net.events.AbstractConnectionEvent;
 import megamek.common.net.events.ConnectedEvent;
 import megamek.common.net.events.DisconnectedEvent;
@@ -30,81 +28,49 @@ import org.apache.logging.log4j.LogManager;
 import java.io.*;
 import java.net.Socket;
 import java.net.SocketException;
-import java.util.Enumeration;
-import java.util.LinkedList;
 import java.util.Objects;
 import java.util.Vector;
-import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 /**
  * Generic bidirectional connection between client and server
  */
 public abstract class AbstractConnection {
 
-    private static PacketMarshallerFactory marshallerFactory = PacketMarshallerFactory.getInstance();
-
+    private static final PacketMarshallerFactory marshallerFactory = PacketMarshallerFactory.getInstance();
     private static final int DEFAULT_MARSHALLING = PacketMarshaller.NATIVE_SERIALIZATION_MARSHALING;
 
-    /**
-     * Peer Host Non null in case if it's a client connection
-     */
+    private Socket socket;
+    private int connectionId;
+
+    /** Peer Host Non null in case if it's a client connection */
     private String host;
 
-    /**
-     * Peer port != 0 in case if it's a client connection
-     */
+    /** Peer port != 0 in case if it's a client connection */
     private int port;
 
-    /**
-     * Connection state
-     */
+    /** Connection state */
     private boolean open;
 
-    /**
-     * The socket for this connection.
-     */
-    private Socket socket;
-
-    /**
-     * The connection ID
-     */
-    private int id;
-
-    /**
-     * Bytes send during the connection lifecycle
-     */
+    /** Bytes send during the connection lifecycle */
     private long bytesSent;
 
-    /**
-     * Bytes received during the connection lifecycle
-     */
+    /** Bytes received during the connection lifecycle */
     private long bytesReceived;
 
-    /**
-     * Queue of <code>Packets</code> to send
-     */
-    private SendQueue sendQueue = new SendQueue();
+    /** Queue of Packets to send */
+    private final SendQueue sendQueue = new SendQueue();
 
-    /**
-     * Connection listeners list
-     */
-    private Vector<ConnectionListener> connectionListeners = new Vector<>();
+    /** Connection listeners list */
+    private final Vector<ConnectionListener> connectionListeners = new Vector<>();
 
-    /**
-     * Type of marshalling used to represent sent packets
-     */
+    /** Type of marshalling used to represent sent packets */
     protected int marshallingType;
 
-    /**
-     * Marshaller used to send packets
-     */
+    /** Marshaller used to send packets */
     protected PacketMarshaller marshaller;
 
-    /**
-     * Indicates the need to compress sent data
-     */
+    /** Indicates the need to compress sent data */
     private boolean zipData = true;
 
     /**
@@ -117,7 +83,7 @@ public abstract class AbstractConnection {
     public AbstractConnection(String host, int port, int id) {
         this.host = host;
         this.port = port;
-        this.id = id;
+        connectionId = id;
         setMarshallingType(DEFAULT_MARSHALLING);
     }
 
@@ -129,20 +95,16 @@ public abstract class AbstractConnection {
      */
     public AbstractConnection(Socket socket, int id) {
         this.socket = socket;
-        this.id = id;
+        connectionId = id;
         setMarshallingType(DEFAULT_MARSHALLING);
     }
 
-    /**
-     * @return <code>true</code> if it's the Server connection
-     */
+    /** @return True if this is the Server connection. */
     public boolean isServer() {
         return host == null;
     }
 
-    /**
-     * @return the type of the marshalling used to send packets
-     */
+    /** @return The type of the marshalling used to send packets. */
     protected int getMarshallingType() {
         return marshallingType;
     }
@@ -162,7 +124,7 @@ public abstract class AbstractConnection {
     /**
      * Opens the connection
      *
-     * @return <code>true</code> on success, <code>false</code> otherwise
+     * @return True on success, false otherwise
      */
     public synchronized boolean open() {
         if (!open) {
@@ -178,9 +140,7 @@ public abstract class AbstractConnection {
         return true;
     }
 
-    /**
-     * Closes the socket and shuts down the receiver and sender threads
-     */
+    /** Closes the socket and shuts down the receiver and sender threads. */
     public void close() {
         synchronized (this) {
             LogManager.getLogger().info("Starting to close " + getConnectionTypeText());
@@ -198,18 +158,14 @@ public abstract class AbstractConnection {
         processConnectionEvent(new DisconnectedEvent(this));
     }
 
-    /**
-     * @return if the socket for this connection has been closed.
-     */
+    /** @return True if the socket for this connection has been closed (or is null). */
     public boolean isClosed() {
         return (socket == null) || socket.isClosed();
     }
 
-    /**
-     * @return the connection ID
-     */
+    /** @return the connection ID. */
     public int getId() {
-        return id;
+        return connectionId;
     }
 
     /**
@@ -218,12 +174,10 @@ public abstract class AbstractConnection {
      * @param id new connection ID
      */
     public void setId(int id) {
-        this.id = id;
+        connectionId = id;
     }
 
-    /**
-     * @return the address this socket is or was connected to
-     */
+    /** @return The address this socket is or was connected to. */
     public String getInetAddress() {
         if (socket != null) {
             return socket.getInetAddress().toString();
@@ -231,11 +185,7 @@ public abstract class AbstractConnection {
         return "Unknown";
     }
 
-    /**
-     * Returns <code>true</code> if this connection compress the sent data
-     *
-     * @return <code>true</code> if this connection compress the sent data
-     */
+    /** @return True if this connection compresses the sent data. */
     public boolean isCompressed() {
         return zipData;
     }
@@ -243,24 +193,20 @@ public abstract class AbstractConnection {
     /**
      * Sets the compression
      *
-     * @param compress
+     * @param compress True when compression is to be used
      */
     public void setCompression(boolean compress) {
         zipData = compress;
     }
 
-    /**
-     * Adds a packet to the send queue to be sent on a separate thread.
-     */
+    /** Adds a packet to the send queue to be sent on a separate thread. */
     public synchronized void send(Packet packet) {
-        sendQueue.addPacket(new SendPacket(packet));
+        sendQueue.addPacket(new SendPacket(packet, this));
         // Send right now
         flush();
     }
 
-    /**
-     * Send the packet now, on a separate thread; This is the blocking call.
-     */
+    /** Send the packet now, on a separate thread; This is the blocking call. */
     public void sendNow(SendPacket packet) {
         try {
             sendNetworkPacket(packet.getData(), packet.isCompressed());
@@ -269,23 +215,17 @@ public abstract class AbstractConnection {
         }
     }
 
-    /**
-     * @return <code>true</code> if there are pending packets
-     */
+    /** @return True if there are pending packets. */
     public synchronized boolean hasPending() {
         return sendQueue.hasPending();
     }
 
-    /**
-     * @return a very approximate count of how many bytes were sent
-     */
+    /** @return a very approximate count of how many bytes were sent. */
     public synchronized long getBytesSent() {
         return bytesSent;
     }
 
-    /**
-     * @return a very approximate count of how many bytes were received
-     */
+    /** @return a very approximate count of how many bytes were received. */
     public synchronized long getBytesReceived() {
         return bytesReceived;
     }
@@ -308,29 +248,17 @@ public abstract class AbstractConnection {
         connectionListeners.removeElement(listener);
     }
 
-    /**
-     * Returns the connection type(client/server) that is used in the debug messages and so on.
-     */
+    /** @return The connection type ("Client" / "Server") that is used in the debug messages and so on. */
     protected String getConnectionTypeText() {
         return isServer() ? "Server" : "Client";
     }
 
-    /**
-     * Returns an input stream
-     *
-     * @return an input stream
-     * @throws IOException
-     */
+    /** @return an input stream */
     protected InputStream getInputStream() throws IOException {
         return socket.getInputStream();
     }
 
-    /**
-     * Returns an output stream
-     *
-     * @return an output stream
-     * @throws IOException
-     */
+    /** @return an output stream */
     protected OutputStream getOutputStream() throws IOException {
         return socket.getOutputStream();
     }
@@ -390,9 +318,7 @@ public abstract class AbstractConnection {
         }
     }
 
-    /**
-     * process a received packet
-     */
+    /** Processes a received packet. */
     protected void processPacket(INetworkPacket np) throws Exception {
         PacketMarshaller pm = marshallerFactory.getMarshaller(np.getMarshallingType());
         Objects.requireNonNull(pm);
@@ -406,18 +332,15 @@ public abstract class AbstractConnection {
         }
     }
 
-    /**
-     * process a packet to be sent
-     */
+    /** Processes a packet to be sent. */
     protected void processPacket(SendPacket packet) {
         sendNow(packet);
     }
 
     /**
-     * Reads a complete <code>NetworkPacket</code> must not block, must return
-     * null instead
+     * Reads a complete NetworkPacket. This method must not block, must return null instead.
      *
-     * @return the <code>NetworkPacket</code> that was sent.
+     * @return the NetworkPacket that was sent.
      */
     protected abstract INetworkPacket readNetworkPacket() throws Exception;
 
@@ -431,137 +354,28 @@ public abstract class AbstractConnection {
     protected abstract void sendNetworkPacket(byte[] data, boolean zipped) throws Exception;
 
     /**
-     * Wrapper around a <code>LinkedList</code> for keeping a queue of packets
-     * to send. Note that this implementation is not synchronized.
-     */
-    static class SendQueue {
-        private LinkedList<SendPacket> queue = new LinkedList<>();
-        private boolean finished = false;
-
-        public void addPacket(SendPacket packet) {
-            queue.add(packet);
-        }
-
-        public void finish() {
-            queue.clear();
-            finished = true;
-        }
-
-        /**
-         * Waits for a packet to appear in the queue and then returns it.
-         *
-         * @return the first available packet in the queue or null if none
-         */
-        public @Nullable SendPacket getPacket() {
-            return finished ? null : queue.poll();
-        }
-
-        /**
-         * Returns true if this connection has pending data
-         */
-        public boolean hasPending() {
-            return !queue.isEmpty();
-        }
-
-        public void reportContents() {
-            final String sb = queue.stream()
-                    .map(p -> '\n' + p.getCommand().toString()).collect(
-                            Collectors.joining("", "Contents of Send Queue:\n", ""));
-            LogManager.getLogger().warn(sb);
-        }
-    }
-
-    /**
      * Processes game events occurring on this connection by dispatching them to
      * any registered GameListener objects.
      *
      * @param event the game event.
      */
     protected void processConnectionEvent(AbstractConnectionEvent event) {
-        for (Enumeration<ConnectionListener> e = connectionListeners.elements(); e.hasMoreElements();) {
-            ConnectionListener l = e.nextElement();
+        for (ConnectionListener listener : connectionListeners) {
             switch (event.getType()) {
                 case CONNECTED:
-                    l.connected((ConnectedEvent) event);
+                    listener.connected((ConnectedEvent) event);
                     break;
                 case DISCONNECTED:
-                    l.disconnected((DisconnectedEvent) event);
+                    listener.disconnected((DisconnectedEvent) event);
                     break;
                 case PACKET_RECEIVED:
-                    l.packetReceived((PacketReceivedEvent) event);
+                    listener.packetReceived((PacketReceivedEvent) event);
                     break;
             }
         }
     }
 
-    private class SendPacket implements INetworkPacket {
-        byte[] data;
-        boolean zipped = false;
-        PacketCommand command;
-
-        public SendPacket(Packet packet) {
-            command = packet.getCommand();
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            OutputStream out;
-            try {
-                if (zipData && (packet.getData() != null)) {
-                    out = new GZIPOutputStream(bos);
-                    zipped = true;
-                } else {
-                    out = bos;
-                }
-                marshaller.marshall(packet, out);
-                out.close();
-                data = bos.toByteArray();
-                bytesSent += data.length;
-            } catch (Exception ex) {
-                LogManager.getLogger().error("", ex);
-            }
-        }
-
-        @Override
-        public int getMarshallingType() {
-            return marshallingType;
-        }
-
-        @Override
-        public byte[] getData() {
-            return data;
-        }
-
-        @Override
-        public boolean isCompressed() {
-            return zipped;
-        }
-
-        public PacketCommand getCommand() {
-            return command;
-        }
-    }
-
-    /**
-     * Connection layer data packet.
-     */
-    protected interface INetworkPacket {
-        /**
-         * Returns data marshalling type
-         *
-         * @return data marshalling type
-         */
-        int getMarshallingType();
-
-        /**
-         * Returns packet data
-         *
-         * @return packet data
-         */
-        byte[] getData();
-
-        /**
-         * Returns <code>true</code> if data is compressed
-         *
-         * @return <code>true</code> if data is compressed
-         */
-        boolean isCompressed();
+    void addBytesSent(int additionalBytesSent) {
+        bytesSent += additionalBytesSent;
     }
 }

--- a/megamek/src/megamek/common/net/connections/DataStreamConnection.java
+++ b/megamek/src/megamek/common/net/connections/DataStreamConnection.java
@@ -1,15 +1,21 @@
 /*
- * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2005 - Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 package megamek.common.net.connections;
 
@@ -21,38 +27,30 @@ import java.net.Socket;
 import java.net.SocketException;
 
 /**
- * Implementation of the <code>Connection</code> that uses the
- * <code>DataInputStream</code> and <code>DataOutputStream</code> to
- * send/receive data.
+ * Implementation of the AbstractConnection that uses the DataInputStream and
+ * DataOutputStream to send/receive data.
  */
 public class DataStreamConnection extends AbstractConnection {
 
-    /**
-     * Input stream
-     */
     private DataInputStream in;
-
-    /**
-     * Output stream
-     */
     private DataOutputStream out;
 
     /**
-     * Creates new server connection
+     * Creates new server connection.
      * 
-     * @param socket
-     * @param id
+     * @param socket The network socket to use
+     * @param id The connection ID
      */
     public DataStreamConnection(Socket socket, int id) {
         super(socket, id);
     }
 
     /**
-     * Creates new Client connection
+     * Creates new Client connection.
      * 
-     * @param host
-     * @param port
-     * @param id
+     * @param host The host address
+     * @param port The network port
+     * @param id The connection ID
      */
     public DataStreamConnection(String host, int port, int id) {
         super(host, port, id);
@@ -123,10 +121,8 @@ public class DataStreamConnection extends AbstractConnection {
                 }
             }
         } catch (SocketException ignored) {
-            // close this connection, because it's broken
-            // This can happen if the connection is closed while being written
-            // to, and it's not a big deal, since the connection is being broken
-            // anyways
+            // close this connection, because it's broken. This can happen if the connection is closed while
+            // being written to, and it's not a big deal, since the connection is being broken anyway
             close();
         } catch (IOException ex) {
             LogManager.getLogger().error("", ex);
@@ -138,51 +134,5 @@ public class DataStreamConnection extends AbstractConnection {
     @Override
     public String toString() {
         return "DataStreamConnection Id " + getId();
-    }
-
-    private static class NetworkPacket implements INetworkPacket {
-
-        /**
-         * Is data compressed
-         */
-        private boolean compressed;
-
-        /**
-         * Data marshalling type
-         */
-        private int marshallingType;
-
-        /**
-         * Packet data
-         */
-        private byte[] data;
-
-        /**
-         * Creates new packet
-         * 
-         * @param compressed
-         * @param marshallingType
-         * @param data
-         */
-        NetworkPacket(boolean compressed, int marshallingType, byte[] data) {
-            this.compressed = compressed;
-            this.marshallingType = marshallingType;
-            this.data = data;
-        }
-
-        @Override
-        public int getMarshallingType() {
-            return marshallingType;
-        }
-
-        @Override
-        public byte[] getData() {
-            return data;
-        }
-
-        @Override
-        public boolean isCompressed() {
-            return compressed;
-        }
     }
 }

--- a/megamek/src/megamek/common/net/connections/INetworkPacket.java
+++ b/megamek/src/megamek/common/net/connections/INetworkPacket.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.net.connections;
+
+/** This is an interface for a connection layer data packet. */
+interface INetworkPacket {
+
+    /** @return The data marshalling type. */
+    int getMarshallingType();
+
+    /** @return The packet data. */
+    byte[] getData();
+
+    /** @return True if the data is compressed. */
+    boolean isCompressed();
+}

--- a/megamek/src/megamek/common/net/connections/NetworkPacket.java
+++ b/megamek/src/megamek/common/net/connections/NetworkPacket.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.net.connections;
+
+class NetworkPacket implements INetworkPacket {
+
+    private final boolean isCompressed;
+    private final int marshallingType;
+    private final byte[] data;
+
+    /**
+     * Creates new packet
+     *
+     * @param compressed True when the data is compressed
+     * @param marshallingType The marhsalling type used
+     * @param data The packet data
+     */
+    NetworkPacket(boolean compressed, int marshallingType, byte[] data) {
+        isCompressed = compressed;
+        this.marshallingType = marshallingType;
+        this.data = data;
+    }
+
+    @Override
+    public int getMarshallingType() {
+        return marshallingType;
+    }
+
+    @Override
+    public byte[] getData() {
+        return data;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return isCompressed;
+    }
+}

--- a/megamek/src/megamek/common/net/connections/SendPacket.java
+++ b/megamek/src/megamek/common/net/connections/SendPacket.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.net.connections;
+
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+class SendPacket implements INetworkPacket {
+    private byte[] data;
+    private boolean zipped = false;
+    private final PacketCommand command;
+    private final AbstractConnection connection;
+
+    public SendPacket(Packet packet, AbstractConnection connection) {
+        command = packet.getCommand();
+        this.connection = connection;
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        OutputStream out;
+        try {
+            if (connection.isCompressed() && (packet.getData() != null)) {
+                out = new GZIPOutputStream(bos);
+                zipped = true;
+            } else {
+                out = bos;
+            }
+            connection.marshaller.marshall(packet, out);
+            out.close();
+            data = bos.toByteArray();
+            connection.addBytesSent(data.length);
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+        }
+    }
+
+    @Override
+    public int getMarshallingType() {
+        return connection.getMarshallingType();
+    }
+
+    @Override
+    public byte[] getData() {
+        return data;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return zipped;
+    }
+
+    public PacketCommand getCommand() {
+        return command;
+    }
+}

--- a/megamek/src/megamek/common/net/connections/SendQueue.java
+++ b/megamek/src/megamek/common/net/connections/SendQueue.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.net.connections;
+
+import megamek.common.annotations.Nullable;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.LinkedList;
+import java.util.stream.Collectors;
+
+/**
+ * Wrapper around a LinkedList for keeping a queue of packets
+ * to send. Note that this implementation is not synchronized.
+ */
+class SendQueue {
+    private final LinkedList<SendPacket> queue = new LinkedList<>();
+    private boolean finished = false;
+
+    public void addPacket(SendPacket packet) {
+        queue.add(packet);
+    }
+
+    public void finish() {
+        queue.clear();
+        finished = true;
+    }
+
+    /**
+     * Waits for a packet to appear in the queue and then returns it.
+     *
+     * @return the first available packet in the queue or null if none
+     */
+    public @Nullable SendPacket getPacket() {
+        return finished ? null : queue.poll();
+    }
+
+    /** @return True if this connection has pending data. */
+    public boolean hasPending() {
+        return !queue.isEmpty();
+    }
+
+    public void reportContents() {
+        final String sb = queue.stream()
+                .map(p -> '\n' + p.getCommand().toString()).collect(
+                        Collectors.joining("", "Contents of Send Queue:\n", ""));
+        LogManager.getLogger().warn(sb);
+    }
+}


### PR DESCRIPTION
I was trying to read the networking code and this is not light reading so I figured the least that should be done is extract inner classes. Apart from that I tried cleaning up comments and a few field names. The only noteworthy code changes are in SendPacket that used to be a non-static inner class and used to access some fields directly.

I played a whole game against Princess with these changes and got no suspicious log entries nor crashes.