### PR TITLE
Mek validation: Partial wing validation

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -2180,6 +2180,7 @@ public class MiscType extends EquipmentType {
         misc.cost = COST_VARIABLE;
         misc.flags = misc.flags.or(F_PARTIAL_WING).or(F_MECH_EQUIPMENT);
         misc.rulesRefs = "292, TO";
+        misc.omniFixedOnly = true;
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_F)
                 .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
@@ -2203,6 +2204,7 @@ public class MiscType extends EquipmentType {
         misc.spreadable = true;
         misc.cost = COST_VARIABLE;
         misc.flags = misc.flags.or(F_PARTIAL_WING).or(F_MECH_EQUIPMENT);
+        misc.omniFixedOnly = true;
         misc.rulesRefs = "292, TO";
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TECH_BASE_CLAN).setIntroLevel(false).setUnofficial(false)

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -855,6 +855,8 @@ public class TestMech extends TestEntity {
         boolean hasTC = false;
         boolean hasMASC = false;
         boolean hasAES = false;
+        boolean hasMechJumpBooster = false;
+        boolean hasPartialWing = false;
         EquipmentType advancedMyomer = null;
 
         //First we find all the equipment that is required or incompatible with other equipment,
@@ -873,6 +875,8 @@ public class TestMech extends TestEntity {
                     || m.getType().hasFlag(MiscType.F_SCM)) {
                 advancedMyomer = m.getType();
             }
+            hasMechJumpBooster |= m.is(EquipmentTypeLookup.MECH_JUMP_BOOSTER);
+            hasPartialWing |= m.getType().hasFlag(MiscType.F_PARTIAL_WING);
         }
 
         for (Mounted m : getEntity().getMisc()) {
@@ -1479,6 +1483,11 @@ public class TestMech extends TestEntity {
         int requiredStructureCrits = structure.getCriticals(mech);
         if (mech.getNumberOfCriticals(structure) != requiredStructureCrits) {
             buff.append("The internal structure of this mek is not using the correct number of crit slots\n");
+            illegal = true;
+        }
+
+        if (hasPartialWing && hasMechJumpBooster) {
+            buff.append("Partial wings cannot be combined with any type of jump boosters\n");
             illegal = true;
         }
 


### PR DESCRIPTION
- Disallows pod-mounting Mek partial wings
- marks the combo partial wings + Mek mechanical jump booster as invalid

Fixes MegaMek/megameklab#1252

Rules in TO:AUE p.104