### PR TITLE
Don't apply grounded fighter attack mod to small craft

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3793,9 +3793,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
             // grounded aero
             if (!ae.isAirborne() && !ae.isSpaceborne()) {
-                if (!(ae instanceof Dropship)) {
+                if (ae.isFighter()) {
                     toHit.addModifier(+2, Messages.getString("WeaponAttackAction.GroundedAero"));
-                } else if (!target.isAirborne() && !isArtilleryIndirect) {
+                } else if (!isArtilleryIndirect) {
                     toHit.addModifier(-2, Messages.getString("WeaponAttackAction.GroundedDs"));
                 }
             }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3795,7 +3795,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             if (!ae.isAirborne() && !ae.isSpaceborne()) {
                 if (ae.isFighter()) {
                     toHit.addModifier(+2, Messages.getString("WeaponAttackAction.GroundedAero"));
-                } else if (!isArtilleryIndirect) {
+                } else if (!target.isAirborne() && !isArtilleryIndirect) {
                     toHit.addModifier(-2, Messages.getString("WeaponAttackAction.GroundedDs"));
                 }
             }


### PR DESCRIPTION
The +2 modifier for grounded fighters should not apply to small craft. In addition, per the forum post linked in the issue cited below, the rules for dropships should apply to small craft as well, giving them a -2 to hit when grounded.

Fixes  #4591