### PR TITLE
dont allow bot to deploy industrial mech in to water depth 2 or greater

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -270,8 +270,9 @@ public abstract class BotClient extends Client {
             if (transport != null && transport.isPermanentlyImmobilized(true)) {
                 boolean stackingViolation = null != Compute.stackingViolation(game, currentEntity.getId(),
                         transport.getPosition(), currentEntity.climbMode());
-                boolean unloadFatal = currentEntity.isBoardProhibited(getGame().getBoard().getType()) ||
-                        currentEntity.isLocationProhibited(transport.getPosition());
+                boolean unloadFatal = currentEntity.isBoardProhibited(getGame().getBoard().getType())
+                        || currentEntity.isLocationProhibited(transport.getPosition())
+                        || currentEntity.isLocationDeadly(transport.getPosition());
 
                 if (!stackingViolation && !unloadFatal) {
                     entitiesToUnload.add(currentEntity.getId());
@@ -628,7 +629,8 @@ public abstract class BotClient extends Client {
             for (int y = 0; y <= board.getHeight(); y++) {
                 Coords c = new Coords(x, y);
                 if (board.isLegalDeployment(c, deployed_ent)
-                    && !deployed_ent.isLocationProhibited(c)) {
+                    && !deployed_ent.isLocationProhibited(c)
+                    && !deployed_ent.isLocationDeadly(c)) {
                     validCoords.add(new RankedCoords(c, 0));
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -812,12 +812,12 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                                                    jumpLanding, step, logMsg);
                     break;
                 case Terrains.ICE:
-                    hazardValue += calcIceHazard(movingUnit, hex, step,
+                    hazardValue += calcIceHazard(movingUnit, hex, step, movePath,
                                                  jumpLanding, logMsg);
                     break;
                 case Terrains.WATER:
                     if (!hazards.contains(Terrains.ICE)) {
-                        hazardValue += calcWaterHazard(movingUnit, hex, step,
+                        hazardValue += calcWaterHazard(movingUnit, hex, step, movePath,
                                                        logMsg);
                     }
                     break;
@@ -885,7 +885,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         return 0;
     }
 
-    private double calcIceHazard(Entity movingUnit, Hex hex, MoveStep step, boolean jumpLanding,
+    private double calcIceHazard(Entity movingUnit, Hex hex, MoveStep step, MovePath movePath, boolean jumpLanding,
                                  StringBuilder logMsg) {
         logMsg.append("\n\tCalculating ice hazard:  ");
 
@@ -908,14 +908,14 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         logMsg.append("\n\t\tChance to break through ice: ")
               .append(LOG_PERCENT.format(breakthroughMod));
 
-        double hazard = calcWaterHazard(movingUnit, hex, step, logMsg) *
+        double hazard = calcWaterHazard(movingUnit, hex, step, movePath, logMsg) *
                         breakthroughMod;
         logMsg.append("\n\t\tHazard value (")
               .append(LOG_DECIMAL.format(hazard)).append(").");
         return hazard;
     }
 
-    private double calcWaterHazard(Entity movingUnit, Hex hex, MoveStep step,
+    private double calcWaterHazard(Entity movingUnit, Hex hex, MoveStep step, MovePath movePath,
                                    StringBuilder logMsg) {
         logMsg.append("\n\tCalculating water hazard:  ");
 
@@ -958,12 +958,14 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             return UNIT_DESTRUCTION_FACTOR;
         }
 
+        MoveStep lastStep = movePath.getLastStep();
         // Unsealed unit will drown.
         if (movingUnit instanceof Mech
                 && ((Mech) movingUnit).isIndustrial()
                 && !movingUnit.hasEnvironmentalSealing()
                 && (movingUnit.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE)
-                && hex.depth() >= 2) {
+                && hex.depth() >= 2
+                && step.equals(lastStep)) {
             logMsg.append("Industrial mechs drown too (1000).");
             return UNIT_DESTRUCTION_FACTOR;
         }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -964,10 +964,11 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 && ((Mech) movingUnit).isIndustrial()
                 && !movingUnit.hasEnvironmentalSealing()
                 && (movingUnit.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE)
-                && hex.depth() >= 2
+                && hex.depth() >= 1
                 && step.equals(lastStep)) {
-            logMsg.append("Industrial mechs drown too (1000).");
-            return UNIT_DESTRUCTION_FACTOR;
+            double destructionFactor = hex.depth() >=2 ? UNIT_DESTRUCTION_FACTOR : UNIT_DESTRUCTION_FACTOR * 0.5d;
+            logMsg.append(String.format("Industrial mechs drown too (%f).", destructionFactor));
+            return destructionFactor;
         }
 
         // Find the submerged locations.

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -959,7 +959,11 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         }
 
         // Unsealed unit will drown.
-        if (movingUnit instanceof Mech && ((Mech) movingUnit).isIndustrial()) {
+        if (movingUnit instanceof Mech
+                && ((Mech) movingUnit).isIndustrial()
+                && !movingUnit.hasEnvironmentalSealing()
+                && (movingUnit.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE)
+                && hex.depth() >= 2) {
             logMsg.append("Industrial mechs drown too (1000).");
             return UNIT_DESTRUCTION_FACTOR;
         }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1966,8 +1966,9 @@ public class Princess extends BotClient {
                 
                 // this condition is a simple check that we're not unloading infantry into deep space
                 // or into lava or some other such nonsense
-                boolean unloadFatal = loadedEntity.isBoardProhibited(getGame().getBoard().getType()) ||
-                        loadedEntity.isLocationProhibited(pathEndpoint);
+                boolean unloadFatal = loadedEntity.isBoardProhibited(getGame().getBoard().getType())
+                        || loadedEntity.isLocationProhibited(pathEndpoint)
+                        || loadedEntity.isLocationDeadly(pathEndpoint);
                 
                 // Unloading a unit may sometimes cause a stacking violation, take that into account when planning
                 boolean unloadIllegal = Compute.stackingViolation(getGame(), loadedEntity, pathEndpoint, movingEntity,

--- a/megamek/src/megamek/client/bot/princess/UnitBehavior.java
+++ b/megamek/src/megamek/client/bot/princess/UnitBehavior.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import megamek.common.Entity;
+import megamek.common.Mech;
 
 public class UnitBehavior {
     public enum BehaviorType {
@@ -30,7 +31,7 @@ public class UnitBehavior {
      */
     private BehaviorType calculateUnitBehavior(Entity entity, Princess owner) {
         BehaviorSettings botSettings = owner.getBehaviorSettings();
-        
+
         if (botSettings.isForcedWithdrawal() && entity.isCrippled()) {
             if (owner.getClusterTracker().getDestinationCoords(entity, owner.getHomeEdge(entity), true).isEmpty()) {
                 return BehaviorType.NoPathToDestination;
@@ -43,6 +44,12 @@ public class UnitBehavior {
             }
             
             return BehaviorType.MoveToDestination;
+        } else if ((entity instanceof Mech) && ((Mech) entity).isJustMovedIntoIndustrialKillingWater()) {
+            if (owner.getClusterTracker().getDestinationCoords(entity, owner.getHomeEdge(entity), true).isEmpty()) {
+                return BehaviorType.NoPathToDestination;
+            }
+
+            return BehaviorType.ForcedWithdrawal;
         } else {
             // if we can't see anyone, move to contact
             if (!entity.getGame().getAllEnemyEntities(entity).hasNext()) {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1822,6 +1822,17 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 }
             }
         }
+
+        for (int i = 0; i < drawHeight; i++) {
+            for (int j = 0; j < drawWidth; j++) {
+                Coords c = new Coords(j + drawX, i + drawY);
+                if (board.isLegalDeployment(c, en_Deployer) &&
+                        !en_Deployer.isLocationProhibited(c) &&
+                        en_Deployer.isLocationDeadly(c)) {
+                    drawHexBorder(g, getHexLocation(c), GUIP.getWarningColor());
+                }
+            }
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3019,6 +3019,27 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
+     * Returns true if the specified hex contains some sort of deadly
+     * terrain.
+     */
+    public boolean isLocationDeadly(Coords c) {
+        return isLocationDeadly(c, elevation);
+    }
+
+    /**
+     * Returns true if the specified hex contains some sort of deadly
+     * terrain if the Entity is at the specified elevation.  Elevation generally
+     * only matters for units like WiGEs or VTOLs.
+     *
+     * @param c
+     * @param currElevation
+     * @return
+     */
+    public boolean isLocationDeadly(Coords c, int currElevation) {
+        return false;
+    }
+
+    /**
      * Returns the name of the type of movement used.
      */
     public abstract String getMovementString(EntityMovementType mtype);

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3023,19 +3023,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * terrain.
      */
     public boolean isLocationDeadly(Coords c) {
-        return isLocationDeadly(c, elevation);
-    }
-
-    /**
-     * Returns true if the specified hex contains some sort of deadly
-     * terrain if the Entity is at the specified elevation.  Elevation generally
-     * only matters for units like WiGEs or VTOLs.
-     *
-     * @param c
-     * @param currElevation
-     * @return
-     */
-    public boolean isLocationDeadly(Coords c, int currElevation) {
         return false;
     }
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5397,6 +5397,17 @@ public abstract class Mech extends Entity {
     }
 
     /**
+     * set if this mech should die at the end of turn because it's an IndustrialMech
+     * without environmental sealing that moved into water last round and stayed
+      * there?
+     *
+     * @param moved
+     */
+    public void setShouldDieAtEndOfTurnBecauseOfWater(boolean moved) {
+        shouldDieAtEndOfTurnBecauseOfWater = moved;
+    }
+
+    /**
      * Set if this Mech's ICE Engine is stalled or not should only be used for
      * industrial mechs carrying an ICE engine
      *

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4130,6 +4130,20 @@ public abstract class Mech extends Entity {
                 || (hex.terrainLevel(Terrains.JUNGLE) > 2);
     }
 
+    @Override
+    public boolean isLocationDeadly(Coords c, int currElevation) {
+        Hex hex = game.getBoard().getHex(c);
+
+        if (this.isIndustrial()
+                && !this.hasEnvironmentalSealing()
+                && (this.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE)
+                && hex.terrainLevel(Terrains.WATER) >= 2) {
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * Get an '.mtf' file representation of the mech. This string can be
      * directly written to disk as a file and later loaded by the MtfFile class.

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4131,7 +4131,7 @@ public abstract class Mech extends Entity {
     }
 
     @Override
-    public boolean isLocationDeadly(Coords c, int currElevation) {
+    public boolean isLocationDeadly(Coords c) {
         Hex hex = game.getBoard().getHex(c);
 
         if (this.isIndustrial()

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -9143,6 +9143,7 @@ public class GameManager implements IGameManager {
 
             } else {
                 ((Mech) entity).setJustMovedIntoIndustrialKillingWater(false);
+                ((Mech) entity).setShouldDieAtEndOfTurnBecauseOfWater(false);
             }
         }
     }


### PR DESCRIPTION
- dont allow bot to deploy industrial mech in to water depth 2 or greater
- add isLocationDeadly() for locations that can be delployed or moved into, but being in them is deadly.  So it is a bad idea for the bot to delploy to them.
- highlight deadly deployment positions for players industrial mech in to water depth 2 or greater
- princess try to get out of water when flagged to die
- dont destroy unit if they get out of water

![image](https://github.com/MegaMek/megamek/assets/116095479/5c5cdb40-f2c0-4fe1-a1f3-1379521dd082)
![image](https://github.com/MegaMek/megamek/assets/116095479/6bdfcda7-81bc-4546-b151-8c47194ecabc)


fixes #4550