### PR TITLE
allow key binds to work on report phases

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -835,13 +835,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     private boolean shouldIgnoreKeyCommands() {
         return getChatterBoxActive() || !isVisible()
                || game.getPhase().isLounge()
-               || game.getPhase().isEndReport()
-               || game.getPhase().isMovementReport()
-               || game.getPhase().isTargetingReport()
-               || game.getPhase().isFiringReport()
-               || game.getPhase().isPhysicalReport()
-               || game.getPhase().isOffboardReport()
-               || game.getPhase().isInitiativeReport()
                || shouldIgnoreKeys;
     }
 


### PR DESCRIPTION
- allow game board key binds to work on report phases, now that these phases have the game board visible.

fixes #4656