### PR TITLE
[POC] Proof of Concept of event-based kill assignment

### DIFF
--- a/megamek/src/megamek/client/bot/ui/swing/BotGUI.java
+++ b/megamek/src/megamek/client/bot/ui/swing/BotGUI.java
@@ -124,7 +124,7 @@ public class BotGUI implements GameListener {
     }
     
     @Override
-    public void gameClientFeedbackRequest(GameCFREvent evt) {
+    public void gameClientFeedbackRequest(GameCFREvent e) {
 
     }
 
@@ -132,4 +132,10 @@ public class BotGUI implements GameListener {
     public void gameVictory(GameVictoryEvent e) {       
 
     }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent e){
+        // Do nothing
+    }
+
 }

--- a/megamek/src/megamek/client/ui/swing/DeployMinefieldDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeployMinefieldDisplay.java
@@ -20,6 +20,7 @@ import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.common.*;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
@@ -413,6 +414,11 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
         if (clientgui.getClient().getGame().getPhase().isDeployMinefields()) {
             setStatusBarText(Messages.getString("DeployMinefieldDisplay.waitingForDeploymentPhase"));
         }
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     //

--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -27,6 +27,7 @@ import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.common.*;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.options.OptionsConstants;
 import org.apache.logging.log4j.LogManager;
 
@@ -441,6 +442,11 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
         if (clientgui.getClient().getGame().getPhase().isDeployment()) {
             setStatusBarText(Messages.getString("DeploymentDisplay.waitingForDeploymentPhase"));
         }
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     //

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -27,6 +27,7 @@ import megamek.common.actions.*;
 import megamek.common.enums.AimingMode;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.FiringSolution;
 import megamek.common.weapons.Weapon;
@@ -2457,6 +2458,12 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
     public void itemStateChanged(ItemEvent ev) {
 
     }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
+    }
+
 
     // board view listener
     @Override

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -38,6 +38,7 @@ import megamek.common.actions.RamAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.options.AbstractOptions;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
@@ -5223,6 +5224,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
             updateLoadButtons();
             butDone.setEnabled(true);
         }
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PhysicalDisplay.java
@@ -23,6 +23,7 @@ import megamek.common.actions.*;
 import megamek.common.enums.AimingMode;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.options.OptionsConstants;
 import org.apache.logging.log4j.LogManager;
 
@@ -1479,6 +1480,11 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         if (clientgui.getClient().getGame().getPhase().isPhysical()) {
             setStatusBarText(Messages.getString("PhysicalDisplay.waitingForPhysicalAttackPhase"));
         }
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     //

--- a/megamek/src/megamek/client/ui/swing/PrephaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PrephaseDisplay.java
@@ -44,6 +44,7 @@ import megamek.common.enums.GamePhase;
 import megamek.common.event.GameEntityChangeEvent;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import org.apache.logging.log4j.LogManager;
 
 import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
@@ -507,6 +508,11 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements
         }
 
         refreshButtons();
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     // ActionListener

--- a/megamek/src/megamek/client/ui/swing/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ReportDisplay.java
@@ -18,6 +18,7 @@ import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
@@ -249,6 +250,11 @@ public class ReportDisplay extends StatusBarPhaseDisplay  {
         }
 
         clientgui.bingMyTurn();
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/SelectArtyAutoHitHexDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/SelectArtyAutoHitHexDisplay.java
@@ -24,6 +24,7 @@ import megamek.common.*;
 import megamek.common.containers.PlayerIDandList;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.options.OptionsConstants;
 
 import java.awt.event.ActionEvent;
