### PR TITLE
Added null check to guard against NPE when offboard artillery target has disengaged

### DIFF
--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -430,8 +430,8 @@ public class ArtilleryTargetingControl {
             // calculate damage: damage - (10 * distance to me), floored at 0
             // we only say that it will actually be damage if the attack coming in is landing right after the movement phase
             double actualDamage = 0.0;
-            
-            if (aaa.getTurnsTilHit() == 0) {
+
+            if ((aaa.getTurnsTilHit() == 0) && (aaa.getTarget(operator.getGame()) != null)) {
                 // damage for artillery weapons is, for some reason, derived from the weapon type's rack size
                 Mounted weapon = aaa.getEntity(operator.getGame()).getEquipment(aaa.getWeaponId());
                 int damage = ((WeaponType) weapon.getType()).getRackSize();

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -79,7 +79,6 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                         + (game.getRoundCount() + aaa.getTurnsTilHit())
                         + ", fired by "
                         + game.getPlayer(aaa.getPlayerId()).getName();
-                // Check for offboard target that has disengaged
                 if (aaa.getTarget(game) != null) {
                     game.getBoard().addSpecialHexDisplay(
                             aaa.getTarget(game).getPosition(),

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -79,13 +79,16 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                         + (game.getRoundCount() + aaa.getTurnsTilHit())
                         + ", fired by "
                         + game.getPlayer(aaa.getPlayerId()).getName();
-                game.getBoard().addSpecialHexDisplay(
-                        aaa.getTarget(game).getPosition(),
-                        new SpecialHexDisplay(
-                                SpecialHexDisplay.Type.ARTILLERY_INCOMING, game
-                                        .getRoundCount() + aaa.getTurnsTilHit(),
-                                game.getPlayer(aaa.getPlayerId()), artyMsg,
-                                SpecialHexDisplay.SHD_OBSCURED_TEAM));
+                // Check for offboard target that has disengaged
+                if (aaa.getTarget(game) != null) {
+                    game.getBoard().addSpecialHexDisplay(
+                            aaa.getTarget(game).getPosition(),
+                            new SpecialHexDisplay(
+                                    SpecialHexDisplay.Type.ARTILLERY_INCOMING, game
+                                    .getRoundCount() + aaa.getTurnsTilHit(),
+                                    game.getPlayer(aaa.getPlayerId()), artyMsg,
+                                    SpecialHexDisplay.SHD_OBSCURED_TEAM));
+                }
             }
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -33562,12 +33562,12 @@ public class GameManager implements IGameManager {
         // which for these particular purposes may or may not be the intent of
         // the rules in all cases.
         // Immobile hovercraft on water sink...
-        if (((te.getMovementMode() == EntityMovementMode.HOVER)
+        if (!te.isOffBoard() && (((te.getMovementMode() == EntityMovementMode.HOVER)
                 || ((te.getMovementMode() == EntityMovementMode.WIGE) && (te.getElevation() == 0)))
                 && (te.isMovementHitPending() || (te.getWalkMP() <= 0))
                 // HACK: Have to check for *pending* hit here and below.
                 && (game.getBoard().getHex(te.getPosition()).terrainLevel(Terrains.WATER) > 0)
-                && !game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ICE)) {
+                && !game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ICE))) {
             vDesc.addAll(destroyEntity(te, "a watery grave", false));
         }
         // ...while immobile WiGEs crash.


### PR DESCRIPTION
The artillery attack action normally targets hexes, but when the target is an offboard artillery unit the target is the unit instead. If the target disengages during the same phase that it is targeted, this will cause a null pointer exception.

Fixes #4553.