### PR TITLE
Add savegame file path resolver to ClientServerCommandLineParser

### DIFF
--- a/megamek/docs/1-Readme/readme.txt
+++ b/megamek/docs/1-Readme/readme.txt
@@ -1,6 +1,6 @@
 INTRODUCTION
 ============
-MegaMek is a Java version of BattleTech that you can play with your friends 
+MegaMek is a Java version of BattleTech that you can play with your friends
 over the internet. All rules from Total Warfare are
 implemented. Rules from Tactical Operations and Strategic Operations are
 constantly in the works, and many of those rules and weapons
@@ -8,11 +8,11 @@ are already implemented.
 
 Players can create their own units, maps, and scenarios for use with MegaMek.
 MegaMek supports all unit types, from infantry, battlemechs, and vehicles, to
-aerospace fighters, dropships, and warships. Ground battles as well as space 
+aerospace fighters, dropships, and warships. Ground battles as well as space
 battles can be played.
 
 If you would like information about how to play the game, see the "PLAYING
-THE GAME" section, below. If you're having trouble getting MegaMek started, 
+THE GAME" section, below. If you're having trouble getting MegaMek started,
 see the next section, "RUNNING MEGAMEK".
 
 For complete game rules, consult the Classic BattleTech rule books published
@@ -24,7 +24,7 @@ Operations, and Strategic Operations.
 RUNNING MEGAMEK
 ===============
 Java programs run in their own environment, called a Virtual Machine or VM
-for short. These Java VMs are available on most systems from a variety of 
+for short. These Java VMs are available on most systems from a variety of
 sources. Most modern systems have one installed by default.
 
 Windows users: To start MegaMek, run the MegaMek.exe file. If this fails
@@ -35,8 +35,8 @@ Other graphical OSes: Many other graphical OSes, such as MacOS and OSX, will
 allow you to double-click the .jar file to run it. If this does not work,
 try running MegaMek from the command line.
 
-Running MegaMek from the command line: To do this using Sun Java, or most 
-other implementations, navigate to the directory containing the .jar file and 
+Running MegaMek from the command line: To do this using Sun Java, or most
+other implementations, navigate to the directory containing the .jar file and
 run:
 
 `java -jar MegaMek.jar`
@@ -72,7 +72,7 @@ This is the largely legacy Java implementation after Oracle open sourced the cod
 http://www.oracle.com/technetwork/java/javase/downloads/index.html
 
 **Mac OSX:**
-See this support article on the apple support website for 
+See this support article on the apple support website for
 instructions:
 https://support.apple.com/en-us/HT204036.
 _Note: For advanced users, it is recommended you install java via
@@ -95,7 +95,7 @@ MegaMek seems to react badly to this VM - it is not recommended.
 CONNECTING
 ==========
 MegaMek is a network game. One player hosts a game and the rest of the
-players connect. The connecting players can connect from anywhere with a 
+players connect. The connecting players can connect from anywhere with a
 TCP/IP connection to the host, including the same computer (see hotseat, below.)
 
 To host a game, press the "Host a New Game..." button in the main menu. Fill
@@ -104,10 +104,10 @@ password for certain server commands (Type /help in the chat line to get a
 list of server commands.) If you don't specify a password, anybody is allowed
 to reset the server or kick players, so be careful.
 
-Once the lobby screen comes up, other players can connect and the game can 
+Once the lobby screen comes up, other players can connect and the game can
 begin. The other players will need to know the IP address of the host computer.
-There are several ways to determine your IP address. If you are on 
-Windows 9x/ME, you can use the Run command on the start menu and enter 
+There are several ways to determine your IP address. If you are on
+Windows 9x/ME, you can use the Run command on the start menu and enter
 `winipcfg`. On Windows 2000/NT/XP/Vista/7/8/10, you will need to open a command
 prompt and type `ipconfig`. As a last resort, there are some web pages, such as
 www.whatismyip.com that will try to detect your IP address, but if your internet
