### PR TITLE
Fix AbstractSmallCraftASFBay: Add null guard for game

### DIFF
--- a/megamek/src/megamek/common/AbstractSmallCraftASFBay.java
+++ b/megamek/src/megamek/common/AbstractSmallCraftASFBay.java
@@ -52,7 +52,13 @@ public abstract class AbstractSmallCraftASFBay extends Bay {
     @Override
     public double getUnused() {
         // loaded fighter squadrons can change size, therefore always update this
-        int used = troops.stream().map(game::getEntity).mapToInt(t -> (int) spaceForUnit(t)).sum();
+        int used = 0;
+        if (game != null) {
+            used = troops.stream()
+                    .map(game::getEntity)
+                    .mapToInt(t -> (int) spaceForUnit(t))
+                    .sum();
+        }
         currentSpace = totalSpace - used;
         return currentSpace - getBayDamage();
     }


### PR DESCRIPTION
Fixes a bug I introduced with the squadron thing. game can be null; but in that case the bay can't have anything loaded