### PR TITLE
Fix battlearmorhandles raises exception when adding transporters

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1253,6 +1253,7 @@ public class BLKFile {
                         default:
                             // Some Transport types (e.g. BattleArmorHandles) are not added here.
                             // Do nothing for now.
+                            break;
                     } // End switch-case
                 }
                 catch(DecodingException|NumberFormatException x){

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1251,7 +1251,8 @@ public class BLKFile {
                             e.addTransporter(new DockingCollar(pbi.getBayNumber()));
                             break;
                         default:
-                            throw new DecodingException(String.format("Could not decode transporter type '%s'", startsWith));
+                            // Some Transport types (e.g. BattleArmorHandles) are not added here.
+                            // Do nothing for now.
                     } // End switch-case
                 }
                 catch(DecodingException|NumberFormatException x){


### PR DESCRIPTION
This should fix any Transporter-derived classes that are not explicitly loaded in BLKFile.java.

I assumed that the lack of a default handler was an oversight, but it appears to be a deliberate choice.

I've restored the original behavior, but added a comment and explicit no-op to (hopefully) avoid further mishaps in the future.

Testing: loaded a couple of the units listed in the #qa bug report (discord):
- Hesiod
- TRO 3058Uu Badger F
and confirmed no exceptions were raised / UI reported no errors.