### PR TITLE
Fix 3870 and 4524: no quirks / SPAs applied to Artillery weapons

### DIFF
--- a/megamek/src/megamek/client/ui/swing/QuirksPanel.java
+++ b/megamek/src/megamek/client/ui/swing/QuirksPanel.java
@@ -74,7 +74,7 @@ public class QuirksPanel extends JPanel {
             for (Enumeration<IOption> j = group.getSortedOptions(); j.hasMoreElements(); ) {
                 IOption option = j.nextElement();
 
-                if (!Quirks.isQuirkLegalFor(option, entity)) {
+                if (null == option || !Quirks.isQuirkLegalFor(option, entity)) {
                     continue;
                 }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
@@ -124,7 +124,7 @@ public final class TipUtil {
                 List<String> origList = new ArrayList<>();
                 for (Enumeration<IOption> advs = advGroup.getOptions(); advs.hasMoreElements();) {
                     IOption adv = advs.nextElement();
-                    if (adv.booleanValue()) {
+                    if (adv != null && adv.booleanValue()) {
                         origList.add(adv.getDisplayableNameWithValue());
                     }
                 }

--- a/megamek/src/megamek/common/QuirksHandler.java
+++ b/megamek/src/megamek/common/QuirksHandler.java
@@ -542,7 +542,7 @@ public class QuirksHandler {
                 while (quirkOptions.hasMoreElements()) {
                     IOption option = quirkOptions.nextElement();
                     // Ignore illegal quirks, and ones that aren't set
-                    if (!Quirks.isQuirkLegalFor(option, entity) || !option.booleanValue()) {
+                    if (option == null || !(Quirks.isQuirkLegalFor(option, entity) && option.booleanValue())) {
                         continue;
                     }
                     // Add new QuirkEntry

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3076,7 +3076,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
         // VSP Lasers
 
-        // Quirks
+        // Quirks and SPAs now handled in toHit
         processAttackerQuirks(toHit, ae, target, weapon);
 
         // SPAs
@@ -4278,14 +4278,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
         }
 
-        // blood stalker SPA
-        if (ae.getBloodStalkerTarget() > Entity.NONE) {
-            if (ae.getBloodStalkerTarget() == target.getId()) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BloodStalkerTarget"));
-            } else {
-                toHit.addModifier(+2, Messages.getString("WeaponAttackAction.BloodStalkerNonTarget"));
-            }
-        }
+        // Quirks
+        processAttackerQuirks(toHit, ae, te, weapon);
+
+        // SPAs
+        processAttackerSPAs(toHit, ae, te, weapon, game);
+        processDefenderSPAs(toHit, ae, te, weapon, game);
 
         return toHit;
     }
@@ -4873,6 +4871,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // Per TO:AR 6th printing, p153, other mods are: Flak (-2), AMM, damage, intervening trees/jungle
             int distance = Compute.effectiveDistance(game, ae, target);
             toHit = new ToHitData(ae.getCrew().getGunnery(), Messages.getString("WeaponAttackAction.GunSkill"));
+
+            // Quirks
+            processAttackerQuirks(toHit, ae, te, weapon);
+
+            // SPAs
+            processAttackerSPAs(toHit, ae, te, weapon, game);
+            processDefenderSPAs(toHit, ae, te, weapon, game);
+
             // Flak; ADA won't hit the later artillery flak check so add this modifier directly.
             toHit.addModifier(-2, Messages.getString("WeaponAttackAction.Flak"));
             // AMM
@@ -5086,30 +5092,42 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SensorGhosts"));
         }
 
-        // Flat -1 for Accurate Weapon
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_ACCURATE)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.AccWeapon"));
-        }
-        // Flat +1 for Inaccurate Weapon
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.InAccWeapon"));
-        }
-        // Stable Weapon - Reduces running/flanking penalty by 1
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_STABLE_WEAPON) && (ae.moved == EntityMovementType.MOVE_RUN)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.StableWeapon"));
-        }
-        // +1 for a Misrepaired Weapon - See StratOps Partial Repairs
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPAIRED)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisrepairedWeapon"));
-        }
-        // +1 for a Misreplaced Weapon - See StratOps Partial Repairs
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPLACED)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisreplacedWeapon"));
+        if (null != weapon) {
+
+            // Flat -1 for Accurate Weapon
+            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_ACCURATE)) {
+                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.AccWeapon"));
+            }
+            // Flat +1 for Inaccurate Weapon
+            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE)) {
+                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.InAccWeapon"));
+            }
+            // Stable Weapon - Reduces running/flanking penalty by 1
+            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_STABLE_WEAPON) && (ae.moved == EntityMovementType.MOVE_RUN)) {
+                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.StableWeapon"));
+            }
+            // +1 for a Misrepaired Weapon - See StratOps Partial Repairs
+            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPAIRED)) {
+                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisrepairedWeapon"));
+            }
+            // +1 for a Misreplaced Weapon - See StratOps Partial Repairs
+            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPLACED)) {
+                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisreplacedWeapon"));
+            }
         }
         return toHit;
     }
 
     public static ToHitData processAttackerSPAs(ToHitData toHit, Entity ae, Targetable target, Mounted weapon, Game game){
+
+        // blood stalker SPA
+        if (ae.getBloodStalkerTarget() > Entity.NONE) {
+            if (ae.getBloodStalkerTarget() == target.getId()) {
+                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BloodStalkerTarget"));
+            } else {
+                toHit.addModifier(+2, Messages.getString("WeaponAttackAction.BloodStalkerNonTarget"));
+            }
+        }
 
         WeaponType wtype = ((weapon != null) && (weapon.getType() instanceof WeaponType)) ? (WeaponType) weapon.getType() : null;
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5221,6 +5221,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             toHit = new ToHitData();
         }
 
