### PR TITLE
Indirect Attacks (semiguided and mortar)

### DIFF
--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -161,6 +161,8 @@ public class LosEffects {
      */
     Coords coverLocSecondary = null;
     int minimumWaterDepth = -1;
+
+    // Arced shots get no modifiers from any intervening terrain
     boolean arcedShot = false;
 
     
@@ -1332,8 +1334,15 @@ public class LosEffects {
         return false;
     }
 
-    public void setArcedAttack(boolean attack) {
-        arcedShot = attack;
+    /**
+     * Sets this LosEffects to the given isArced value. When this is true, the line of sight is treated
+     * as for an indirect shot without spotter or with semi-guided ammo on a TAGged target, i.e. one
+     * that gets no terrain modifiers.
+     *
+     * @param isArced True for a shot that shouldn't get any terrain modifiers
+     */
+    public void setArcedAttack(boolean isArced) {
+        arcedShot = isArced;
     }
 
     /**


### PR DESCRIPTION
Currently, Mek Mortar indirect fire without spotter ignores intervening terrain but not the terrain in the target's hex. Semiguided indirect+TAG ignores the target's hex but not the intervening terrain. This PR makes both cases be treated equally:
Indirect mortar attacks without spotter and indirect semi-guided+tag attacks ignore all terrain modifiers according to TW p.111 and 142 (and confirmed by Hammer)

Fixes #4459 
Fixes #4638 

Note: the deleted toSubtract = ... in line 4536 was unused according to the IDE