### PR TITLE
Remove ignite hex target for inferno ammo

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -1079,10 +1079,7 @@ public class MapMenu extends JPopupMenu {
             if (canStartFires
                 && (h.containsTerrain(Terrains.WOODS)
                     || h.containsTerrain(Terrains.JUNGLE)
-                    || h.containsTerrain(Terrains.FIELDS)
-                    || hasMunitionType(AmmoType.M_INFERNO)
-                    || hasMunitionType(AmmoType.M_INFERNO_IV)
-                    || hasMunitionType(AmmoType.M_THUNDER_INFERNO))) {
+                    || h.containsTerrain(Terrains.FIELDS))) {
                 menu.add(TargetMenuItem(new HexTarget(coords, Targetable.TYPE_HEX_IGNITE)));
             }
             // Targeting fuel tanks


### PR DESCRIPTION
As clarified by the BMM (p. 107), inferno missiles can only intentionally start fires in woods, jungle, and building hexes. TO gives a modifier for planted fields, implying that they are also acceptable targets. The rules for inferno missile artillery and bombs state that they will automatically start a fire in any hex, but that is handled by MM without having to declare the ignition attempt as part of the target.

Fixes #935