+        // Anti-air targeting quirk vs airborne unit (excluding Indirect)
+        if (ae.hasQuirk(OptionsConstants.QUIRK_POS_ANTI_AIR) && (null != te)) {
+            if (te.isAirborneVTOLorWIGE() || te.isAirborne()) {
+                toHit.addModifier(-2, Messages.getString("WeaponAttackAction.AaVsAir"));
+            }
+        }
+
         //Homing warheads just need a flat 4 to seek out a successful TAG
         if (isHoming) {
             srt.setSpecialResolution(true);

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3075,12 +3075,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         // VSP Lasers
-
         // Quirks and SPAs now handled in toHit
-        processAttackerQuirks(toHit, ae, target, weapon);
-
-        // SPAs
-        processAttackerSPAs(toHit, ae, target, weapon, game);
 
         return toHit;
     }
@@ -3494,9 +3489,6 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                         "stabiliser damage");
             }
         }
-
-        // Quirks
-        processAttackerQuirks(toHit, ae, target, weapon);
 
         return toHit;
     }
@@ -3938,12 +3930,6 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
         }
 
-        // Attacker SPAs
-        processAttackerSPAs(toHit, ae, te, weapon, game);
-
-        // Target SPAs
-        processDefenderSPAs(toHit, ae, te, weapon, game);
-
         return toHit;
     }
 
@@ -3951,6 +3937,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
      * Convenience method that compiles the ToHit modifiers applicable to the defender's condition and actions
      * -4 for shooting at an immobile target?  You'll find that here.
      * Attacker strafing?  Using a weapon with a TH penalty?  Those are in other methods.
+     * For simplicity's sake, Quirks and SPAs now get applied here for general cases (elsewhere for Artillery or ADA)
      *
      * @param game The current {@link Game}
      * @param ae The Entity making this attack
@@ -4872,6 +4859,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             int distance = Compute.effectiveDistance(game, ae, target);
             toHit = new ToHitData(ae.getCrew().getGunnery(), Messages.getString("WeaponAttackAction.GunSkill"));
 
