### PR TITLE
Quirks: VTOL Rotor Arrangement Co-Axial/Dual Rotor

### DIFF
--- a/megamek/data/canonUnitQuirks.xml
+++ b/megamek/data/canonUnitQuirks.xml
@@ -18894,21 +18894,21 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<chassis>Balac Strike VTOL</chassis>
 		<model>all</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_coaxial</quirk>
 	</unit>
 
 	<unit>
 		<chassis>Bishop Transport VTOL</chassis>		
 		<unitType>VTOL</unitType>
 		<quirk>easy_pilot</quirk>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
 		<chassis>Cardinal Transport</chassis>
 		<model>all</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
@@ -18924,7 +18924,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<unitType>VTOL</unitType>
 		<quirk>non_standard</quirk>
 		<quirk>obsolete</quirk>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
@@ -18933,13 +18933,13 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<unitType>VTOL</unitType>
 		<quirk>non_standard</quirk>
 		<quirk>obsolete</quirk>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
 		<chassis>Crane Heavy Transport</chassis>		
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
@@ -18955,7 +18955,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<model>all</model>
 		<unitType>VTOL</unitType>
 		<quirk>imp_com</quirk>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_coaxial</quirk>
 	</unit>
 
 	<unit>
@@ -18981,16 +18981,16 @@ Example: You can define quirks that affect all units of a given chassis and then
 
 	<unit>
 		<chassis>Hawk Moth Gunship</chassis>
-		<model>'Vedwandlung'</model>
+		<model>'Verwandlung'</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_coaxial</quirk>
 	</unit>
 
 	<unit>
 		<chassis>Hawk Moth II Gunship</chassis>
 		<model>all</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_coaxial</quirk>
 	</unit>
 
 
@@ -18998,7 +18998,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<chassis>Kamakiri Attack VTOL</chassis>
 		<model>all</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 		<quirk>hard_pilot</quirk>
 	</unit>
 
@@ -19006,7 +19006,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<chassis>Karnov UR Transport</chassis>
 		<model>(Heavy Stealth)</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 		<quirk>non_standard</quirk>
 	</unit>
 
@@ -19014,7 +19014,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<chassis>Karnov UR Transport</chassis>
 		<model>all</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
@@ -19035,7 +19035,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<model>(Production)</model>
 		<unitType>VTOL</unitType>
 		<quirk>bad_rep_is</quirk>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 		<quirk>imp_sensors</quirk>
 	</unit>
 
@@ -19049,7 +19049,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 	<unit>
 		<chassis>Red Kite Attack VTOL</chassis>		
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 		<weaponQuirk>
 			<weaponQuirkName>ammo_feed_problems</weaponQuirkName>
 			<location>TU</location>
@@ -19097,7 +19097,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 	<unit>
 		<chassis>Skadi Swift Attack VTOL</chassis>		
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_dual</quirk>
 	</unit>
 
 	<unit>
@@ -19118,7 +19118,7 @@ Example: You can define quirks that affect all units of a given chassis and then
 		<chassis>Warrior Attack Helicopter</chassis>
 		<model>all</model>
 		<unitType>VTOL</unitType>
-		<quirk>vtol_rotor</quirk>
+		<quirk>vtol_rotor_coaxial</quirk>
 	</unit>
 
 	<unit>

--- a/megamek/data/mechfiles/vehicles/XTRs/Most Wanted/Hawk Moth Verwandlung.blk
+++ b/megamek/data/mechfiles/vehicles/XTRs/Most Wanted/Hawk Moth Verwandlung.blk
@@ -17,7 +17,7 @@ Hawk Moth Gunship
 </Name>
 
 <Model>
-'Vedwandlung'
+'Verwandlung'
 </Model>
 
 <mul id:>

--- a/megamek/i18n/megamek/common/options/messages.properties
+++ b/megamek/i18n/megamek/common/options/messages.properties
@@ -873,8 +873,10 @@ QuirksInfo.option.vestigial_hands_la.displayableName=Vestigial Hands (Left)
 QuirksInfo.option.vestigial_hands_la.description=Mek equipped with left hand capable of simplied actions,, but no hand crit slots. \nNot Implemented (BMM pg 86)
 QuirksInfo.option.vestigial_hands_ra.displayableName=Vestigial Hands (Right)
 QuirksInfo.option.vestigial_hands_ra.description=Mek equipped with right hand capable of simplied actions, but no hand crit slots. \nNot Implemented (BMM pg 86) 
