### PR TITLE
allow field of fire and sensors rings to display in indirect attacks …

### DIFF
--- a/megamek/src/megamek/client/ui/swing/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PhysicalDisplay.java
@@ -1402,7 +1402,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         } else if (targets.size() > 1) {
             // If we have multiple choices, display a selection dialog.
             choice = TargetChoiceDialog.showSingleChoiceDialog(clientgui.getFrame(),
-                    Messages.getString("PhysicalDisplay.ChooseTargetDialog.title"),
+                    "PhysicalDisplay.ChooseTargetDialog.title",
                     Messages.getString("PhysicalDisplay.ChooseTargetDialog.message", pos.getBoardNum()),
                     targets, clientgui, ce());
         }

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -1300,7 +1300,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements
         } else if (targets.size() > 1) {;
             // If we have multiple choices, display a selection dialog.
             choice = TargetChoiceDialog.showSingleChoiceDialog(clientgui.getFrame(),
-                    Messages.getString("FiringDisplay.ChooseTargetDialog.title"),
+                    "FiringDisplay.ChooseTargetDialog.title",
                     Messages.getString("FiringDisplay.ChooseTargetDialog.message", new Object[] { pos.getBoardNum() }),
                     targets, clientgui, ce());
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6664,13 +6664,15 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     public boolean shouldShowFieldOfFire() {
         return GUIP.getShowFieldOfFire() &&
                 (game.getPhase().isDeployment() || game.getPhase().isMovement()
-                        || game.getPhase().isTargeting() || game.getPhase().isFiring());
+                        || game.getPhase().isTargeting() || game.getPhase().isFiring()
+                        || game.getPhase().isOffboard());
     }
 
     public boolean shouldShowSensorRange() {
         return GUIP.getShowSensorRange() &&
                 (game.getPhase().isDeployment() || game.getPhase().isMovement()
-                        || game.getPhase().isTargeting() || game.getPhase().isFiring());
+                        || game.getPhase().isTargeting() || game.getPhase().isFiring()
+                        || game.getPhase().isOffboard());
     }
 
 }


### PR DESCRIPTION
- allow field of fire and sensors rings to display in indirect attacks for tag
- correct issue when selecting a target in the indirect attacks or physical phase

![image](https://github.com/MegaMek/megamek/assets/116095479/e5b0d3b2-1e2a-48c2-bb8a-8649f170e21e)


fixes #4540