### PR TITLE
Allow dropship nose LRM indirect fire

### DIFF
--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -356,6 +356,7 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
         lblSearch.setLabelFor(txtSearch);
         lblSearch.setToolTipText(Messages.getString("GameOptionsDialog.SearchToolTip"));
         txtSearch.setToolTipText(Messages.getString("GameOptionsDialog.SearchToolTip"));
+        txtSearch.setColumns(20);
         txtSearch.getDocument().addDocumentListener(new DocumentListener() {
             @Override
             public void changedUpdate(DocumentEvent e) {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1508,20 +1508,20 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // for spheroid dropships in atmosphere (and on ground), the rules about
         // firing arcs are more complicated
         // TW errata 2.1
-        boolean isLandedSpheroid = ae.isAero() && ((IAero) ae).isSpheroid() && (ae.getAltitude() == 0) && game.getBoard().onGround();
-        int altDif = target.getAltitude() - ae.getAltitude();
-        boolean noseWeaponAimedAtGroundTarget = (weapon != null) && (weapon.getLocation() == Aero.LOC_NOSE) && (altDif < 1);
         
         if ((Compute.useSpheroidAtmosphere(game, ae) ||
-                isLandedSpheroid)
+                (ae.isAero() && ((IAero) ae).isSpheroid() && (ae.getAltitude() == 0) && game.getBoard().onGround()))
                 && (weapon != null)) {
             int range = Compute.effectiveDistance(game, ae, target, false);
             // Only aft-mounted weapons can be fired at range 0 (targets directly underneath)
             if (!ae.isAirborne() && (range == 0) && (weapon.getLocation() != Aero.LOC_AFT)) {
                 return Messages.getString("WeaponAttackAction.OnlyAftAtZero");
             }
+            
+            int altDif = target.getAltitude() - ae.getAltitude();
+            
             // Nose-mounted weapons can only be fired at targets at least 1 altitude higher
-            if (noseWeaponAimedAtGroundTarget
+            if ((weapon.getLocation() == Aero.LOC_NOSE) && (altDif < 1)
                     && wtype != null
                     // Unless the weapon is used as artillery
                     && (!(wtype instanceof ArtilleryWeapon || wtype.hasFlag(WeaponType.F_ARTILLERY)
@@ -2200,7 +2200,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     return Messages.getString("WeaponAttackAction.InvalidForFirefighting");
                 }
                 Hex hexTarget = game.getBoard().getHex(target.getPosition());
-                if (!hexTarget.containsTerrain(Terrains.FIRE)) {
+                if ((hexTarget != null) && !hexTarget.containsTerrain(Terrains.FIRE)) {
                     return Messages.getString("WeaponAttackAction.TargetNotBurning");
                 }
             } else if (wtype.hasFlag(WeaponType.F_EXTINGUISHER)) {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1148,7 +1148,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // Infantry can't clear woods.
         if (isAttackerInfantry && (Targetable.TYPE_HEX_CLEAR == target.getTargetType())) {
             Hex hexTarget = game.getBoard().getHex(target.getPosition());
-            if (hexTarget.containsTerrain(Terrains.WOODS)) {
+            if ((hexTarget != null) && hexTarget.containsTerrain(Terrains.WOODS)) {
                 return Messages.getString("WeaponAttackAction.NoInfantryWoodsClearing");
             }
         }
@@ -1508,21 +1508,25 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         // for spheroid dropships in atmosphere (and on ground), the rules about
         // firing arcs are more complicated
         // TW errata 2.1
+        boolean isLandedSpheroid = ae.isAero() && ((IAero) ae).isSpheroid() && (ae.getAltitude() == 0) && game.getBoard().onGround();
+        int altDif = target.getAltitude() - ae.getAltitude();
+        boolean noseWeaponAimedAtGroundTarget = (weapon != null) && (weapon.getLocation() == Aero.LOC_NOSE) && (altDif < 1);
+        
         if ((Compute.useSpheroidAtmosphere(game, ae) ||
-                (ae.isAero() && ((IAero) ae).isSpheroid() && (ae.getAltitude() == 0) && game.getBoard().onGround()))
-                && weapon != null) {
-            int altDif = target.getAltitude() - ae.getAltitude();
+                isLandedSpheroid)
+                && (weapon != null)) {
             int range = Compute.effectiveDistance(game, ae, target, false);
             // Only aft-mounted weapons can be fired at range 0 (targets directly underneath)
             if (!ae.isAirborne() && (range == 0) && (weapon.getLocation() != Aero.LOC_AFT)) {
                 return Messages.getString("WeaponAttackAction.OnlyAftAtZero");
             }
             // Nose-mounted weapons can only be fired at targets at least 1 altitude higher
-            if ((weapon.getLocation() == Aero.LOC_NOSE) && (altDif < 1)
+            if (noseWeaponAimedAtGroundTarget
                     && wtype != null
                     // Unless the weapon is used as artillery
                     && (!(wtype instanceof ArtilleryWeapon || wtype.hasFlag(WeaponType.F_ARTILLERY)
-                            || (ae.getAltitude() == 0 && wtype instanceof CapitalMissileWeapon)))) {
+                            || (ae.getAltitude() == 0 && wtype instanceof CapitalMissileWeapon) 
+                            || isIndirect))) {
                 return Messages.getString("WeaponAttackAction.TooLowForNose");
             }
             // Front-side-mounted weapons can only be fired at targets at the same altitude or higher
@@ -2277,13 +2281,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // Indirect Fire (LRMs)
 
             // Can't fire Indirect LRM with direct LOS
-            if (isIndirect && game.getOptions().booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)
-                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_INDIRECT_ALWAYS_POSSIBLE)
-                    && LosEffects.calculateLOS(game, ae, target).canSee()
-                    && (!game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
-                            || Compute.canSee(game, ae, target))
-                    && !(wtype instanceof ArtilleryCannonWeapon)
-                    && !wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT)) {
+            if (isIndirect && Compute.indirectAttackImpossible(game, ae, target, wtype, weapon)) {
                 return Messages.getString("WeaponAttackAction.NoIndirectWithLOS");
             }
 


### PR DESCRIPTION
Slight buff to dropships with nose LRM launchers - Fixes #4527 

Also unifies logic for "no indirect LRM fire allowed with LOS" message. Not sure why it's in there twice, but I'm going to not touch that.

Also fixes a long-term personal peeve of mine: "search" in game options would always start tiny; now it always stays at 20 characters wide.