### PR TITLE
Fix QuadVee fall after converting to vehicle mode

### DIFF
--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -91,7 +91,7 @@ public class QuadVee extends QuadMech {
 
     public String getMotiveTypeString(int motiveType) {
         if (motiveType < 0 || motiveType >= MOTIVE_STRING.length) {
-            return MOTIVE_STRING[MOTIVE_UNKNOWN];
+            return "Unknown";
         }
         return MOTIVE_STRING[motiveType];
     }
@@ -377,8 +377,8 @@ public class QuadVee extends QuadMech {
     }
 
     /**
-     * The cost to convert between quad and vehicle modes.
-     * @return
+     * Computes conversion cost.
+     * @return The cost to convert between quad and vehicle modes.
      */
     public int conversionCost() {
         int cost = 2;

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -373,7 +373,7 @@ public class QuadVee extends QuadMech {
     @Override
     public boolean canFall(boolean gyroLegDamage) {
         // QuadVees cannot fall due to failed PSR in vehicle mode.
-        return getConversionMode() == CONV_MODE_MECH || convertingNow;
+        return getConversionMode() == CONV_MODE_MECH || (convertingNow && game.getPhase().isMovement());
     }
 
     /**


### PR DESCRIPTION
When a QuadVee converts it is considered to be in its new mode at the end of the movement phase. MM keeps track of the fact that it converted because it affects movement heat and adds +3 to weapons fire, but in phases after movement it should not be able to fall.

I also fixed a howler I wrote when I coded this to begin with where it checks for an index outside the range of an array then accesses the array with an index of -1.