### PR TITLE
Fix 4754 vtols and cvs missing troop space bays

### DIFF
--- a/megamek/data/mechfiles/vehicles/3039u/Coolant Truck (Hover).blk
+++ b/megamek/data/mechfiles/vehicles/3039u/Coolant Truck (Hover).blk
@@ -3,7 +3,7 @@
 1
 </BlockVersion>
 
-# Write the version number just in case...
+##Write the version number just in case...
 <Version>
 MAM0
 </Version>
@@ -28,6 +28,10 @@ Coolant Truck
 2602
 </year>
 
+<originalBuildYear>
+2602
+</originalBuildYear>
+
 <type>
 IS Level 1
 </type>
@@ -37,8 +41,7 @@ Hover
 </motion_type>
 
 <transporters>
-insulatedcargobay:3.48:1:1
-insulatedcargobay:1.74:1:1
+insulatedcargobay:4.35:1:1::-1:0
 </transporters>
 
 <cruiseMP>
@@ -75,8 +78,8 @@ IS Vehicle Flamer Ammo
 </Rear Equipment>
 
 <Turret Equipment>
-Vehicle Flamer
-Vehicle Flamer
+Flamer (Vehicle)
+Flamer (Vehicle)
 </Turret Equipment>
 
 <source>
@@ -86,3 +89,8 @@ TRO: 3039
 <tonnage>
 30.0
 </tonnage>
+
+<fuelType>
+PETROCHEMICALS
+</fuelType>
+

--- a/megamek/data/mechfiles/vehicles/3039u/Coolant Truck (Hover).blk
+++ b/megamek/data/mechfiles/vehicles/3039u/Coolant Truck (Hover).blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 insulatedcargobay:3.48:1:1
-</transporters>
-
-<transporters>
 insulatedcargobay:1.74:1:1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3039u/Coolant Truck (Tracked).blk
+++ b/megamek/data/mechfiles/vehicles/3039u/Coolant Truck (Tracked).blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 insulatedcargobay:4.35:1:1
-</transporters>
-
-<transporters>
 insulatedcargobay:1.74:1:2
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3039u/Coolant Truck 135-K.blk
+++ b/megamek/data/mechfiles/vehicles/3039u/Coolant Truck 135-K.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 insulatedcargobay:5.655:1:1
-</transporters>
-
-<transporters>
 insulatedcargobay:2.175:1:2
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport A.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport A.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport B.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport B.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport C.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport C.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport D.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport D.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport E.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport E.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport F.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport F.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport H.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport H.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport Prime.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger (C) Tracked Transport Prime.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport A.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport A.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport B.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport B.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport C.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport C.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport D.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport D.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport E.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport E.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport G.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport G.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport Prime.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Badger Tracked Transport Prime.blk
@@ -38,9 +38,6 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft A.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft A.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft B.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft B.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft C.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft C.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft D.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft D.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft E.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft E.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft F.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft F.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft G.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft G.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft H.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft H.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft Prime.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit (C) Hovercraft Prime.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft A.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft A.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft B.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft B.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft C.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft C.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft D.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft D.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft E.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft E.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft F.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft F.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft G.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft G.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft H.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft H.blk
@@ -1,6 +1,6 @@
 #building block data file
 <BlockVersion>
-1.1
+1
 </BlockVersion>
 
 ##Write the version number just in case...
@@ -41,8 +41,9 @@ Hover
 </motion_type>
 
 <transporters>
-troopspace:8.0
 BattleArmorHandles - troopers:-1
+troopspace:4.0
+troopspace:4.0:omni
 </transporters>
 
 <cruiseMP>

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft I.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft I.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft Prime.blk
+++ b/megamek/data/mechfiles/vehicles/3058Uu/Bandit Hovercraft Prime.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067 Unabridged/Clan Vehicles/Hephaestus Scout Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3067 Unabridged/Clan Vehicles/Hephaestus Scout Tank D.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:5.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank D.blk
@@ -3,7 +3,7 @@
 1
 </BlockVersion>
 
-# Write the version number just in case...
+##Write the version number just in case...
 <Version>
 MAM0
 </Version>
@@ -28,6 +28,10 @@ D
 3075
 </year>
 
+<originalBuildYear>
+3075
+</originalBuildYear>
+
 <type>
 IS Level 3
 </type>
@@ -37,9 +41,9 @@ Tracked
 </motion_type>
 
 <transporters>
-troopspace:4.0
 BattleArmorHandles - troopers:-1
-troopspace:4.0
+troopspace:4.0:omni
+cargobay:8.0:1:1::-1:0:omni
 </transporters>
 
 <cruiseMP>
@@ -63,7 +67,7 @@ troopspace:4.0
 </armor>
 
 <Body Equipment>
-ISDroneCarrierControlSystem:OMNI
+ISDroneCarrierControlSystem:OMNI:SIZE:6.0
 ISGuardianECMSuite:OMNI
 ISArrowIVHomingAmmo:OMNI
 ISArrowIVHomingAmmo:OMNI
@@ -74,6 +78,7 @@ ISCASE
 </Body Equipment>
 
 <Front Equipment>
+Light Machine Gun:OMNI
 </Front Equipment>
 
 <Right Equipment>
@@ -93,14 +98,6 @@ ISArrowIV:OMNI
 ISERMediumLaser:OMNI
 ISERMediumLaser:OMNI
 </Turret Equipment>
-
-<tonnage>
-90.0
-</tonnage>
-
-<baseChassisTurretWeight>
-3.5
-</baseChassisTurretWeight>
 
 <capabilities>
 The Ajax follows on the heels of the successful Manteuffel OmniVehicle. The Ajax is slow, only capable of attaining speeds up to 54 km/h. Since speed is not its defense, the designers gave the Ajax nineteen tons of armor. The room for all of this armor comes from the XL engine the Ajax uses for power.
