### PR TITLE
Fix various Artillery Cannon and Flak bugs

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -3923,6 +3923,7 @@ WeaponAttackAction.InvalidAmmoForFighter=cannot use this ammunition in fighter m
 WeaponAttackAction.LegBlockedByTerrain=Nearby terrain blocks leg weapons.
 WeaponAttackAction.MinimumAlt1=attacker must be at least at elevation 1
 WeaponAttackAction.NoAeroDirectArty=Airborne aerospace units cannot make direct-fire artillery attacks.
+WeaponAttackAction.FlakOnGroundedAero=Grounded aerospace/vtol units are not valid Flak targets.
 WeaponAttackAction.NoAttacker=Invalid Attacker!
 WeaponAttackAction.NoBombInMechMode=Cannot launch bomb in mech mode.
 WeaponAttackAction.NoFiringSolution=no firing solution to target.

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -15,6 +15,7 @@
 package megamek.common;
 
 import megamek.common.options.OptionsConstants;
+import org.apache.commons.lang.ArrayUtils;
 
 import java.math.BigInteger;
 import java.util.*;
@@ -263,7 +264,7 @@ public class AmmoType extends EquipmentType {
     public static final long M_FASCAM = 1L << 40;
     public static final long M_INFERNO_IV = 1L << 41;
     public static final long M_VIBRABOMB_IV = 1L << 42;
-//  public static final long M_ACTIVE_IV   
+//  public static final long M_ACTIVE_IV
     public static final long M_SMOKE = 1L << 43;
     public static final long M_LASER_INHIB = 1L << 44;
 
@@ -328,6 +329,13 @@ public class AmmoType extends EquipmentType {
 
     // Short name of Ammo or RS Printing
     protected String shortName = "";
+
+
+    // Collate artillery / artillery cannon types for flak check
+    // Add ADA here when implemented
+    private int[] ARTILLERY_TYPES = {T_LONG_TOM, T_SNIPER, T_THUMPER, T_ARROW_IV};
+    private int[] ARTILLERY_CANNON_TYPES = {T_LONG_TOM_CANNON, T_SNIPER_CANNON, T_THUMPER_CANNON};
+    private long[] ARTILLERY_FLAK_MUNITIONS = {M_CLUSTER, M_STANDARD};
 
     public AmmoType() {
         criticals = 1;
@@ -434,6 +442,23 @@ public class AmmoType extends EquipmentType {
      */
     public boolean is(int ammoType) {
         return getAmmoType() == ammoType;
+    }
+
+    /**
+     * We need a way to quickly determine if a given ammo type / munition counts as "Flak"
+     * Note, not _is_ Flak (as in the case of M_FLAK) but can be considered Flak by TW/TO/IO
+     * rules.
+     * @return counts true if this ammo can be considered Flak in some situations
+     */
+    public boolean countsAsFlak() {
+        boolean counts = false;
+
+        if(ArrayUtils.contains(ARTILLERY_TYPES, this.getAmmoType())){
+            counts = ArrayUtils.contains(ARTILLERY_FLAK_MUNITIONS, this.getMunitionType());
+        } else if(ArrayUtils.contains(ARTILLERY_CANNON_TYPES, this.getAmmoType())){
+            counts = this.getMunitionType() == AmmoType.M_STANDARD;
+        }
+        return counts;
     }
 
     public long getMunitionType() {
@@ -795,7 +820,7 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(AmmoType.createISThunderbolt15Ammo());
         EquipmentType.addType(AmmoType.createISThunderbolt20Ammo());
         EquipmentType.addType(AmmoType.createISMagshotGRAmmo());
-        //Removed all references to Phoenix/Hawk/Streak MRM. Was ammo only with 
+        //Removed all references to Phoenix/Hawk/Streak MRM. Was ammo only with
         //no weapon or code to support them.
         EquipmentType.addType(AmmoType.createISHeavyMGAmmo());
         EquipmentType.addType(AmmoType.createISHeavyMGAmmoHalf());
@@ -1810,7 +1835,7 @@ public class AmmoType extends EquipmentType {
                         .setProductionFactions(F_TH).setStaticTechLevel(SimpleTechLevel.ADVANCED),
                 "371, TO"));
 
-        //Note of Swarms the intro dates in IntOps are off and it allows Swarm-I to appear before Swarm during the 
+        //Note of Swarms the intro dates in IntOps are off and it allows Swarm-I to appear before Swarm during the
         //Clan Invasion. Proposed errata makes 3052 for Swarm-I a hard date, and 3053 for Swarm re-iintroduction a flexible date.
         munitions.add(new MunitionMutator("Swarm", 1, M_SWARM, new TechAdvancement(TECH_BASE_IS).setIntroLevel(false)
                 .setUnofficial(false).setTechRating(RATING_E).setAvailability(RATING_E, RATING_X, RATING_D, RATING_D)
@@ -4878,7 +4903,7 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(false, false, false, true, false);
         return ammo;
     }
-    
+
     // Machine Gun Ammos
     // Standard MGs
     private static AmmoType createISMGAmmo() {
@@ -6172,7 +6197,7 @@ public class AmmoType extends EquipmentType {
             .setPrototypeFactions(F_FS)
             .setProductionFactions(F_FS)
             .setStaticTechLevel(SimpleTechLevel.STANDARD);
-        
+
         return ammo;
     }
 
@@ -12779,7 +12804,7 @@ public class AmmoType extends EquipmentType {
         return ammo;
     }
 
-  
+
 
     private static AmmoType createISAC10iAmmo() {
         AmmoType ammo = new AmmoType();
@@ -13483,7 +13508,7 @@ public class AmmoType extends EquipmentType {
                     || (munition.getAmmoType() == AmmoType.T_SRM_IMP) || (munition.getAmmoType() == AmmoType.T_NLRM))
                     && ((munition.getMunitionType() == AmmoType.M_DEAD_FIRE))) {
                 cost *= 0.6;
-                // TODO - DEAD-FIRE AMMO needs BV which is not a constant but launcher Ammo. 
+                // TODO - DEAD-FIRE AMMO needs BV which is not a constant but launcher Ammo.
             }
 
             if (((munition.getAmmoType() == AmmoType.T_MML) || (munition.getAmmoType() == AmmoType.T_SRM)

--- a/megamek/src/megamek/common/ToHitData.java
+++ b/megamek/src/megamek/common/ToHitData.java
@@ -46,7 +46,7 @@ public class ToHitData extends TargetRoll {
     private int hitTable = HIT_NORMAL;
     private int sideTable = SIDE_FRONT;
     private int cover = LosEffects.COVER_NONE;
-    private int margineOfSuccess = 0;
+    private int marginOfSuccess = 0;
 
     private Coords location;
 
@@ -230,14 +230,14 @@ public class ToHitData extends TargetRoll {
      * MoS returns a positive while
      * MoF returns a negative
      *
-     * @return <code>int</code> 
+     * @return <code>int</code>
      */
     public int getMoS() {
-        return margineOfSuccess;
+        return marginOfSuccess;
     }
 
     public void setMoS(int moS) {
-        margineOfSuccess = moS;
+        marginOfSuccess = moS;
     }
 
     public void setLocation(Coords l) {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1752,7 +1752,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 // homing ammo.
 
                 if ((ttype != Targetable.TYPE_HEX_ARTILLERY) && (ttype != Targetable.TYPE_MINEFIELD_CLEAR)
-                        && !isArtilleryFLAK && !isHoming && !target.isOffBoard()) {
+                        && !(isArtilleryFLAK || (atype != null && atype.countsAsFlak())) && !isHoming && !target.isOffBoard()) {
                     return Messages.getString("WeaponAttackAction.ArtyAttacksOnly");
                 }
                 // Airborne units can't make direct-fire artillery attacks
@@ -1801,6 +1801,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
             // Direct-fire artillery attacks.
             if (isArtilleryDirect) {
+                if ((atype != null && atype.countsAsFlak()) && !(target.isAirborne() || target.isAirborneVTOLorWIGE())){
+                    return Messages.getString("WeaponAttackAction.FlakOnGroundedAero");
+                }
                 // Cruise missiles cannot make direct-fire attacks
                 if (isCruiseMissile) {
                     return Messages.getString("WeaponAttackAction.NoDirectCruiseMissile");
@@ -5056,7 +5059,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         if (isArtilleryDirect) {
             //If an airborne unit occupies the target hex, standard artillery ammo makes a flak attack against it
             //TN is a flat 3 + the altitude mod + the attacker's weapon skill
-            if (isArtilleryFLAK && te != null) {
+            if ((isArtilleryFLAK || (atype != null && atype.countsAsFlak())) && te != null) {
                 toHit.addModifier(3, Messages.getString("WeaponAttackAction.ArtyFlak"));
                 if (te.isAirborne()) {
                     if (te.getAltitude() > 3) {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -360,16 +360,15 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             bMekTankStealthActive = ae.isStealthActive();
         }
 
-        // Collate artillery / artillery cannon types for flak check
-        int[] artillery_types = {AmmoType.T_LONG_TOM, AmmoType.T_SNIPER, AmmoType.T_THUMPER, AmmoType.T_LONG_TOM_CANNON, AmmoType.T_SNIPER_CANNON, AmmoType.T_THUMPER_CANNON};
         boolean isFlakAttack = !game.getBoard().inSpace() && (te != null)
                 && (te.isAirborne() || te.isAirborneVTOLorWIGE()) && (atype != null)
                 && (
                         (((atype.getAmmoType() == AmmoType.T_AC_LBX) || (atype.getAmmoType() == AmmoType.T_AC_LBX_THB)
                             || (atype.getAmmoType() == AmmoType.T_SBGAUSS))
-                            && (munition == AmmoType.M_CLUSTER))
+                            && (munition == AmmoType.M_CLUSTER)
+                        )
                         || (munition == AmmoType.M_FLAK) || (atype.getAmmoType() == AmmoType.T_HAG)
-                        || (ArrayUtils.contains(artillery_types, atype.getAmmoType()) && atype.getMunitionType() == AmmoType.M_STANDARD)
+                        || atype.countsAsFlak()
         );
 
         boolean isIndirect = (wtype.hasModes() && weapon.curMode().equals(Weapon.MODE_MISSILE_INDIRECT));

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -1,15 +1,15 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
 */
 package megamek.common.weapons;
 
@@ -20,27 +20,27 @@ import org.apache.logging.log4j.LogManager;
 import java.util.*;
 
 /**
- * Class containing functionality that helps out with area effect weapons. 
+ * Class containing functionality that helps out with area effect weapons.
  * @author NickAragua
  */
 public class AreaEffectHelper {
     // maps equipment name to blast radius index for fuel-air ordnance
     private static Map<String, Integer> fuelAirBlastRadiusIndex;
     private static final int[] fuelAirDamage = { 5, 10, 20, 30 };
-    
+
     private static Map<Integer, NukeStats> nukeStats;
-    
+
     /**
      * Worker function that initializes blast radius data for fuel-air explosives of various types.
      */
     private static void initializeFuelAirBlastRadiusIndexData() {
         fuelAirBlastRadiusIndex = new HashMap<>();
-        
+
         fuelAirBlastRadiusIndex.put(BombType.getBombInternalName(BombType.B_FAE_SMALL), 2);
         fuelAirBlastRadiusIndex.put(BombType.getBombInternalName(BombType.B_FAE_LARGE), 3);
-        
+
         // the following ammo types have the capability to load FAE munitions:
-        // Arrow IV, Thumper, Sniper, Long Tom        
+        // Arrow IV, Thumper, Sniper, Long Tom
         addFuelAirBlastRadiusIndex(AmmoType.T_ARROW_IV, 2);
         addFuelAirBlastRadiusIndex(AmmoType.T_THUMPER, 1);
         addFuelAirBlastRadiusIndex(AmmoType.T_THUMPER_CANNON, 1);
@@ -49,47 +49,47 @@ public class AreaEffectHelper {
         addFuelAirBlastRadiusIndex(AmmoType.T_LONG_TOM_CANNON, 3);
         addFuelAirBlastRadiusIndex(AmmoType.T_LONG_TOM, 3);
     }
-    
+
     /**
      * Worker function that initializes data for NUCLEAR WEAPONS
      */
     private static void initializeNukeStats() {
         nukeStats = new HashMap<>();
-        
+
         NukeStats nukeEntry = new NukeStats();
         nukeEntry.baseDamage = 100;
         nukeEntry.degradation = 5;
         nukeEntry.secondaryRadius = 40;
         nukeEntry.craterDepth = 0;
-        
+
         nukeStats.put(0, nukeEntry);
         nukeStats.put(1, nukeEntry);
-        
+
         nukeEntry = new NukeStats();
         nukeEntry.baseDamage = 1000;
         nukeEntry.degradation = 23;
         nukeEntry.secondaryRadius = 86;
         nukeEntry.craterDepth = 1;
-        
+
         nukeStats.put(2, nukeEntry);
-        
+
         nukeEntry = new NukeStats();
         nukeEntry.baseDamage = 10000;
         nukeEntry.degradation = 109;
         nukeEntry.secondaryRadius = 184;
         nukeEntry.craterDepth = 3;
-        
+
         nukeStats.put(3, nukeEntry);
-        
+
         nukeEntry = new NukeStats();
         nukeEntry.baseDamage = 100000;
         nukeEntry.degradation = 505;
         nukeEntry.secondaryRadius = 396;
         nukeEntry.craterDepth = 5;
-        
+
         nukeStats.put(4, nukeEntry);
     }
-    
+
     /**
      * Helper function that adds elements to the fuel blast radius index
      */
@@ -102,7 +102,7 @@ public class AreaEffectHelper {
             }
         }
     }
-    
+
     /**
      * Get the blast radius of a particular equipment type, given the internal name.
      */
@@ -110,10 +110,10 @@ public class AreaEffectHelper {
         if (fuelAirBlastRadiusIndex == null) {
             initializeFuelAirBlastRadiusIndexData();
         }
-        
+
         return fuelAirBlastRadiusIndex.getOrDefault(name, 0);
     }
-    
+
     /**
      * Helper function that processes damage for fuel-air explosives.
      * Single-entity version.
@@ -121,10 +121,10 @@ public class AreaEffectHelper {
     public static void processFuelAirDamage(Entity target, Coords center, EquipmentType ordnanceType, Entity attacker,
                                             Vector<Report> vPhaseReport, GameManager gameManager) {
         Game game = attacker.getGame();
-        // sanity check: if this attack is happening in vacuum through very thin atmo, add that to the phase report and terminate early 
+        // sanity check: if this attack is happening in vacuum through very thin atmo, add that to the phase report and terminate early
         boolean notEnoughAtmo = game.getBoard().inSpace() ||
                 game.getPlanetaryConditions().getAtmosphere() <= PlanetaryConditions.ATMO_TRACE;
-        
+
         if (notEnoughAtmo) {
             Report r = new Report(9986);
             r.indent(1);
@@ -133,10 +133,10 @@ public class AreaEffectHelper {
             vPhaseReport.addElement(r);
             return;
         }
-        
+
         boolean thinAtmo = game.getPlanetaryConditions().getAtmosphere() == PlanetaryConditions.ATMO_THIN;
         int blastRadius = getFuelAirBlastRadiusIndex(ordnanceType.getInternalName());
-        
+
         if (thinAtmo) {
             Report r = new Report(9990);
             r.indent(1);
@@ -144,9 +144,9 @@ public class AreaEffectHelper {
             r.newlines = 1;
             vPhaseReport.addElement(r);
         }
-        
+
         Vector<Integer> entitiesToExclude = new Vector<>();
-        
+
         // determine distance to entity
         // look up damage on radius chart
         //      (divided by half, round up for thin atmo)
@@ -159,28 +159,28 @@ public class AreaEffectHelper {
         if (damageBracket < 0) {
             return;
         }
-        
+
         int damage = AreaEffectHelper.fuelAirDamage[damageBracket];
         if (thinAtmo) {
             damage = (int) Math.ceil(damage / 2.0);
         }
-                
+
         checkInfantryDestruction(target, distFromCenter, attacker, entitiesToExclude, vPhaseReport, game, gameManager);
-                
+
         artilleryDamageEntity(target, damage, null, 0, false, false, false, 0, center, (AmmoType) ordnanceType, target.getPosition(), true,
                 attacker, null, attacker.getId(), vPhaseReport, gameManager);
     }
-    
+
     /**
      * Helper function that processes damage for fuel-air explosives.
      */
     public static void processFuelAirDamage(Coords center, EquipmentType ordnanceType, Entity attacker,
                                             Vector<Report> vPhaseReport, GameManager gameManager) {
         Game game = attacker.getGame();
-        // sanity check: if this attack is happening in vacuum through very thin atmo, add that to the phase report and terminate early 
+        // sanity check: if this attack is happening in vacuum through very thin atmo, add that to the phase report and terminate early
         boolean notEnoughAtmo = game.getBoard().inSpace() ||
                 game.getPlanetaryConditions().getAtmosphere() <= PlanetaryConditions.ATMO_TRACE;
-        
+
         if (notEnoughAtmo) {
             Report r = new Report(9986);
             r.indent(1);
@@ -189,10 +189,10 @@ public class AreaEffectHelper {
             vPhaseReport.addElement(r);
             return;
         }
-        
+
         boolean thinAtmo = game.getPlanetaryConditions().getAtmosphere() == PlanetaryConditions.ATMO_THIN;
         int blastRadius = getFuelAirBlastRadiusIndex(ordnanceType.getInternalName());
-        
+
         if (thinAtmo) {
             Report r = new Report(9990);
             r.indent(1);
@@ -200,12 +200,12 @@ public class AreaEffectHelper {
             r.newlines = 1;
             vPhaseReport.addElement(r);
         }
-        
+
         Vector<Integer> entitiesToExclude = new Vector<>();
-        
+
         // assemble collection of hexes at ranges 0 to radius
         // for each hex, invoke artilleryDamageHex, with the damage set according to this:
-        //      radius chart 
+        //      radius chart
         //      (divided by half, round up for thin atmo)
         //      not here, but in artilleryDamageHex, make sure to 2x damage for infantry outside of building
         //      not here, but in artilleryDamageHex, make sure to 1.5x damage for light building or unit with armor BAR < 10
@@ -218,20 +218,20 @@ public class AreaEffectHelper {
                 if (thinAtmo) {
                     damage = (int) Math.ceil(damage / 2.0);
                 }
-                
+
                 checkInfantryDestruction(coords, distFromCenter, attacker, entitiesToExclude, vPhaseReport, game, gameManager);
-                
+
                 gameManager.artilleryDamageHex(coords, center, damage, (AmmoType) ordnanceType, attacker.getId(), attacker, null, false, 0, vPhaseReport, false,
                         entitiesToExclude, false);
-                
+
                 TargetRoll fireRoll = new TargetRoll(7, "fuel-air ordnance");
                 gameManager.tryIgniteHex(coords, attacker.getId(), false, false, fireRoll, true, -1, vPhaseReport);
-                
+
                 clearMineFields(coords, Minefield.CLEAR_NUMBER_WEAPON_ACCIDENT, attacker, vPhaseReport, game, gameManager);
             }
         }
     }
-    
+
     /**
      * Worker function that checks for and implements instant infantry destruction due to fuel air ordnance, if necessary.
      * Checks all units at given coords.
@@ -242,7 +242,7 @@ public class AreaEffectHelper {
             checkInfantryDestruction(entity, distFromCenter, attacker, alreadyHit, vPhaseReport, game, gameManager);
         }
     }
-    
+
     /**
      * Worker function that checks for and implements instant infantry destruction due to fuel air ordnance, if necessary.
      * Single-entity version.
@@ -257,11 +257,11 @@ public class AreaEffectHelper {
         } else {
             return;
         }
-        
+
         int roll = Compute.d6(2);
         int result = roll + distFromCenter;
         boolean destroyed = result <= rollTarget;
-        
+
         Report r = new Report(9987);
         r.indent(1);
         r.subject = attacker.getId();
@@ -271,14 +271,14 @@ public class AreaEffectHelper {
         r.add(distFromCenter);
         r.choose(destroyed);
         vPhaseReport.addElement(r);
-        
+
         if (destroyed) {
             vPhaseReport.addAll(gameManager.destroyEntity(entity, "fuel-air ordnance detonation", false, false));
             alreadyHit.add(entity.getId());
         }
         return;
     }
-    
+
     /**
      * Worker function that clears minefields.
      */
@@ -319,12 +319,12 @@ public class AreaEffectHelper {
      * @param vPhaseReport Vector of reports to which we append reports
      * @param gameManager GameManager object for invocation of various methods
      */
-    public static void artilleryDamageEntity(Entity entity, int damage, Building bldg, int bldgAbsorbs, 
+    public static void artilleryDamageEntity(Entity entity, int damage, Building bldg, int bldgAbsorbs,
             boolean variableDamage, boolean asfFlak, boolean flak, int altitude,
             Coords attackSource, AmmoType ammo, Coords coords, boolean isFuelAirBomb,
             Entity killer, Hex hex, int subjectId, Vector<Report> vPhaseReport, GameManager gameManager) {
         Report r;
-        
+
         int hits = damage;
         if (variableDamage) {
             hits = Compute.d6(damage);
@@ -408,7 +408,7 @@ public class AreaEffectHelper {
         // convention infantry take x2 damage from AE weapons
         if (entity.isConventionalInfantry()) {
             hits *= 2;
-            
+
             // if it's fuel-air, we take even more damage!
             if (isFuelAirBomb) {
                 hits *= 2;
@@ -439,7 +439,7 @@ public class AreaEffectHelper {
                     vPhaseReport.addAll(gameManager.vehicleMotiveDamage((Tank) entity, 0));
                     return;
                 }
-                
+
                 // only infantry and support vees with bar < 5 are affected
                 if ((entity instanceof BattleArmor) || ((entity instanceof SupportTank)
                         && !entity.hasPatchworkArmor() && (entity.getBARRating(1) > 4))) {
@@ -543,7 +543,7 @@ public class AreaEffectHelper {
                 // fuel-air bombs do 1.5x damage to locations hit that have a BAR rating of less than 10.
                 } else if (isFuelAirBomb && !(entity instanceof Infantry) && (entity.getBARRating(hit.getLocation()) < 10)) {
                     damageToDeal = (int) Math.ceil(damageToDeal * 1.5);
-                    
+
                     r = new Report(9991);
                     r.indent(1);
                     r.subject = killer.getId();
@@ -559,7 +559,7 @@ public class AreaEffectHelper {
             gameManager.creditKill(entity, killer);
         }
     }
-    
+
     /**
      * Calculate the damage and falloff for a particular ammo type, taking into account
      * whether the attack is being carried out by a battle armor squad or a mine clearance attack.
@@ -581,11 +581,11 @@ public class AreaEffectHelper {
             empty.clusterMunitionsFlag = false;
             return empty;
         }
-        
+
         int damage = ammo.getRackSize();
         int falloff = 10;
         boolean clusterMunitionsFlag = false;
-        
+
         // Capital and Sub-capital missiles
         if (ammo.getAmmoType() == AmmoType.T_KRAKEN_T
                 || ammo.getAmmoType() == AmmoType.T_KRAKENM
@@ -633,7 +633,7 @@ public class AreaEffectHelper {
             if (ammo.getAmmoType() == AmmoType.T_THUMPER) {
                 falloff = 9;
             }
-            
+
             clusterMunitionsFlag = true;
         } else if (ammo.getMunitionType() == AmmoType.M_FLECHETTE) {
             switch (ammo.getAmmoType()) {
@@ -652,42 +652,42 @@ public class AreaEffectHelper {
                     falloff = 1;
             }
         // if this was a mine clearance, then it only affects the hex hit
-        } else if (mineClear) {
+        }else if (mineClear) {
             falloff = damage;
         }
-        
+
         DamageFalloff retVal = new DamageFalloff();
         retVal.damage = damage;
         retVal.falloff = falloff;
         retVal.clusterMunitionsFlag = clusterMunitionsFlag;
-        
+
         return retVal;
     }
-    
+
     /**
      * Abbreviated nuclear explosion logic when the weapon is targeted at a single off-board entity.
      */
     public static void doNuclearExplosion(Entity entity, Coords coords, int nukeType, Vector<Report> vPhaseReport,
                                           GameManager gameManager) {
         NukeStats nukeStats = getNukeStats(nukeType);
-                
+
         if (nukeStats == null) {
             Report r = new Report(9998);
             r.add(nukeType);
             vPhaseReport.add(r);
             return;
         }
-        
+
         Report r = new Report(1215, Report.PUBLIC);
 
         r.indent();
         r.add("offboard");
         vPhaseReport.add(r);
-        
+
         // crater radius is crater depth x2 as per Server.doNuclearExplosion
         int craterRadius = nukeStats.craterDepth * 2;
         int blastDistance = entity.getPosition().distance(coords);
-        
+
         // if the entity is in the crater radius, bye
         if (blastDistance < craterRadius) {
             vPhaseReport.addAll(gameManager.destroyEntity(entity, "nuclear explosion proximity", false, false));
@@ -696,7 +696,7 @@ public class AreaEffectHelper {
             // no need to do any more damage, it's already destroyed.
             return;
         }
-        
+
         // calculate the damage to the entity based on the range to the nuke
         int damageToEntity = nukeStats.baseDamage - (blastDistance * nukeStats.degradation);
         if (damageToEntity < 0) {
@@ -704,17 +704,17 @@ public class AreaEffectHelper {
         } else {
             applyExplosionClusterDamageToEntity(entity, damageToEntity, 5, coords, vPhaseReport, gameManager);
         }
-        
-        // if the entity hasn't been blown up yet, 
+
+        // if the entity hasn't been blown up yet,
         // Apply secondary effects against the entity if it's within the secondary blast radius
         // Since the effects are unit-dependent, we'll just define it in the
-        // entity. 
+        // entity.
         if (!entity.isDestroyed() && (blastDistance <= nukeStats.secondaryRadius)) {
             gameManager.applySecondaryNuclearEffects(entity, coords, vPhaseReport);
         }
-        
+
     }
-    
+
     /**
      * Apply a series of cluster hits to the given entity, as from an explosion at a particular position.
      * Generate reports for each cluster.
@@ -744,7 +744,7 @@ public class AreaEffectHelper {
             damage -= cluster;
         }
     }
-    
+
     /**
      * Helper function that retrieves the stat block for a particular type of nuke, or null
      * if such a type is not defined.
@@ -753,14 +753,14 @@ public class AreaEffectHelper {
         if (nukeStats == null) {
             initializeNukeStats();
         }
-        
+
         if (nukeStats.containsKey(nukeType)) {
             return nukeStats.get(nukeType);
         }
-        
+
         return null;
     }
-    
+
     /**
      * Dumb data structure intended to hold results from the calculateDamageFalloff method.
      */
@@ -769,28 +769,28 @@ public class AreaEffectHelper {
         public int falloff;
         public boolean clusterMunitionsFlag;
     }
-    
+
     /**
-     * Dumb data structure intended to hold characteristics associated with various types of 
+     * Dumb data structure intended to hold characteristics associated with various types of
      * NUCLEAR WEAPONS (thanks Ghandi).
      */
     public static class NukeStats {
         /**
-         * This is the base damage of the weapon. 
+         * This is the base damage of the weapon.
          * Note that a unit will never actually take this much damage unless the craterDepth is specified as 0.
          */
         public int baseDamage;
-        
+
         /**
          * How much to subtract, per hex distance from impact point, from the base damage
          */
         public int degradation;
-        
+
         /**
-         * The maximum distance, in hexes, from the impact point, at which "secondary" effects are applied to units 
+         * The maximum distance, in hexes, from the impact point, at which "secondary" effects are applied to units
          */
         public int secondaryRadius;
-        
+
         /**
          * The depth, in hex levels, of the crater generated by this nuke at the impact hex
          * Note that the crater radius is this number multiplied by 2

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -15,6 +15,7 @@
 package megamek.common.weapons;
 
 import megamek.common.*;
+import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.enums.GamePhase;
 import megamek.server.GameManager;
@@ -45,7 +46,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
         if (!cares(phase)) {
             return true;
         }
-        
+
         Coords targetPos = target.getPosition();
         boolean isFlak = (target instanceof VTOL) || target.isAero();
         boolean asfFlak = target.isAero();
@@ -148,7 +149,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
         }
 
         // According to TacOps eratta, artillery cannons can only fire standard
-        // rounds.
+        // rounds and fuel-air cannon shells (Interstellar Ops p165).
         // But, they're still in as unofficial tech, because they're fun. :)
         if (ammoType.getMunitionType() == AmmoType.M_FLARE) {
             int radius;
@@ -171,6 +172,11 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
             return false;
         } else if (ammoType.getMunitionType() == AmmoType.M_SMOKE) {
             gameManager.deliverArtillerySmoke(targetPos, vPhaseReport);
+            return false;
+        } else if (ammoType.getMunitionType() == AmmoType.M_FAE) {
+            AreaEffectHelper.processFuelAirDamage(targetPos,
+                    ammoType, ae, vPhaseReport, gameManager);
+
             return false;
         }
 


### PR DESCRIPTION
This PR fixes several issues with Artillery, Artillery Cannons, Flak, and Fuel-Air Explosive munitions:

1. Let Artillery / Artillery Cannons firing FAE rounds use the full radius.
2. Make Artillery / Artillery Cannon munitions properly act as Flak based on IO table of artillery munitions marked "F" (specifically, Cluster)
3. Clean up some of the checks to determine if a Flak attack is allowed.
4. Explicitly _disallow_ Artillery / Artillery Cannon Flak attacks against a grounded or crashed VTOL/ASF unit.
5. Correct spelling of "margin" from "margine".

Desired but not included: 
- implement ADA munition for Arrow IV, with Flak capability
- confirm if Artillery / Arty Cannon munitions used as Flak gain the additional -2 bonus (RIP your ASF, by the way) or not.
- Fix LTC/SnC/ThC miss drift radius

Close #3546
Close #4359