### PR TITLE
only reload report tabs that have changed

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1195,7 +1195,6 @@ public class Client implements IClientCommandHandler {
         }
     }
 
-
     // Should be private?
     public String receiveReport(Vector<Report> v) {
         if (v == null) {
@@ -1209,7 +1208,7 @@ public class Client implements IClientCommandHandler {
 
         Set<Integer> set = new HashSet<>();
         //find id stored in spans and extract it
-        Pattern p = Pattern.compile("<span id=(.*?)span>");
+        Pattern p = Pattern.compile("<span id=(.*?)></span>");
         Matcher m = p.matcher(report.toString());
 
         // add all instances to a hashset to prevent duplicates

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -717,7 +717,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
     public void miniReportDisplayAddReportPages() {
         ignoreHotKeys = true;
         if (getMiniReportDisplay() != null) {
-            getMiniReportDisplay().addReportPages();
+            getMiniReportDisplay().addReportPages(client.getGame().getPhase());
         }
         ignoreHotKeys = false;
     }

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -305,7 +305,10 @@ public class MiniReportDisplay extends JPanel implements ActionListener, Hyperli
             tabs.removeAll();
         } else if (tabs.getTabCount() > 1) {
             tabs.removeTabAt(tabs.getTabCount() - 1);
-            tabs.removeTabAt(tabs.getTabCount() - 1);
+            // don't remove on round change
+            if (tabs.getTabCount() == numRounds) {
+                tabs.removeTabAt(tabs.getTabCount() - 1);
+            }
             startIndex = tabs.getTabCount() + 1;
         }
 

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -17,6 +17,7 @@ import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.BASE64ToolKit;
 import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.enums.GamePhase;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
@@ -295,11 +296,20 @@ public class MiniReportDisplay extends JPanel implements ActionListener, Hyperli
         return new JScrollPane(ta);
     }
 
-    public void addReportPages() {
+    public void addReportPages(GamePhase phase) {
         int numRounds = currentClient.getGame().getRoundCount();
-        tabs.removeAll();
+        int startIndex = 1;
 
-        for (int round = 1; round <= numRounds; round++) {
+        // only reload what has changed
+        if (numRounds < 2 || phase.isVictory()) {
+            tabs.removeAll();
+        } else if (tabs.getTabCount() > 1) {
+            tabs.removeTabAt(tabs.getTabCount() - 1);
+            tabs.removeTabAt(tabs.getTabCount() - 1);
+            startIndex = tabs.getTabCount() + 1;
+        }
+
+        for (int round = startIndex; round <= numRounds; round++) {
             String text = currentClient.receiveReport(currentClient.getGame().getReports(round));
             tabs.add(Messages.getString("MiniReportDisplay.Round") + " " + round, loadHtmlScrollPane(text));
         }
@@ -360,7 +370,7 @@ public class MiniReportDisplay extends JPanel implements ActionListener, Hyperli
                 default:
                     if ((!e.getNewPhase().equals((e.getOldPhase())))
                             && ((e.getNewPhase().isReport()) || ((e.getNewPhase().isOnMap()) && (tabs.getTabCount() == 0)))){
-                        addReportPages();
+                        addReportPages(e.getNewPhase());
                         updatePlayerChoice();
                         updateEntityChoice();
                     }


### PR DESCRIPTION
- only reload report tabs that have changed, to help with long report load times on phase change.
- it will run long, if there are a lot of rounds and using a lot of units and a full reload is needed.  this happens when loading a game save, reconnecting to a game, and the victory phase