### PR TITLE
Tech level filtering in unit selector revisited

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -116,6 +116,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     protected boolean allowInvalid = true;
     protected int gameTechLevel = TechConstants.T_SIMPLE_INTRO;
     protected int techLevelDisplayType = TECH_LEVEL_DISPLAY_IS_CLAN;
+    protected boolean eraBasedTechLevel = false;
     private static final GUIPreferences GUIP = GUIPreferences.getInstance();
     //endregion Variable Declarations
 
@@ -543,7 +544,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
                     MechTableModel mechModel = entry.getModel();
                     MechSummary mech = mechModel.getMechSummary(entry.getIdentifier());
                     boolean techLevelMatch = false;
-                    int type = gameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED) ?
+                    int type = eraBasedTechLevel ?
                             mech.getType(allowedYear) : mech.getType();
                     for (int tl : nTypes) {
                         if (type == tl) {

--- a/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
@@ -63,6 +63,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         canonOnly = gameOptions.booleanOption(OptionsConstants.ALLOWED_CANON_ONLY);
         allowInvalid = gameOptions.booleanOption(OptionsConstants.ALLOWED_ALLOW_ILLEGAL_UNITS);
         gameTechLevel = TechConstants.getSimpleLevel(gameOptions.stringOption("techlevel"));
+        eraBasedTechLevel = gameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED);
     }
 
     //region Button Methods


### PR DESCRIPTION
My previous fix for #4708 broke MML because it takes the variable tech setting from gameOptions, which is null in MML. This fix corrects #4718 by introducing a variable in AbstractUnitSelectorDialog that is set by the implementations in all three programs according to their own configuration options.