### PR TITLE
safer movement for princess

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -235,8 +235,8 @@ public class PathEnumerator {
                 paths.add(new MovePath(game, mover));
             } else { // Non-Aero movement
                 // TODO: Will this cause Princess to never use MASC?
-                LongestPathFinder lpf = LongestPathFinder
-                        .newInstanceOfLongestPath(mover.getRunMPwithoutMASC(),
+                int maxMove = Math.min(mover.getRunMPwithoutMASC(), mover.getRunMP(MPCalculationSetting.NO_GRAVITY));
+                LongestPathFinder lpf = LongestPathFinder.newInstanceOfLongestPath(maxMove,
                                 MoveStepType.FORWARDS, getGame());
                 lpf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
                 lpf.run(new MovePath(game, mover));

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1239,8 +1239,8 @@ public class Princess extends BotClient {
 
             final long startTime = System.currentTimeMillis();
             getPathRanker(entity).initUnitTurn(entity, getGame());
-            final double fallTolerance =
-                    getBehaviorSettings().getFallShameIndex() / 10d;
+            // fall tolerance range between 0.50 and 1.0
+            final double fallTolerance = getBehaviorSettings().getFallShameIndex() / 20d + 0.50d;
                        
             final List<RankedPath> rankedpaths = getPathRanker(entity).rankPaths(paths,
                     getGame(), getMaxWeaponRange(entity), fallTolerance, getEnemyEntities(),


### PR DESCRIPTION
- adjust fall tolerance range to 0.50 and 1.0 instead of 0.0 to 1.0 for PSRs.    
  Behavior -> Highway Menace ---- Never takes a risk. 

- when calculating fallback paths use lower of getRunMPwithoutMASC and getRunMP(MPCalculationSetting.NO_GRAVITY) 
  so that when there is low gravity fewer extended moves will be used.

- these should lower the chance for having excessive PSR movement failures when there is low gravity.

fixes #2698


