### PR TITLE
Prevent Princess from trying to use ammo from a different bay in Large Craft

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2498,7 +2498,10 @@ public class FireControl {
             final List<Mounted> ammo = shooter.getAmmo();
             final List<Mounted> validAmmo = new ArrayList<>();
             for (final Mounted a : ammo) {
-                if (AmmoType.isAmmoValid(a, weaponType) && AmmoType.canSwitchToAmmo(weapon, (AmmoType) a.getType())) {
+                if (AmmoType.isAmmoValid(a, weaponType)
+                        && AmmoType.canSwitchToAmmo(weapon, (AmmoType) a.getType())
+                        && (!shooter.isLargeCraft()
+                            || shooter.whichBay(shooter.getEquipmentNum(weapon)).ammoInBay(shooter.getEquipmentNum(a)))) {
                     validAmmo.add(a);
                 }
             }


### PR DESCRIPTION
Added a check to the valid ammo condition. If the ammo selected is from a different bay the ammoId does not get set, which results in an NPE when the ammo is dereferenced by the handler.

Fixes #4703