@@ -116,7 +116,7 @@ service uses a proxy or firewall, these pages cannot accurately detect it.
 To connect to a game, press the connect button on the main menu and fill in your
 player name and the host's IP address.
 
-To play in a hotseat fashion, you can run the host and any number of other 
+To play in a hotseat fashion, you can run the host and any number of other
 players on the same computer. First, launch and host a game. Then, launch
 another copy of the game for each connecting player, and in the "Server Address"
 field of the connect dialog, type `localhost`. Each player will need to switch
@@ -125,12 +125,12 @@ to his/her copy of the game to play their turn.
 To start a dedicated server, use the `-dedicated` command line switch. A
 dedicated server just runs the server, in the console, without a "host" player
 in the game. People, including yourself, can join it like a game with a host.
-The dedicated server reads the password and port options from the 
+The dedicated server reads the password and port options from the
 `clientsettings.xml` file, or uses the default (no password and port 2346.) If you
-want the dedicated server to load a saved game, supply the filename after the
-`-dedicated` switch, like this: `-dedicated savedgame.sav`. To stop the server,
-you will need to tell the Java machine to halt execution, which is `CTRL + C` on
-most platforms.
+want the dedicated server to load a saved game, supply the filename at the end of
+`-dedicated` args, like this: `-dedicated savedgame.sav` or
+`-dedicated -port 2346 savedgame.sav`. To stop the server, you will need to tell the
+Java machine to halt execution, which is `CTRL + C` on most platforms.
 
 
 PLAYING THE GAME
@@ -173,7 +173,7 @@ You need to use the "generated map settings" button to select what kind of terra
 you want.
 
 There is a set of settings with drop down list of choices. For most settings, you
-can pick "none", "low", "medium" or "high". Except for cities, where you pick a 
+can pick "none", "low", "medium" or "high". Except for cities, where you pick a
 type of city instead.
 
 **Theme** - leave blank for the default theme, or enter a theme supported by your tileset.
@@ -188,7 +188,7 @@ type of city instead.
 **Roughs** - higher settings have more and larger rough patches
 
 **Lakes** - works the same as woods, but deep water instead of heavy woods
-Swamps/Pavement/Ice/Rubble/Fortified all work like roughs. 
+Swamps/Pavement/Ice/Rubble/Fortified all work like roughs.
 Fortified hexes are described in the MaxTech rulebook.
 
 **River** - chance to have a river running across the map
@@ -204,11 +204,11 @@ Fortified hexes are described in the MaxTech rulebook.
 **GRID** - vertical and horizontal roads divide the city into rectangular blocks. A pattern
         common in newer cities, especially in north america and asia.
 
-**METRO** - a grid with roads forming a diagonal X from the centre as well. 
+**METRO** - a grid with roads forming a diagonal X from the centre as well.
 
 Water and swamp will affect the city plan, as the builders will have to make bridges to
         cross it or just give up and stop the road at the edge.
-Mountain tops (4+ height) are expensive to build on, so they will only build in the valleys. 
+Mountain tops (4+ height) are expensive to build on, so they will only build in the valleys.
 Other terrain will just be bulldozed in the name of progress, though you may find a few
         hexes left between buildings.
 
@@ -232,36 +232,36 @@ the board, showing your unit's path to the target hex. The numbers in the
 center represent how many movement points you will have to use to reach each
 hex. Cyan indicates walking, yellow running, and red jump movement. Dark grey
 sections of the path indicate where you have exceeded your movement capacity,
-or other illegal moves. You can drag the mouse to see movement options for 
+or other illegal moves. You can drag the mouse to see movement options for
 several different hexes. Please note that you can change the colors used to
 display the movement points by editing `clientsettings.xml`; you may specify a
 color in RGB notation (e.g. 255 255 255 for white) or with any of the following
-text values: black, blue, cyan, darkgray, gray, green, lightgray, magenta, 
+text values: black, blue, cyan, darkgray, gray, green, lightgray, magenta,
 orange, pink, red, white, or yellow.
 