-QuirksInfo.option.vtol_rotor.displayableName=VTOL Rotor Arrangement
-QuirksInfo.option.vtol_rotor.description=Not implemented because advanced vee move rules not implemented. (SO pg 196)
+QuirksInfo.option.vtol_rotor_coaxial.displayableName=VTOL Rotor Arrangement (Co-Axial)
+QuirksInfo.option.vtol_rotor_coaxial.description=Not implemented (CO pg 230)
+QuirksInfo.option.vtol_rotor_dual.displayableName=VTOL Rotor Arrangement (Dual Rotors)
+QuirksInfo.option.vtol_rotor_dual.description=Not implemented (CO pg 230)
 
 
 QuirksInfo.group.neg_quirks.displayableName=Negative Quirks

--- a/megamek/src/megamek/common/options/OptionsConstants.java
+++ b/megamek/src/megamek/common/options/OptionsConstants.java
@@ -74,7 +74,8 @@ public class OptionsConstants {
     // TODO Game Rules
     public static final String QUIRK_POS_VESTIGIAL_HANDS_LA = "vestigial_hands_la";
     public static final String QUIRK_POS_VESTIGIAL_HANDS_RA = "vestigial_hands_ra";
-    public static final String QUIRK_POS_VTOL_ROTOR = "vtol_rotor";
+    public static final String QUIRK_POS_VTOL_ROTOR_COAXIAL = "vtol_rotor_coaxial";
+    public static final String QUIRK_POS_VTOL_ROTOR_DUAL = "vtol_rotor_dual";
 
     public static final String QUIRK_WEAP_POS_ACCURATE = "accurate";
     public static final String QUIRK_WEAP_POS_IMP_COOLING = "imp_cooling";

--- a/megamek/src/megamek/common/options/Quirks.java
+++ b/megamek/src/megamek/common/options/Quirks.java
@@ -93,7 +93,8 @@ public class Quirks extends AbstractOptions {
         addOption(posQuirk, OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S, false);
         addOption(posQuirk, OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_LA, false);
         addOption(posQuirk, OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_RA, false);
-        addOption(posQuirk, OptionsConstants.QUIRK_POS_VTOL_ROTOR, false);
+        addOption(posQuirk, OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL, false);
+        addOption(posQuirk, OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL, false);
 
         
         //not yet implemented
@@ -221,7 +222,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_TRAILER_HITCH)
                     || qName.equals(OptionsConstants.QUIRK_NEG_LARGE_DROPPER)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_UNDERCARRIAGE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_GAS_HOG)
                     || qName.equals(OptionsConstants.QUIRK_POS_POWER_REVERSE)
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)) {
@@ -270,12 +272,10 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_TRAILER_HITCH)
                     || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_OVERHEAD_ARMS)
-                    || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_COMPACT)
                     || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_RA)
                     || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_LA)
                     || qName.equals(OptionsConstants.QUIRK_POS_PRO_ACTUATOR)
-
                     || qName.equals(OptionsConstants.QUIRK_NEG_ATMO_INSTABILITY)
                     || qName.equals(OptionsConstants.QUIRK_NEG_BAD_REP_CLAN)
                     || qName.equals(OptionsConstants.QUIRK_NEG_CRAMPED_COCKPIT)
@@ -300,7 +300,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNBALANCED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_LEGS)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_UNDERCARRIAGE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_FLAWED_COOLING)
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_GAS_HOG)
@@ -350,7 +351,6 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_REINFORCED_LEGS)
                     || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_OVERHEAD_ARMS)
-                    || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_COMPACT)
                     || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_RA)
                     || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_LA)
