### PR TITLE
Added null check to squadron active filter.

### DIFF
--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -41,7 +41,7 @@ public class FighterSquadron extends Aero {
     // when using the option for larger squadrons
     public static final int ALTERNATE_MAX_SIZE = 10;
 
-    private static final Predicate<Entity> ACTIVE_CHECK = ent -> !(ent.isDestroyed() || ent.isDoomed());
+    private static final Predicate<Entity> ACTIVE_CHECK = ent -> !((ent == null) || ent.isDestroyed() || ent.isDoomed());
     
     private final List<Integer> fighters = new ArrayList<>();
 


### PR DESCRIPTION
I couldn't figure out what caused there to be a null entity in the squadron in the lobby, but it caused an NPE in response to a preference changed event.

Fixes #4711