+            /// Re-apply quirks and SPAs after wiping out toHit
             // Quirks
             processAttackerQuirks(toHit, ae, te, weapon);
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -30,9 +30,7 @@ import megamek.common.weapons.gaussrifles.ISHGaussRifle;
 import megamek.common.weapons.lasers.ISBombastLaser;
 import megamek.common.weapons.lasers.VariableSpeedPulseLaserWeapon;
 import megamek.common.weapons.lrms.LRTWeapon;
-import megamek.common.weapons.mortars.MekMortarWeapon;
 import megamek.common.weapons.srms.SRTWeapon;
-import org.apache.commons.lang.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 
 import java.io.Serializable;
@@ -3078,105 +3076,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
         // VSP Lasers
 
-        // SPA Environmental Specialist
-        // Fog Specialist
-        if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_FOG)
-                && wtype.hasFlag(WeaponType.F_ENERGY) && !game.getBoard().inSpace()
-                && (game.getPlanetaryConditions().getFog() == PlanetaryConditions.FOG_HEAVY)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.FogSpec"));
-        }
+        // Quirks
+        processAttackerQuirks(toHit, ae, target, weapon);
 
-        // Light Specialist
-        if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_LIGHT)) {
-            if ((te != null) && !te.isIlluminated()
-                    && ((game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_DUSK)
-                    || (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_FULL_MOON)
-                    || (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_MOONLESS)
-                    || (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_PITCH_BLACK))) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.LightSpec"));
-            } else if ((te != null) && te.isIlluminated()
-                    && (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_PITCH_BLACK)) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.LightSpec"));
-            }
-        }
+        // SPAs
+        processAttackerSPAs(toHit, ae, target, weapon, game);
 
-        // Rain Specialist
-        if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_RAIN)) {
-            if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_LIGHT_RAIN)
-                    && ae.isConventionalInfantry()) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.RainSpec"));
-            }
-
-            if  ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_MOD_RAIN)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_HEAVY_RAIN)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_GUSTING_RAIN)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_DOWNPOUR)) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.RainSpec"));
-            }
-        }
-
-        // Snow Specialist
-        if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_SNOW)) {
-            if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_LIGHT_SNOW)
-                    && ae.isConventionalInfantry()) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
-            }
-
-            if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_ICE_STORM)
-                    && wtype.hasFlag(WeaponType.F_MISSILE)) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
-            }
-
-            if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_SLEET)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_SNOW_FLURRIES)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_MOD_SNOW)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_HEAVY_SNOW)) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
-            }
-        }
-
-        // Wind Specialist
-        if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_WIND)) {
-            if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_MOD_GALE)
-                    && wtype.hasFlag(WeaponType.F_MISSILE)) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
-            }
-
-            if (wtype.hasFlag(WeaponType.F_MISSILE) && wtype.hasFlag(WeaponType.F_BALLISTIC)
-                    && ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_STRONG_GALE)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_STORM))) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.WindSpec"));
-            }
-
-            if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_TORNADO_F13)
-                    || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_TORNADO_F4)) {
-                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.WindSpec"));
-            }
-        }
-
-
-        // quirks
-
-        // Flat -1 for Accurate Weapon
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_ACCURATE)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.AccWeapon"));
-        }
-        // Flat +1 for Inaccurate Weapon
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.InAccWeapon"));
-        }
-        // Stable Weapon - Reduces running/flanking penalty by 1
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_STABLE_WEAPON) && (ae.moved == EntityMovementType.MOVE_RUN)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.StableWeapon"));
-        }
-        // +1 for a Misrepaired Weapon - See StratOps Partial Repairs
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPAIRED)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisrepairedWeapon"));
-        }
-        // +1 for a Misreplaced Weapon - See StratOps Partial Repairs
-        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPLACED)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisreplacedWeapon"));
-        }
         return toHit;
     }
 
