### PR TITLE
Fix 4739 custom protomech bay does not load

### DIFF
--- a/megamek/src/megamek/common/ProtomechBay.java
+++ b/megamek/src/megamek/common/ProtomechBay.java
@@ -96,7 +96,7 @@ public final class ProtomechBay extends Bay {
 
     @Override
     public String toString() {
-        String bayType = "ProtoMechBay";
+        String bayType = "ProtoMekBay";
         return this.bayString(
                 bayType,
                 totalSpace,

--- a/megamek/src/megamek/common/ProtomechBay.java
+++ b/megamek/src/megamek/common/ProtomechBay.java
@@ -67,7 +67,7 @@ public final class ProtomechBay extends Bay {
         if (doors <= loadedThisTurn) {
             result = false;
         }
-        
+
         // Return our result.
         return result;
     }
@@ -96,7 +96,7 @@ public final class ProtomechBay extends Bay {
 
     @Override
     public String toString() {
-        String bayType = "ProtoMekBay";
+        String bayType = "ProtoMechBay";
         return this.bayString(
                 bayType,
                 totalSpace,
@@ -104,14 +104,14 @@ public final class ProtomechBay extends Bay {
                 bayNumber
         );
     }
-    
+
     public static TechAdvancement techAdvancement() {
         return new TechAdvancement(TECH_BASE_CLAN).setClanAdvancement(3060, 3066, 3070)
                 .setClanApproximate(true, false, false).setTechRating(RATING_C)
                 .setAvailability(RATING_X, RATING_X, RATING_D, RATING_D)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return ProtomechBay.techAdvancement();

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1193,6 +1193,7 @@ public class BLKFile {
                             pbi = new ParsedBayInfo(numbers, usedBayNumbers);
                             e.addTransporter(new Bay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber()), isPod);
                             break;
+                        // case "protomekbay":
                         case "protomechbay":
                             pbi = new ParsedBayInfo(numbers, usedBayNumbers);
                             e.addTransporter(new ProtomechBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber()), isPod);

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1193,8 +1193,10 @@ public class BLKFile {
                             pbi = new ParsedBayInfo(numbers, usedBayNumbers);
                             e.addTransporter(new Bay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber()), isPod);
                             break;
-                        // case "protomekbay":
+                        case "protomekbay":
+                            // Newer custom BLK handling
                         case "protomechbay":
+                            // Backward compatibility
                             pbi = new ParsedBayInfo(numbers, usedBayNumbers);
                             e.addTransporter(new ProtomechBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber()), isPod);
                             break;


### PR DESCRIPTION
It looks like there was a change, or series of changes, to ProtoMechBay.java back in March of 2022 that broke compatibility between _saving_ ProtoMech bays (or "ProtoMekBays") and _loading_ them.

The fix I've proposed here just reads both lines and treats them equally.  It's quick and easy and I've tested it with the original file from #4739 successfully.

An alternative fix would be to revert the March 2022 change completely; I feel this warrants consideration as there are several places in the MML UI (not to mention _in the filename itself_) where we use "ProtoMech".

Close #4739 