### PR TITLE
correct issues with nat apt gunnery to hit odds, automatic success me…

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1974,7 +1974,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                 setFireEnabled(true);
             } else {
                 boolean natAptGunnery = ce().hasAbility(OptionsConstants.PILOT_APTITUDE_GUNNERY);
-                clientgui.getUnitDisplay().wPan.setToHit(toHit, true);
+                clientgui.getUnitDisplay().wPan.setToHit(toHit, natAptGunnery);
 
                 setFireEnabled(true);
             }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -874,14 +874,17 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         switch (toHit.getValue()) {
             case TargetRoll.IMPOSSIBLE:
             case TargetRoll.AUTOMATIC_FAIL:
-                toHitText.setText(String.format("<html>%sTo Hit: (0%%) %s</body></html>", BODY,
-                        toHit.getDesc()));
+                toHitText.setText(String.format("<html>%sTo Hit: (0%%) %s</body></html>", BODY, toHit.getDesc()));
+                break;
+            case TargetRoll.AUTOMATIC_SUCCESS:
+                toHitText.setText(String.format("<html>%sTo Hit: (100%%) %s</body></html>", BODY, toHit.getDesc()));
                 break;
             default:
                 toHitText.setText(String.format("<html>%sTo Hit: <b>%2d (%2.0f%%)</b>%s = %s</font></body></html>", BODY,
                         toHit.getValue(), Compute.oddsAbove(toHit.getValue(), natAptGunnery), LOW_CONTRAST_FONT, toHit.getDesc()));
                 break;
         }
+        toHitText.setCaretPosition(0);
     }
 
     public void setToHit(String message) {


### PR DESCRIPTION
- set to hit text box scroll position to top when setting to hit text value
- correct issue with natural aptitude gunnery to hit odds display
- automatic success to hit message

![image](https://github.com/MegaMek/megamek/assets/116095479/c7cc5318-273b-4d73-8e3e-ad5848da8ff4)

fixes #4543
fixes #4547