@@ -314,6 +315,11 @@ public class SelectArtyAutoHitHexDisplay extends StatusBarPhaseDisplay {
         if (clientgui.getClient().getGame().getPhase().isSetArtilleryAutohitHexes()) {
             setStatusBarText(Messages.getString("SelectArtyAutoHitHexDisplay.waitingMinefieldPhase"));
         }
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     //

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -28,6 +28,7 @@ import megamek.common.enums.AimingMode;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.FiringSolution;
 import megamek.common.weapons.Weapon;
@@ -1530,6 +1531,11 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements
         clientgui.getClient().getGame().removeGameListener(this);
         clientgui.getBoardView().removeBoardViewListener(this);
         clientgui.getUnitDisplay().wPan.weaponList.removeListSelectionListener(this);
+    }
+
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1662,6 +1662,11 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         // Do nothing
     }
 
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent evt){
+        // Do nothing
+    }
+
     private ActionListener lobbyListener = new ActionListener() {
         @Override
         public void actionPerformed(ActionEvent ev) {

--- a/megamek/src/megamek/common/event/GameListener.java
+++ b/megamek/src/megamek/common/event/GameListener.java
@@ -65,4 +65,6 @@ public interface GameListener extends java.util.EventListener {
     void gameClientFeedbackRequest(GameCFREvent e);
     
     void gameVictory(GameVictoryEvent e);
+
+    void gameUnitDied(GameUnitDiedEvent e);
 }

--- a/megamek/src/megamek/common/event/GameListenerAdapter.java
+++ b/megamek/src/megamek/common/event/GameListenerAdapter.java
@@ -103,4 +103,7 @@ public class GameListenerAdapter implements GameListener {
     public void gameVictory(GameVictoryEvent e) {        
     }    
 
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent e){
+    }
 }

--- a/megamek/src/megamek/common/event/GameUnitDiedEvent.java
+++ b/megamek/src/megamek/common/event/GameUnitDiedEvent.java
@@ -22,9 +22,10 @@ import java.util.Hashtable;
 import java.util.Vector;
 
 /**
- * An event that is fired at the end of the victory phase, before the game state
- * is reset. It can be used to retrieve information from the game before the
- * state is reset and the lounge phase begins.
+ * An event that we will fire when an entity is destroyed or otherwise dies;
+ * attackers will register listeners temporarily, allowing us to determine if
+ * the current death occurred because of a specific units action - and give that
+ * unit credit for the kill
  *
  * @see Game#end(int, int)
  * @see GameListener
@@ -33,119 +34,30 @@ public class GameUnitDiedEvent extends GameEvent {
     private static final long serialVersionUID = -8470655646019563063L;
 
     /**
-     * Track game entities
+     * Track game entity that just died
      */
-    private Vector<Entity> entities = new Vector<>();
-    private Hashtable<Integer, Entity> entityIds = new Hashtable<>();
-
-    /**
-     * Track entities removed from the game (probably by death)
-     */
-    Vector<Entity> vOutOfGame = new Vector<>();
+    private Entity entity;
+    private int condition;
 
     /**
      * @param source event source
+     * @param game the game in question
+     * @param entity that died
      */
     @SuppressWarnings("unchecked")
-    public GameUnitDiedEvent(Object source, Game game) {
+    public GameUnitDiedEvent(Object source, Game game, Entity entity, int condition) {
         super(source);
-        for (Entity entity : game.getEntitiesVector()) {
-            entities.add(entity);
-            entityIds.put(entity.getId(), entity);
-        }
-
-        vOutOfGame = (Vector<Entity>) game.getOutOfGameEntitiesVector().clone();
-        for (Entity entity : vOutOfGame) {
-            entityIds.put(entity.getId(), entity);
-        }
+        this.entity = entity;
+        this.condition = condition;
     }
 
     @Override
     public void fireEvent(GameListener gl) {
-        gl.gameVictory(this);
+        gl.gameUnitDied(this);
     }
 
     @Override
     public String getEventName() {
-        return "Game Victory";
-    }
-
-    /**
-     * @return an enumeration of all the entities in the game.
-     */
-    public Enumeration<Entity> getEntities() {
-        return entities.elements();
-    }
-
-    /**
-     * @return the entity with the given id number, if any.
-     */
-    public Entity getEntity(int id) {
-        return entityIds.get(id);
-    }
-
-    /**
-     * @return an enumeration of salvageable entities.
-     */
-    // TODO: Correctly implement "Captured" Entities
-    public Enumeration<Entity> getGraveyardEntities() {
-        Vector<Entity> graveyard = new Vector<>();
-
-        for (Entity entity : vOutOfGame) {
-            if ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_SALVAGEABLE)
-                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_CAPTURED)
-                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_EJECTED)) {
-                graveyard.addElement(entity);
-            }
-        }
-
-        return graveyard.elements();
-    }
-
-    /**
-     * @return an enumeration of wrecked entities.
-     */
-    public Enumeration<Entity> getWreckedEntities() {
-        Vector<Entity> wrecks = new Vector<>();
-        for (Entity entity : vOutOfGame) {
-            if ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_SALVAGEABLE)
-                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_EJECTED)
-                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_CAPTURED)) {
-                wrecks.addElement(entity);
-            }
-        }
-
-        return wrecks.elements();
-    }
-
-    /**
-     * Returns an enumeration of entities that have retreated
-     */
-    public Enumeration<Entity> getRetreatedEntities() {
-        Vector<Entity> sanctuary = new Vector<>();
-
-        for (Entity entity : vOutOfGame) {
-            if ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_IN_RETREAT)
-                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_PUSHED)) {
-                sanctuary.addElement(entity);
-            }
-        }
-
-        return sanctuary.elements();
-    }
-
-    /**
-     * Returns an enumeration of entities that were utterly destroyed
-     */
-    public Enumeration<Entity> getDevastatedEntities() {
-        Vector<Entity> smithereens = new Vector<>();
-
-        for (Entity entity : vOutOfGame) {
-            if (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_DEVASTATED) {
-                smithereens.addElement(entity);
-            }
-        }
-
-        return smithereens.elements();
+        return "Unit Died";
     }
 }

