### PR TITLE
Reinforced Structure data

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -9041,7 +9041,6 @@ public class MiscType extends EquipmentType {
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 0;
         misc.hittable = false;
-        misc.spreadable = true;
         misc.bv = 0;
         misc.flags = misc.flags.or(F_REINFORCED);
         misc.omniFixedOnly = true;


### PR DESCRIPTION
Removes the "spreadable" flag from reinforced structure as it doesn't need any crit slots. The flag had the side-effect of adding a false "Reinforced" crit slot to units in MML.

Fixes MegaMek/megameklab#1155