### PR TITLE
TestMech update (Internal structure validation)

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1455,6 +1455,17 @@ public class TestMech extends TestEntity {
             }
         }
 
+        // Test if the crit slots for internal structure match the required crits; Note that this intentionally
+        // counts crit slots, not mounted equipment as the latter only works with a fully loaded unit in MML and
+        // will make units appear invalid during loading (MML calls UnitUtil.expandUnitMounts() after loading)
+        String structureName = EquipmentType.getStructureTypeName(mech.getStructureType(), mech.isClan());
+        EquipmentType structure = EquipmentType.get(structureName);
+        int requiredStructureCrits = structure.getCriticals(mech);
+        if (mech.getNumberOfCriticals(structure) != requiredStructureCrits) {
+            buff.append("The internal structure of this mek is not using the correct number of crit slots\n");
+            illegal = true;
+        }
+
         return illegal;
     }
 


### PR DESCRIPTION
Adds a validation for the correct number of internal structure crits. This can fail when the GUI failed somehow or the unit file was altered or when a unit was saved in an invalid state.

Fixes MegaMek/megameklab#759