-Units can also be moved by using "waypoints." By clicking each hex between 
-the unit's current location and destination, you can delineate the exact path 
+Units can also be moved by using "waypoints." By clicking each hex between
+the unit's current location and destination, you can delineate the exact path
 to be taken.
 
 Holding the `Shift` key while clicking on the map allows you to change the
-unit's facing without moving. Since you automatically change facing while 
+unit's facing without moving. Since you automatically change facing while
 moving, this is best done at the end of any movement.
 
 To move backwards, click the "Back Up" button before clicking a hex in the arc
 behind the unit. To jump, click the "Jump" button before the destination hex.
 Facing changes during jumps are free.
 
-Prone units can change facing without getting up at the normal cost. To get up, 
+Prone units can change facing without getting up at the normal cost. To get up,
 click the "Get Up" button, then the desired destination hex and/or facing.
-Facing changes performed immediately after getting up are free. To get up and 
-back up, click "Get Up," then "Back Up," then the destination hex and/or 
+Facing changes performed immediately after getting up are free. To get up and
+back up, click "Get Up," then "Back Up," then the destination hex and/or
 facing. You cannot get up and jump in the same turn.
 
-Charging and death from above attacks are also declared during the movement 
+Charging and death from above attacks are also declared during the movement
 phase. Click the "Charge" or "D.F.A." button and then click on the mech you
-wish to target. If the attack is valid, it will be sent to the server 
+wish to target. If the attack is valid, it will be sent to the server
 immediately (but resolve during the physical attack phase.) If the program is
-not using the path you want for your attack, you may plot a path near the 
+not using the path you want for your attack, you may plot a path near the
 target using the appropriate type of movement and then use the charge or dfa
 button to complete the attack.
 
@@ -281,13 +281,13 @@ Movement Phase can not move or fire for the rest of the turn. Swarming units
 can not move off of their target Mek until they use the Stop Swarm action in
 the Weapons Fire Phase.
 
-VTOLs and VTOL BA use the "go up" and "go down" buttons to change 
+VTOLs and VTOL BA use the "go up" and "go down" buttons to change
 elevation (flight level).
 
 Movement around structures (buildings/bridges) is a little more complicated, because
 of the different floors a unit can occupy. The "climb mode" button sets your current
 preference. "Go thru" means you prefer to go under bridges or through the walls of
-buildings, if there is a choice. "Climb up" means you prefer to climb on top of 
+buildings, if there is a choice. "Climb up" means you prefer to climb on top of
 structures when possible. You can change mode multiple times during your movement,
 for example a stormcrow prime could use "climb up" to go over a heavy building to save
 MP, then change to "go thru" to pass a light building that won't support its weight.
@@ -310,15 +310,15 @@ showing the results of these rolls will be shown.
 
 ### Weapons Fire Phase:
 
-If you need to check the range and line of sight (LoS) between two hexes, 
-there are two tools available for you to use; the LoS tool and the ruler 
+If you need to check the range and line of sight (LoS) between two hexes,
+there are two tools available for you to use; the LoS tool and the ruler
 tool. To use the LoS tool, hold `CTRL` and click on the two hexes you want to
 check. The ruler tool works like the LoS tool, but uses the `ALT` key instead
 of the `CTRL` key. The ruler tool can also be used by middle-clicking the
 two hexes with a three-button mouse. Both tools will pop up a window that
 tells you what terrain is intervening and whether one or both hexes has
-partial cover. The ruler tool also draws the line of sight on the board 
-so that you can see which hexes LoS passes through. 
+partial cover. The ruler tool also draws the line of sight on the board
+so that you can see which hexes LoS passes through.
 
 You can switch between 'Mech line of sight and non-'Mech line of sight in the
 "LoS Setting" panel, located under the "View" menu at the top of the screen.
@@ -328,29 +328,29 @@ they are in, whereas infantry and vehicles only take up the elevation level
 of their hex.
 
 The buttons at the bottom of the screen allow you to fire your weapons,
