### PR TITLE
Fix MekHQ #3761: update munitions equality tests in mm

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -229,7 +229,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 int totalShots = 0;
                 EnumSet<AmmoType.Munitions> munition = ((AmmoType) mounted.getLinked().getType()).getMunitionType();
                 for (Mounted current = mounted.getLinked(); current != null; current = current.getLinked()) {
-                    if (((AmmoType) current.getType()).getMunitionType() == munition) {
+                    if (((AmmoType) current.getType()).getMunitionType().contains(munition)) {
                         shotsLeft += current.getUsableShotsLeft();
                         totalShots += current.getOriginalShots();
                     }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -229,7 +229,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 int totalShots = 0;
                 EnumSet<AmmoType.Munitions> munition = ((AmmoType) mounted.getLinked().getType()).getMunitionType();
                 for (Mounted current = mounted.getLinked(); current != null; current = current.getLinked()) {
-                    if (((AmmoType) current.getType()).getMunitionType().containsAll(munition)) {
+                    if (((AmmoType) current.getType()).getMunitionType().equals(munition)) {
                         shotsLeft += current.getUsableShotsLeft();
                         totalShots += current.getOriginalShots();
                     }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -229,7 +229,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 int totalShots = 0;
                 EnumSet<AmmoType.Munitions> munition = ((AmmoType) mounted.getLinked().getType()).getMunitionType();
                 for (Mounted current = mounted.getLinked(); current != null; current = current.getLinked()) {
-                    if (((AmmoType) current.getType()).getMunitionType().contains(munition)) {
+                    if (((AmmoType) current.getType()).getMunitionType().containsAll(munition)) {
                         shotsLeft += current.getUsableShotsLeft();
                         totalShots += current.getOriginalShots();
                     }

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -407,7 +407,7 @@ public class AmmoType extends EquipmentType {
         }
 
         // MML Launchers, ugh.
-        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType().containsAll(other.getMunitionType()))) {
+        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType().equals(other.getMunitionType()))) {
             // LRMs...
             if (is(T_MML) && hasFlag(F_MML_LRM) && other.is(T_LRM)) {
                 return true;
@@ -424,7 +424,7 @@ public class AmmoType extends EquipmentType {
         }
 
         // General Launchers
-        if (is(other.getAmmoType()) && (getMunitionType().containsAll(other.getMunitionType()))) {
+        if (is(other.getAmmoType()) && (getMunitionType().equals(other.getMunitionType()))) {
             return true;
         }
 

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -407,7 +407,7 @@ public class AmmoType extends EquipmentType {
         }
 
         // MML Launchers, ugh.
-        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType() == other.getMunitionType())) {
+        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType().contains(other.getMunitionType()))) {
             // LRMs...
             if (is(T_MML) && hasFlag(F_MML_LRM) && other.is(T_LRM)) {
                 return true;
@@ -424,7 +424,7 @@ public class AmmoType extends EquipmentType {
         }
 
         // General Launchers
-        if (is(other.getAmmoType()) && (getMunitionType() == other.getMunitionType())) {
+        if (is(other.getAmmoType()) && (getMunitionType().contains(other.getMunitionType()))) {
             return true;
         }
 

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -407,7 +407,7 @@ public class AmmoType extends EquipmentType {
         }
 
         // MML Launchers, ugh.
-        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType().contains(other.getMunitionType()))) {
+        if ((is(T_MML) || other.is(T_MML)) && (getMunitionType().containsAll(other.getMunitionType()))) {
             // LRMs...
             if (is(T_MML) && hasFlag(F_MML_LRM) && other.is(T_LRM)) {
                 return true;
@@ -424,7 +424,7 @@ public class AmmoType extends EquipmentType {
         }
 
         // General Launchers
-        if (is(other.getAmmoType()) && (getMunitionType().contains(other.getMunitionType()))) {
+        if (is(other.getAmmoType()) && (getMunitionType().containsAll(other.getMunitionType()))) {
             return true;
         }
 


### PR DESCRIPTION
I missed a couple of equality checks between munitions; as `.getMunitionType()` now returns an EnumSet of applicable Munitions from the Munitions Enum (usually M_STANDARD, but occasionally two or more), we need to use X.equals(Y).

If X has all the same flags as Y, this returns true.  I'd initially used .containsAll() but this would have introduced subtle errors with some Munitions mixtures.

See also related PRs for MekHQ and MML.