### PR TITLE
MegaMek command-line handling

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4163,8 +4163,14 @@ MegaMek.Help.Mail=Mail service. Default is no mail
 MegaMek.Help.SaveGame=Open the named saved game. Default is no saved game 
 MegaMek.Help.PlayerName=Name client gets in game. Default is from preferences
 MegaMek.Help.Server=Name or URL of the server to join. Default is from preferences or '%s'
-MegaMek.Help.RatgenEdit=Open the RAT Generator Editor gui
-MegaMek.Help.DataDir=Use alternate source for data files. Default is '%s'
+MegaMek.Help.RatgenEdit=Open the RAT Generator Editor GUI
+MegaMek.Help.DataDir=Use an alternative directory for data files. Default is '%s'
+MegaMek.Help.EquipmentDB=Create an equipment database csv export
+MegaMek.Help.EquipmentExtendedDB=Create an extended equipment database csv export
+MegaMek.Help.UnitExport=Create a unit database csv export
+MegaMek.Help.UnitValidator=Run the unit validator tool
+MegaMek.Help.OfficialUnitList=Create the canon unit list
+MegaMek.Help.UnitAlphastrikeConversion=Create a csv export of alpha strike converted units
 MegaMek.ServerStarted=Server Started at %s:%d : Password %s
 
 #Overheating Effects

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -15,7 +15,6 @@
  */
 package megamek;
 
-import megamek.client.ui.Messages;
 import megamek.client.ui.preferences.SuitePreferences;
 import megamek.client.ui.swing.ButtonOrderPreferences;
 import megamek.client.ui.swing.MegaMekGUI;
@@ -31,7 +30,9 @@ import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.net.URL;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
@@ -73,6 +74,7 @@ public class MegaMek {
         MegaMekCommandLineParser parser = new MegaMekCommandLineParser(args);
 
         try {
+            // Parse the command line arguments and deal with them, if they are about data export or help
             parser.parse();
 
             String[] restArgs = parser.getRestArgs();
@@ -114,41 +116,6 @@ public class MegaMek {
     public static void initializeLogging(final String originProject) {
         final String initialMessage = getUnderlyingInformation(originProject);
         LogManager.getLogger().info(initialMessage);
-        handleLegacyLogging();
-        System.out.println(initialMessage);
-    }
-
-    /**
-     * This function redirects the standard error and output streams... It's a legacy method that
-     * is currently being used as a fallback while migrating the last of our legacy logging and
-     * testing out the new global exception handling
-     */
-    @Deprecated
-    public static void handleLegacyLogging() {
-        try {
-            LogManager.getLogger().info("Redirecting System.out, System.err, and Throwable::printStackTrace output to legacy.log");
-            File logDir = new File("logs");
-            if (!logDir.exists()) {
-                logDir.mkdir();
-            }
-
-            File file = new File(PreferenceManager.getClientPreferences().getLogDirectory()
-                    + File.separator + "legacy.log");
-            if (file.exists()) {
-                try (PrintWriter writer = new PrintWriter(file)) {
-                    writer.print("");
-                } catch (Exception ex) {
-                    LogManager.getLogger().error("Failed to write to legacy.log", ex);
-                }
-            }
-
-            // Note: these are not closed on purpose
-            PrintStream ps = new PrintStream(new BufferedOutputStream(new FileOutputStream(file, true), 64));
-            System.setOut(ps);
-            System.setErr(ps);
-        } catch (Exception ex) {
-            LogManager.getLogger().error("Unable to redirect output to legacy.log", ex);
-        }
     }
 
     public static SuitePreferences getMMPreferences() {

--- a/megamek/src/megamek/common/commandline/ClientServerCommandLineParser.java
+++ b/megamek/src/megamek/common/commandline/ClientServerCommandLineParser.java
@@ -119,7 +119,7 @@ public class ClientServerCommandLineParser extends AbstractCommandLineParser {
                     try {
                         switch (ClientServerCommandLineFlag.parseFromString(value)) {
                             case HELP:
-                                LogManager.getLogger().info(help());
+                                System.out.println(help());
                                 System.exit(0);
                             case PORT:
                                 nextToken();

--- a/megamek/src/megamek/common/commandline/MegaMekCommandLineFlag.java
+++ b/megamek/src/megamek/common/commandline/MegaMekCommandLineFlag.java
@@ -29,7 +29,7 @@ public enum MegaMekCommandLineFlag {
     CLIENT(Messages.getString("MegaMek.Help.Client")),
     QUICK(Messages.getFormattedString("MegaMek.Help.Quick", MMConstants.QUICKSAVE_FILE)),
     // exporters and utilities
-    EQDB("MegaMek.Help.EquipmentDB"),
+    EQDB(Messages.getString("MegaMek.Help.EquipmentDB")),
     EQEDB(Messages.getString("MegaMek.Help.EquipmentExtendedDB")),
     EXPORT(Messages.getString("MegaMek.Help.UnitExport")),
     VALIDATE(Messages.getString("MegaMek.Help.UnitValidator")),

--- a/megamek/src/megamek/common/commandline/MegaMekCommandLineParser.java
+++ b/megamek/src/megamek/common/commandline/MegaMekCommandLineParser.java
@@ -91,7 +91,7 @@ public class MegaMekCommandLineParser extends AbstractCommandLineParser {
             try {
                 switch (MegaMekCommandLineFlag.parseFromString(tokenVal)) {
                     case HELP:
-                        LogManager.getLogger().info(help());
+                        System.out.println(help());
                         System.exit(0);
                     case EQDB:
                         processEquipmentDb();


### PR DESCRIPTION
This PR makes megamek print command line help messages to the console instead of the log, removes legacy logging as it's no longer necessary and adds some missing help texts. It seems to me that command line commands do work, at least eqdb and oul, so I'll make this 

Fixes #4690 