-switch to another unit, or commit to your currently declared fire. Again, 
+switch to another unit, or commit to your currently declared fire. Again,
 you do not need to declare fire for your first selected unit first.
 
 To target another unit, click on it on the board. Targeting information
 for your current weapon should appear in the mech display window. To fire
-your current weapon at the target, press the "Fire" button at the bottom of 
+your current weapon at the target, press the "Fire" button at the bottom of
 the screen. To switch to another weapon, click on its name at the top of the
-mech display window. Spread your fire among multiple targets by repeating 
-these steps using unassigned weapons. When all desired weapons have been 
+mech display window. Spread your fire among multiple targets by repeating
+these steps using unassigned weapons. When all desired weapons have been
 assigned to a target, press the "Done" button at the bottom of the screen.
 
-Note that fire is resolved in the order that it is declared, so if you feel 
-that it is a good idea to fire weapons in a different order than they are 
+Note that fire is resolved in the order that it is declared, so if you feel
+that it is a good idea to fire weapons in a different order than they are
 listed, go ahead.
 
 Secondary facing changes (torso twists) are accomplished by holding `Shift` and
-clicking on the board. Your unit will attempt to change its secondary facing 
+clicking on the board. Your unit will attempt to change its secondary facing
 in the direction specified. If you assign a weapon to a target and then
 attempt a facing change, the weapons fire will be canceled.
 
-You can not switch to another unit after declaring some weapons fire. To 
+You can not switch to another unit after declaring some weapons fire. To
 switch to another unit, first cancel all current fire by hitting the `Esc` key.
-When you hit the fire button for your last available weapon, all declared 
+When you hit the fire button for your last available weapon, all declared
 fire will be committed.
 
 An Anti-Mek trained infantry platoon or Battle Armor squad that is in the same
@@ -382,11 +382,11 @@ report.
 ### Physical Attacks Phase:
 
 To declare a physical attack, select your target on the board and click the