@@ -3591,18 +3496,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         // Quirks
-
-        // Anti-air targeting quirk vs airborne unit
-        if (ae.hasQuirk(OptionsConstants.QUIRK_POS_ANTI_AIR) && (target instanceof Entity)) {
-            if (target.isAirborneVTOLorWIGE() || target.isAirborne()) {
-                toHit.addModifier(-2, Messages.getString("WeaponAttackAction.AaVsAir"));
-            }
-        }
-
-        // Sensor ghosts quirk
-        if (ae.hasQuirk(OptionsConstants.QUIRK_NEG_SENSOR_GHOSTS)) {
-            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SensorGhosts"));
-        }
+        processAttackerQuirks(toHit, ae, target, weapon);
 
         return toHit;
     }
@@ -4044,90 +3938,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             }
         }
 
-        // SPAs
-
-        // Unofficial weapon class specialist - Does not have an unspecialized penalty
-        if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_LASER)
-                && wtype != null && wtype.hasFlag(WeaponType.F_ENERGY)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunLSkill"));
-        }
-
-        if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_BALLISTIC)
-                && wtype != null && wtype.hasFlag(WeaponType.F_BALLISTIC)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunBSkill"));
-        }
-
-        if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_MISSILE)
-                && wtype != null && wtype.hasFlag(WeaponType.F_MISSILE)) {
-            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunMSkill"));
-        }
-
-        // Is the pilot a weapon specialist?
-        if (wtype instanceof BayWeapon
-                && weapon.getBayWeapons().stream().map(ae::getEquipment)
-                .allMatch(w -> ae.hasAbility(OptionsConstants.GUNNERY_WEAPON_SPECIALIST, w.getName()))) {
-            // All weapons in a bay must match the specialization
-            toHit.addModifier(-2, Messages.getString("WeaponAttackAction.WeaponSpec"));
-        } else if (wtype != null && ae.hasAbility(OptionsConstants.GUNNERY_WEAPON_SPECIALIST, wtype.getName())) {
-            toHit.addModifier(-2, Messages.getString("WeaponAttackAction.WeaponSpec"));
-        } else if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST)) {
-            // aToW style gunnery specialist: -1 to specialized weapon and +1 to all other weapons
-            // Note that weapon specialist supersedes gunnery specialization, so if you have
-            // a specialization in Medium Lasers and a Laser specialization, you only get the -2 specialization mod
-            if (wtype != null && wtype.hasFlag(WeaponType.F_ENERGY)) {
-                if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST, Crew.SPECIAL_ENERGY)) {
-                    toHit.addModifier(-1, Messages.getString("WeaponAttackAction.EnergySpec"));
-                } else {
-                    toHit.addModifier(+1, Messages.getString("WeaponAttackAction.Unspec"));
-                }
-            } else if (wtype != null && wtype.hasFlag(WeaponType.F_BALLISTIC)) {
-                if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST, Crew.SPECIAL_BALLISTIC)) {
-                    toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BallisticSpec"));
-                } else {
-                    toHit.addModifier(+1, Messages.getString("WeaponAttackAction.Unspec"));
-                }
-            } else if (wtype != null && wtype.hasFlag(WeaponType.F_MISSILE)) {
-                if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST, Crew.SPECIAL_MISSILE)) {
-                    toHit.addModifier(-1, Messages.getString("WeaponAttackAction.MissileSpec"));
-                } else {
-                    toHit.addModifier(+1, Messages.getString("WeaponAttackAction.Unspec"));
-                }
-            }
-        }
+        // Attacker SPAs
+        processAttackerSPAs(toHit, ae, te, weapon, game);
 
         // Target SPAs
