### PR TITLE
Add secondary positions for dropships that start a scenario grounded

### DIFF
--- a/megamek/src/megamek/server/ScenarioLoader.java
+++ b/megamek/src/megamek/server/ScenarioLoader.java
@@ -370,6 +370,11 @@ public class ScenarioLoader {
                 entity.setId(entityId);
                 ++ entityId;
                 g.addEntity(entity);
+                // Grounded DropShips don't set secondary positions unless they're part of a game and can verify
+                // they're not on a space map.
+                if (entity.isLargeCraft() && !entity.isAirborne()) {
+                    entity.setAltitude(0);
+                }
             }
         }
         // game's ready


### PR DESCRIPTION
A grounded dropship's secondary positions are added in setPosition and setAltitude whenever altitude is zero and the unit is not on a space map. The check for map type requires game to be non-null. ScenarioLoader sets the position and altitude before adding the Entity to the game, so the secondary positions are never added and a dropship that starts the game on the ground only occupies one hex.

I added a check for grounded dropship that will set the altitude again after it is added to the game to get the secondary positions added. It's a little hacky, but changing the sequence in which entities are loaded would be much more involved and could have unforeseen effects.

Fixes #4692