-button corresponding to the attack you want to make. If a physical attack 
+button corresponding to the attack you want to make. If a physical attack
 type is unavailable (or isn't programmed yet) the button will be greyed out.
 
 Units ineligible to make physical attacks due to being out of range, having
-made weapons attacks, or for any other reason, will be skipped. If all units 
+made weapons attacks, or for any other reason, will be skipped. If all units
 are ineligible, the entire phase will be skipped.
 
 Prone Meks that are in the same hex as a vehicle can punch the vehicle, if
@@ -472,11 +472,11 @@ multiple mapsheets.
 **Theme** - leave blank, or enter a theme supported by the tileset.
         grass, lunar, mars, snow are themes supported by the standard tileset.
 
-**Elevation settings:** 
+**Elevation settings:**
 
 **Amount of elevation** - changes the "roughness" of the map, a low number
 will have less elevation changes than a high number
-Elevation range: height difference between the lowest and highest hex 
+Elevation range: height difference between the lowest and highest hex
 on the map. Level 0 is set to the most common height.
 
 **Probability of inverting** - % chance to make a sinkhole instead of a mountain.
@@ -500,7 +500,7 @@ scales up if you have a bigger map.
 
 **Probability for heavy woods/deep water** - % chance to place instead of light.
 
-**River/road settings** - Probability is a % chance to have one on the map. If a road crosses water, 
+**River/road settings** - Probability is a % chance to have one on the map. If a road crosses water,
 you'll get a bridge.
 
 **Crater settings:**
@@ -532,29 +532,29 @@ modifier changes the "sea level"
 **Drought** - water hexes are dried up, to shallower water, swamp or rough. Modifier
 changes the severity of the drought.
 
-_**Special effects can be combined** - e.g. flood + drought = rocky shore, 
+_**Special effects can be combined** - e.g. flood + drought = rocky shore,
 flood + frozen + high modifier = glacier_
 
 **City Settings:**
 
 City type is the same as for the basic settings.
 
-**City Blocks (0-) [16 default]** - higher numbers mean more roads on the map. 
+**City Blocks (0-) [16 default]** - higher numbers mean more roads on the map.
 Scales with map size.
 
-**CF min/max (1-150) [10-100 default]** - CF range for generated buildings. 
+**CF min/max (1-150) [10-100 default]** - CF range for generated buildings.
 The CF determines the building type from the table in BMR.
 
 **Floors min/max (1-50) [1-6 default]** - height range for generated buildings
- 
-**Density (1-100) [75 default]** - % chance of a building in each hex where a 
-building is possible. Also chance to try and build multi-hex buildings. 
+
+**Density (1-100) [75 default]** - % chance of a building in each hex where a
+building is possible. Also chance to try and build multi-hex buildings.
 
 DIFFERENCES BETWEEN THE BOARD GAME AND MEGAMEK
 ==============================================
 Although MegaMek tries to be faithful to the original board game rules, in
 some cases, due to technical or design limitations, this is not possible.
-These differences are not considered "bugs." If you spot any more 
+These differences are not considered "bugs." If you spot any more
 discrepancies, please contact the author (see "CONTACT" below.)
 
 - If the line of fire lies along the edge of two hexes, in the board game,
@@ -592,14 +592,14 @@ COPYRIGHT & LICENSE INFORMATION
 ===============================
 MegaMek - Copyright (C) 2002 Ben Mazur (bmazur@sev.org)
 
-This program is free software; you can redistribute it and/or modify it 
-under the terms of the GNU General Public License as published by the Free 
-Software Foundation; either version 2 of the License, or (at your option) 
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 2 of the License, or (at your option)
 any later version.
 
-This program is distributed in the hope that it will be useful, but 
-WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
-or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
 for more details.
 
 _MechWarrior, BattleMech, ‘Mech and AeroTech are registered trademarks of

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -249,14 +249,7 @@ public class MegaMek {
             MegaMekGUI mmg = new MegaMekGUI();
             mmg.start(false);
 
-            File gameFile = null;
-            if (resolver.saveGameFileName != null ) {
-                gameFile = new File(resolver.saveGameFileName);
-                if (!gameFile.isAbsolute()) {
-                    gameFile = new File("./savegames", resolver.saveGameFileName);
-                }
-            }
-
+            File gameFile = resolver.getSaveGameFile();
             mmg.startHost(resolver.password, resolver.port, resolver.registerServer,
                     resolver.announceUrl, resolver.mailPropertiesFile, gameFile,
                     resolver.playerName );

--- a/megamek/src/megamek/common/commandline/AbstractCommandLineParser.java
+++ b/megamek/src/megamek/common/commandline/AbstractCommandLineParser.java
@@ -80,11 +80,11 @@ public abstract class AbstractCommandLineParser {
     /**
      * Current token value
      */
-    private String tokenValue;
+    private String value;
 
     /**
      * Constructs new parser
-     * 
+     *
      * @param args <code>array</code> of arguments to parse
      */
     public AbstractCommandLineParser(String... args) {
@@ -94,7 +94,7 @@ public abstract class AbstractCommandLineParser {
 
     /**
      * Main entry point of the parser
-     * 
+     *
      * @throws ParseException if it fails to parse
      */
     public void parse() throws ParseException {
@@ -103,7 +103,7 @@ public abstract class AbstractCommandLineParser {
     }
 
     /**
-     * 
+     *
      * @return current argument
      */
     protected String getArgValue() {
@@ -119,7 +119,7 @@ public abstract class AbstractCommandLineParser {
     }
 
     /**
-     * 
+     *
      * @param token to set the current token to
      */
     protected void setToken(int token) {
@@ -127,23 +127,23 @@ public abstract class AbstractCommandLineParser {
     }
 
     /**
-     * 
+     *
      * @return <code>String</code> value of the current token
      */
     protected String getTokenValue() {
-        return tokenValue;
+        return value;
     }
 
     /**
-     * 
+     *
      * @param tokenValue to set the current token to
      */
     protected void setTokenValue(String tokenValue) {
-        this.tokenValue = tokenValue;
+        this.value = tokenValue;
     }
 
     /**
-     * 
+     *
      * @return <code>String</code> value of the current token
      */
     protected int getPosition() {
@@ -152,7 +152,7 @@ public abstract class AbstractCommandLineParser {
 
     /**
      * Real entry point of parser
-     * 
+     *
      * @throws ParseException if the parser fails
      */
     protected abstract void start() throws ParseException;
@@ -171,13 +171,13 @@ public abstract class AbstractCommandLineParser {
         if (argValue != null) {
             if (argValue.startsWith(OPTION_PREFIX)) {
                 token = TOK_OPTION;
-                tokenValue = argValue.substring(OPTION_PREFIX.length());
+                value = argValue.substring(OPTION_PREFIX.length());
             } else {
                 token = TOK_LITERAL;
-                tokenValue = argValue;
+                value = argValue;
             }
         } else {
-            tokenValue = null;
+            value = null;
             token = TOK_EOF;
         }
     }

--- a/megamek/src/megamek/common/commandline/ClientServerCommandLineParser.java
+++ b/megamek/src/megamek/common/commandline/ClientServerCommandLineParser.java
@@ -258,9 +258,10 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
     }
 
     public class Resolver {
-        public final String playerName, serverAddress, password, saveGameFileName, announceUrl, mailPropertiesFile;
+        public final String playerName, serverAddress, password, announceUrl, mailPropertiesFile;
         public final boolean registerServer;
         public final int port;
+        protected final String saveGameFileName;
 
         public Resolver(ClientServerCommandLineParser parser, String defaultPassword, int defaultPort,
                         String defaultServerAddress, String defaultPlayerName)
@@ -325,5 +326,36 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
             this.registerServer = registerServer;
             this.mailPropertiesFile = mailPropertiesFile;
         }
+
+        /**
+         * path resolves the saveGameFileName arg if it was provided.
+         * If it is an absolute path, uses that, otherwise looks first in
+         * current working directory and then in ./savegame/
+         * @return File object if valid file, null if not
+         */
+        public File getSaveGameFile() {
+            if (saveGameFileName == null) {
+                return null;
+            }
+            File gameFile = new File(saveGameFileName);
+
+            if (gameFile.canRead()) {
+                return gameFile;
+            } else if (gameFile.isAbsolute()) {
+                LogManager.getLogger().error("Unable to read savegame file: " + gameFile.getPath());
+                return null;
+            } else {
+                String searched = '"'+gameFile.getAbsolutePath()+'"';
+                gameFile = new File("./savegames", saveGameFileName);
+                if (gameFile.canRead()) {
+                    return gameFile;
+                } else {
+                    searched += " or \"" + gameFile.getAbsolutePath()+'"';
+                    LogManager.getLogger().error("Unable to read savegame file at " + searched);
+                    return null;
+                }
+            }
+        }
+
     }
 }

--- a/megamek/src/megamek/common/commandline/ClientServerCommandLineParser.java
+++ b/megamek/src/megamek/common/commandline/ClientServerCommandLineParser.java
@@ -21,6 +21,7 @@ import megamek.server.Server;
 import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
+import java.net.URI;
 
 public class ClientServerCommandLineParser extends AbstractCommandLineParser {
 
@@ -112,11 +113,11 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
     protected void start() throws ParseException {
         while (getTokenType() != TOK_EOF) {
             int tokenType = getTokenType();
-            final String tokenValue = getTokenValue();
+            final String value = getTokenValue();
             switch (tokenType) {
                 case TOK_OPTION:
                     try {
-                        switch (ClientServerCommandLineFlag.parseFromString(tokenValue)) {
+                        switch (ClientServerCommandLineFlag.parseFromString(value)) {
                             case HELP:
                                 LogManager.getLogger().info(help());
                                 System.exit(0);
@@ -162,16 +163,14 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
                     }
                     break;
                 case TOK_LITERAL:
-                    // this is old behavior, but it didn't seem to work
-                    // It works now and I left it in just in case
-                    saveGameFileName = tokenValue;
+                    saveGameFileName = value;
                     nextToken();
                     break;
                 case TOK_EOF:
                     // Do nothing, although this shouldn't happen
                     break;
                 default:
-                    throw new ParseException(String.format("Unexpected input %s", tokenValue));
+                    throw new ParseException(String.format("Unexpected input %s", value));
             }
             nextToken();
         }
@@ -342,10 +341,10 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
             if (gameFile.canRead()) {
                 return gameFile;
             } else if (gameFile.isAbsolute()) {
-                LogManager.getLogger().error("Unable to read savegame file: " + gameFile.getPath());
+                LogManager.getLogger().error("Unable to read savegame file: " + gameFile.getAbsolutePath());
                 return null;
             } else {
-                String searched = '"'+gameFile.getAbsolutePath()+'"';
+                String searched = '"'+ gameFile.getAbsolutePath()+'"';
                 gameFile = new File("./savegames", saveGameFileName);
                 if (gameFile.canRead()) {
                     return gameFile;
@@ -356,6 +355,5 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
                 }
             }
         }
-
     }
 }

--- a/megamek/src/megamek/server/DedicatedServer.java
+++ b/megamek/src/megamek/server/DedicatedServer.java
@@ -70,8 +70,16 @@ public class DedicatedServer {
             return;
         }
 
+        File gameFile = null;
+        if (resolver.saveGameFileName != null ) {
+            gameFile = new File(resolver.saveGameFileName);
+            if (!gameFile.isAbsolute()) {
+                gameFile = new File("./savegames", resolver.saveGameFileName);
+            }
+        }
+
         if (null != resolver.saveGameFileName) {
-            server.loadGame(new File(resolver.saveGameFileName));
+            server.loadGame(gameFile);
         }
     }
 }

--- a/megamek/src/megamek/server/DedicatedServer.java
+++ b/megamek/src/megamek/server/DedicatedServer.java
@@ -70,15 +70,8 @@ public class DedicatedServer {
             return;
         }
 
-        File gameFile = null;
-        if (resolver.saveGameFileName != null ) {
-            gameFile = new File(resolver.saveGameFileName);
-            if (!gameFile.isAbsolute()) {
-                gameFile = new File("./savegames", resolver.saveGameFileName);
-            }
-        }
-
-        if (null != resolver.saveGameFileName) {
+        File gameFile = resolver.getSaveGameFile();
+        if (null != gameFile) {
             server.loadGame(gameFile);
         }
     }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -863,7 +863,7 @@ public class Server implements Runnable {
      * @return A <code>boolean</code> value whether or not the loading was successful
      */
     public boolean loadGame(File f, boolean sendInfo) {
-        LogManager.getLogger().info("s: loading saved game file '" + f + '\'');
+        LogManager.getLogger().info("s: loading saved game file '" + f.getAbsolutePath() + '\'');
 
         Game newGame;
         try (InputStream is = new FileInputStream(f)) {


### PR DESCRIPTION
This moves the savegame file checks from DedicatedServer and MegaMekGUI into a common method on ClientServerCommandLineParser.
This new method fixes https://github.com/MegaMek/megamek/issues/4618, a common user error
 -host and -dedicated args now both will look in ./savegames for a non-absolute file if it is not readable from ./ 
It also improves the error reporting by reporting the absolute paths of where it looked:
_-dedicated ddmysave.sav,gz_, which does not exist in this example, will report in the log:
`Unable to read savegame file at "C:\Users\Natasha\Games\megamek\ddmysave.sav.gz" or "C:\Users\Natasha\Games\MegaMek\megamek\.\savegames\ddmysave.sav.gz"`
This should work on macOS and Linux as well.