### PR TITLE
Non-Meks in fire hexes

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -297,12 +297,12 @@ public class SharedUtility {
                     lastPos, curPos, isPavementStep);
             checkNag(rollTarget, nagReport, psrList);
 
-            // check for non-mech entering a fire
+            // check for non-heat tracking entering a fire
             boolean underwater = curHex.containsTerrain(Terrains.WATER)
                     && (curHex.depth() > 0)
                     && (step.getElevation() < curHex.getLevel());
             if (curHex.containsTerrain(Terrains.FIRE) && !underwater
-                    && !(entity instanceof Mech) && (step.getElevation() <= 1)
+                    && !entity.tracksHeat() && (step.getElevation() <= 1) && !entity.isAirborne()
                     && (moveType != EntityMovementType.MOVE_JUMP)
                     && !(curPos.equals(lastPos))) {
                 nagReport.append(Messages.getString("MovementDisplay.FireMoving", 8));

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -19508,11 +19508,6 @@ public class GameManager implements IGameManager {
             return;
         }
 
-        // fire has no effect on dropships
-        if (entity instanceof Dropship) {
-            return;
-        }
-
         // Must roll 8+ to survive...
         r = new Report(5100);
         r.subject = entity.getId();


### PR DESCRIPTION
The way I understand TO:AR pg.41-43, all heat-tracking unit types (Mek, ASF, SC) are treated equally when standing in fire. All of those are not "All Other units" of pg.43 and don't get destroyed on a bad roll. They just suffer heat. This PR implements this.

Fixes #4734 