### PR TITLE
Fix 4801: silent NPE while Princess moving Wraith BA

### DIFF
--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -135,7 +135,7 @@ public class InfantryFireControl extends FireControl {
                 maxFGDamage += damage;
             } else if (otherWeaponsMayShoot) {
                 // case 5
-                if (shooter.isInfantry()) {
+                if (shooterIsActualInfantry) {
                     // field guns can't fire if the infantry unit has done anything
                     // other than turning, so we only get here if infantry has not used MP.
                     // All valid Infantry Field Weapons can consider rackSize as their damage.

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -22,8 +22,6 @@ import org.apache.logging.log4j.LogManager;
 import java.util.ArrayList;
 import java.util.List;
 
-import static megamek.common.WeaponType.F_ARTILLERY;
-
 /**
  * This class is intended to help the bot calculate firing plans for infantry
  * units.
@@ -110,10 +108,8 @@ public class InfantryFireControl extends FireControl {
 
                 maxInfantryWeaponDamage += ((InfantryWeapon) weaponType).getInfantryDamage()
                         * infantryCount;
-                // field guns can't fire if the infantry unit has done anything
-                // other than turning
             } else if (targetIsActualInfantry && otherWeaponsMayShoot) {
-                double damage = 0;
+                double damage;
 
                 // if we're outside, use the direct blow infantry damage
                 // calculation

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -67,8 +67,7 @@ public class InfantryFireControl extends FireControl {
         boolean shooterIsActualInfantry = shooter.hasETypeFlag(Entity.ETYPE_INFANTRY)
                 && !shooter.hasETypeFlag(Entity.ETYPE_BATTLEARMOR);
         // field guns can't fire if the unit in question moved
-        boolean fieldGunsDoDamage = (shooterIsActualInfantry && shooterPath.getMpUsed() == 0)
-                || !shooterIsActualInfantry;
+        boolean otherWeaponsMayShoot = !shooterIsActualInfantry || shooterPath.getMpUsed() == 0;
         boolean inBuilding = Compute.isInBuilding(target.getGame(), targetPath.getFinalElevation(),
                 targetPath.getFinalCoords());
         boolean inOpen = ServerHelper.infantryInOpen(target, targetHex, target.getGame(), targetIsPlatoon, false,
@@ -96,8 +95,8 @@ public class InfantryFireControl extends FireControl {
             // weapon damage, multiply by building dmg reduction.
             // 4. Shooter is non-infantry, target is infantry in "cover". Use
             // "directBlowInfantryDamage".
-            // 5. Shooter is non-infantry, target is non-infantry. Use base
-            // class.
+            // 5. Shooter is infantry with field gun / field artillery and needs special damage calc.
+            // 6. Shooter is non-infantry, target is non-infantry. Use base class.
 
             // case 1
             if (weaponType.hasFlag(WeaponType.F_INFANTRY)) {
@@ -113,7 +112,7 @@ public class InfantryFireControl extends FireControl {
                         * infantryCount;
                 // field guns can't fire if the infantry unit has done anything
                 // other than turning
-            } else if (targetIsActualInfantry && fieldGunsDoDamage) {
+            } else if (targetIsActualInfantry && otherWeaponsMayShoot) {
                 double damage = 0;
 
                 // if we're outside, use the direct blow infantry damage
@@ -134,15 +133,17 @@ public class InfantryFireControl extends FireControl {
                 }
 
                 maxFGDamage += damage;
-                // field guns can't fire if the infantry unit has done anything
-                // other than turning
-            // case 5
-            } else if (fieldGunsDoDamage) {
-                // Some FGs are artillery, so check both damage/shot * shot num _and_ rack size.
-                AmmoType ammoType = (AmmoType) weapon.getLinked().getType();
-                int wDamage = (weaponType.hasFlag(F_ARTILLERY) ? weaponType.rackSize : weaponType.getDamage());
-                int ammoDamage = ammoType.getDamagePerShot()*ammoType.getShots();
-                maxFGDamage += Math.max(wDamage, ammoDamage);
+            } else if (otherWeaponsMayShoot) {
+                // case 5
+                if (shooter.isInfantry()) {
+                    // field guns can't fire if the infantry unit has done anything
+                    // other than turning, so we only get here if infantry has not used MP.
+                    // All valid Infantry Field Weapons can consider rackSize as their damage.
+                    maxFGDamage += weaponType.rackSize;
+                // Case 6: all other unit types / weapons
+                } else {
+                    maxFGDamage += weaponType.getDamage();
+                }
             }
         }
 


### PR DESCRIPTION
This issue was caused by some confusion on my part when implementing proper Field Gun / Field Artillery expected damage computations for Princess.
The boolean fieldGunsDoDamage is actually checking if a unit can make any non-personal weapons attacks, because either:
1. the unit is infantry that hasn't moved this turn, or
2. the unit is _literally any other thing_.

The root cause was attempting to dereference the linked ammo for BA AP weapons, which doesn't work.  That throws an NPE, which is caught in the movement path computation code, which returns a null `mp` object in that case.  But then we try to use the null `mp` object anyhow, with predictable results.

Fix is to clean up some of the checks in that section of code:
- Rename the boolean for clarity
- Formally separate infantry with field weapons from other unit types in comments and code
- Simplify the field weapon expected damage check; we can let Princess assume only one shot from multi-fire field guns will hit, in which case we can use the rack value for all types instead of trying to compute expected damage more completely.  This should also make Princess more likely to use infantry weapons in some cases.

Tested on the save file from the issue, as well as a custom save to verify other infantry and non-infantry predictions still work correctly. 

Close #4801 