### PR TITLE
apply sensor geek modifier to check when calculating sensor ranges for display

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4969,7 +4969,13 @@ public class Compute {
         if (null == e.getActiveSensor()) {
             return null;
         }
-        int bracket = Compute.getSensorBracket(e.getSensorCheck());
+
+        int check = e.getSensorCheck();
+        if ((null != e.getCrew()) && e.hasAbility(OptionsConstants.UNOFF_SENSOR_GEEK)) {
+            check -= 2;
+        }
+
+        int bracket = Compute.getSensorBracket(check);
         if (e.isSpaceborne()) {
             bracket = Compute.getSensorBracket(7);
         }


### PR DESCRIPTION
- apply sensor geek modifier to check when calculating sensor ranges for display
- before there was a mismatch between the display and sensor detections.  the display could be 1 range smaller than the actual sensor range.