### PR TITLE
Clan TAG: Remove "(Clan)" from name

### DIFF
--- a/megamek/src/megamek/common/weapons/tag/CLTAG.java
+++ b/megamek/src/megamek/common/weapons/tag/CLTAG.java
@@ -22,9 +22,10 @@ public class CLTAG extends TAGWeapon {
 
     public CLTAG() {
         super();
-        name = "TAG (Clan)";
+        name = "TAG";
         setInternalName("CLTAG");
         addLookupName("Clan TAG");
+        addLookupName("TAG (Clan)");
         tonnage = 1;
         criticals = 1;
         hittable = true;


### PR DESCRIPTION
This is to fix MegaMek/megameklab#1172 as well as the need to edit out this (Clan) text in MML's InventoryWriter, l.224. I think we generally add (Clan) or (IS) when necessary instead of hardcoding it into names. I checked searching and loading units in MML with this change and it seemed to work. Still, marking this for after release so as not to break things in the last minute.