### PR TITLE
BA validation: Add multiple equipment validation tests

### DIFF
--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
 public class EquipmentTypeLookup {
 
     /**
-     * Static fields in this class annotated with {code }@EquipmentName} will be checked by the unit tests
+     * Static fields in this class annotated with {code @EquipmentName} will be checked by the unit tests
      * to verify they are valid {@link EquipmentType} lookup keys.
      */
     @Retention(RetentionPolicy.RUNTIME)
@@ -62,6 +62,10 @@ public class EquipmentTypeLookup {
     @EquipmentName public static final String BA_JUMP_BOOSTER = "BAJumpBooster";
     @EquipmentName public static final String BA_MECHANICAL_JUMP_BOOSTER = "BAMechanicalJumpBooster";
     @EquipmentName public static final String BA_MANIPULATOR_CARGO_LIFTER = "BACargoLifter";
+    @EquipmentName public static final String BA_MAGNETIC_CLAMP = "BA-Magnetic Clamp";
+    @EquipmentName public static final String BA_PARAFOIL = "BAParafoil";
+    @EquipmentName public static final String BA_MISSION_EQUIPMENT = "Mission Equipment Storage";
+    @EquipmentName public static final String BA_DWP = "ISDetachableWeaponPack";
 
     @EquipmentName public static final String SINGLE_HS = "Heat Sink";
     @EquipmentName public static final String IS_DOUBLE_HS = "ISDoubleHeatSink";

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -10249,7 +10249,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Parafoil";
-        misc.setInternalName("BAParafoil");
+        misc.setInternalName(EquipmentTypeLookup.BA_PARAFOIL);
         misc.tonnage = .035;
         misc.criticals = 1;
         misc.hittable = false;
@@ -10776,7 +10776,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Magnetic Clamps [BA]";
-        misc.setInternalName("BA-Magnetic Clamp");
+        misc.setInternalName(EquipmentTypeLookup.BA_MAGNETIC_CLAMP);
         misc.addLookupName("Magnetic Clamp");
         misc.shortName = "Magnetic Clamps";
         misc.tonnage = .030;
@@ -10985,7 +10985,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Detachable Weapon Pack";
-        misc.setInternalName("ISDetachableWeaponPack");
+        misc.setInternalName(EquipmentTypeLookup.BA_DWP);
         misc.addLookupName("CLDetachableWeaponPack");
         misc.tonnage = 0;
         misc.criticals = 1;
@@ -11035,7 +11035,7 @@ public class MiscType extends EquipmentType {
         misc.addLookupName("Mission Equipment Storage (20 kg)");
         misc.addLookupName("Mission Equipment Storage (5kg)");
         misc.addLookupName("Mission Equipment Storage (200 kg)");
-        misc.setInternalName(misc.name);
+        misc.setInternalName(EquipmentTypeLookup.BA_MISSION_EQUIPMENT);
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = 1;
         misc.flags = misc.flags.or(F_VARIABLE_SIZE).or(F_BA_EQUIPMENT).or(F_BA_MISSION_EQUIPMENT)

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -140,8 +140,8 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     protected int damageTaken = 0;
 
     /**
-     * BA use locations for troopers, so we need a way to keep track of where
-     *  a piece of equipment is moutned on BA
+     * BattleArmor use the standard locations to track troopers. On BA, this field keeps track of where
+     * a piece of equipment is mounted.
      */
     private int baMountLoc = BattleArmor.MOUNT_LOC_NONE;
 
@@ -1038,6 +1038,14 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         }
     }
 
+    /**
+     * Returns the location this equipment is mounted in, such as {@link Tank#LOC_FRONT}. May also return
+     * {@link Entity#LOC_NONE} for unallocated equipment and some special equipment. For BattleArmor, will
+     * return one of the trooper locations, such as {@link BattleArmor#LOC_TROOPER_1}. To get the equipment
+     * location on BA, use {@link #getBaMountLoc()}.
+     *
+     * @return The location of this equipment on its unit
+     */
     public int getLocation() {
         return location;
     }
@@ -1928,6 +1936,10 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         */
     }
 
+    /**
+     * @return For BattleArmor, returns the location where a piece of equipment is mounted, e.g.
+     * {@link BattleArmor#MOUNT_LOC_LARM}.
+     */
     public int getBaMountLoc() {
         return baMountLoc;
     }

--- a/megamek/src/megamek/utilities/FilteredUnitListTool.java
+++ b/megamek/src/megamek/utilities/FilteredUnitListTool.java
@@ -20,6 +20,10 @@ package megamek.utilities;
 
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.verifier.EntityVerifier;
+import megamek.common.verifier.TestBattleArmor;
+import megamek.common.verifier.TestEntity;
+
 import java.io.File;
 
 /**
@@ -45,8 +49,15 @@ public final class FilteredUnitListTool {
      * @return True if this unit is to be listed
      */
     private static boolean filter(final Entity entity, final MechSummary summary) {
-        return summary.getASUnitType().isBattleArmor() && entity.getMovementMode().isJumpInfantry()
-                && entity.getJumpMP() == 0;
+//        return summary.getASUnitType().isBattleArmor() && entity.getMovementMode().isJumpInfantry()
+//                && entity.getJumpMP() == 0;
+        if (!entity.isBattleArmor()) {
+            return false;
+        }
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+                "data/mechfiles/UnitVerifierOptions.xml"));
+        TestBattleArmor testBattleArmor = new TestBattleArmor((BattleArmor) entity, entityVerifier.baOption, null);
+        return !testBattleArmor.correctEntity(new StringBuffer(), entity.getTechLevel());
     }
 
     // No changes necessary after here:


### PR DESCRIPTION
This adds various tests for BattleArmor validity (although certainly not all by far). It makes one unit invalid, the Clan Interface Armor, which uses two Mission equipment, where TM p262 seems to say that only one is allowed on a suit (Edit: The TRO entry uses two mission equipments, this is not an MM data issue).
Accidentally included the change to the FilteredUnitListTool, but it doesnt matter, it's only a tool.

Fixes MegaMek/megameklab#1265
Fixes MegaMek/megameklab#1173