-        if (te != null) {
-            // Shaky Stick -  Target gets a +1 bonus against Ground-to-Air attacks
-            if (te.hasAbility(OptionsConstants.PILOT_SHAKY_STICK)
-                    && (te.isAirborne() || te.isAirborneVTOLorWIGE())
-                    && !ae.isAirborne() && !ae.isAirborneVTOLorWIGE()) {
-                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.ShakyStick"));
-            }
-            // Urban Guerrilla - Target gets a +1 bonus in any sort of urban terrain
-            if (te.hasAbility(OptionsConstants.INFANTRY_URBAN_GUERRILLA)
-                    && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.PAVEMENT)
-                            || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROAD)
-                            || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.RUBBLE)
-                            || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.BUILDING)
-                            || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROUGH))) {
-                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.UrbanGuerilla"));
-            }
-            // Forest Ranger - Target gets a +1 bonus in wooded terrain when moving at walking speed or greater
-            if (te.hasAbility(OptionsConstants.PILOT_TM_FOREST_RANGER)
-                    && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS)
-                       || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE))
-                    && te.moved == EntityMovementType.MOVE_WALK) {
-                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.ForestRanger"));
-            }
-            // Swamp Beast - Target gets a +1 bonus in mud/swamp terrain when running/flanking
-            if (te.hasAbility(OptionsConstants.PILOT_TM_SWAMP_BEAST)
-                    && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.MUD)
-                        || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.SWAMP))
-                    && te.moved == EntityMovementType.MOVE_RUN) {
-                toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SwampBeast"));
-            }
+        processDefenderSPAs(toHit, ae, te, weapon, game);
 
-        }
         return toHit;
     }
 
@@ -5221,12 +5037,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             toHit = new ToHitData();
         }
 
-        // Anti-air targeting quirk vs airborne unit (excluding Indirect)
-        if (ae.hasQuirk(OptionsConstants.QUIRK_POS_ANTI_AIR) && (null != te)) {
-            if (te.isAirborneVTOLorWIGE() || te.isAirborne()) {
-                toHit.addModifier(-2, Messages.getString("WeaponAttackAction.AaVsAir"));
-            }
-        }
+        // Quirks
+        processAttackerQuirks(toHit, ae, te, weapon);
+
+        // SPAs
+        processAttackerSPAs(toHit, ae, te, weapon, game);
+        processDefenderSPAs(toHit, ae, te, weapon, game);
 
         //Homing warheads just need a flat 4 to seek out a successful TAG
         if (isHoming) {
@@ -5252,6 +5068,222 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             return artilleryIndirectToHit(ae, target, toHit, wtype, weapon, srt);
         }
         //If we get here, this isn't an artillery attack
