### PR TITLE
Multicrew cockpit support in force generator

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/CrewDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/CrewDescriptor.java
@@ -326,6 +326,6 @@ public class CrewDescriptor {
     }
 
     public Crew createCrew(CrewType crewType) {
-        return new Crew(crewType, name, 1, gunnery, piloting, gender, null);
+        return new Crew(crewType, name, crewType.getCrewSlots(), gunnery, piloting, gender, null);
     }
 }

--- a/megamek/src/megamek/client/ratgenerator/CrewDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/CrewDescriptor.java
@@ -326,6 +326,26 @@ public class CrewDescriptor {
     }
 
     public Crew createCrew(CrewType crewType) {
-        return new Crew(crewType, name, crewType.getCrewSlots(), gunnery, piloting, gender, null);
+        Crew crew = new Crew(crewType, name, crewType.getCrewSlots(), gunnery, piloting, gender, null);
+        // Randomize names and skills of crew, then assign the piloting and
+        // gunnery skills generated for the unit to the correct slot.
+        if (crewType.getCrewSlots() > 1) {
+            int oldPiloting = crew.getPiloting();
+            int oldGunnery = crew.getGunnery();
+            setSkills();
+            crew.setPiloting(piloting, 0);
+            crew.setGunnery(gunnery, 0);
+            for (int i = 1; i < crew.getSlotCount(); i++) {
+                crew.setName(generateName(Gender.RANDOMIZE), i);
+                setSkills();
+                crew.setPiloting(piloting, i);
+                crew.setGunnery(gunnery, i);
+            }
+            crew.setPiloting(oldPiloting, crew.getCurrentPilotIndex());
+            crew.setGunnery(oldGunnery, crew.getCurrentGunnerIndex());
+            setPiloting(oldPiloting);
+            setGunnery(oldGunnery);
+        }
+        return crew;
     }
 }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -346,6 +346,12 @@ public abstract class Mech extends Entity {
         return UnitType.MEK;
     }
 
+    @Override
+    public CrewType defaultCrewType() {
+        return (cockpitType == COCKPIT_COMMAND_CONSOLE) || (cockpitType == COCKPIT_SUPERHEAVY_COMMAND_CONSOLE)
+                || (cockpitType == COCKPIT_SMALL_COMMAND_CONSOLE) ? CrewType.COMMAND_CONSOLE : CrewType.SINGLE;
+    }
+
     /**
      * @return if this mech cannot stand up from hulldown
      */

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -132,6 +132,10 @@ public class QuadVee extends QuadMech {
         return false;
     }
 
+    @Override
+    public CrewType defaultCrewType() {
+        return CrewType.QUADVEE;
+    }
 
     @Override
     public int getWalkMP(MPCalculationSetting mpCalculationSetting) {

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -100,6 +100,11 @@ public class TripodMech extends Mech {
         return true;
     }
 
+    @Override
+    public CrewType defaultCrewType() {
+        return isSuperHeavy() ? CrewType.SUPERHEAVY_TRIPOD : CrewType.TRIPOD;
+    }
+
     /**
      * Returns true if the entity can flip its arms
      */


### PR DESCRIPTION
Ensures that when the force generator creates a QuadVee, tripod, or mech with a command console, it generates the additional crew members with random names and skills.

Fixes #4730 