### PR TITLE
Fix homing arty splash

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -147,6 +147,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         r.add(roll);
         vPhaseReport.addElement(r);
 
+        roll = 12;
         // do we hit?
         bMissed = roll < toHit.getValue();
 
@@ -179,9 +180,11 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             bMissed = true;
         }
         nDamPerHit = wtype.getRackSize();
+        
+        AmmoType ammoType = (AmmoType) ammo.getType();
 
         // copperhead gets 10 damage less than standard
-        if (((AmmoType) ammo.getType()).getAmmoType() != AmmoType.T_ARROW_IV) {
+        if (ammoType.getAmmoType() != AmmoType.T_ARROW_IV) {
             nDamPerHit -= 10;
         }
 
@@ -282,24 +285,17 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         bldgAbsorbs = Math.min(bldgAbsorbs, ratedDamage);
         handleClearDamage(vPhaseReport, bldg, hexDamage, false);
         ratedDamage -= bldgAbsorbs;
+        Hex hex = game.getBoard().getHex(coords);
+        
         if (ratedDamage > 0) {
             for (Entity entity : game.getEntitiesVector(coords)) {
-                if (!bMissed) {
-                    if (entity == entityTarget) {
-                        continue; // don't splash the target unless missile
-                        // missed
-                    }
+                if (!bMissed && (entity == entityTarget)) {
+                        continue; // don't splash the original target unless it's a miss
                 }
-                toHit.setSideTable(entity.sideTable(aaa.getCoords()));
-                HitData hit = entity.rollHitLocation(toHit.getHitTable(),
-                        toHit.getSideTable(), waa.getAimedLocation(),
-                        waa.getAimingMode(), toHit.getCover());
-                hit.setAttackerId(getAttackerId());
-                // BA gets damage to all troopers
-                vPhaseReport.addAll(gameManager.damageEntity(entity, hit,
-                            ratedDamage, false, DamageType.NONE, false, true,
-                            throughFront, underWater));
-                gameManager.creditKill(entity, ae);
+                
+                AreaEffectHelper.artilleryDamageEntity(entity, ratedDamage, bldg, bldgAbsorbs, 
+                        targetInBuilding, bldgDamagedOnMiss, missReported, ratedDamage, coords, ammoType, 
+                        coords, targetingHex, entityTarget, hex, hexDamage, vPhaseReport, gameManager);
             }
         }
         Report.addNewline(vPhaseReport);

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -147,7 +147,6 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         r.add(roll);
         vPhaseReport.addElement(r);
 
-        roll = 12;
         // do we hit?
         bMissed = roll < toHit.getValue();
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -284,9 +284,10 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         bldgAbsorbs = Math.min(bldgAbsorbs, ratedDamage);
         handleClearDamage(vPhaseReport, bldg, hexDamage, false);
         ratedDamage -= bldgAbsorbs;
-        Hex hex = game.getBoard().getHex(coords);
         
         if (ratedDamage > 0) {
+            Hex hex = game.getBoard().getHex(coords);
+            
             for (Entity entity : game.getEntitiesVector(coords)) {
                 if (!bMissed && (entity == entityTarget)) {
                         continue; // don't splash the original target unless it's a miss


### PR DESCRIPTION
Switched the homing artillery handler to use the standard "damage entity" logic rather than its own version. Fixes #4697.