--- a/megamek/src/megamek/common/event/GameUnitDiedEvent.java
+++ b/megamek/src/megamek/common/event/GameUnitDiedEvent.java
@@ -16,6 +16,7 @@ package megamek.common.event;
 import megamek.common.Entity;
 import megamek.common.Game;
 import megamek.common.IEntityRemovalConditions;
+import megamek.server.GameManager;
 
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -36,8 +37,10 @@ public class GameUnitDiedEvent extends GameEvent {
     /**
      * Track game entity that just died
      */
-    private Entity entity;
-    private int condition;
+    private final Entity entity;
+    private final Game game;
+    private final int damage;
+    private final String reason;
 
     /**
      * @param source event source
@@ -45,10 +48,12 @@ public class GameUnitDiedEvent extends GameEvent {
      * @param entity that died
      */
     @SuppressWarnings("unchecked")
-    public GameUnitDiedEvent(Object source, Game game, Entity entity, int condition) {
+    public GameUnitDiedEvent(Object source, Game game, Entity entity, int damage, String reason) {
         super(source);
         this.entity = entity;
-        this.condition = condition;
+        this.game = game;
+        this.damage = damage;
+        this.reason = reason;
     }
 
     @Override
@@ -60,4 +65,12 @@ public class GameUnitDiedEvent extends GameEvent {
     public String getEventName() {
         return "Unit Died";
     }
+
+    public Entity getEntity(){
+        return this.entity;
+    }
+
+    public Game getGame() { return this.game; }
+    public int getDamage() { return this.damage; }
+    public String getReason() { return this.reason; }
 }

--- a/megamek/src/megamek/common/event/GameUnitDiedEvent.java
+++ b/megamek/src/megamek/common/event/GameUnitDiedEvent.java
@@ -1,0 +1,151 @@
+/*
+ * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+package megamek.common.event;
+
+import megamek.common.Entity;
+import megamek.common.Game;
+import megamek.common.IEntityRemovalConditions;
+
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Vector;
+
+/**
+ * An event that is fired at the end of the victory phase, before the game state
+ * is reset. It can be used to retrieve information from the game before the
+ * state is reset and the lounge phase begins.
+ *
+ * @see Game#end(int, int)
+ * @see GameListener
+ */
+public class GameUnitDiedEvent extends GameEvent {
+    private static final long serialVersionUID = -8470655646019563063L;
+
+    /**
+     * Track game entities
+     */
+    private Vector<Entity> entities = new Vector<>();
+    private Hashtable<Integer, Entity> entityIds = new Hashtable<>();
+
+    /**
+     * Track entities removed from the game (probably by death)
+     */
+    Vector<Entity> vOutOfGame = new Vector<>();
+
+    /**
+     * @param source event source
+     */
+    @SuppressWarnings("unchecked")
+    public GameUnitDiedEvent(Object source, Game game) {
+        super(source);
+        for (Entity entity : game.getEntitiesVector()) {
+            entities.add(entity);
+            entityIds.put(entity.getId(), entity);
+        }
+
+        vOutOfGame = (Vector<Entity>) game.getOutOfGameEntitiesVector().clone();
+        for (Entity entity : vOutOfGame) {
+            entityIds.put(entity.getId(), entity);
+        }
+    }
+
+    @Override
+    public void fireEvent(GameListener gl) {
+        gl.gameVictory(this);
+    }
+
+    @Override
+    public String getEventName() {
+        return "Game Victory";
+    }
+
+    /**
+     * @return an enumeration of all the entities in the game.
+     */
+    public Enumeration<Entity> getEntities() {
+        return entities.elements();
+    }
+
+    /**
+     * @return the entity with the given id number, if any.
+     */
+    public Entity getEntity(int id) {
+        return entityIds.get(id);
+    }
+
+    /**
+     * @return an enumeration of salvageable entities.
+     */
+    // TODO: Correctly implement "Captured" Entities
+    public Enumeration<Entity> getGraveyardEntities() {
+        Vector<Entity> graveyard = new Vector<>();
+
+        for (Entity entity : vOutOfGame) {
+            if ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_SALVAGEABLE)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_CAPTURED)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_EJECTED)) {
+                graveyard.addElement(entity);
+            }
+        }
+
+        return graveyard.elements();
+    }
+
+    /**
+     * @return an enumeration of wrecked entities.
+     */
+    public Enumeration<Entity> getWreckedEntities() {
+        Vector<Entity> wrecks = new Vector<>();
+        for (Entity entity : vOutOfGame) {
+            if ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_SALVAGEABLE)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_EJECTED)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_CAPTURED)) {
+                wrecks.addElement(entity);
+            }
+        }
+
+        return wrecks.elements();
+    }
+
+    /**
+     * Returns an enumeration of entities that have retreated
+     */
+    public Enumeration<Entity> getRetreatedEntities() {
+        Vector<Entity> sanctuary = new Vector<>();
+
+        for (Entity entity : vOutOfGame) {
+            if ((entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_IN_RETREAT)
+                    || (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_PUSHED)) {
+                sanctuary.addElement(entity);
+            }
+        }
+
+        return sanctuary.elements();
+    }
+
+    /**
+     * Returns an enumeration of entities that were utterly destroyed
+     */
+    public Enumeration<Entity> getDevastatedEntities() {
+        Vector<Entity> smithereens = new Vector<>();
+
+        for (Entity entity : vOutOfGame) {
+            if (entity.getRemovalCondition() == IEntityRemovalConditions.REMOVE_DEVASTATED) {
+                smithereens.addElement(entity);
+            }
+        }
+
+        return smithereens.elements();
+    }
+}

