### PR TITLE
Minor issues

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -182,7 +182,7 @@ class LobbyMekCellFormatter {
             if (entity.isShutDown()) {
                 result.append(DOT_SPACER);
                 result.append(guiScaledFontHTML(GUIP.getWarningColor()));
-                result.append("\u23FC ").append(Messages.getString("ChatLounge.shutdown"));
+                result.append(WARNING_SIGN).append(Messages.getString("ChatLounge.shutdown"));
                 result.append("</FONT>");
             }
         }

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -84,7 +84,7 @@ public class TestSupportVehicle extends TestEntity {
         }
 
         /**
-         * Finds the enum value corresponding to a support vehicle based on movement mode.
+         * Finds the enum value corresponding to a support vehicle.
          *
          * @param entity The support vehicle
          * @return       The support vehicle type, or {@code null} if the entity's movement type is not
@@ -92,6 +92,10 @@ public class TestSupportVehicle extends TestEntity {
          */
         public static @Nullable
         SVType getVehicleType(Entity entity) {
+            // When grounded, FWS revert to wheeled movement mode; must be independent of this
+            if (entity instanceof FixedWingSupport) {
+                return FIXED_WING;
+            }
             switch (entity.getMovementMode()) {
                 case AIRSHIP:
                     return AIRSHIP;


### PR DESCRIPTION
This changes the unicode icon for shutdown in the lobby. The former was not displayed for me, even in a browser on a unicode site, so my guess is it's not available for most people on Windows. The new one is the ! in triangle that is already used in the lobby. I hope it displays for most people.

Also, this prevents fixed wing support from being shown as invalid in the lobby when they have the STOL chassis mod and are set to altitude 0 (the reason being that they report wheeled as move mode when grounded).