### PR TITLE
Fix #4790: uncaught NPE when Sniper Turret fired on fleeing off-board target

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -104,11 +104,10 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
 
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();
 
+        Coords targetPos = target.getPosition();
+
         // Handle counter-battery on fleeing/fled off-board targets.
-        Coords targetPos;
-        try {
-            targetPos = target.getPosition();
-        } catch (Exception e) {
+        if (null == targetPos) {
             LogManager.getLogger().error(String.format("Artillery Target %s is missing; off-board target fled?", waa.getTargetId()));
             return false;
         }

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -103,7 +103,16 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         }
 
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();
-        Coords targetPos = target.getPosition();
+
+        // Handle counter-battery on fleeing/fled off-board targets.
+        Coords targetPos;
+        try {
+            targetPos = target.getPosition();
+        } catch (Exception e) {
+            LogManager.getLogger().error(String.format("Artillery Target %s is missing; off-board target fled?", waa.getTargetId()));
+            return false;
+        }
+
         final int playerId = aaa.getPlayerId();
         boolean targetIsEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
         boolean targetIsAirborneVTOL = targetIsEntity && target.isAirborneVTOLorWIGE();


### PR DESCRIPTION
Issue is that target is null by the time we get around to handling this indirect attack, because it has fled already.

Fix is to ignore this failure and just log the incident, as there doesn't seem to be any way to resolve damage from a missed counter-battery attack on an off-board target that has fled.

Tested by implementing this code in 0.49.14 and running OP's save file past the point that previously got hung.

close #4790 