### PR TITLE
add GM indicator to player list in lobby

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
@@ -241,6 +241,13 @@ class PlayerTable extends JTable {
                 result.append("</FONT>");
             }
 
+            if (player.getGameMaster()) {
+                result.append(UIUtil.DOT_SPACER);
+                result.append(guiScaledFontHTML(uiGreen()));
+                result.append("\uD83D\uDD2E  GM");
+                result.append("</FONT>");
+            }
+
             setText(result.toString());
 
             setIconTextGap(scaleForGUI(10));


### PR DESCRIPTION
- add GM indicator to player list in lobby.  To make it easier to see when someone is a GM when starting a game.

![image](https://github.com/MegaMek/megamek/assets/116095479/9b3b9382-dba2-4fea-bbec-0cdc77b70e36)
