### PR TITLE
Fix 4724 old format clan ds gets is ba bay

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1185,7 +1185,7 @@ public class BLKFile {
                             e.addTransporter(new InfantryBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber(), pbi.getPlatoonType()), isPod);
                             break;
                         case "battlearmorbay":
-                            pbi = new ParsedBayInfo(numbers, usedBayNumbers);
+                            pbi = new ParsedBayInfo(numbers, usedBayNumbers, e.isClan());
                             e.addTransporter(new BattleArmorBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber(),
                                     pbi.isClan(), pbi.isComstarBay()), isPod);
                             break;
@@ -1284,6 +1284,11 @@ public class BLKFile {
         private int tech_base = 0;
 
         public ParsedBayInfo(String numbers, HashSet<Integer> usedBayNumbers) throws DecodingException {
+            // Overloaded constructor that assumes IS tech base
+            this(numbers, usedBayNumbers, false);
+        }
+
+        public ParsedBayInfo(String numbers, HashSet<Integer> usedBayNumbers, boolean clanTechBase) throws DecodingException {
             // expected format of "numbers" string:
             // 0:1:2:3:4:5
             // Field 0 is the size of the bay, in tons or # of units and is required
@@ -1305,8 +1310,11 @@ public class BLKFile {
                 platoonType = decodePlatoonType(fields[3]);
                 facing = Integer.parseInt(fields[4]);
 
-                // Split up bitmap
+                // Convert and unpack bitmap
                 int bitmap = Integer.parseInt(fields[5]);
+                // update bitmap for old-style Clan bay format if clanTechBase set
+                bitmap = (clanTechBase)? bitmap | TECH_CLAN_BASE : bitmap;
+
                 isComstarBay = (COMSTAR_BIT & bitmap) > 0;
                 isClanBay = (TECH_CLAN_BASE & bitmap) > 0;
 

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1302,7 +1302,7 @@ public class BLKFile {
             String[] fields = {};
             try {
                 // Turn 2-, 3-, or 4-field number lines into standardized 6-field line.
-                fields = normalizeTransporterNumbers(numbers);
+                fields = normalizeTransporterNumbers(numbers, clanTechBase);
 
                 size = Double.parseDouble(fields[0]);
                 doors = Integer.parseInt(fields[1]);
@@ -1312,8 +1312,6 @@ public class BLKFile {
 
                 // Convert and unpack bitmap
                 int bitmap = Integer.parseInt(fields[5]);
-                // update bitmap for old-style Clan bay format if clanTechBase set
-                bitmap = (clanTechBase)? bitmap | TECH_CLAN_BASE : bitmap;
 
                 isComstarBay = (COMSTAR_BIT & bitmap) > 0;
                 isClanBay = (TECH_CLAN_BASE & bitmap) > 0;
@@ -1371,6 +1369,10 @@ public class BLKFile {
         }
 
         public static String[] normalizeTransporterNumbers(String numbers) throws DecodingException {
+            // If we don't care about the tech base (e.g., non BA bays) use default value
+            return normalizeTransporterNumbers(numbers, false);
+        }
+        public static String[] normalizeTransporterNumbers(String numbers, boolean clanTechBase) throws DecodingException {
             /** In order to make all transporter bays use the same number of data fields,
              *  but maintain compatibility with older blk files, we will do some
              *  pre-processing to check what format of field we are looking at, and convert it
@@ -1411,6 +1413,9 @@ public class BLKFile {
 
             // Add bitmap field
             int bitmap = 0;
+            if (clanTechBase){
+               bitmap |= TECH_CLAN_BASE;
+            }
 
             // the bay type indicator will be either the third or fourth item, but the bay number always comes before it,
             // so we make sure to pick the last item in the array

--- a/megamek/unittests/megamek/common/loaders/BLKDropshipFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BLKDropshipFileTest.java
@@ -335,6 +335,7 @@ public class BLKDropshipFileTest {
         boolean mixedTech = false;
         boolean clan = false;
         boolean ClanBACorrect = false;
+        boolean ISBAExists = false;
         Vector<Bay> bays = null;
 
         try{
@@ -344,12 +345,14 @@ public class BLKDropshipFileTest {
             clan = ds.isClan();             // confirm clan tech base
             bays = ds.getTransportBays();
             ClanBACorrect = confirmBayTypeinBays(bays, "BA_CLAN");
+            ISBAExists = confirmBayTypeinBays(bays, "BA_IS");
         } catch (Exception e){
         }
         assertTrue(parsed);
         assertTrue(clan);
         assertFalse(mixedTech);
         assertTrue(ClanBACorrect);
+        assertFalse(ISBAExists);
 
     }
 }

--- a/megamek/unittests/megamek/common/loaders/BLKDropshipFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BLKDropshipFileTest.java
@@ -141,6 +141,114 @@ public class BLKDropshipFileTest {
             "</escape_pod>"
             );
 
+    private static String oldFormatClanDSwithBA = String.join(
+            System.getProperty("line.separator"),
+            "<BlockVersion>",
+            "1",
+            "</BlockVersion>",
+            "<Version>",
+            "MAM0",
+            "</Version>",
+            "<UnitType>",
+            "Dropship",
+            "</UnitType>",
+            "<Name>",
+            "Old",
+            "</Name>",
+            "<Model>",
+            "Dropship",
+            "</Model>",
+            "<year>",
+            "3145",
+            "</year>",
+            "<originalBuildYear>",
+            "3145",
+            "</originalBuildYear>",
+            "<type>",
+            "Clan Level 3",
+            "</type>",
+            "<motion_type>",
+            "Aerodyne",
+            "</motion_type>",
+            "<transporters>",
+            "battlearmorbay:5.0:1:1",
+            "1stclassquarters:10.0:0:-1::-1:0",
+            "crewquarters:28.0:0:-1::-1:0",
+            "</transporters>",
+            "<SafeThrust>",
+            "2",
+            "</SafeThrust>",
+            "<heatsinks>",
+            "1",
+            "</heatsinks>",
+            "<sink_type>",
+            "1",
+            "</sink_type>",
+            "<fuel>",
+            "4280",
+            "</fuel>",
+            "<armor_type>",
+            "41",
+            "</armor_type>",
+            "<armor_tech>",
+            "2",
+            "</armor_tech>",
+            "<internal_type>",
+            "-1",
+            "</internal_type>",
+            "<armor>",
+            "85",
+            "70",
+            "70",
+            "57",
+            "</armor>",
+            "<Nose Equipment>",
+            "</Nose Equipment>",
+            "<Left Side Equipment>",
+            "</Left Side Equipment>",
+            "<Right Side Equipment>",
+            "</Right Side Equipment>",
+            "<Aft Equipment>",
+            "</Aft Equipment>",
+            "<Hull Equipment>",
+            "</Hull Equipment>",
+            "<structural_integrity>",
+            "3",
+            "</structural_integrity>",
+            "<tonnage>",
+            "200.0",
+            "</tonnage>",
+            "<designtype>",
+            "1",
+            "</designtype>",
+            "<crew>",
+            "41",
+            "</crew>",
+            "<officers>",
+            "1",
+            "</officers>",
+            "<gunners>",
+            "0",
+            "</gunners>",
+            "<passengers>",
+            "0",
+            "</passengers>",
+            "<marines>",
+            "0",
+            "</marines>",
+            "<battlearmor>",
+            "0",
+            "</battlearmor>",
+            "<otherpassenger>",
+            "0",
+            "</otherpassenger>",
+            "<life_boat>",
+            "0",
+            "</life_boat>",
+            "<escape_pod>",
+            "0",
+            "</escape_pod>"
+    );
     private Dropship loadDropshipFromString(String strOfBLK) throws Exception {
         /**
          *  Load a string of BLK-style blocks as an InputStream and create a new DropShip
@@ -219,6 +327,29 @@ public class BLKDropshipFileTest {
         assertTrue(ISBACorrect);
         assertTrue(ClanBACorrect);
         assertTrue(ComStarBACorrect);
+
+    }
+    @Test
+    public void testLoadOldFormatDSHasClanBATechLevels() {
+        boolean parsed = false;
+        boolean mixedTech = false;
+        boolean clan = false;
+        boolean ClanBACorrect = false;
+        Vector<Bay> bays = null;
+
+        try{
+            Dropship ds = loadDropshipFromString(oldFormatClanDSwithBA);
+            parsed = true;
+            mixedTech = ds.isMixedTech();   // confirm not mixed tech
+            clan = ds.isClan();             // confirm clan tech base
+            bays = ds.getTransportBays();
+            ClanBACorrect = confirmBayTypeinBays(bays, "BA_CLAN");
+        } catch (Exception e){
+        }
+        assertTrue(parsed);
+        assertTrue(clan);
+        assertFalse(mixedTech);
+        assertTrue(ClanBACorrect);
 
     }
 }

--- a/megamek/unittests/megamek/common/loaders/BLKDropshipFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BLKDropshipFileTest.java
@@ -330,7 +330,9 @@ public class BLKDropshipFileTest {
 
     }
     @Test
-    public void testLoadOldFormatDSHasClanBATechLevels() {
+    public void testLoadOldFormatClanDSHasClanBATech() {
+        // We want to verify that the correct tech type is applied to non-mixed
+        // Clan BA bays when loading old-format files.
         boolean parsed = false;
         boolean mixedTech = false;
         boolean clan = false;


### PR DESCRIPTION
I missed an interaction with the old bay format, the format normalizer code, and Clan-tech BA bays.
As of now, a Clan DS in the old format will load, but its BA bay(s) will be converted from Clan tech to IS tech.

The fix is to pass the Clan tech t/f boolean down to the normalizing code.  There it will set the Clan bit iff the loaded numbers do not include the new Clan/IS info already.

Tested with the Outpost Clan DS per the report, also other Clan DS models as I could find them.

Added a unit test to verify the correct behavior in this specific case.