### PR TITLE
Small log cleanup

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -178,6 +178,11 @@ public class MegaMek {
             filename = "MegaMek.app/Contents/Resources/Java/" + filename;
         }
 
+        if (!new File(filename).exists()) {
+            LogManager.getLogger().warn("MegaMek.jar not found. Returning null checksum.");
+            return null;
+        }
+
         MessageDigest md;
         // Calculate the digest for the given file.
         try {

--- a/megamek/src/megamek/common/options/GameOptions.java
+++ b/megamek/src/megamek/common/options/GameOptions.java
@@ -333,9 +333,11 @@ public class GameOptions extends AbstractOptions {
             InputStream is = new FileInputStream(file);
             GameOptionsXML opts = (GameOptionsXML) um.unmarshal(MMXMLUtility.createSafeXmlSource(is));
 
+            StringBuilder logMessages = new StringBuilder("\n");
             for (IBasicOption bo : opts.getOptions()) {
-                changedOptions.add(parseOptionNode(bo, print));
+                changedOptions.add(parseOptionNode(bo, print, logMessages));
             }
+            LogManager.getLogger().info(logMessages.toString());
         } catch (Exception e) {
             LogManager.getLogger().error("Error loading XML for game options: " + e.getMessage(), e);
         }
@@ -343,7 +345,7 @@ public class GameOptions extends AbstractOptions {
         return changedOptions;
     }
 
-    private IOption parseOptionNode(final IBasicOption node, final boolean print) {
+    private IOption parseOptionNode(final IBasicOption node, final boolean print, final StringBuilder logMessages) {
         IOption option = null;
 
         String name = node.getName();
@@ -372,17 +374,17 @@ public class GameOptions extends AbstractOptions {
                         }
 
                         if (print) {
-                            LogManager.getLogger().info(String.format("Set option '%s' to '%s'.", name, value));
+                            logMessages.append(String.format("\tSet option '%s' to '%s'\n", name, value));
                         }
 
                         option = tempOption;
                     } catch (Exception ex) {
                         LogManager.getLogger().error(String.format(
-                                "Error trying to load option '%s' with a value of '%s'.", name, value));
+                                "Error trying to load option '%s' with a value of '%s'!", name, value));
                     }
                 }
             } else {
-                LogManager.getLogger().warn("Invalid option '" + name + "' when trying to load options file.");
+                LogManager.getLogger().warn("Invalid option '" + name + "' when trying to load options file!");
             }
         }
 


### PR DESCRIPTION
This replaces the everpresent exception that is logged when MegaMek.jar isnt there with a simple warning; also loaded game options are now logged as one block instead of a load of individual entries

![image](https://github.com/MegaMek/megamek/assets/17069663/35d5c432-4528-4a62-8275-f14ff0ddc4a1)
![image](https://github.com/MegaMek/megamek/assets/17069663/d2e811ae-5c3d-42ea-9b95-cc14573f2492)
