### PR TITLE
Respect variable tech level setting in unit selector filtering

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -543,7 +543,8 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
                     MechTableModel mechModel = entry.getModel();
                     MechSummary mech = mechModel.getMechSummary(entry.getIdentifier());
                     boolean techLevelMatch = false;
-                    int type = enableYearLimits ? mech.getType(allowedYear) : mech.getType();
+                    int type = gameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED) ?
+                            mech.getType(allowedYear) : mech.getType();
                     for (int tl : nTypes) {
                         if (type == tl) {
                             techLevelMatch = true;


### PR DESCRIPTION
Whether to sort by static tech level or variable tech level should be determined by the ALLOWED_ERA_BASED game option rather than whether the list is limited by year.

Fixes #4708