### PR TITLE
aeros firing iGauss take +1 to hit penalty

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3705,7 +3705,10 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // check for heavy gauss rifle on fighter of small craft
             // Arguably a weapon effect, except that it only applies when used by a fighter (isn't recoil fun?)
             // So it's here instead of with other weapon mods that apply across the board
-            if ((wtype instanceof ISHGaussRifle) && !(ae instanceof Dropship)
+            if ((wtype != null) &&
+                    ((wtype.ammoType == AmmoType.T_GAUSS_HEAVY) ||
+                    (wtype.ammoType == AmmoType.T_IGAUSS_HEAVY)) && 
+                    !(ae instanceof Dropship)
                     && !(ae instanceof Jumpship)) {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.FighterHeavyGauss"));
             }


### PR DESCRIPTION
Fixes #4768 

Also, instead of checking data type, check ammo type.