### PR TITLE
Fix 4694: Silver Bullet Gauss Rifle damage incorrect on ASFs

### DIFF
--- a/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
@@ -27,6 +27,9 @@ import megamek.server.GameManager;
 /**
  * @author Andrew Hunter
  * @since Oct 15, 2004
+ *
+ * Note: The AV values declared here are then processed by the LBXHandler to arrive at the correct
+ * ASF AV values at runtime.  This seems less janky than writing a new handler, but only just.
  */
 public class ISSilverBulletGauss extends GaussWeapon {
     private static final long serialVersionUID = -6873790245999096707L;
@@ -50,9 +53,9 @@ public class ISSilverBulletGauss extends GaussWeapon {
         criticals = 7;
         bv = 198;
         cost = 350000;
-        shortAV = 9;
-        medAV = 9;
-        longAV = 9;
+        shortAV = 15; // Due to LBXHandler
+        medAV = 15;   // Due to LBXHandler
+        longAV = 15;  // Due to LBXHandler
         maxRange = RANGE_LONG;
         ammoType = AmmoType.T_SBGAUSS;
         // SB Gauss rifles can neither benefit from a targeting computer nor
@@ -83,7 +86,7 @@ public class ISSilverBulletGauss extends GaussWeapon {
                                               GameManager manager) {
         return new LBXHandler(toHit, waa, game, manager);
     }
-    
+
     @Override
     public double getBattleForceDamage(int range) {
         double damage = 0;
@@ -95,7 +98,7 @@ public class ISSilverBulletGauss extends GaussWeapon {
             }
         }
         return damage;
-    }    
+    }
 
     @Override
     public int getBattleForceClass() {


### PR DESCRIPTION
It turns out that we were doing the wrong thing by doing the right thing, twice.
The SBGR Attack Values were set to '9', as in the rulebook, but then we were handling it as an LBX weapon.
The LBXHandler calculates ASF Attack Value at runtime by multiplying the base AV by 0.6.  This was giving us 5 damage, instead of 9, the correct value.

Fix is to set the SBGR AV to 15 at all ranges; then the LBX Handler will give us the correct value in the end.
This is how our LBX weapons work currently as well.