@@ -137,3 +134,12 @@ TARGETING:Sync Tracker (39-42071)
 <source>
 TRO: 3067
 </source>
+
+<tonnage>
+90.0
+</tonnage>
+
+<baseChassisTurretWeight>
+3.5
+</baseChassisTurretWeight>
+

--- a/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Ajax Assault Tank D.blk
@@ -38,13 +38,7 @@ Tracked
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
-</transporters>
-
-<transporters>
 troopspace:4.0
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank D.blk
@@ -38,13 +38,7 @@ Tracked
 
 <transporters>
 troopspace:8.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
-</transporters>
-
-<transporters>
 troopspace:8.0
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3067 Unabridged/IS Vehicles/Manteuffel Attack Tank D.blk
@@ -3,7 +3,7 @@
 1
 </BlockVersion>
 
-# Write the version number just in case...
+##Write the version number just in case...
 <Version>
 MAM0
 </Version>
@@ -28,6 +28,10 @@ D
 3075
 </year>
 
+<originalBuildYear>
+3075
+</originalBuildYear>
+
 <type>
 IS Level 3
 </type>
@@ -37,9 +41,8 @@ Tracked
 </motion_type>
 
 <transporters>
-troopspace:8.0
 BattleArmorHandles - troopers:-1
-troopspace:8.0
+troopspace:8.0:omni
 </transporters>
 
 <cruiseMP>
@@ -97,6 +100,10 @@ Light PPC:OMNI
 Light PPC:OMNI
 </Turret Equipment>
 
+<source>
+TRO: 3067
+</source>
+
 <tonnage>
 70.0
 </tonnage>
@@ -105,6 +112,3 @@ Light PPC:OMNI
 1.5
 </baseChassisTurretWeight>
 
-<source>
-TRO: 3067
-</source>

--- a/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank A.blk
+++ b/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank A.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank B.blk
+++ b/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank B.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank C.blk
+++ b/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank C.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank Prime.blk
+++ b/megamek/data/mechfiles/vehicles/3067/3067 Clan Land/Hephaestus Scout Tank Prime.blk
@@ -38,9 +38,6 @@ Hover
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank A.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank A.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank B.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank B.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank C.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank C.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Comminus.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Comminus.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:6.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Dominus.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Dominus.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:6.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Infernus.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Infernus.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:6.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Invictus.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Invictus.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:6.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Prime.blk
+++ b/megamek/data/mechfiles/vehicles/3085u/Cutting Edge/Bolla Stealth Tank Prime.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3145/Marik/R10 Mechanized ICV (A).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Marik/R10 Mechanized ICV (A).blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3145/Marik/R10 Mechanized ICV (B).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Marik/R10 Mechanized ICV (B).blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/data/mechfiles/vehicles/3145/Marik/R10 Mechanized ICV (Prime).blk
+++ b/megamek/data/mechfiles/vehicles/3145/Marik/R10 Mechanized ICV (Prime).blk
@@ -37,11 +37,9 @@ Wheeled
 </motion_type>
 
 <transporters>
-troopspace:12.0
-</transporters>
-
-<transporters>
+troopspace:4.0
 BattleArmorHandles - troopers:-1
+troopspace:8.0:OMNI
 </transporters>
 
 <transporters>

--- a/megamek/data/mechfiles/vehicles/3145/NTNU/Bolla Stealth Tank D.blk
+++ b/megamek/data/mechfiles/vehicles/3145/NTNU/Bolla Stealth Tank D.blk
@@ -38,9 +38,6 @@ Wheeled
 
 <transporters>
 troopspace:4.0
-</transporters>
-
-<transporters>
 BattleArmorHandles - troopers:-1
 </transporters>
 

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -543,8 +543,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
                     MechTableModel mechModel = entry.getModel();
                     MechSummary mech = mechModel.getMechSummary(entry.getIdentifier());
                     boolean techLevelMatch = false;
-                    int type = gameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED) ?
-                            mech.getType(allowedYear) : mech.getType();
+                    int type = enableYearLimits ? mech.getType(allowedYear) : mech.getType();
                     for (int tl : nTypes) {
                         if (type == tl) {
                             techLevelMatch = true;

--- a/megamek/src/megamek/common/util/BuildingBlock.java
+++ b/megamek/src/megamek/common/util/BuildingBlock.java
@@ -720,7 +720,7 @@ public class BuildingBlock {
         // Otherwise it contains data.
         int start = findStartIndex(blockName);
         int end = findEndIndex(blockName);
-        return (end - start) > 1;
+        return (end - start) >= 1;
 
     }
 }


### PR DESCRIPTION
Fixes:
1) An off-by-one error I introduced, which prevents units with single bays (usually troop/infantry) from populating.
2) 55 or so BLK files with multiple `<transporters>` blocks that wouldn't have loaded correctly anyhow - only the first can be read.
3) Corrected several vehicles where multiple bays had been added, or the top bay was a correction for the lower bay, or (especially in the case of the Ajax D) bays, weapons, and equipment were incorrect.
4) Reverted the change that is causing MML to crash in the cache view, so that I could use it to correct 2 and 3 above.

Testing:
- loaded all of the vehicles with corrected bays in MML, with a sampling also loaded in MM, to verify all loadouts are now valid.
- loaded vehicles in MM and populated troop bays / BA handholds with various infantry and BA units:

<img width="484" alt="image" src="https://github.com/MegaMek/megamek/assets/22018319/62f0216c-47ec-4b06-aa92-ccc1a680f9e0">

close #4754 