### PR TITLE
Prep work for MML #1230

### DIFF
--- a/megamek/src/megamek/common/BattleArmorBay.java
+++ b/megamek/src/megamek/common/BattleArmorBay.java
@@ -46,6 +46,7 @@ public final class BattleArmorBay extends Bay {
     public BattleArmorBay(double space, int doors, int bayNumber, boolean isClan, boolean isComStar) {
         totalSpace = space;
         currentSpace = space;
+        this.minDoors = 0;
         this.doors = doors;
         doorsNext = doors;
         this.bayNumber = bayNumber;

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -37,6 +37,8 @@ public class Bay implements Transporter, ITechnology {
     public static final String FIELD_SEPARATOR = ":";
     public static final String FACING_PREFIX = "f";
 
+    /** Minimum number of doors for all bays (except infantry) is 1 **/
+    int minDoors = 1;
     int doors = 1;
     int doorsNext = 1;
     int currentdoors = doors;
@@ -103,11 +105,11 @@ public class Bay implements Transporter, ITechnology {
     public void setBayDamage(double damage) {
         this.damage = Math.min(damage, totalSpace);
     }
-    
+
     /**
      * Method used by MHQ to update bay space when loading units in lobby. See Utilities.loadPlayerTransports
      * This ensures that consumed space is kept in sync between the MM client and MHQ game thread
-     * 
+     *
      * @param space - double representing space consumed by the unit being loaded. 1 except in the case of infantry
      */
     public void setCurrentSpace(double space) {
@@ -119,6 +121,10 @@ public class Bay implements Transporter, ITechnology {
         return doors;
     }
 
+    // the required minimum number of doors for the bay.
+    public int getMinDoors() {
+        return minDoors;
+    }
     public void setDoors(int d) {
         doors = d;
         doorsNext = d;
@@ -206,7 +212,7 @@ public class Bay implements Transporter, ITechnology {
     }
 
     /**
-     * Generate a raw list of the Ids stored in troops. 
+     * Generate a raw list of the Ids stored in troops.
      * Used by MHQ in cases where we can't get the entities via Game
      *
      * @return A list of unit IDs of loaded units
@@ -524,7 +530,7 @@ public class Bay implements Transporter, ITechnology {
     public long getCost() {
         return 0;
     }
-    
+
     /** @return The safe launch rate for this particular bay: # of intact doors x 2 */
     public int getSafeLaunchRate() {
         return getCurrentDoors() * 2;

--- a/megamek/src/megamek/common/CrewQuartersCargoBay.java
+++ b/megamek/src/megamek/common/CrewQuartersCargoBay.java
@@ -40,6 +40,7 @@ public final class CrewQuartersCargoBay extends Bay {
         totalSpace = (int) weight / 7;
         this.weight = weight;
         currentSpace = (int) weight / 7;
+        this.minDoors = 0;
         this.doors = doors;
         currentdoors = doors;
     }

--- a/megamek/src/megamek/common/FirstClassQuartersCargoBay.java
+++ b/megamek/src/megamek/common/FirstClassQuartersCargoBay.java
@@ -40,6 +40,7 @@ public final class FirstClassQuartersCargoBay extends Bay {
         totalSpace = (int) weight / 10;
         this.weight = weight;
         currentSpace = (int) weight / 10;
+        this.minDoors = 0;
         this.doors = doors;
         currentdoors = doors;
     }

--- a/megamek/src/megamek/common/InfantryBay.java
+++ b/megamek/src/megamek/common/InfantryBay.java
@@ -19,7 +19,7 @@ package megamek.common;
  */
 public final class InfantryBay extends Bay {
     private static final long serialVersionUID = 946578184870030662L;
-    
+
     /** The amount of space taken up by an infantry unit in a transport bay differs from the space
      * in an infantry compartment (used in APCs) due to quarters, equipment storage, and maintenance
      * equipment. A single cubicle holds a platoon, except in the case of mechanized which requires
@@ -29,34 +29,34 @@ public final class InfantryBay extends Bay {
         JUMP (6, 21, 20),
         MOTORIZED (7, 28, 25),
         MECHANIZED (8, 7, 5);
-        
+
         private int weight;
         private int isPersonnel;
         private int clanPersonnel;
-        
+
         PlatoonType(int weight, int isPersonnel, int clanPersonnel) {
             this.weight = weight;
             this.isPersonnel = isPersonnel;
             this.clanPersonnel = clanPersonnel;
         }
-        
+
         public int getWeight() {
             return weight;
         }
-        
+
         public int getISPersonnel() {
             return isPersonnel;
         }
-        
+
         public int getClanPersonnel() {
             return clanPersonnel;
         }
-        
+
         @Override
         public String toString() {
             return name().charAt(0) + name().substring(1).toLowerCase();
         }
-        
+
         public static PlatoonType getPlatoonType(Entity en) {
             switch (en.getMovementMode()) {
                 case TRACKED:
@@ -74,11 +74,11 @@ public final class InfantryBay extends Bay {
             }
         }
     }
-    
+
     // This represents the "factory setting" of the bay, and is used primarily by the construction rules.
     // In practice we support loading any type of infantry into the bay as long as there is room to avoid
     // the headache of having to do formal reconfigurations.
-    private PlatoonType platoonType = PlatoonType.FOOT; 
+    private PlatoonType platoonType = PlatoonType.FOOT;
 
     /**
      * The default constructor is only for serialization.
@@ -101,13 +101,14 @@ public final class InfantryBay extends Bay {
         // We need to track by total tonnage rather than individual platoons
         totalSpace = space * bayType.getWeight();
         currentSpace = totalSpace;
+        this.minDoors = 0;
         this.doors = doors;
         doorsNext = doors;
         this.bayNumber = bayNumber;
         currentdoors = doors;
         this.platoonType = bayType;
     }
-    
+
     @Override
     public double spaceForUnit(Entity unit) {
         PlatoonType type = PlatoonType.getPlatoonType(unit);
@@ -142,7 +143,7 @@ public final class InfantryBay extends Bay {
         if (currentdoors < loadedThisTurn) {
             result = false;
         }
-        
+
         // Return our result.
         return result;
     }
@@ -163,7 +164,7 @@ public final class InfantryBay extends Bay {
         }
         return sb.toString();
     }
-    
+
     @Override
     public double getUnusedSlots() {
         return currentSpace / platoonType.getWeight() - getBayDamage();
@@ -190,7 +191,7 @@ public final class InfantryBay extends Bay {
         return "infantrybay:" + (totalSpace / platoonType.getWeight()) + ":" + doors + ":"
                 + bayNumber + ":" + platoonType;
     }
-    
+
     public PlatoonType getPlatoonType() {
         return platoonType;
     }

--- a/megamek/src/megamek/common/SecondClassQuartersCargoBay.java
+++ b/megamek/src/megamek/common/SecondClassQuartersCargoBay.java
@@ -40,6 +40,7 @@ public final class SecondClassQuartersCargoBay extends Bay {
         totalSpace = (int) weight / 7;
         this.weight = weight;
         currentSpace = (int) weight / 7;
+        this.minDoors = 0;
         this.doors = doors;
         currentdoors = doors;
     }

--- a/megamek/src/megamek/common/SteerageQuartersCargoBay.java
+++ b/megamek/src/megamek/common/SteerageQuartersCargoBay.java
@@ -42,6 +42,7 @@ public final class SteerageQuartersCargoBay extends Bay {
         totalSpace = ((int) weight) / 5;
         this.weight = weight;
         currentSpace = ((int) weight) / 5;
+        this.minDoors = 0;
         this.doors = doors;
         currentdoors = doors;
     }

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -35,23 +35,23 @@ import java.util.function.Function;
 /**
  * Class for testing and validating instantiations for Conventional Fighters and
  * Aerospace Fighters.
- * 
+ *
  * @author arlith
  * @author Reinhard Vicinus
  */
 public class TestAero extends TestEntity {
     private Aero aero = null;
-    
+
     /**
-     * An enumeration that keeps track of the legal armors for Aerospace and 
-     * Conventional fighters.  Each entry consists of the type, which 
+     * An enumeration that keeps track of the legal armors for Aerospace and
+     * Conventional fighters.  Each entry consists of the type, which
      * corresponds to the types defined in <code>EquipmentType</code> as well
      * as the number of slots the armor takes up.
-     * 
+     *
      * @author arlith
      */
     public static enum AeroArmor {
-        STANDARD(EquipmentType.T_ARMOR_STANDARD, 0, 0, false),   
+        STANDARD(EquipmentType.T_ARMOR_STANDARD, 0, 0, false),
         CLAN_FERRO_ALUM(EquipmentType.T_ARMOR_ALUM, 1, 1, true),
         FERRO_LAMELLOR(EquipmentType.T_ARMOR_FERRO_LAMELLOR, 2, 1, true),
         CLAN_REACTIVE(EquipmentType.T_ARMOR_REACTIVE, 1, 1, true),
@@ -61,53 +61,53 @@ public class TestAero extends TestEntity {
         BALLISTIC_REINFORCED(
                 EquipmentType.T_ARMOR_BALLISTIC_REINFORCED, 2, 1, false),
         FERRO_ALUM(EquipmentType.T_ARMOR_ALUM, 2, 1, false),
-        FERRO_PROTO(EquipmentType.T_ARMOR_FERRO_ALUM_PROTO, 3, 1, false),        
+        FERRO_PROTO(EquipmentType.T_ARMOR_FERRO_ALUM_PROTO, 3, 1, false),
         HEAVY_FERRO_ALUM(EquipmentType.T_ARMOR_HEAVY_ALUM, 4, 2, false),
         LIGHT_FERRO_ALUM(EquipmentType.T_ARMOR_LIGHT_ALUM, 1, 1, false),
-        PRIMITIVE(EquipmentType.T_ARMOR_PRIMITIVE_FIGHTER, 0, 0, false),        
-        REACTIVE(EquipmentType.T_ARMOR_REACTIVE, 3, 1, false),        
+        PRIMITIVE(EquipmentType.T_ARMOR_PRIMITIVE_FIGHTER, 0, 0, false),
+        REACTIVE(EquipmentType.T_ARMOR_REACTIVE, 3, 1, false),
         REFLECTIVE(EquipmentType.T_ARMOR_REFLECTIVE, 2, 1, false),
         STEALTH_VEHICLE(EquipmentType.T_ARMOR_STEALTH_VEHICLE, 2, 1, false);
 
         /**
-         * The type, corresponding to types defined in 
+         * The type, corresponding to types defined in
          * <code>EquipmentType</code>.
          */
         public final int type;
-        
+
         /**
-         * The number of spaces occupied by the armor type.  Armors that take 
+         * The number of spaces occupied by the armor type.  Armors that take
          * up 1 space take up space in the aft, those with 2 take up space in
          * each wing, 3 takes up space in both wings and the aft, 4 takes up
          * space in each possible arc (nose, aft, left wing, right wing).
          */
         public final int space;
-        
+
         /**
          * The number of weapon spaces occupied by patchwork armor. Unlike standard armor, patchwork
          * armor takes up slots in the location where it's used.
          */
         public final int patchworkSpace;
-        
+
         /**
          * Denotes whether this armor is Clan or not.
          */
         public boolean isClan;
-        
+
         AeroArmor(int t, int s, int p, boolean c) {
             type = t;
             space = s;
             patchworkSpace = p;
             isClan = c;
         }
-        
+
         /**
          * Given an armor type, return the <code>AeroArmor</code> instance that
          * represents that type.
-         * 
+         *
          * @param t  The armor type.
          * @param c  Whether this armor type is Clan or not.
-         * @return   The <code>AeroArmor</code> that correspondes to the given 
+         * @return   The <code>AeroArmor</code> that correspondes to the given
          *              type or null if no match was found.
          */
         public static AeroArmor getArmor(int t, boolean c) {
@@ -119,7 +119,7 @@ public class TestAero extends TestEntity {
             }
             return null;
         }
-        
+
         /**
          * @return The <code>MiscType</code> for this armor.
          */
@@ -128,10 +128,10 @@ public class TestAero extends TestEntity {
             return EquipmentType.get(name);
         }
     }
-    
+
     /**
      * Filters all fighter armor according to given tech constraints
-     * 
+     *
      * @param techManager
      * @return A list of all armors that meet the tech constraints
      */
@@ -145,7 +145,7 @@ public class TestAero extends TestEntity {
         }
         return retVal;
     }
-    
+
     /**
      * Defines how many spaces each arc has for weapons. Large units can add more by increasing weight
      * of master fire control systems.
@@ -161,7 +161,7 @@ public class TestAero extends TestEntity {
             return 5;
         }
     }
-    
+
     /**
      * @param aero A large craft
      * @return     The maximum number of bay doors. Aerospace units that are not large craft have
@@ -170,10 +170,12 @@ public class TestAero extends TestEntity {
     public static int maxBayDoors(Aero aero) {
         if (aero.hasETypeFlag(Entity.ETYPE_WARSHIP)) {
             return 8 + (int) Math.ceil(aero.getWeight() / 100000);
-        } else if (aero.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+        } else if (aero.hasETypeFlag(Entity.ETYPE_SPACE_STATION)) {
             return 8 + (int) Math.ceil(aero.getWeight() / 75000);
         } else if (aero.hasETypeFlag(Entity.ETYPE_JUMPSHIP)
-                || (aero.hasETypeFlag(Entity.ETYPE_DROPSHIP))) {
+                || (aero.hasETypeFlag(Entity.ETYPE_DROPSHIP))
+                || (aero.hasETypeFlag(Entity.ETYPE_FIXED_WING_SUPPORT))
+        ) {
             return 7 + (int) Math.ceil(aero.getWeight() / 50000);
         } else if (aero.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
             return aero.isSpheroid() ? 4 : 2;
@@ -181,27 +183,27 @@ public class TestAero extends TestEntity {
             return 0;
         }
     }
-    
+
     public enum Quarters {
         FIRST_CLASS (10, FirstClassQuartersCargoBay.class, size -> new FirstClassQuartersCargoBay(size, 0)),
         STANDARD (7, CrewQuartersCargoBay.class, size -> new CrewQuartersCargoBay(size, 0)),
         SECOND_CLASS (7, SecondClassQuartersCargoBay.class, size -> new SecondClassQuartersCargoBay(size, 0)),
         STEERAGE (5, SteerageQuartersCargoBay.class, size -> new SteerageQuartersCargoBay(size, 0));
-        
+
         private int tonnage;
         private Class<? extends Bay> bayClass;
         private Function<Integer, Bay> init;
-        
+
         Quarters(int tonnage, Class<? extends Bay> bayClass, Function<Integer, Bay> init) {
             this.tonnage = tonnage;
             this.bayClass = bayClass;
             this.init = init;
         }
-        
+
         public int getTonnage() {
             return tonnage;
         }
-        
+
         public static @Nullable Quarters getQuartersForBay(Bay bay) {
             for (Quarters q : values()) {
                 if (bay.getClass() == q.bayClass) {
@@ -210,11 +212,11 @@ public class TestAero extends TestEntity {
             }
             return null;
         }
-        
+
         public Bay newQuarters(int size) {
             return init.apply(size * tonnage);
         }
-        
+
         public static Map<Quarters, Integer> getQuartersByType(Aero aero) {
             EnumMap<TestAero.Quarters, Integer> sizes = new EnumMap<>(TestAero.Quarters.class);
             for (Quarters q : values()) {
@@ -229,11 +231,11 @@ public class TestAero extends TestEntity {
             return sizes;
         }
     }
-    
+
     /**
      *  Computes the maximum number of armor points for a given Aero
      *  at the given tonnage.
-     *   
+     *
      * @param aero
      * @param tonnage
      * @return
@@ -250,14 +252,14 @@ public class TestAero extends TestEntity {
             return 0;
         }
     }
-    
+
     /**
      * Computes the available space for each location in the supplied Aero.
      * Aeros can only have so many weapons in each location, and this available
      * space is reduced by the armor type.
-     * 
+     *
      * @param a  The aero in question
-     * @return   Returns an int array, where each element corresponds to a 
+     * @return   Returns an int array, where each element corresponds to a
      *           location and the value is the number of weapons the Aero can
      *           have in that location. Returns null if the space cannot be determined
      *           due to illegal armor type value.
@@ -266,12 +268,12 @@ public class TestAero extends TestEntity {
         // Keep track of the max space we have in each arc
         int slots = slotsPerArc(a);
         int[] availSpace = { slots, slots, slots, slots };
-        
+
         if (!a.hasPatchworkArmor()) {
             // Get the armor type, to determine how much space it uses
             AeroArmor armor = AeroArmor.getArmor(a.getArmorType(Aero.LOC_NOSE), a.isClanArmor(Aero.LOC_NOSE));
-            
-            if (armor == null) {            
+
+            if (armor == null) {
                 return null;
             }
             // Remove space for each location until we've allocated the armor
@@ -301,7 +303,7 @@ public class TestAero extends TestEntity {
                 availSpace[i]--;
             }
         }
-        
+
         // Large engines take up extra space in the aft in conventional fighters
         if (((a.getEntityType() & Entity.ETYPE_CONV_FIGHTER) != 0)
                 && a.hasEngine() && (a.getEngine().hasFlag(Engine.LARGE_ENGINE))) {
@@ -309,7 +311,7 @@ public class TestAero extends TestEntity {
         }
         return availSpace;
     }
-    
+
     public static boolean usesWeaponSlot(Entity en, EquipmentType eq) {
         if (eq instanceof WeaponType) {
             return !(eq instanceof BayWeapon);
@@ -325,7 +327,7 @@ public class TestAero extends TestEntity {
                             || eq.hasFlag(MiscType.F_BOOBY_TRAP)
                             || eq.hasFlag(MiscType.F_SENSOR_DISPENSER))) {
                 return true;
-                
+
             }
             // Equipment that takes a slot on all aerospace units
             return  eq.hasFlag(MiscType.F_CHAFF_POD)
@@ -339,10 +341,10 @@ public class TestAero extends TestEntity {
         }
         return false;
     }
-    
+
     /**
      * Computes the engine rating for the given entity type.
-     * 
+     *
      * @param unit
      * @param tonnage
      * @param desiredSafeThrust
@@ -358,7 +360,7 @@ public class TestAero extends TestEntity {
         } else {
             rating = 0;
         }
-        
+
         if (unit.isPrimitive()) {
             double dRating = rating;
             dRating *= 1.2;
@@ -444,22 +446,22 @@ public class TestAero extends TestEntity {
     public boolean isMech() {
         return false;
     }
-    
+
     @Override
     public boolean isAero() {
         return true;
     }
-    
+
     @Override
     public boolean isSmallCraft() {
         return false;
     }
-    
+
     @Override
     public boolean isAdvancedAerospace() {
         return false;
     }
-    
+
     @Override
     public boolean isProtomech() {
         return false;
@@ -483,14 +485,14 @@ public class TestAero extends TestEntity {
             double weight = 0;
             for (Mounted m : aero.getWeaponList()) {
                 WeaponType wt = (WeaponType) m.getType();
-                if (wt.hasFlag(WeaponType.F_ENERGY) && 
-                        !(wt instanceof CLChemicalLaserWeapon) && 
+                if (wt.hasFlag(WeaponType.F_ENERGY) &&
+                        !(wt instanceof CLChemicalLaserWeapon) &&
                         !(wt instanceof VehicleFlamerWeapon)) {
                     weight += m.getTonnage();
                 }
                 Mounted linkedBy = m.getLinkedBy();
-                if ((linkedBy != null) && 
-                        (linkedBy.getType() instanceof MiscType) && 
+                if ((linkedBy != null) &&
+                        (linkedBy.getType() instanceof MiscType) &&
                         linkedBy.getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
                     weight += linkedBy.getTonnage();
                 }
@@ -501,7 +503,7 @@ public class TestAero extends TestEntity {
         }
         return 0;
     }
-    
+
     @Override
     public double getWeightEngine() {
         double wt = super.getWeightEngine();
@@ -527,15 +529,15 @@ public class TestAero extends TestEntity {
             weight = 3.0;
             if (aero.getCockpitType() == Aero.COCKPIT_SMALL) {
                 weight = 2.0;
-        } else if (aero.getCockpitType() == Aero.COCKPIT_COMMAND_CONSOLE) {                       
+        } else if (aero.getCockpitType() == Aero.COCKPIT_COMMAND_CONSOLE) {
                 weight = 6.0;
             } else if (aero.getCockpitType() == Aero.COCKPIT_PRIMITIVE) {
                 weight = 5.0;
-            } 
-        }   
+            }
+        }
         return weight;
     }
-    
+
     public double getWeightFuel() {
         return aero.getFuelTonnage();
     }
@@ -584,7 +586,7 @@ public class TestAero extends TestEntity {
         retVal.append("\n");
         return retVal.toString();
     }
-        
+
     public String printWeightFuel() {
         StringBuffer retVal = new StringBuffer(StringUtil.makeLength(
                 "Fuel: ", getPrintSize() - 5));
@@ -603,7 +605,7 @@ public class TestAero extends TestEntity {
 
     /**
      * Checks to see if this unit has valid armor assignment.
-     * 
+     *
      * @param buff
      * @return
      */
@@ -619,19 +621,19 @@ public class TestAero extends TestEntity {
             armorTotal += aero.getOArmor(loc);
         }
         if (armorTotal > maxArmorPoints) {
-            buff.append("Total armor," + armorTotal + 
+            buff.append("Total armor," + armorTotal +
                     ", is greater than the maximum: " + maxArmorPoints + "\n");
             correct = false;
         }
 
         return correct ;
     }
-    
+
     /**
      * Checks that Conventional fighters only have a standard cockpit and that
-     * Aerospace fighters have a valid cockpit (standard, small, primitive, 
+     * Aerospace fighters have a valid cockpit (standard, small, primitive,
      * command console).
-     * 
+     *
      * @param buff
      * @return
      */
@@ -641,7 +643,7 @@ public class TestAero extends TestEntity {
             buff.append(
                     "Conventional fighters may only have standard cockpits!");
             return false;
-        } else if (aero.getCockpitType() < Aero.COCKPIT_STANDARD || 
+        } else if (aero.getCockpitType() < Aero.COCKPIT_STANDARD ||
                 aero.getCockpitType() > Aero.COCKPIT_PRIMITIVE) {
             buff.append(
                     "Invalid cockpit type!");
@@ -649,7 +651,7 @@ public class TestAero extends TestEntity {
         }
         return true;
     }
-    
+
     public List<Mounted> checkCriticalSlotsForEquipment(Entity entity) {
         List<Mounted> unallocated = new ArrayList<>();
         for (Mounted m : entity.getEquipment()) {
@@ -663,9 +665,9 @@ public class TestAero extends TestEntity {
     /**
      * For Aerospace and Conventional fighters the only thing we need to ensure
      * is that they do not mount more weapons in each arc then allowed.  They
-     * have boundless space for equipment.  Certain armor types reduce the 
+     * have boundless space for equipment.  Certain armor types reduce the
      * number of spaces available in each arc.
-     * 
+     *
      * @param buff  A buffer for error messages
      * @return  True if the mounted weapons are valid, else false
      */
@@ -682,21 +684,21 @@ public class TestAero extends TestEntity {
         }
         int[] numWeapons = new int[aero.locations()];
         int numBombs = 0;
-        
+
         for (Mounted m : aero.getWeaponList()) {
             if (m.getLocation() == Entity.LOC_NONE) {
                 continue;
             }
-            
+
             // Aeros can't use special munitions except for artemis, exceptions
             //  LBX's must use clusters
             WeaponType wt = (WeaponType) m.getType();
-            boolean canHaveSpecialMunitions = 
+            boolean canHaveSpecialMunitions =
                     ((wt.getAmmoType() == AmmoType.T_MML)
                     || (wt.getAmmoType() == AmmoType.T_ATM)
                     || (wt.getAmmoType() == AmmoType.T_NARC));
             if (wt.getAmmoType() != AmmoType.T_NA
-                    && m.getLinked() != null 
+                    && m.getLinked() != null
                     && !canHaveSpecialMunitions) {
                 EquipmentType linkedType = m.getLinked().getType();
                 boolean hasArtemisFCS = m.getLinkedBy() != null
@@ -706,7 +708,7 @@ public class TestAero extends TestEntity {
                 if (linkedType instanceof AmmoType) {
                     AmmoType linkedAT = (AmmoType) linkedType;
                     // Check LBX's
-                    if (wt.getAmmoType() == AmmoType.T_AC_LBX && 
+                    if (wt.getAmmoType() == AmmoType.T_AC_LBX &&
                             linkedAT.getMunitionType() != AmmoType.M_CLUSTER) {
                         correct = false;
                         buff.append("Aeros must use cluster munitions!").append(m.getType().getInternalName())
@@ -721,19 +723,19 @@ public class TestAero extends TestEntity {
                         buff.append("Aero using illegal special missile type!").append(m.getType().getInternalName())
                                 .append(" is using ").append(linkedAT.getInternalName()).append("\n");
                     }
-                    if (linkedAT.getMunitionType() != AmmoType.M_STANDARD 
-                            && !hasArtemisFCS 
+                    if (linkedAT.getMunitionType() != AmmoType.M_STANDARD
+                            && !hasArtemisFCS
                             && wt.getAmmoType() != AmmoType.T_AC_LBX
                             && wt.getAmmoType() != AmmoType.T_SBGAUSS) {
                         correct = false;
                         buff.append("Aeros may not use special munitions! ").append(m.getType().getInternalName())
                                 .append(" is using ").append(linkedAT.getInternalName()).append("\n");
                     }
-                    
+
                 }
             }
-            
-            if (m.getType().hasFlag(AmmoType.F_SPACE_BOMB) 
+
+            if (m.getType().hasFlag(AmmoType.F_SPACE_BOMB)
                     || m.getType().hasFlag(AmmoType.F_GROUND_BOMB)
                     || m.getType().hasFlag(WeaponType.F_DIVE_BOMB)
                     || m.getType().hasFlag(WeaponType.F_ALT_BOMB)
@@ -771,22 +773,22 @@ public class TestAero extends TestEntity {
                 loc--;
             }
         }
-        
+
         return correct;
     }
-    
-    
+
+
     /**
      * Checks that the heatsink assignment is legal.  Conventional fighters must
      * have enough heatsinks to dissipate heat from all of their energy weapons
      * and they may only mount standard heatsinks.
      * Aerospace fighters must have at least 10 heatsinks.
-     * 
+     *
      * @param buff
      * @return
      */
     public boolean correctHeatSinks(StringBuffer buff) {
-        if ((aero.getHeatType() != Aero.HEAT_SINGLE) 
+        if ((aero.getHeatType() != Aero.HEAT_SINGLE)
                 && (aero.getHeatType() != Aero.HEAT_DOUBLE)) {
             buff.append("Invalid heatsink type!  Valid types are "
                     + Aero.HEAT_SINGLE + " and " + Aero.HEAT_DOUBLE
@@ -804,19 +806,19 @@ public class TestAero extends TestEntity {
     @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
-        
+
         // We only support Conventional Fighters and ASF
-        if (aero.getEntityType() == Entity.ETYPE_DROPSHIP || 
+        if (aero.getEntityType() == Entity.ETYPE_DROPSHIP ||
                 aero.getEntityType() == Entity.ETYPE_SMALL_CRAFT ||
                 aero.getEntityType() == Entity.ETYPE_FIGHTER_SQUADRON ||
                 aero.getEntityType() == Entity.ETYPE_JUMPSHIP ||
                 aero.getEntityType() == Entity.ETYPE_SPACE_STATION) {
             System.out.println("TestAero only supports Aerospace Fighters " +
-                    "and Conventional fighters.  Supplied unit was a " + 
+                    "and Conventional fighters.  Supplied unit was a " +
                     Entity.getEntityTypeName(aero.getEntityType()));
-            return true;            
+            return true;
         }
-        
+
         if (skip()) {
             return true;
         }
@@ -838,8 +840,8 @@ public class TestAero extends TestEntity {
             buff.append(" Required  " + engine.getWeightFreeEngineHeatSinks()
                     + "\n");
             correct = false;
-        }                
-        
+        }
+
         if (showCorrectArmor() && !correctArmor(buff)) {
             correct = false;
         }
@@ -852,13 +854,13 @@ public class TestAero extends TestEntity {
         if (showIncorrectIntroYear() && hasIncorrectIntroYear(buff)) {
             correct = false;
         }
-        
+
         correct &= correctControlSystems(buff);
         correct &= !hasIllegalTechLevels(buff, ammoTechLvl);
         correct &= !hasIllegalEquipmentCombinations(buff);
         correct &= !hasMismatchedLateralWeapons(buff);
         correct &= correctHeatSinks(buff);
-        
+
         return correct;
     }
 
@@ -991,7 +993,7 @@ public class TestAero extends TestEntity {
         }
 
         WeaponType weapon = (WeaponType) eq;
-        
+
         // small craft only; lacks aero weapon flag
         if (weapon.getAmmoType() == AmmoType.T_C3_REMOTE_SENSOR) {
             return en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)
@@ -1003,7 +1005,7 @@ public class TestAero extends TestEntity {
                     || en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)
                     || en.hasETypeFlag(Entity.ETYPE_JUMPSHIP);
         }
-        
+
         if (weapon.isSubCapital() || (weapon.isCapital() && (weapon.hasFlag(WeaponType.F_MISSILE)))
                 || (weapon.getAtClass() == WeaponType.CLASS_SCREEN)) {
             return en.hasETypeFlag(Entity.ETYPE_DROPSHIP)
@@ -1017,7 +1019,7 @@ public class TestAero extends TestEntity {
         if (weapon.isCapital()) {
             return en.hasETypeFlag(Entity.ETYPE_JUMPSHIP);
         }
-        
+
         if (weapon instanceof BayWeapon) {
             return en.usesWeaponBays();
         }
@@ -1046,7 +1048,7 @@ public class TestAero extends TestEntity {
         if ((weapon instanceof RLWeapon) && (weapon.getRackSize() < 10)) {
             return false;
         }
-        
+
         if (weapon.hasFlag(WeaponType.F_ENERGY)
                 || (weapon.hasFlag(WeaponType.F_PLASMA) && (weapon
                         .getAmmoType() == AmmoType.T_PLASMA))) {
@@ -1064,7 +1066,7 @@ public class TestAero extends TestEntity {
     public StringBuffer printEntity() {
         StringBuffer buff = new StringBuffer();
         buff.append("Aero: ").append(aero.getDisplayName()).append("\n");
-        buff.append("Found in: ").append(fileString).append("\n");        
+        buff.append("Found in: ").append(fileString).append("\n");
         buff.append(printTechLevel());
         buff.append("Intro year: ").append(aero.getYear()).append("\n");
         buff.append(printSource());
@@ -1083,7 +1085,7 @@ public class TestAero extends TestEntity {
         printFailedEquipment(buff);
         return buff;
     }
-    
+
     @Override
     public double calculateWeight() {
         double weight = 0;
@@ -1108,13 +1110,13 @@ public class TestAero extends TestEntity {
     @Override
     public String printWeightCalculation() {
         return printWeightEngine()
-                + printWeightControls() + printWeightFuel() 
+                + printWeightControls() + printWeightFuel()
                 + printWeightHeatSinks()
                 + printWeightArmor() + printWeightMisc()
                 + printWeightCarryingSpace() + "Equipment:\n"
                 + printMiscEquip() + printWeapon() + printAmmo();
     }
-    
+
     @Override
     public String printLocations() {
         StringBuffer buff = new StringBuffer();
@@ -1125,7 +1127,7 @@ public class TestAero extends TestEntity {
             for (int j = 0; j < getEntity().getNumberOfCriticals(i); j++) {
                 CriticalSlot slot = getEntity().getCritical(i, j);
                 if (slot == null) {
-                    j = getEntity().getNumberOfCriticals(i);                    
+                    j = getEntity().getNumberOfCriticals(i);
                 } else if (slot.getType() == CriticalSlot.TYPE_SYSTEM) {
                         buff.append(j).append(". UNKNOWN SYSTEM NAME").append("\n");
                 } else if (slot.getType() == CriticalSlot.TYPE_EQUIPMENT) {
@@ -1136,7 +1138,7 @@ public class TestAero extends TestEntity {
         }
         return buff.toString();
     }
-    
+
     public double getWeightQuarters() {
         double quartersWeight = 0;
         for (Bay bay : getEntity().getTransportBays()) {
@@ -1195,10 +1197,10 @@ public class TestAero extends TestEntity {
         }
         return Math.ceil(tonnage * 2) / 2.0;
     }
-    
+
     /**
      * Get the maximum tonnage for the type of unit
-     * 
+     *
      * @param aero      The unit
      * @param faction   An ITechnology faction constant used for primitive jumpships. A value
      *                  of F_NONE will use the least restrictive values (TA/TH).
@@ -1231,7 +1233,7 @@ public class TestAero extends TestEntity {
             return 100;
         }
     }
-    
+
     /**
      * @param jumpship
      * @return Max tonnage allowed by construction rules.
@@ -1286,7 +1288,7 @@ public class TestAero extends TestEntity {
                 }
         }
     }
-    
+
     public static int getPrimitiveDropshipMaxTonnage(Aero dropship) {
         if (dropship.getYear() < 2130) {
             return dropship.isSpheroid() ? 3000 : 1000;
@@ -1323,7 +1325,7 @@ public class TestAero extends TestEntity {
             return 1;
         }
     }
-    
+
     /**
      * One gunner is required for each capital weapon and each six standard scale weapons, rounding up
      * @return The vessel's minimum gunner requirements.
@@ -1356,7 +1358,7 @@ public class TestAero extends TestEntity {
     /**
      * Determines whether a piece of equipment should be mounted in a specific location, as opposed
      * to the fuselage.
-     * 
+     *
      * @param eq       The equipment
      * @param fighter  If the aero is a fighter (including fixed wing support), the ammo is mounted in the
      *                 fuselage. Otherwise, it's in the location with the weapon.


### PR DESCRIPTION
This change adds a minDoors field for all bays, with only Quarters and Infantry Bays (including BA) allowed to not designate any doors.

Also fixes a typo where Jump Ships had two max door count definitions but Space Stations had none.

NOTE: needs to be pulled prior to the MML PR or that one will break.