### PR TITLE
Allow free facing change only after aerospace maneuvers that allow it.

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3895,9 +3895,10 @@ public class MoveStep implements Serializable {
         }
 
         // if its part of a maneuver then you can turn
-        if (isManeuver()) {
+        if (isFacingChangeManeuver()) {
             return true;
         }
+
 
         if (en instanceof ConvFighter) {
             // conventional fighters can only turn on free turns or maneuvers
@@ -4008,6 +4009,17 @@ public class MoveStep implements Serializable {
 
     public boolean isManeuver() {
         return maneuver;
+    }
+
+    /**
+     * @return Whether this step is a maneuver that allows a free facing change.
+     */
+    public boolean isFacingChangeManeuver() {
+        return maneuver && (
+                maneuverType == ManeuverType.MAN_HAMMERHEAD
+                || maneuverType == ManeuverType.MAN_IMMELMAN
+                || maneuverType == ManeuverType.MAN_SPLIT_S
+            );
     }
 
     public Minefield getMinefield() {

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -4016,8 +4016,7 @@ public class MoveStep implements Serializable {
      */
     public boolean isFacingChangeManeuver() {
         return maneuver && (
-                maneuverType == ManeuverType.MAN_HAMMERHEAD
-                || maneuverType == ManeuverType.MAN_IMMELMAN
+                maneuverType == ManeuverType.MAN_IMMELMAN
                 || maneuverType == ManeuverType.MAN_SPLIT_S
             );
     }


### PR DESCRIPTION
Currently facing changes are allowed after any aerospace maneuver, but these should only apply to the immelmann, the hammerhead, and the split-s.

Fixes #4606.