### PR TITLE
Transporters: Code cleanup

### DIFF
--- a/megamek/src/megamek/common/BattleArmorHandles.java
+++ b/megamek/src/megamek/common/BattleArmorHandles.java
@@ -15,8 +15,8 @@ package megamek.common;
 
 import megamek.common.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * Represents a set of handles on an OmniMech used by Battle Armor units
@@ -28,117 +28,18 @@ import java.util.Vector;
 class BattleArmorHandles implements Transporter {
     private static final long serialVersionUID = -7149931565043762975L;
 
-    /**
-     * The troopers being carried.
-     */
-    protected int troopers = Entity.NONE;
+    /** The troopers being carried. */
+    protected int carriedUnit = Entity.NONE;
     transient Game game;
 
-    /**
-     * The set of front locations that load troopers externally.
-     */
-    private static final int[] EXTERIOR_LOCATIONS_FRONT = { Mech.LOC_RT, Mech.LOC_LT };
-
-    /**
-     * The set of rear locations that load troopers externally.
-     */
-    private static final int[] EXTERIOR_LOCATIONS_REAR = { Mech.LOC_CT, Mech.LOC_RT, Mech.LOC_LT };
-
-    /**
-     * The <code>String</code> reported when the handles are in use.
-     */
     private static final String NO_VACANCY_STRING = "A squad is loaded";
-
-    /**
-     * The <code>String</code> reported when the handles are available.
-     */
     private static final String HAVE_VACANCY_STRING = "One battle armor squad";
 
-    /**
-     * Get the exterior locations that a loaded squad covers.
-     * <p>
-     * Sub-classes are encouraged to override this method.
-     *
-     * @param isRear
-     *            - a <code>boolean</code> value stating if the given location
-     *            is rear facing; if <code>false</code>, the location is front
-     *            facing.
-     * @return an array of <code>int</code> listing the exterior locations.
-     */
-    protected int[] getExteriorLocs(boolean isRear) {
-        if (isRear) {
-            return BattleArmorHandles.EXTERIOR_LOCATIONS_REAR;
-        }
-        return BattleArmorHandles.EXTERIOR_LOCATIONS_FRONT;
-    }
-
-    /**
-     * Get the <code>String</code> to report the presence (or lack thereof) of a
-     * loaded squad of Battle Armor troopers.
-     * <p>
-     * Sub-classes are encouraged to override this method.
-     *
-     * @param isLoaded
-     *            - a <code>boolean</code> that indicates that troopers are
-     *            currently loaded (if the value is <code>true</code>) or not
-     *            (if the value is <code>false</code>).
-     * @return a <code>String</code> describing the occupancy state of this
-     *         transporter.
-     */
-    protected String getVacancyString(boolean isLoaded) {
-        if (isLoaded) {
-            return BattleArmorHandles.NO_VACANCY_STRING;
-        }
-        return BattleArmorHandles.HAVE_VACANCY_STRING;
-    }
-
-    /**
-     * Create a set of handles.
-     */
-    public BattleArmorHandles() {
-
-    }
-
-    /**
-     * Determines if this object can accept the given unit. The unit may not be
-     * of the appropriate type or there may be no room for the unit.
-     * <p>
-     *
-     * @param unit
-     *            - the <code>Entity</code> to be loaded.
-     * @return <code>true</code> if the unit can be loaded, <code>false</code>
-     *         otherwise.
-     */
     @Override
     public boolean canLoad(Entity unit) {
-        // Assume that we can carry the unit.
-        boolean result = true;
-
-        // Only BattleArmor can be carried in BattleArmorHandles.
-        if (!(unit instanceof BattleArmor)) {
-            result = false;
-        }
-
-        // We must have enough space for the new troopers.
-        else if (troopers != Entity.NONE) {
-            result = false;
-        }
-
-        // The unit must be capable of doing mechanized BA
-        else {
-            result = ((BattleArmor) unit).canDoMechanizedBA();
-        }
-
-        // Return our result.
-        return result;
+        return (carriedUnit == Entity.NONE) && (unit instanceof BattleArmor) && ((BattleArmor) unit).canDoMechanizedBA();
     }
 
-    /**
-     * Load the given unit.
-     *
-     * @param unit the <code>Entity</code> to be loaded.
-     * @throws IllegalArgumentException If the unit can't be loaded
-     */
     @Override
     public final void load(Entity unit) throws IllegalArgumentException {
         // If we can't load the unit, throw an exception.
@@ -147,103 +48,54 @@ class BattleArmorHandles implements Transporter {
         }
 
         // Assign the unit as our carried troopers.
-        troopers = unit.getId();
+        carriedUnit = unit.getId();
     }
 
-    /**
-     * Get a <code>List</code> of the units currently loaded into this payload.
-     *
-     * @return A <code>List</code> of loaded <code>Entity</code> units. This
-     *         list will never be <code>null</code>, but it may be empty. The
-     *         returned <code>List</code> is independent from the underlying
-     *         data structure; modifying one does not affect the other.
-     */
     @Override
-    public final Vector<Entity> getLoadedUnits() {
-        // Return a list of our carried troopers.
-        Vector<Entity> units = new Vector<>(1);
-        if (troopers != Entity.NONE) {
-            Entity entity = game.getEntity(troopers);
-            
-            if (entity != null) {
-                units.addElement(entity);
-            }
+    public final List<Entity> getLoadedUnits() {
+        List<Entity> units = new ArrayList<>(1);
+        Entity entity = game.getEntity(carriedUnit);
+        if (entity != null) {
+            units.add(entity);
         }
         return units;
     }
 
-    /**
-     * Unload the given unit.
-     *
-     * @param unit
-     *            - the <code>Entity</code> to be unloaded.
-     * @return <code>true</code> if the unit was contained is loaded in this
-     *         space, <code>false</code> otherwise.
-     */
     @Override
     public final boolean unload(Entity unit) {
         // Are we carrying the unit?
-        Entity trooper = game.getEntity(troopers);
+        Entity trooper = game.getEntity(carriedUnit);
         if ((trooper == null) || !trooper.equals(unit)) {
             // Nope.
             return false;
         }
 
         // Remove the troopers.
-        troopers = Entity.NONE;
+        carriedUnit = Entity.NONE;
         return true;
     }
 
-    /**
-     * Return a string that identifies the unused capacity of this transporter.
-     * <p>
-     * Sub-classes should override the <code>getVacancyString</code> method.
-     *
-     * @return A <code>String</code> meant for a human.
-     * @see megamek.common.BattleArmorHandles#getUnusedString()
-     */
     @Override
-    public final String getUnusedString() {
-        return getVacancyString(troopers != Entity.NONE);
+    public String getUnusedString() {
+        return (carriedUnit != Entity.NONE) ? NO_VACANCY_STRING : HAVE_VACANCY_STRING;
     }
 
     @Override
     public double getUnused() {
-        if (troopers == Entity.NONE) {
-            return 1;
-        } else {
-            return 0;
-        }
+        return (carriedUnit == Entity.NONE) ? 1 : 0;
     }
 
     @Override
     public void resetTransporter() {
-        troopers = Entity.NONE;
+        carriedUnit = Entity.NONE;
     }
     
-    /**
-     * Determine if transported units prevent a weapon in the given location
-     * from firing.
-     *
-     * @param loc
-     *            - the <code>int</code> location attempting to fire.
-     * @param isRear
-     *            - a <code>boolean</code> value stating if the given location
-     *            is rear facing; if <code>false</code>, the location is front
-     *            facing.
-     * @return <code>true</code> if a transported unit is in the way,
-     *         <code>false</code> if the weapon can fire.
-     */
     @Override
     public boolean isWeaponBlockedAt(int loc, boolean isRear) {
-        // Assume that the weapon is not blocked.
-        boolean result = false;
-
-        // The weapon can only be blocked if we are carrying troopers.
-        Entity trooper = game.getEntity(troopers);
-        if (null != trooper) {
-
-            // Is the relevant trooper alive?
+        Entity carriedBA = game.getEntity(carriedUnit);
+        if (carriedBA == null) {
+            return false;
+        } else {
             int tloc = BattleArmor.LOC_SQUAD;
             switch (loc) {
                 case Mech.LOC_CT:
@@ -256,37 +108,13 @@ class BattleArmorHandles implements Transporter {
                     tloc = isRear ? BattleArmor.LOC_TROOPER_3 : BattleArmor.LOC_TROOPER_1;
                     break;
             }
-            if ((trooper.locations() > tloc) && (trooper.getInternal(tloc) > 0)) {
-                result = true;
-            }
+            return (carriedBA.locations() > tloc) && (carriedBA.getInternal(tloc) > 0);
         }
-
-        // Return our result.
-        return result;
     }
 
-    /**
-     * If a unit is being transported on the outside of the transporter, it can
-     * suffer damage when the transporter is hit by an attack. Currently, no
-     * more than one unit can be at any single location; that same unit can be
-     * "spread" over multiple locations.
-     * <p>
-     * Sub-classes should override the <code>getExteriorLocs</code> method.
-     *
-     * @param loc
-     *            - the <code>int</code> location hit by attack.
-     * @param isRear
-     *            - a <code>boolean</code> value stating if the given location
-     *            is rear facing; if <code>false</code>, the location is front
-     *            facing.
-     * @return The <code>Entity</code> being transported on the outside at that
-     *         location. This value will be <code>null</code> if no unit is
-     *         transported on the outside at that location.
-     * @see megamek.common.BattleArmorHandles#getExteriorLocs(boolean)
-     */
     @Override
     public final @Nullable Entity getExteriorUnitAt(int loc, boolean isRear) {
-        return isWeaponBlockedAt(loc, isRear) ? game.getEntity(troopers) : null;
+        return isWeaponBlockedAt(loc, isRear) ? game.getEntity(carriedUnit) : null;
     }
 
     @Override
@@ -301,7 +129,7 @@ class BattleArmorHandles implements Transporter {
     
     @Override
     public String toString() {
-        return "BattleArmorHandles - troopers:" + troopers;
+        return "BattleArmorHandles - troopers:" + carriedUnit;
     }
 
     @Override

--- a/megamek/src/megamek/common/BattleArmorHandlesTank.java
+++ b/megamek/src/megamek/common/BattleArmorHandlesTank.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010 - Ben Mazur (bmazur@sev.org).
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,47 +17,12 @@ package megamek.common;
 public class BattleArmorHandlesTank extends BattleArmorHandles {
     private static final long serialVersionUID = 1031947858009941399L;
 
-    /**
-     * The set of front locations that load troopers externally.
-     */
-    private static final int[] EXTERIOR_LOCATIONS = { Tank.LOC_RIGHT, Tank.LOC_LEFT, Tank.LOC_REAR };
-
-    /**
-     * Get the exterior locations that a loaded squad covers.
-     * <p>
-     * Sub-classes are encouraged to override this method.
-     *
-     * @param isRear a <code>boolean</code> value stating if the given location is rear facing; if
-     *              <code>false</code>, the location is front facing.
-     * @return an array of <code>int</code> listing the exterior locations.
-     */
-    @Override
-    protected int[] getExteriorLocs(boolean isRear) {
-        return BattleArmorHandlesTank.EXTERIOR_LOCATIONS;
-    }
-
-    /**
-     * Determine if transported units prevent a weapon in the given location
-     * from firing.
-     * <p>
-     *
-     * @param loc - the <code>int</code> location attempting to fire.
-     * @param isRear - a <code>boolean</code> value stating if the given
-     *            location is rear facing; if <code>false</code>, the
-     *            location is front facing.
-     * @return <code>true</code> if a transported unit is in the way,
-     *         <code>false</code> if the weapon can fire.
-     */
     @Override
     public final boolean isWeaponBlockedAt(int loc, boolean isRear) {
-        // Assume that the weapon is not blocked.
-        boolean result = false;
-
-        // The weapon can only be blocked if we are carrying troopers.
-        Entity trooper = game.getEntity(troopers);
-        if (null != trooper) {
-
-            // Is the relevant trooper alive?
+        Entity carriedBA = game.getEntity(carriedUnit);
+        if (carriedBA == null) {
+            return false;
+        } else {
             int tloc = BattleArmor.LOC_SQUAD;
             int tloc2 = BattleArmor.LOC_SQUAD;
             switch (loc) {
@@ -74,13 +39,8 @@ public class BattleArmorHandlesTank extends BattleArmorHandles {
                     tloc2 = BattleArmor.LOC_TROOPER_2;
                     break;
             }
-            if (((trooper.locations() > tloc) && (trooper.getInternal(tloc) > 0))
-                    || ((trooper.locations() > tloc2) && (trooper.getInternal(tloc2) > 0))) {
-                result = true;
-            }
+            return ((carriedBA.locations() > tloc) && (carriedBA.getInternal(tloc) > 0))
+                    || ((carriedBA.locations() > tloc2) && (carriedBA.getInternal(tloc2) > 0));
         }
-
-        // Return our result.
-        return result;
     }
 }

--- a/megamek/src/megamek/common/ClampMountMech.java
+++ b/megamek/src/megamek/common/ClampMountMech.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2002 - Ben Mazur (bmazur@sev.org).
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -24,40 +24,12 @@ package megamek.common;
 public class ClampMountMech extends BattleArmorHandles {
     private static final long serialVersionUID = -5687854937528642266L;
 
-    /**
-     * The <code>String</code> reported when the handles are in use.
-     */
     private static final String NO_VACANCY_STRING = "A BA squad with magnetic clamps is loaded";
-
-    /**
-     * The <code>String</code> reported when the handles are available.
-     */
     private static final String HAVE_VACANCY_STRING = "One BA-magclamp squad";
 
-    /**
-     * Get the <code>String</code> to report the presence (or lack thereof) of a loaded squad of
-     * Battle Armor troopers.
-     * <p>
-     * Sub-classes are encouraged to override this method.
-     *
-     * @param isLoaded A <code>boolean</code> that indicates that troopers are currently loaded
-     *                (if the value is <code>true</code>) or not (if the value is <code>false</code>).
-     * @return a <code>String</code> describing the occupancy state of this transporter.
-     */
     @Override
-    protected String getVacancyString(boolean isLoaded) {
-        if (isLoaded) {
-            return ClampMountMech.NO_VACANCY_STRING;
-        }
-        return ClampMountMech.HAVE_VACANCY_STRING;
-    }
-
-    /**
-     * Create a space to mount clamp-equipped troopers on a Mech.
-     */
-    public ClampMountMech() {
-        // Initialize our super-class.
-        super();
+    public String getUnusedString() {
+        return (carriedUnit != Entity.NONE) ? NO_VACANCY_STRING : HAVE_VACANCY_STRING;
     }
 
     @Override
@@ -67,20 +39,11 @@ public class ClampMountMech extends BattleArmorHandles {
 
     @Override
     public boolean canLoad(Entity unit) {
-        if (!(unit instanceof BattleArmor)) {
-            // Only BattleArmor can be carried in BattleArmorHandles.
-            return false;
-        } else if (troopers != -1) {
-            // We must have enough space for the new troopers.
-            return false;
-        } else {
-            // The unit must be capable of doing mechanized BA
-            return ((BattleArmor) unit).hasMagneticClamps();
-        }
+        return (carriedUnit == Entity.NONE) && (unit instanceof BattleArmor) && ((BattleArmor) unit).hasMagneticClamps();
     }
 
     @Override
     public String toString() {
-        return "ClampMountMech - troopers:" + troopers;
+        return "ClampMountMech - troopers:" + carriedUnit;
     }
 }

--- a/megamek/src/megamek/common/ClampMountTank.java
+++ b/megamek/src/megamek/common/ClampMountTank.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2002 - Ben Mazur (bmazur@sev.org).
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2023 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -23,59 +23,13 @@ package megamek.common;
 public class ClampMountTank extends BattleArmorHandlesTank {
     private static final long serialVersionUID = 593951005031815098L;
 
-    /**
-     * The set of front locations that load troopers externally.
-     */
-    private static final int[] EXTERIOR_LOCATIONS = { Tank.LOC_RIGHT, Tank.LOC_LEFT, Tank.LOC_REAR };
-
-    /**
-     * The <code>String</code> reported when the handles are in use.
-     */
     private static final String NO_VACANCY_STRING = "A BA squad with magnetic clamps is loaded";
-
-    /**
-     * The <code>String</code> reported when the handles are available.
-     */
     private static final String HAVE_VACANCY_STRING = "One BA-magclamp squad";
 
-    /**
-     * Get the exterior locations that a loaded squad covers.
-     * <p>
-     * Sub-classes are encouraged to override this method.
-     *
-     * @param isRear A <code>boolean</code> value stating if the given location is rear facing; if
-     *              <code>false</code>, the location is front facing.
-     * @return an array of <code>int</code> listing the exterior locations.
-     */
-    @Override
-    protected int[] getExteriorLocs(boolean isRear) {
-        return ClampMountTank.EXTERIOR_LOCATIONS;
-    }
 
-    /**
-     * Create a space to mount clamp-equipped troopers on a Mech.
-     */
-    public ClampMountTank() {
-        // Initialize our super-class.
-        super();
-    }
-
-    /**
-     * Get the <code>String</code> to report the presence (or lack thereof) of
-     * a loaded squad of Battle Armor troopers. <p> Sub-classes are encouraged
-     * to override this method.
-     *
-     * @param isLoaded - a <code>boolean</code> that indicates that troopers
-     *            are currently loaded (if the value is <code>true</code>) or
-     *            not (if the value is <code>false</code>).
-     * @return a <code>String</code> describing the occupancy state of this transporter.
-     */
     @Override
-    protected String getVacancyString(boolean isLoaded) {
-        if (isLoaded) {
-            return ClampMountTank.NO_VACANCY_STRING;
-        }
-        return ClampMountTank.HAVE_VACANCY_STRING;
+    public String getUnusedString() {
+        return (carriedUnit != Entity.NONE) ? NO_VACANCY_STRING : HAVE_VACANCY_STRING;
     }
 
     @Override
@@ -83,35 +37,13 @@ public class ClampMountTank extends BattleArmorHandlesTank {
         return getLoadedUnits().size();
     }
 
-    /**
-     * Determines if this object can accept the given unit. The unit may not be
-     * of the appropriate type or there may be no room for the unit.
-     *
-     * @param unit The <code>Entity</code> to be loaded.
-     * @return <code>true</code> if the unit can be loaded, <code>false</code> otherwise.
-     */
     @Override
     public boolean canLoad(Entity unit) {
-        // Assume that we can carry the unit.
-        boolean result = true;
-
-        if (!(unit instanceof BattleArmor)) {
-            // Only BattleArmor can be carried in BattleArmorHandles.
-            result = false;
-        } else if (troopers != -1) {
-            // We must have enough space for the new troopers.
-            result = false;
-        } else {
-            // The unit must be capable of doing mechanized BA
-            result = ((BattleArmor) unit).hasMagneticClamps();
-        }
-
-        // Return our result.
-        return result;
+        return (carriedUnit == Entity.NONE) && (unit instanceof BattleArmor) && ((BattleArmor) unit).hasMagneticClamps();
     }
 
     @Override
     public String toString() {
-        return "ClampMountTank - troopers:" + troopers;
+        return "ClampMountTank - troopers:" + carriedUnit;
     }
 }

--- a/megamek/src/megamek/common/ProtomechClampMount.java
+++ b/megamek/src/megamek/common/ProtomechClampMount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 - The MegaMek Team
+ * Copyright (C) 2018, 2023 - The MegaMek Team
  *
  *  This program is free software; you can redistribute it and/or modify it
  *  under the terms of the GNU General Public License as published by the Free
@@ -21,32 +21,13 @@ package megamek.common;
  * handles loading to enforce this limitation.
  * 
  * @author Neoancient
- *
  */
 public class ProtomechClampMount extends BattleArmorHandles {
-
     private static final long serialVersionUID = 3937766099677646981L;
 
     private final boolean rear;
 
-    /**
-     * The set of locations that loads a protomech externally
-     */
-    private static int[] EXTERIOR_LOCATIONS = { Mech.LOC_CT };
-    
-    /**
-     * The set of locations that loads a protomech externally on the opposite side
-     */
-    private static int[] OTHER_SIDE_LOCATIONS = { };
-    
-    /**
-     * The <code>String</code> reported when the mount is in use.
-     */
     private static final String NO_VACANCY_STRING = "A protomech is loaded";
-
-    /**
-     * The <code>String</code> reported when the mount is available.
-     */
     private static final String HAVE_VACANCY_STRING = "One protomech";
 
     public ProtomechClampMount(boolean rear) {
@@ -58,42 +39,26 @@ public class ProtomechClampMount extends BattleArmorHandles {
     }
 
     @Override
-    protected int[] getExteriorLocs(boolean isRear) {
-        if (rear == isRear) {
-            return EXTERIOR_LOCATIONS;
-        } else {
-            return OTHER_SIDE_LOCATIONS;
-        }
-    }
-
-    @Override
-    protected String getVacancyString(boolean isLoaded) {
-        if (isLoaded) {
-            return NO_VACANCY_STRING;
-        }
-        return HAVE_VACANCY_STRING;
+    public String getUnusedString() {
+        return (carriedUnit != Entity.NONE) ? NO_VACANCY_STRING : HAVE_VACANCY_STRING;
     }
 
     @Override
     public boolean canLoad(Entity unit) {
-        return (troopers == Entity.NONE)
-                && unit.hasETypeFlag(Entity.ETYPE_PROTOMECH)
-                && unit.hasWorkingMisc(MiscType.F_MAGNETIC_CLAMP)
+        return (carriedUnit == Entity.NONE) && unit.isProtoMek() && unit.hasWorkingMisc(MiscType.F_MAGNETIC_CLAMP)
                 && (!rear || unit.getWeightClass() < EntityWeightClass.WEIGHT_SUPER_HEAVY);
     }
 
     @Override
     public boolean isWeaponBlockedAt(int loc, boolean isRear) {
-        return (rear == isRear)
-                && (loc == Mech.LOC_CT)
-                && troopers != Entity.LOC_NONE;
+        return (rear == isRear) && (loc == Mech.LOC_CT) && (carriedUnit != Entity.NONE);
     }
 
     @Override
     public int getCargoMpReduction(Entity carrier) {
         double protoWeight = 0.0;
-        if (troopers != Entity.NONE) {
-            protoWeight = game.getEntity(troopers).getWeight();
+        if (carriedUnit != Entity.NONE) {
+            protoWeight = game.getEntity(carriedUnit).getWeight();
             if (carrier.isOmni()) {
                 protoWeight = Math.max(0, protoWeight - 3.0);
             }
@@ -109,6 +74,6 @@ public class ProtomechClampMount extends BattleArmorHandles {
 
     @Override
     public String toString() {
-        return "Protomech clamp mount:" + troopers;
+        return "Protomech clamp mount:" + carriedUnit;
     }
-} // End package class BattleArmorHandles implements Transporter
+}

--- a/megamek/src/megamek/common/Transporter.java
+++ b/megamek/src/megamek/common/Transporter.java
@@ -84,15 +84,11 @@ public interface Transporter extends Serializable {
     String getUnusedString();
 
     /**
-     * Determine if transported units prevent a weapon in the given location
-     * from firing.
+     * Determine if transported units prevent a weapon in the given location from firing.
      *
-     * @param loc - the <code>int</code> location attempting to fire.
-     * @param isRear - a <code>boolean</code> value stating if the given
-     *            location is rear facing; if <code>false</code>, the
-     *            location is front facing.
-     * @return <code>true</code> if a transported unit is in the way,
-     *         <code>false</code> if the weapon can fire.
+     * @param loc the location attempting to fire.
+     * @param isRear true if the weapon is rear-facing
+     * @return True if a transported unit is in the way, false if the weapon can fire.
      */
     boolean isWeaponBlockedAt(int loc, boolean isRear);
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -27096,7 +27096,7 @@ public class GameManager implements IGameManager {
             }
 
             // Mechanized BA that could die on a 3+
-            ArrayList<Entity> externalUnits = entity.getExternalUnits();
+            List<Entity> externalUnits = entity.getExternalUnits();
 
             // Handle escape of transported units.
             if (!entity.getLoadedUnits().isEmpty()) {


### PR DESCRIPTION
This cleans up the code in the BA transporters without any intended changes to behavior.

Edit: I checked the deleted method for uses in MML and MHQ as well