### PR TITLE
Fix for #4796: NPE in Princess off-board artillery targeting

### DIFF
--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -170,13 +170,14 @@ public class ArtilleryTargetingControl {
     private boolean getADAAvailable(Entity shooter){
         boolean available = false;
         for (Mounted weapon: shooter.getWeaponList()){
-            if(((AmmoType) weapon.getLinked().getType()).getMunitionType().contains(AmmoType.Munitions.M_ADA)
-                && !weapon.isFired() && weapon.getLinked().getUsableShotsLeft() > 0){
-                available = true;
-                break;
+            if (weapon.getType().hasFlag(WeaponType.F_ARTILLERY)){
+                if(((AmmoType) weapon.getLinked().getType()).getMunitionType().contains(AmmoType.Munitions.M_ADA)
+                    && !weapon.isFired() && weapon.getLinked().getUsableShotsLeft() > 0) {
+                    available = true;
+                    break;
+                }
             }
         }
-
         return available;
     }
     /**


### PR DESCRIPTION
I got too "efficient" and didn't account for non-Artillery weapons on off-board
units.  This caused an NPE when attempting to dereference non-existent ammo bins of energy weapons.

Fix is to only run the ADA check on Artillery weapons.

Testing: confirmed that Princess can pass the indirect fire declaration phase using off-board units in the provided save file.

Close #4796 