### PR TITLE
Unit Selector: Speed up row height calculation

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -214,7 +214,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
                     }
                 });
 
-
         for (int i = 0; i < unitModel.getColumnCount(); i++) {
             tableUnits.getColumnModel().getColumn(i).setPreferredWidth(unitModel.getPreferredWidth(i));
         }
@@ -225,8 +224,8 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         scrollTableUnits = new JScrollPane(tableUnits);
         scrollTableUnits.setName("scrollTableUnits");
 
-        unitModel.addTableModelListener((e) -> UIUtil.updateRowHeights(tableUnits));
-        sorter.addRowSorterListener((e) -> UIUtil.updateRowHeights(tableUnits));
+        unitModel.addTableModelListener((e) -> UIUtil.updateRowHeightsForEqualHeights(tableUnits));
+        sorter.addRowSorterListener((e) -> UIUtil.updateRowHeightsForEqualHeights(tableUnits));
         unitColumnModel.addColumnModelListener(columnModelListener);
 
         gridBagConstraints.insets = new Insets(5, 0, 0, 0);
@@ -973,17 +972,17 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
         @Override
         public void columnMoved(TableColumnModelEvent e) {
-            UIUtil.updateRowHeights(tableUnits);
+            UIUtil.updateRowHeightsForEqualHeights(tableUnits);
         }
 
         @Override
         public void columnMarginChanged(ChangeEvent e) {
-            UIUtil.updateRowHeights(tableUnits);
+            UIUtil.updateRowHeightsForEqualHeights(tableUnits);
         }
 
         @Override
         public void columnSelectionChanged(ListSelectionEvent e) {
-            UIUtil.updateRowHeights(tableUnits);
+            if (!e.getValueIsAdjusting()) UIUtil.updateRowHeightsForEqualHeights(tableUnits);
         }
     };
 }

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -1179,6 +1179,9 @@ public final class UIUtil {
      *  typically not work well. Instead, it must be called from a {@link javax.swing.event.TableModelListener},
      *  a {@link javax.swing.event.TableColumnModelListener} and (if a row sorter is used) a
      *  {@link javax.swing.event.RowSorterListener} to be effective.
+     *  Note: For tables of more than about 200 entries or with slow renderers this will become noticeably slow
+     *  when drag-resizing the table. When the table has uniform row heights, better use
+     *  {@link #updateRowHeightsForEqualHeights(JTable)}.
      */
     public static void updateRowHeights(JTable table) {
         for (int row = 0; row < table.getRowCount(); row++) {
@@ -1188,6 +1191,26 @@ public final class UIUtil {
                 rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
             }
             table.setRowHeight(row, rowHeight);
+        }
+    }
+
+    /**
+     *  Automatically determines the correct row height for the given JTable and sets it, assuming it has a
+     *  uniform row height for all rows.
+     *  Note: Just calling this after a data change or after {@link #adjustDialog(JDialog, int)} will
+     *  typically not work well. Instead, it must be called from a {@link javax.swing.event.TableModelListener},
+     *  a {@link javax.swing.event.TableColumnModelListener} and (if a row sorter is used) a
+     *  {@link javax.swing.event.RowSorterListener} to be effective.
+     */
+    public static void updateRowHeightsForEqualHeights(JTable table) {
+        if (table.getRowCount() > 0) {
+            int row = 0;
+            int rowHeight = 0;
+            for (int column = 0; column < table.getColumnCount(); column++) {
+                Component comp = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
+                rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
+            }
+            table.setRowHeight(rowHeight);
         }
     }
 


### PR DESCRIPTION
I noticed that drag-resizing the unit selector table is very sluggish now when many units are displayed which is due to the row height calculation listeners. This fixes it (the unit selector table fortunately has uniform row height)