### PR TITLE
AS Conversion: No ENE for fighters without weapons

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASAeroSpecialAbilityConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASAeroSpecialAbilityConverter.java
@@ -42,6 +42,13 @@ public class ASAeroSpecialAbilityConverter extends ASSpecialAbilityConverter {
     }
 
     @Override
+    protected void processENE() {
+        if (element.getStandardDamage().hasDamage()) {
+            super.processENE();
+        }
+    }
+
+    @Override
     protected void processUnitFeatures() {
         super.processUnitFeatures();
 


### PR DESCRIPTION
As aerospace units can't have ammo crits and therefore don't need protection from them, they don't get ENE when they don't have any damage capability.