--- a/megamek/src/megamek/common/event/GameUnitDiedListenerAdapter.java
+++ b/megamek/src/megamek/common/event/GameUnitDiedListenerAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+
+package megamek.common.event;
+import megamek.common.Entity;
+
+/**
+ * This adapter class overrides just the GameUnitDiedEvent handling of the
+ * by the <code>GameListenerAdapter</code> class.
+ *
+ * @see GameListenerAdapter
+ * @see GameListener
+ * @see GameEvent
+ */
+public class GameUnitDiedListenerAdapter extends GameListenerAdapter {
+
+    // Who would claim the death as a kill?
+    private Entity attacker;
+
+    public GameUnitDiedListenerAdapter(Entity attacker){
+        this.attacker = attacker;
+    }
+    @Override
+    public void gameUnitDied(GameUnitDiedEvent e){
+    }
+}

--- a/megamek/src/megamek/common/event/GameUnitDiedListenerAdapter.java
+++ b/megamek/src/megamek/common/event/GameUnitDiedListenerAdapter.java
@@ -14,6 +14,9 @@
 
 package megamek.common.event;
 import megamek.common.Entity;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.weapons.Weapon;
+import megamek.server.GameManager;
 
 /**
  * This adapter class overrides just the GameUnitDiedEvent handling of the
@@ -26,12 +29,21 @@ import megamek.common.Entity;
 public class GameUnitDiedListenerAdapter extends GameListenerAdapter {
 
     // Who would claim the death as a kill?
-    private Entity attacker;
+    private final Entity attacker;
+    // How was it done?
+    private final WeaponAttackAction action;
 
-    public GameUnitDiedListenerAdapter(Entity attacker){
+    public GameUnitDiedListenerAdapter(Entity attacker, WeaponAttackAction action){
         this.attacker = attacker;
+        this.action = action;
     }
     @Override
-    public void gameUnitDied(GameUnitDiedEvent e){
+    public void gameUnitDied(GameUnitDiedEvent e) {
+        GameManager gm = (GameManager) e.getSource();
+        Entity en = (Entity) e.getEntity();
+        // If our attacker's weapon action originally targeted this entity, take credit
+        if (action.getOriginalTargetId() == en.getId()){
+            gm.creditKill(en, attacker);
+        }
     }
 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -28,6 +28,7 @@ import megamek.common.enums.GamePhase;
 import megamek.common.enums.WeaponSortOrder;
 import megamek.common.event.GameListener;
 import megamek.common.event.GameVictoryEvent;
+import megamek.common.event.GameUnitDiedEvent;
 import megamek.common.force.Force;
 import megamek.common.force.Forces;
 import megamek.common.net.enums.PacketCommand;
@@ -981,8 +982,16 @@ public class GameManager implements IGameManager {
                 send(createTurnVectorPacket());
             }
             entityUpdate(entity.getId());
+
+            // Fire GameUnitDiedEvent here?
+            // GameVictoryEvent gve = new GameVictoryEvent(this, game);
+            // game.processGameEvent(gve);
+            GameUnitDiedEvent gude = new GameUnitDiedEvent(this, game, entity, condition);
+            game.processGameEvent(gude);
+
             game.removeEntity(entity.getId(), condition);
             send(createRemoveEntityPacket(entity.getId(), condition));
+
         }
     }
 
@@ -14053,6 +14062,8 @@ public class GameManager implements IGameManager {
                 if (ah != null) {
                     ah.setStrafing(waa.isStrafing());
                     ah.setStrafingFirstShot(waa.isStrafingFirstShot());
+                    // TODO: @sleet01 Possibly add GameUnitDiedEvent GameListenerAdapter here!
+                    // ideally we can pass the attacker and damage of the attack, at least.
                     game.addAttack(ah);
                 }
             }
@@ -34327,6 +34338,8 @@ public class GameManager implements IGameManager {
                     handleAttackReports.addElement(r);
                     ah.setAnnouncedEntityFiring(true);
                     lastAttackerId = aId;
+                    // TODO: @sleet01 Possibly add GameUnitDiedEvent GameListenerAdapter here!
+                    // ideally we can pass the attacker and damage of the attack, at least.
                 }
                 boolean keep = ah.handle(game.getPhase(), handleAttackReports);
                 if (keep) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -27122,9 +27122,6 @@ public class GameManager implements IGameManager {
 
         // Destroy the entity, unless it's already destroyed.
         if (!entity.isDoomed() && !entity.isDestroyed()) {
-            GameUnitDiedEvent gude = new GameUnitDiedEvent(this, game, entity, entity.damageThisRound, reason);
-            game.processGameEvent(gude);
-
             r = new Report(6365);
             r.subject = entity.getId();
             r.addDesc(entity);
@@ -27132,6 +27129,11 @@ public class GameManager implements IGameManager {
             vDesc.addElement(r);
 
             entity.setDoomed(true);
+
+            // Fire GameUnitDiedEvent here?
+            // @sleet01
+            GameUnitDiedEvent gude = new GameUnitDiedEvent(this, game, entity, entity.damageThisRound, reason);
+            game.processGameEvent(gude);
 
             // Kill any picked up MechWarriors
             Enumeration<Integer> iter = entity.getPickedUpMechWarriors().elements();


### PR DESCRIPTION
# Event-based Kill Tracking Proof of Concept

## Summary
This is the rough initial attempt to implement some measure of Event-based kill claiming.
I'd like to have this looked at, and if it seems feasible at scale, implement a more robust version.

## Details
The basic gist is:
- There are too many points at which we need to track damage cause and effect for linear, sequential damage tracking alone to be workable.
- There are also circumstances where it is difficult to track the effects of an action or PSR forward through to unit destruction, such as a physical attack that causes one enemy to deal physical damage to another, causing the second enemy's destruction.

Rather than tracking damage and attackers down into the multifarious damage resolution methods and special cases, I believe using event handling simplifies this problem considerably:

- When damage is dealt (or when an entity's attacks are registered), a "Unit has died" Listener can be created.  As it is created concurrently with the damage itself, information about the attack / damage dealt, including the dealer, type, intended target, etc. can be easily stored in the listener.
- When a unit is destroyed, a "Unit has died" Event can be dispatched.  The event knows who has died, and generally _why_, but due to how our damage code is organized, likely does not know who killed it<sup>1</sup>.  
- When an event is dispatched, all current Listeners can examine the event to see if they might be responsible for the kill, and if so, claim it for the unit whose attack dispatched them originally<sup>2</sup>.  If not, they can ignore it.
- At some point, either the end of a phase or the end of a round, all Listeners can be wiped, readying the game for the next round of attacks and (possible) fatalities.

Because destruction must chronologically follow attacks or actions - there is no effect without a cause - this approach of registering Causes and then letting them decide which one is responsible for a later Effect assures us that we will not credit later Attacks for prior Kills, something that could happen with our depth-first approach to damage generation and limited tracking now.  Conversely, while the linear approach to tracking damage to subsequent kills requires tracing multiple paths to confirm, say, that _nobody_ died, the event-based approach can simply do nothing if nothing dies; it's quite economical.

## Proof of Concept

This _extremely rough_ POC adds only unit-level kill credit for:

1. direct weapon attacks,
2. ejections,
3. crew kills,
4. generic "destruction"

It makes no attempt to resolve disputes over kill claims, awarding credit to any units that can "prove" that they attacked the dying unit.  It cannot deal with long-range artillery, or accurately accumulate damage dealt over several turns.  There are a number of methods of destruction it is not instrumented for.  It's janky<sup>3</sup>.
Most importantly, it only claims kills for _units_, not for the team they belong to.

But I can already see how this approach would simplify kill accounting without requiring onerous levels of plumbing.  For instance, to add kill-sharing for TAG scouts and missile boats, we would need only to add the following lines to the TAG-handling code:
```
            registerDiedListener(ah.getAttacker(), ah.waa);
```

somewhere around line 34,342 (!?) of `GameManager.java`.  That should be all that's needed to give TAGgers credit for helping with kills.

## Full Implementation

I believe a full implementation will require rewriting the existing kill-tracking code completely; if part of it uses Events, it all should, for consistency and clarity.  In writing the POC I didn't even find the final victory scoring code, so I can't say yet how much work it will require to replace.  But it should be on the order of adding one or two lines in a few dozen places throughout `GameManager.java`, with a more substantial rework of victory scoring and implementation of a map of Unit->Kill Claims objects to tally damage dealt and claimed kills over the course of a game.

I'd also say that tracking criteria for awarding kills (per unit or per team) should be split out of the GameUnitDeathListenerAdapter implementation, for a few reasons.  While event handlers are terrific for ignoring everything except the specific information they are interested in, there are a few things they're ill-suited to:

1. comparisons with other Listener instances: two different units' attacks may both think they killed a dying target, but they can't see or talk to each other so by themselves they can't determine who "wins", by damage or some other metric.  
2. heavy calculations in general: Java's docs recommends keeping Events _and_ EventListeners as lightweight as possible, as they will be interrupting the same thread when fired and handled.
3. sticking around.  Because the EventListeners all live in Game, there's no guarantee that they'll be around from round to round.  In fact, they _should_ be cleared from time to time, so no accumulated state should live in them.

That said, the simple Listener-clearing function I used in the POC should be replaced by a method of self-deleting<sup>4</sup>, within the listeners themselves, based on a timeframe and/or count of deaths:
- A Listener may only last one Phase: perhaps we only want to track Physical Attack kills within that phase, for instance.
- A Listener may last one Round: we may wish to let an Indirect Artillery attack claim deaths from damage _and_ from failed PSRs all the way through from the Indirect phase to the end of the round.
- A Listener may last multiple Rounds: off-board Artillery attacks with non-zero flight times should at least stick around until their arrival Round, to see what happens.
- We may want a given Listener to only try to claim one kill maximum: in the TAG example, perhaps we only share credit on the directly-tagged target, while the IF unit also gets credit for any collateral kills in the AE template.
etc.


## Concerns

There are a lot of unknowns and provisos here: 
- I have no idea how using this system for multiple 10s of units with between 0 and possibly dozens of attacks per turn will perform, for instance.
- Thread safety is a concern (although Java should enforce that only Listeners in the same thread as Event dispatchers can see those Events).
- Memory usage could get higher if we are not careful.
- Reasoning about the event-handling system is difficult until one has experience with it.

## Future

I could see us replacing a lot of fiddly multi-stage unit updating and nested if/else/switch/case code with fired events and simple handlers; this paradigm seems particularly well-suited to board games with limited numbers of units that need to deal with a wealth of different rules.

For instance, we could move a lot of the spaghetti code out of `GameManager.java` and into the individual unit Types.  Green Gas attacks could just fire an Event that only units with old TSM would need to listen for.  This approach is especially nice as an alternative to repeatedly polling each and every unit for location in the case of, e.g., an AE weapon.  Well, code-wise it's nicer; under the hood it's doing much the same thing.

## Footnotes
1. There are some members in Entity that appear to be used for tracking who last attacked a unit and with what, but there is no guarantee that they will be set properly and in many cases the source of damage is a special-case handler function in some weapon handler code, or `GameManager.java` itself.  Additionally, they do not allow for much information: we might know that Atlas A dealt 10 damage to Crusader C most recently, but lose the information that Blackjack B dealt 20 damage immediately prior, so can only give the kill to A.
2. In the POC, multiple attacks can claim the same kill for their dealer entity; in a full implementation, a leaderboard for each kill, managed by the Game or GameManager and compiled at the end of the game, would likely be necessary for more accuracy.
3.  The amount of information each event carries is probably overkill, and needing no-op handlers in the various sub-windows that inherit or implement GameListener Feels Bad.  This, however, can all be tuned.
4. I have already tested this approach, but did not implement it for the POC as it would require adding more fields to the Listener.

## Media

I still want to do more testing, but here are files from a test game with the POC code bolted on to the side of the existing kill claim code.  It seems to be working pretty well: although the majority of "deaths" came from auto-ejecting pilots, the kills were assigned (afiact) correctly to the units who made the attacks that _caused_ those ejections.  Dead units may still be listed as killed by "pilot error", but replacing that code with events would fix that.

[megamek.log](https://github.com/MegaMek/megamek/files/12617029/megamek.log)

[gamelog.tar.gz](https://github.com/MegaMek/megamek/files/12617036/gamelog.tar.gz)

[salvage.mul.tar.gz](https://github.com/MegaMek/megamek/files/12617059/salvage.mul.tar.gz)

[Bot_Princess.mul.tar.gz](https://github.com/MegaMek/megamek/files/12617064/Bot_Princess.mul.tar.gz)

![20230914_aftermath_of_2xShiva_vs_12_x_Gurkha_fight](https://github.com/MegaMek/megamek/assets/22018319/9617dd14-658d-46f0-968c-04980ae2bd37)