@@ -368,7 +368,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNBALANCED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_LEGS)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_UNDERCARRIAGE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_FLAWED_COOLING)
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_GAS_HOG)
@@ -443,7 +444,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNBALANCED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_LEGS)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_UNDERCARRIAGE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_FLAWED_COOLING)
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_HEAD_1)
@@ -455,7 +457,6 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_RUMBLE_SEAT)
                     || qName.equals(OptionsConstants.QUIRK_NEG_POOR_PERFORMANCE)
                     || qName.equals(OptionsConstants.QUIRK_POS_POWER_REVERSE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_COMPACT)
                     || qName.equals(OptionsConstants.QUIRK_POS_OVERHEAD_ARMS)   
                     || qName.equals(OptionsConstants.QUIRK_POS_PRO_ACTUATOR)
@@ -510,7 +511,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNBALANCED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_LEGS)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_UNDERCARRIAGE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_FLAWED_COOLING)
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNSTREAMLINED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_HEAD_1)
@@ -524,13 +526,10 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_DISTRACTING)
                     || qName.equals(OptionsConstants.QUIRK_NEG_POOR_SEALING)
                     || qName.equals(OptionsConstants.QUIRK_POS_POWER_REVERSE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_COMPACT)
                     || qName.equals(OptionsConstants.QUIRK_POS_PRO_ACTUATOR)
                     || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_LA)
-                    || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_RA)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_LA)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_RA)) {
+                    || qName.equals(OptionsConstants.QUIRK_POS_BATTLE_FIST_RA)) {
                 return false;
             }
             return true;
@@ -555,11 +554,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_OVERHEAD_ARMS)
                     || qName.equals(OptionsConstants.QUIRK_POS_LOW_PROFILE)
                     || qName.equals(OptionsConstants.QUIRK_POS_REINFORCED_LEGS)
-                    || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_SEARCHLIGHT)
                     || qName.equals(OptionsConstants.QUIRK_POS_TRAILER_HITCH)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_LA)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_RA)
                     || qName.equals(OptionsConstants.QUIRK_NEG_CRAMPED_COCKPIT)
                     || qName.equals(OptionsConstants.QUIRK_NEG_DIFFICULT_EJECT)
                     || qName.equals(OptionsConstants.QUIRK_NEG_EXP_ACTUATOR)
@@ -571,7 +567,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNBALANCED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_UNDERCARRIAGE)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_LEGS)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_FLAWED_COOLING)
                     || qName.equals(OptionsConstants.QUIRK_POS_RUMBLE_SEAT)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_HEAD_1)
@@ -610,12 +607,9 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_POS_OVERHEAD_ARMS)
                     || qName.equals(OptionsConstants.QUIRK_POS_PRO_ACTUATOR)
                     || qName.equals(OptionsConstants.QUIRK_POS_LOW_PROFILE)
-                    || qName.equals(OptionsConstants.QUIRK_POS_STABLE)
                     || qName.equals(OptionsConstants.QUIRK_POS_SEARCHLIGHT)
                     || qName.equals(OptionsConstants.QUIRK_POS_TRAILER_HITCH)
                     || qName.equals(OptionsConstants.QUIRK_POS_REINFORCED_LEGS)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_LA)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VESTIGIAL_HANDS_RA)
                     || qName.equals(OptionsConstants.QUIRK_NEG_EXP_ACTUATOR)
                     || qName.equals(OptionsConstants.QUIRK_NEG_FLAWED_COOLING)
                     || qName.equals(OptionsConstants.QUIRK_NEG_NO_ARMS)
@@ -624,7 +618,8 @@ public class Quirks extends AbstractOptions {
                     || qName.equals(OptionsConstants.QUIRK_NEG_LOW_ARMS)
                     || qName.equals(OptionsConstants.QUIRK_NEG_UNBALANCED)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_LEGS)
-                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_COAXIAL)
+                    || qName.equals(OptionsConstants.QUIRK_POS_VTOL_ROTOR_DUAL)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_HEAD_1)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_HEAD_2)
                     || qName.equals(OptionsConstants.QUIRK_NEG_WEAK_HEAD_3)


### PR DESCRIPTION
Replaces the single VTOL Rotor Arrangement quirk with the two variations Dual Rotor and Co-Ax of CO p.230 and adapts the canon unit quirks. There's also a small correction in a Hawk Moth and some duplicate lines (as noted by the IDE) in Quirks.java are removed.

Fixes #4756 