### PR TITLE
Don't override called shots (high) for units with partial cover.

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4399,11 +4399,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 toHit.setCover(LosEffects.COVER_UPPER);
             } else {
                 if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PARTIAL_COVER)) {
-                    toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
                     toHit.setCover(los.getTargetCover());
                 } else {
-                    toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
                     toHit.setCover(LosEffects.COVER_HORIZONTAL);
+                }
+                // If this is a called shot (high) the table has already been set and should be used instead of partial cover.
+                if (toHit.getHitTable() != ToHitData.HIT_ABOVE) {
+                    toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
                 }
                 // Set damageable cover state information
                 toHit.setDamagableCoverTypePrimary(los.getDamagableCoverTypePrimary());


### PR DESCRIPTION
When using the called shots rule (TO:AR pp 76-77), aiming high uses the attacks from above table. When the target is also in partial cover, MM is changing the table before resolving the hit location.

Fixes #4738