### PR TITLE
clear calcDmgPerHitReport once it is added to vPhaseReport

### DIFF
--- a/megamek/src/megamek/common/weapons/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/ACAPHandler.java
@@ -75,6 +75,7 @@ public class ACAPHandler extends ACWeaponHandler {
         // Report calcDmgPerHitReports here
         if (!calcDmgPerHitReport.isEmpty()) {
             vPhaseReport.addAll(calcDmgPerHitReport);
+            calcDmgPerHitReport.clear();
         }
 
         // if the target was in partial cover, then we already handled

--- a/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MGAWeaponHandler.java
@@ -171,6 +171,7 @@ public class MGAWeaponHandler extends MGHandler {
         // Report calcDmgPerHitReports here
         if (!calcDmgPerHitReport.isEmpty()) {
             vPhaseReport.addAll(calcDmgPerHitReport);
+            calcDmgPerHitReport.clear();
         }
 
         // if the target was in partial cover, then we already handled

--- a/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RifleWeaponHandler.java
@@ -137,6 +137,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
         // Report calcDmgPerHitReports here
         if (!calcDmgPerHitReport.isEmpty()) {
             vPhaseReport.addAll(calcDmgPerHitReport);
+            calcDmgPerHitReport.clear();
         }
 
         // if the target was in partial cover, then we already handled

--- a/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMTandemChargeHandler.java
@@ -82,6 +82,7 @@ public class SRMTandemChargeHandler extends SRMHandler {
         // Report calcDmgPerHitReports here
         if (!calcDmgPerHitReport.isEmpty()) {
             vPhaseReport.addAll(calcDmgPerHitReport);
+            calcDmgPerHitReport.clear();
         }
 
         // if the target was in partial cover, then we already handled

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1499,6 +1499,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         // Report calcDmgPerHitReports here
         if (!calcDmgPerHitReport.isEmpty()) {
             vPhaseReport.addAll(calcDmgPerHitReport);
+            calcDmgPerHitReport.clear();
         }
         
         // if the target was in partial cover, then we already handled


### PR DESCRIPTION
- clear calcDmgPerHitReport, once it is added to vPhaseReport

![image](https://github.com/MegaMek/megamek/assets/116095479/9199ad60-b92b-4ff5-a0e1-7e853b7e9ae8)

fixes #3654 