### PR TITLE
Sideslip mod for using VTOL jet booster

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -332,7 +332,7 @@ public class SharedUtility {
                             && step.getClearance() > 0)) {
                 rollTarget = entity.checkSideSlip(moveType, prevHex,
                         overallMoveType, prevStep, prevFacing, curFacing,
-                        lastPos, curPos, distance);
+                        lastPos, curPos, distance, ((entity instanceof VTOL) && md.hasActiveMASC()));
                 checkNag(rollTarget, nagReport, psrList);
             }
 

--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -332,7 +332,7 @@ public class SharedUtility {
                             && step.getClearance() > 0)) {
                 rollTarget = entity.checkSideSlip(moveType, prevHex,
                         overallMoveType, prevStep, prevFacing, curFacing,
-                        lastPos, curPos, distance, ((entity instanceof VTOL) && md.hasActiveMASC()));
+                        lastPos, curPos, distance, md.hasActiveMASC());
                 checkNag(rollTarget, nagReport, psrList);
             }
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1438,7 +1438,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
 
-        if (GUIP.getNagForMASC() && cmd.hasActiveMASC()) {
+        if (GUIP.getNagForMASC() && cmd.hasActiveMASC() && !(ce() instanceof VTOL)) {
             // pop up are you sure dialog
             ConfirmDialog nag = new ConfirmDialog(clientgui.frame,
                     Messages.getString("MovementDisplay.areYouSure"),

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11348,7 +11348,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public PilotingRollData checkSideSlip(EntityMovementType moveType,
                                           Hex prevHex, EntityMovementType overallMoveType,
                                           MoveStep prevStep, int prevFacing, int curFacing, Coords lastPos,
-                                          Coords curPos, int distance) {
+                                          Coords curPos, int distance, boolean usingJetBooster) {
         PilotingRollData roll = getBasePilotingRoll(overallMoveType);
 
         if ((moveType != EntityMovementType.MOVE_JUMP)
@@ -11365,8 +11365,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             if (isUsingManAce()) {
                 roll.addModifier(-1, "Maneuvering Ace");
             }
-            if ((getMovementMode() == EntityMovementMode.VTOL) && isMASCUsed()
-                    && hasWorkingMisc(MiscType.F_JET_BOOSTER)) {
+            if (usingJetBooster) {
                 roll.addModifier(3, "used VTOL Jet Booster");
             }
         } else if (moveType != EntityMovementType.MOVE_JUMP

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11348,7 +11348,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public PilotingRollData checkSideSlip(EntityMovementType moveType,
                                           Hex prevHex, EntityMovementType overallMoveType,
                                           MoveStep prevStep, int prevFacing, int curFacing, Coords lastPos,
-                                          Coords curPos, int distance, boolean usingJetBooster) {
+                                          Coords curPos, int distance, boolean speedBooster) {
         PilotingRollData roll = getBasePilotingRoll(overallMoveType);
 
         if ((moveType != EntityMovementType.MOVE_JUMP)
@@ -11364,9 +11364,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             roll.append(new PilotingRollData(getId(), 0, "flanking and turning"));
             if (isUsingManAce()) {
                 roll.addModifier(-1, "Maneuvering Ace");
-            }
-            if (usingJetBooster) {
-                roll.addModifier(3, "used VTOL Jet Booster");
             }
         } else if (moveType != EntityMovementType.MOVE_JUMP
                 && prevFacing == curFacing && !lastPos.equals(curPos)

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2876,7 +2876,9 @@ public class MoveStep implements Serializable {
      */
     private void UseEitherMASCOrSupercharger(boolean hasMASCBeenUsed, boolean hasSuperchargerBeenUsed) {
         MPBoosters mpBoosters = entity.getArmedMPBoosters();
-        if (!hasMASCBeenUsed && !hasSuperchargerBeenUsed) {
+        if (mpBoosters.isJetBooster() && !hasMASCBeenUsed) {
+            setUsingMASC(true);
+        } else if (!hasMASCBeenUsed && !hasSuperchargerBeenUsed) {
             int scTarget = mpBoosters.hasSupercharger() ? entity.getSuperchargerTarget() : 2000;
             int mascTarget = mpBoosters.hasMASC() ? entity.getMASCTarget() : 2000;
             if (mascTarget < scTarget) {

--- a/megamek/src/megamek/common/VTOL.java
+++ b/megamek/src/megamek/common/VTOL.java
@@ -633,6 +633,19 @@ public class VTOL extends Tank implements IBomber {
         return MPBoosters.NONE;
     }
 
+    @Override
+    public PilotingRollData checkSideSlip(EntityMovementType moveType,
+                                          Hex prevHex, EntityMovementType overallMoveType,
+                                          MoveStep prevStep, int prevFacing, int curFacing, Coords lastPos,
+                                          Coords curPos, int distance, boolean speedBooster) {
+        PilotingRollData roll = super.checkSideSlip(moveType, prevHex, overallMoveType, prevStep, prevFacing,
+                curFacing, lastPos, curPos, distance, speedBooster);
+        if (speedBooster) {
+            roll.addModifier(3, "used VTOL Jet Booster");
+        }
+        return roll;
+    }
+
         @Override
     public int height() {
         if (isSuperHeavy()) {

--- a/megamek/src/megamek/common/VTOL.java
+++ b/megamek/src/megamek/common/VTOL.java
@@ -14,6 +14,7 @@
 package megamek.common;
 
 import megamek.common.enums.AimingMode;
+import megamek.common.enums.MPBoosters;
 import megamek.common.options.OptionsConstants;
 
 import java.util.ArrayList;
@@ -622,6 +623,17 @@ public class VTOL extends Tank implements IBomber {
     }
 
     @Override
+    public MPBoosters getMPBoosters(boolean onlyArmed) {
+        for (Mounted m : getEquipment()) {
+            if (!m.isInoperable() && (m.getType() instanceof MiscType)
+                    && m.getType().hasFlag(MiscType.F_MASC)) {
+                return MPBoosters.VTOL_JET_BOOSTER;
+            }
+        }
+        return MPBoosters.NONE;
+    }
+
+        @Override
     public int height() {
         if (isSuperHeavy()) {
             return 1;

--- a/megamek/src/megamek/common/enums/MPBoosters.java
+++ b/megamek/src/megamek/common/enums/MPBoosters.java
@@ -23,7 +23,8 @@ public enum MPBoosters {
     NONE,
     MASC_ONLY,
     SUPERCHARGER_ONLY,
-    MASC_AND_SUPERCHARGER;
+    MASC_AND_SUPERCHARGER,
+    VTOL_JET_BOOSTER;
     //endregion Enum Declarations
 
     //region Boolean Comparisons
@@ -54,10 +55,14 @@ public enum MPBoosters {
     public boolean isMASCXorSupercharger() {
         return isMASCOnly() || isSuperchargerOnly();
     }
+
+    public boolean isJetBooster() {
+        return this == VTOL_JET_BOOSTER;
+    }
     //endregion Boolean Comparisons
 
     public int calculateRunMP(int walkMP) {
-        if (isMASCXorSupercharger()) {
+        if (isMASCXorSupercharger() || isJetBooster()) {
             return (int) Math.ceil(walkMP * 2);
         } else if (isMASCAndSupercharger()) {
             return (int) Math.ceil(walkMP * 2.5);
@@ -67,7 +72,7 @@ public enum MPBoosters {
     }
 
     public int calculateSprintMP(int walkMP) {
-        if (isMASCXorSupercharger()) {
+        if (isMASCXorSupercharger() || isJetBooster()) {
             return (int) Math.ceil(walkMP * 2.5);
         } else if (isMASCAndSupercharger()) {
             return (int) Math.ceil(walkMP * 3);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -7416,7 +7416,7 @@ public class GameManager implements IGameManager {
                     && step.getClearance() > 0)) {
                 rollTarget = entity.checkSideSlip(moveType, prevHex,
                         overallMoveType, prevStep, prevFacing, curFacing,
-                        lastPos, curPos, distance, ((entity instanceof VTOL) && md.hasActiveMASC()));
+                        lastPos, curPos, distance, md.hasActiveMASC());
                 if (rollTarget.getValue() != TargetRoll.CHECK_FALSE) {
                     int moF = doSkillCheckWhileMoving(entity, lastElevation,
                             lastPos, curPos, rollTarget, false);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -6377,10 +6377,15 @@ public class GameManager implements IGameManager {
             // check for MASC failure on first step
             // also check Tanks because they can have superchargers that act
             // like MASc
-            if (firstStep && ((entity instanceof Mech) || (entity instanceof Tank))) {
-                // Not necessarily a fall, but we need to give them a new turn to plot movement with
-                // likely reduced MP.
-                fellDuringMovement = checkMASCFailure(entity, md) || checkSuperchargerFailure(entity, md);
+            if (firstStep) {
+                if (entity instanceof VTOL) {
+                    // No roll for failure, but +3 on rolls to avoid sideslip.
+                    entity.setMASCUsed(md.hasActiveMASC());
+                } else if ((entity instanceof Mech) || (entity instanceof Tank)) {
+                    // Not necessarily a fall, but we need to give them a new turn to plot movement with
+                    // likely reduced MP.
+                    fellDuringMovement = checkMASCFailure(entity, md) || checkSuperchargerFailure(entity, md);
+                }
             }
 
             if (firstStep) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -7416,7 +7416,7 @@ public class GameManager implements IGameManager {
                     && step.getClearance() > 0)) {
                 rollTarget = entity.checkSideSlip(moveType, prevHex,
                         overallMoveType, prevStep, prevFacing, curFacing,
-                        lastPos, curPos, distance);
+                        lastPos, curPos, distance, ((entity instanceof VTOL) && md.hasActiveMASC()));
                 if (rollTarget.getValue() != TargetRoll.CHECK_FALSE) {
                     int moF = doSkillCheckWhileMoving(entity, lastElevation,
                             lastPos, curPos, rollTarget, false);


### PR DESCRIPTION
The rules for the VTOL jet booster are found on p 160 of TO: AU&E.

It works like MASC/supercharger except there is no roll for failure. Instead there is a +3 mod to the PSR to avoid sideslipping. The code is there to add it, but the mascUsed field of Entity never gets set. Furthermore the nag popup cannot depend on Entity::isMascUsed because it doesn't get set until the move is processed, and must rely on the MovePath.

Fixes #4652.