### PR TITLE
reset 'turn interrupted' flag between phases

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1083,6 +1083,9 @@ public class GameManager implements IGameManager {
             entity.setUsedSearchlight(false);
             entity.setCarefulStand(false);
             entity.setNetworkBAP(false);
+            
+            // this flag is relevant only within the context of a single phase, but not between phases
+            entity.setTurnInterrupted(false);
 
             if (entity instanceof MechWarrior) {
                 ((MechWarrior) entity).setLanded(true);


### PR DESCRIPTION
Fixes #4457

Turns out that, when a vehicle skids or a mech falls down during the movement phase, the "turn interrupted" flag gets set. It just doesn't get cleared until the very end of a turn - and there's a check in the "sim fire" code that looks at it for whatever reason.

Resetting the flag properly looks like it prevents skipping the last few units (the number of units skipped is equal to the number of units that skidded/fell/etc) during sim fire.

Note: this won't fix the issue "in place", but will prevent it from occurring in future games.