### PR TITLE
TestSmallCraft: weight calculation 

### DIFF
--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -218,7 +218,7 @@ public class TestSmallCraft extends TestAero {
     }
     
     public static int weightFreeHeatSinks(SmallCraft sc) {
-        double engineTonnage = calculateEngineTonnage(sc.isClan(), sc.getWeight(), sc.getWalkMP(),
+        double engineTonnage = calculateEngineTonnage(sc.isClan(), sc.getWeight(), sc.getOriginalWalkMP(),
                 sc.hasETypeFlag(Entity.ETYPE_DROPSHIP), sc.getOriginalBuildYear());
         if (sc.isSpheroid()) {
             if (sc.isPrimitive()) {


### PR DESCRIPTION
This makes weight free heat sink calculation use the original walk mp for engine weight calc to prevent dropships in the lobby being invalid when their altitude is set to 0 or some other circumstance changes their MP. 