### PR TITLE
show sensor info and sensor rings when TacOps Sensors Rules are on OR …

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6433,9 +6433,10 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         int maxSensorRange = 0;
         int minAirSensorRange = 0;
         int maxAirSensorRange = 0;
+        GameOptions gameOptions = game.getOptions();
 
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)
-                || game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)) {
+        if (gameOptions.booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)
+                || (gameOptions.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)) && entity.isSpaceborne()) {
             Compute.SensorRangeHelper srh = Compute.getSensorRanges(entity.getGame(), entity);
 
             if (srh != null) {

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -20,6 +20,7 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.annotations.Nullable;
+import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.templates.TROView;
@@ -1038,6 +1039,7 @@ public final class UnitToolTip {
     private static StringBuilder inGameValues(Entity entity, Player localPlayer, boolean inGameValue,
                                               boolean showBV, boolean showSensors, boolean showSeenBy) {
         Game game = entity.getGame();
+        GameOptions gameOptions = game.getOptions();
         boolean isGunEmplacement = entity instanceof GunEmplacement;
         String result = "";
 
@@ -1049,7 +1051,7 @@ public final class UnitToolTip {
             // BV Info
             // Hidden for invisible units when in double blind and hide enemy bv is selected
             // Also not shown in the lobby as BV is shown there outside the tooltip
-            boolean showEnemyBV = !(game.getOptions().booleanOption(OptionsConstants.ADVANCED_SUPPRESS_DB_BV) && game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND));
+            boolean showEnemyBV = !(gameOptions.booleanOption(OptionsConstants.ADVANCED_SUPPRESS_DB_BV) && gameOptions.booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND));
             boolean isVisible = EntityVisibilityUtils.trackThisEntitiesVisibilityInfo(localPlayer, entity);
 
             if (isVisible || showEnemyBV) {
@@ -1224,9 +1226,9 @@ public final class UnitToolTip {
 
         if (showSeenBy) {
             // If Double Blind, add information about who sees this Entity
-            if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)) {
+            if (gameOptions.booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)) {
                 StringBuffer tempList = new StringBuffer();
-                boolean teamVision = game.getOptions().booleanOption(OptionsConstants.ADVANCED_TEAM_VISION);
+                boolean teamVision = gameOptions.booleanOption(OptionsConstants.ADVANCED_TEAM_VISION);
                 int seenByResolution = GUIP.getUnitToolTipSeenByResolution();
                 String tmpStr = "";
 
@@ -1269,7 +1271,8 @@ public final class UnitToolTip {
 
         if (showSensors) {
             // If sensors, display what sensors this unit is using
-            if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS) || game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)) {
+            if (gameOptions.booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)
+                    || (gameOptions.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)) && entity.isSpaceborne()) {
                 String visualRange = Compute.getMaxVisualRange(entity, false) + "";
                 if (game.getPlanetaryConditions().isIlluminationEffective()) {
                     visualRange += " (" + Compute.getMaxVisualRange(entity, true) + ")";

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -12,6 +12,7 @@ import megamek.client.ui.swing.widget.*;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
+import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
@@ -333,11 +334,15 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener, IPrefer
             chSensors.setEnabled(true);
             dontChange = false;
         }
+
+        Game game = clientgui.getClient().getGame();
+        GameOptions gameOptions = game.getOptions();
+
         // Walk through the list of teams. There
         // can't be more teams than players.
         StringBuffer buff;
         if (clientgui != null) {
-            Enumeration<Player> loop = clientgui.getClient().getGame().getPlayers();
+            Enumeration<Player> loop = game.getPlayers();
             while (loop.hasMoreElements()) {
                 Player player = loop.nextElement();
                 int team = player.getTeam();
@@ -520,9 +525,7 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener, IPrefer
                 hasTSM = true;
             }
 
-            if ((clientgui != null)
-                    && clientgui.getClient().getGame().getOptions()
-                            .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HEAT)) {
+            if ((clientgui != null) && gameOptions.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HEAT)) {
                 mtHeat = true;
             }
             heatR.setForeground(GUIPreferences.getInstance().getColorForHeat(en.heat));
@@ -537,7 +540,12 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener, IPrefer
         refreshSensorChoices(en);
 
         if (null != en.getActiveSensor()) {
-            String tmpStr = Messages.getString("MechDisplay.CurrentSensors") + " " + UnitToolTip.getSensorDesc(en);
+            String sensorDesc = "";
+            if (gameOptions.booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)
+                    || (gameOptions.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)) && en.isSpaceborne()) {
+                sensorDesc = UnitToolTip.getSensorDesc(en);
+            }
+            String tmpStr = Messages.getString("MechDisplay.CurrentSensors") + " " + sensorDesc;
             tmpStr = String.format("<html><div WIDTH=%d>%s</div></html>",  250, tmpStr);
             curSensorsL.setText(tmpStr);
         } else {


### PR DESCRIPTION
- show sensor info and sensor rings when TacOps Sensors Rules are on OR (StratOps Advanced Sensors are on AND in Space)
- it was confusing before when TacOps Sensors Rules turned off, but StratOps Advanced Sensors was on.  It was showing sensor ranges and rings.  With the sensors showing you think they are on, but they are not for ground maps.


![image](https://github.com/MegaMek/megamek/assets/116095479/35a6a404-5268-44ab-bce3-3ee159dd78eb)