+        return toHit;
+    }
+
+
+    public static ToHitData processAttackerQuirks(ToHitData toHit, Entity ae, Targetable target, Mounted weapon){
+
+        // Anti-air targeting quirk vs airborne unit
+        if (ae.hasQuirk(OptionsConstants.QUIRK_POS_ANTI_AIR) && (target instanceof Entity)) {
+            if (target.isAirborneVTOLorWIGE() || target.isAirborne()) {
+                toHit.addModifier(-2, Messages.getString("WeaponAttackAction.AaVsAir"));
+            }
+        }
+
+        // Sensor ghosts quirk
+        if (ae.hasQuirk(OptionsConstants.QUIRK_NEG_SENSOR_GHOSTS)) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SensorGhosts"));
+        }
+
+        // Flat -1 for Accurate Weapon
+        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_ACCURATE)) {
+            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.AccWeapon"));
+        }
+        // Flat +1 for Inaccurate Weapon
+        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE)) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.InAccWeapon"));
+        }
+        // Stable Weapon - Reduces running/flanking penalty by 1
+        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_STABLE_WEAPON) && (ae.moved == EntityMovementType.MOVE_RUN)) {
+            toHit.addModifier(-1, Messages.getString("WeaponAttackAction.StableWeapon"));
+        }
+        // +1 for a Misrepaired Weapon - See StratOps Partial Repairs
+        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPAIRED)) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisrepairedWeapon"));
+        }
+        // +1 for a Misreplaced Weapon - See StratOps Partial Repairs
+        if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_MISREPLACED)) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.MisreplacedWeapon"));
+        }
+        return toHit;
+    }
+
+    public static ToHitData processAttackerSPAs(ToHitData toHit, Entity ae, Targetable target, Mounted weapon, Game game){
+
+        WeaponType wtype = ((weapon != null) && (weapon.getType() instanceof WeaponType)) ? (WeaponType) weapon.getType() : null;
+
+        if (wtype != null) {
+            // Unofficial weapon class specialist - Does not have an unspecialized penalty
+            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_LASER)
+                    && wtype.hasFlag(WeaponType.F_ENERGY)) {
+                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunLSkill"));
+            }
+
+            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_BALLISTIC)
+                    && wtype.hasFlag(WeaponType.F_BALLISTIC)) {
+                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunBSkill"));
+            }
+
+            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_MISSILE)
+                    && wtype.hasFlag(WeaponType.F_MISSILE)) {
+                toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunMSkill"));
+            }
+
+            // Is the pilot a weapon specialist?
+            if (wtype instanceof BayWeapon
+                    && weapon.getBayWeapons().stream().map(ae::getEquipment)
+                    .allMatch(w -> ae.hasAbility(OptionsConstants.GUNNERY_WEAPON_SPECIALIST, w.getName()))) {
+                // All weapons in a bay must match the specialization
+                toHit.addModifier(-2, Messages.getString("WeaponAttackAction.WeaponSpec"));
+            } else if (ae.hasAbility(OptionsConstants.GUNNERY_WEAPON_SPECIALIST, wtype.getName())) {
+                toHit.addModifier(-2, Messages.getString("WeaponAttackAction.WeaponSpec"));
+            } else if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST)) {
+                // aToW style gunnery specialist: -1 to specialized weapon and +1 to all other weapons
+                // Note that weapon specialist supersedes gunnery specialization, so if you have
+                // a specialization in Medium Lasers and a Laser specialization, you only get the -2 specialization mod
+                if (wtype.hasFlag(WeaponType.F_ENERGY)) {
+                    if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST, Crew.SPECIAL_ENERGY)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.EnergySpec"));
+                    } else {
+                        toHit.addModifier(+1, Messages.getString("WeaponAttackAction.Unspec"));
+                    }
+                } else if (wtype.hasFlag(WeaponType.F_BALLISTIC)) {
+                    if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST, Crew.SPECIAL_BALLISTIC)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BallisticSpec"));
+                    } else {
+                        toHit.addModifier(+1, Messages.getString("WeaponAttackAction.Unspec"));
+                    }
+                } else if (wtype.hasFlag(WeaponType.F_MISSILE)) {
+                    if (ae.hasAbility(OptionsConstants.GUNNERY_SPECIALIST, Crew.SPECIAL_MISSILE)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.MissileSpec"));
+                    } else {
+                        toHit.addModifier(+1, Messages.getString("WeaponAttackAction.Unspec"));
+                    }
+                }
+            }
+
+            // SPA Environmental Specialist
+            // Could be pattern-matching instanceof in Java 17
+            if (target instanceof Entity) {
+                Entity te = (Entity) target;
+
+                // Fog Specialist
+                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_FOG)
+                        && wtype.hasFlag(WeaponType.F_ENERGY) && !game.getBoard().inSpace()
+                        && (game.getPlanetaryConditions().getFog() == PlanetaryConditions.FOG_HEAVY)) {
+                    toHit.addModifier(-1, Messages.getString("WeaponAttackAction.FogSpec"));
+                }
+
+                // Light Specialist
+                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_LIGHT)) {
+                    if (!te.isIlluminated()
+                            && ((game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_DUSK)
+                            || (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_FULL_MOON)
+                            || (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_MOONLESS)
+                            || (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_PITCH_BLACK))) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.LightSpec"));
+                    } else if (te.isIlluminated()
+                            && (game.getPlanetaryConditions().getLight() == PlanetaryConditions.L_PITCH_BLACK)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.LightSpec"));
+                    }
+                }
+
+                // Rain Specialist
+                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_RAIN)) {
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_LIGHT_RAIN)
+                            && ae.isConventionalInfantry()) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.RainSpec"));
+                    }
+
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_MOD_RAIN)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_HEAVY_RAIN)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_GUSTING_RAIN)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_DOWNPOUR)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.RainSpec"));
+                    }
+                }
+
+                // Snow Specialist
+                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_SNOW)) {
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_LIGHT_SNOW)
+                            && ae.isConventionalInfantry()) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
+                    }
+
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_ICE_STORM)
+                            && wtype.hasFlag(WeaponType.F_MISSILE)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
+                    }
+
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_SLEET)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_SNOW_FLURRIES)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_MOD_SNOW)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WE_HEAVY_SNOW)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
+                    }
+                }
+
+                // Wind Specialist
+                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_WIND)) {
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_MOD_GALE)
+                            && wtype.hasFlag(WeaponType.F_MISSILE)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
+                    }
+
+                    if (wtype.hasFlag(WeaponType.F_MISSILE) && wtype.hasFlag(WeaponType.F_BALLISTIC)
+                            && ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_STRONG_GALE)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_STORM))) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.WindSpec"));
+                    }
+
+                    if ((game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_TORNADO_F13)
+                            || (game.getPlanetaryConditions().getWeather() == PlanetaryConditions.WI_TORNADO_F4)) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.WindSpec"));
+                    }
+                }
+            }
+        }
+
+        return toHit;
+    }
+
+    public static ToHitData processDefenderSPAs(ToHitData toHit, Entity ae, Entity te, Mounted weapon, Game game){
+
+        if (null == te) {
+            return toHit;
+        }
+
+        // Shaky Stick -  Target gets a +1 bonus against Ground-to-Air attacks
+        if (te.hasAbility(OptionsConstants.PILOT_SHAKY_STICK)
+                && (te.isAirborne() || te.isAirborneVTOLorWIGE())
+                && !ae.isAirborne() && !ae.isAirborneVTOLorWIGE()) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.ShakyStick"));
+        }
+        // Urban Guerrilla - Target gets a +1 bonus in any sort of urban terrain
+        if (te.hasAbility(OptionsConstants.INFANTRY_URBAN_GUERRILLA)
+                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.PAVEMENT)
+                || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROAD)
+                || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.RUBBLE)
+                || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.BUILDING)
+                || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROUGH))) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.UrbanGuerilla"));
+        }
+        // Forest Ranger - Target gets a +1 bonus in wooded terrain when moving at walking speed or greater
+        if (te.hasAbility(OptionsConstants.PILOT_TM_FOREST_RANGER)
+                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS)
+                || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE))
+                && te.moved == EntityMovementType.MOVE_WALK) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.ForestRanger"));
+        }
+        // Swamp Beast - Target gets a +1 bonus in mud/swamp terrain when running/flanking
+        if (te.hasAbility(OptionsConstants.PILOT_TM_SWAMP_BEAST)
+                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.MUD)
+                || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.SWAMP))
+                && te.moved == EntityMovementType.MOVE_RUN) {
+            toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SwampBeast"));
+        }
+
         return toHit;
     }
 


### PR DESCRIPTION
It looks like the Quirk and SPA check paths got broken for Artillery back when the artillery handling was split out from regular attacks.

I've combined all Attacker Quirks, Attacker SPAs, and Defender SPAs into functions and consolidated the calls to these functions to three locations:

- compileTargetToHitMods()
- handleArtilleryAttacks()
- artilleryDirectToHit() (just the ADA section, as this section creates an entirely new toHit object from scratch)

I believe this will apply all relevant modifiers to all weapon types, provided the game options to enable Quirks and SPAs are set correctly.
Also cleaned up some NPE paths:
- NPE while moving through the unit configuration options if Quirks were enabled but the selected / next unit was Infantry;
- NPE in packet handling during start of Indirect phase while checking Quirks and SPAs (weapon or target might be null)
- NPE while Princess traverses enemy unit -> target probabilities

Testing:

1. Created a game with various positive and negative quirks and SPAs on several AAA Artillery platforms;
2. Added several different types of ground, VTOL, and ASF targets with their own quirks and SPAs.
3. Aimed at various targets and recorded reported toHit mods, then fired and confirmed mods were applied as projected.

Edit:
close #3870
close #4524