### PR TITLE
Aerospace landing fixes

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2465,6 +2465,7 @@ MovementDisplay.ConfirmUnJamRACDlg.title=Unjam?
 MovementDisplay.ConfirmPilotingRoll=You must make the following piloting\nskill check(s) for your movement:\n
 MovementDisplay.ConfirmSprint=Are you sure you want to sprint?
 MovementDisplay.ConfirmSuperchargerRoll=The movement you have selected will require a roll of {0} or higher\nto avoid Supercharger failure. Do you wish to proceed?
+MovementDisplay.ConfirmLandingGearDamage=Landing in a rough or rubble hex will damage the landing ger.\n\nAre you sure you want to land here?
 MovementDisplay.DFADialog.message=To Hit: {0} ({1}%)   ({2})\nDamage to Target: {3} (in 5pt clusters){4}\nDamage to Self: {5} (in 5pt clusters) (using Kick table)
 MovementDisplay.DFADialog.title=D.F.A. {0}?
 MovementDisplay.Done=Done

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -1182,6 +1182,8 @@
 #crash related
 9700=<newline><font color='C00000'><data> (<data>) crashes, suffering <data> damage!</font>
 9701=<newline><font color='C00000'><data> (<data>) crashes off the map!</font>
+9702=<data> (<data>) is destroyed by landing in water.
+9703=<data> (<data>) is immobilized by landing in water.
 9705=<newline><data> (<data>) must roll a <data> or lower to avoid <data> damage, rolls a <data>: <msg:9706,9707>
 9706=<font color='C00000'>hit by crash!</font>
 9707=avoids crash.

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1700,7 +1700,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         if (cmd.contains(MoveStepType.LAND) || cmd.contains(MoveStepType.VLAND)) {
             Set<Coords> landingPath = ((IAero) ce()).getLandingCoords(cmd.contains(MoveStepType.VLAND),
                     cmd.getFinalCoords(), cmd.getFinalFacing());
-            if (landingPath.stream().map(c -> game().getBoard().getHex(c))
+            if (landingPath.stream().map(c -> game().getBoard().getHex(c)).filter(Objects::nonNull)
                     .anyMatch(h -> h.containsTerrain(Terrains.ROUGH) || h.containsTerrain(Terrains.RUBBLE))) {
                 ConfirmDialog nag = new ConfirmDialog(clientgui.frame,
                         Messages.getString("MovementDisplay.areYourSure"),

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1697,6 +1697,22 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
 
+        if (cmd.contains(MoveStepType.LAND) || cmd.contains(MoveStepType.VLAND)) {
+            Set<Coords> landingPath = ((IAero) ce()).getLandingCoords(cmd.contains(MoveStepType.VLAND),
+                    cmd.getFinalCoords(), cmd.getFinalFacing());
+            if (landingPath.stream().map(c -> game().getBoard().getHex(c))
+                    .anyMatch(h -> h.containsTerrain(Terrains.ROUGH) || h.containsTerrain(Terrains.RUBBLE))) {
+                ConfirmDialog nag = new ConfirmDialog(clientgui.frame,
+                        Messages.getString("MovementDisplay.areYourSure"),
+                        Messages.getString("MovementDisplay.ConfirmLandingGearDamage"),
+                        false);
+                nag.setVisible(true);
+                if (!nag.getAnswer()) {
+                    return;
+                }
+            }
+        }
+
         if (isUsingChaff) {
             addStepToMovePath(MoveStepType.CHAFF);
             isUsingChaff = false;

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -474,6 +474,18 @@ public class Dropship extends SmallCraft {
         return 4;
     }
 
+    @Override
+    public int getWalkMP(MPCalculationSetting mpCalculationSetting) {
+        // A grounded dropship with the center hex in level 1 water is immobile.
+        if ((game != null) && !game.getBoard().inSpace() && !isAirborne()) {
+            Hex hex = game.getBoard().getHex(getPosition());
+            if ((hex != null) && (hex.containsTerrain(Terrains.WATER, 1) && !hex.containsTerrain(Terrains.ICE))) {
+                return 0;
+            }
+        }
+        return super.getWalkMP(mpCalculationSetting);
+    }
+
     /*
      * (non-Javadoc)
      *

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -525,22 +525,30 @@ public interface IAero {
         }
 
         if (heavyWoods) {
-            roll.addModifier(+5, "heavy woods in landing path");
+            addLandingModifier(roll, +5, "heavy woods in landing path", isVertical);
         }
         if (lightWoods) {
-            roll.addModifier(+4, "light woods in landing path");
+            addLandingModifier(roll, +4, "light woods in landing path", isVertical);
         }
         if (rough) {
-            roll.addModifier(+3, "rough/rubble in landing path");
+            addLandingModifier(roll, +3, "rough/rubble in landing path", isVertical);
         }
         if (paved) {
-            roll.addModifier(+0, "paved/road landing strip");
+            addLandingModifier(roll, +0, "paved/road landing strip", isVertical);
         }
         if (clear) {
-            roll.addModifier(+2, "clear hex in landing path");
+            addLandingModifier(roll, +2, "clear hex in landing path", isVertical);
         }
 
         return roll;
+    }
+
+    default void addLandingModifier(PilotingRollData roll, int mod, String reason, boolean isVertical) {
+        if (isVertical) {
+            // divide by 2, rounding up
+            mod = mod / 2 + mod % 2;
+        }
+        roll.addModifier(mod, reason);
     }
 
     /**

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -481,7 +481,7 @@ public interface IAero {
         boolean clear = false;
         for (Coords pos : landingPositions) {
             Hex hex = ((Entity) this).getGame().getBoard().getHex(pos);
-            if (hex.hasPavement()) {
+            if ((hex == null) || hex.hasPavement()) {
                 continue;
             }
             if (hex.isClearHex()) {
@@ -729,6 +729,14 @@ public interface IAero {
         // landing must contain only acceptable terrain
         if (!hex.isClearForLanding()) {
             return "Unacceptable terrain for landing";
+        }
+        // Aerospace units are destroyed by water landings except for those that have flotation hulls.
+        // LAMs are not.
+        if (hex.containsTerrain(Terrains.WATER) && !hex.containsTerrain(Terrains.ICE)
+                && (hex.terrainLevel(Terrains.WATER) > 0)
+                && (this instanceof Aero)
+                && !((Entity) this).hasWorkingMisc(MiscType.F_FLOTATION_HULL)) {
+            return "cannot land on water";
         }
 
         return null;

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -482,7 +482,7 @@ public interface IAero {
         boolean rough = false;
         boolean heavyWoods = false;
         boolean clear = false;
-        boolean paved = true;
+        boolean paved = false;
 
         Set<Coords> landingPositions = new HashSet<>();
         boolean isDropship = (this instanceof Dropship);
@@ -516,8 +516,9 @@ public interface IAero {
                 heavyWoods = true;
             } else if (hex.containsTerrain(Terrains.WOODS, 1)) {
                 lightWoods = true;
-            } else if (!hex.containsTerrain(Terrains.PAVEMENT) && !hex.containsTerrain(Terrains.ROAD)) {
-                paved = false;
+            } else if (hex.containsTerrain(Terrains.PAVEMENT) || hex.containsTerrain(Terrains.ROAD)) {
+                paved = true;
+            } else {
                 // Landing in other terrains isn't allowed, so if we reach here
                 // it must be a clear hex
                 clear = true;

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -484,29 +484,9 @@ public interface IAero {
         boolean clear = false;
         boolean paved = false;
 
-        Set<Coords> landingPositions = new HashSet<>();
+        Set<Coords> landingPositions = getLandingCoords(isVertical, landingPos, face);
         boolean isDropship = (this instanceof Dropship);
         // Vertical landing just checks the landing hex
-        if (isVertical) {
-            landingPositions.add(landingPos);
-            // Dropships must also check the adjacent 6 hexes
-            if (isDropship) {
-                for (int i = 0; i < 6; i++) {
-                    landingPositions.add(landingPos.translated(i));
-                }
-            }
-            // Horizontal landing requires checking whole landing strip
-        } else {
-            for (int i = 0; i < getLandingLength(); i++) {
-                Coords pos = landingPos.translated(face, i);
-                landingPositions.add(pos);
-                // Dropships have to check the front adjacent hexes
-                if (isDropship) {
-                    landingPositions.add(pos.translated((face + 4) % 6));
-                    landingPositions.add(pos.translated((face + 2) % 6));
-                }
-            }
-        }
 
         for (Coords pos : landingPositions) {
             Hex hex = ((Entity) this).getGame().getBoard().getHex(pos);
@@ -542,6 +522,31 @@ public interface IAero {
         }
 
         return roll;
+    }
+
+    default Set<Coords> getLandingCoords(boolean isVertical, Coords landingPos, int facing) {
+        Set<Coords> landingPositions = new HashSet<Coords>();
+        if (isVertical) {
+            landingPositions.add(landingPos);
+            // Dropships must also check the adjacent 6 hexes
+            if (this instanceof Dropship) {
+                for (int i = 0; i < 6; i++) {
+                    landingPositions.add(landingPos.translated(i));
+                }
+            }
+            // Horizontal landing requires checking whole landing strip
+        } else {
+            for (int i = 0; i < getLandingLength(); i++) {
+                Coords pos = landingPos.translated(facing, i);
+                landingPositions.add(pos);
+                // Dropships have to check the front adjacent hexes
+                if (this instanceof Dropship) {
+                    landingPositions.add(pos.translated((facing + 4) % 6));
+                    landingPositions.add(pos.translated((facing + 2) % 6));
+                }
+            }
+        }
+        return landingPositions;
     }
 
     default void addLandingModifier(PilotingRollData roll, int mod, String reason, boolean isVertical) {

--- a/megamek/src/megamek/common/Terrains.java
+++ b/megamek/src/megamek/common/Terrains.java
@@ -500,4 +500,39 @@ public class Terrains implements Serializable {
             }
         }
     }
+
+    /**
+     * Modifier to control roll when the terrain is in the landing path.
+     * @param terrainType   Type of terrain
+     * @param terrainLevel  The level of the terrain
+     * @return The control roll modifier
+     */
+    public static int landingModifier(int terrainType, int  terrainLevel) {
+        switch (terrainType) {
+            case WOODS:
+            case JUNGLE:
+                return (terrainLevel == 3) ? 7 : terrainLevel + 3;
+            case WATER:
+                return (terrainLevel > 0) ? 3 : 2;
+            case ROUGH:
+                return terrainLevel == 2 ? 5 : 3;
+            case RUBBLE:
+                return terrainLevel == 6 ? 5 : 3;
+            case SAND:
+            case TUNDRA:
+            case MAGMA:
+            case FIELDS:
+            case SWAMP:
+                return 2;
+            case BUILDING:
+                return terrainLevel + 1;
+            case SNOW:
+                return (terrainLevel == 2) ? 1 : 0;
+            case ICE:
+            case MUD:
+                return 1;
+            default:
+                return 0;
+        }
+    }
 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -4011,6 +4011,25 @@ public class GameManager implements IGameManager {
         }
     }
 
+    /**
+     * Any aerospace unit that lands in a rough or rubble hex takes landing hear damage.
+     * @param aero      The landing unit
+     * @param vertical  Whether the landing is vertical
+     * @param pos       The coordinates of the hex of touchdown
+     * @param facing    The facing of the landing unit
+     */
+    private void checkForLandingGearDamage(IAero aero, boolean vertical, Coords pos, int facing) {
+        Set<Coords> landingPositions = aero.getLandingCoords(vertical, pos, facing);
+        if (landingPositions.stream().map(c -> game.getBoard().getHex(c))
+                .anyMatch(h -> h.containsTerrain(Terrains.ROUGH) || h.containsTerrain(Terrains.RUBBLE))) {
+            aero.setGearHit(true);
+        }
+        Report r = new Report(9125);
+        r.subject = ((Entity) aero).getId();
+        addReport(r);
+
+    }
+
     private boolean launchUnit(Entity unloader, Targetable unloaded,
                                Coords pos, int facing, int velocity, int altitude, int[] moveVec,
                                int bonus) {
@@ -6124,6 +6143,7 @@ public class GameManager implements IGameManager {
             rollTarget = a.checkLanding(md.getLastStepMovementType(), md.getFinalVelocity(),
                     md.getFinalCoords(), md.getFinalFacing(), false);
             attemptLanding(entity, rollTarget);
+            checkForLandingGearDamage(a, true, md.getFinalCoords(), md.getFinalFacing());
             a.land();
             entity.setPosition(md.getFinalCoords().translated(md.getFinalFacing(),
                     a.getLandingLength()));
@@ -6141,6 +6161,7 @@ public class GameManager implements IGameManager {
             if (entity instanceof Dropship) {
                 applyDropShipLandingDamage(md.getFinalCoords(), (Dropship) a);
             }
+            checkForLandingGearDamage(a, true, md.getFinalCoords(), md.getFinalFacing());
             a.land();
             entity.setPosition(md.getFinalCoords());
             entity.setDone(true);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -4023,11 +4023,10 @@ public class GameManager implements IGameManager {
         if (landingPositions.stream().map(c -> game.getBoard().getHex(c))
                 .anyMatch(h -> h.containsTerrain(Terrains.ROUGH) || h.containsTerrain(Terrains.RUBBLE))) {
             aero.setGearHit(true);
+            Report r = new Report(9125);
+            r.subject = ((Entity) aero).getId();
+            addReport(r);
         }
-        Report r = new Report(9125);
-        r.subject = ((Entity) aero).getId();
-        addReport(r);
-
     }
 
     private boolean launchUnit(Entity unloader, Targetable unloaded,

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -4013,19 +4013,35 @@ public class GameManager implements IGameManager {
 
     /**
      * Any aerospace unit that lands in a rough or rubble hex takes landing hear damage.
-     * @param aero      The landing unit
-     * @param vertical  Whether the landing is vertical
-     * @param pos       The coordinates of the hex of touchdown
-     * @param facing    The facing of the landing unit
+     * @param aero         The landing unit
+     * @param vertical     Whether the landing is vertical
+     * @param touchdownPos The coordinates of the hex of touchdown
+     * @param finalPos     The coordinates of the hex in which the unit comes to a stop
+     * @param facing       The facing of the landing unit
+     * @
      */
-    private void checkForLandingGearDamage(IAero aero, boolean vertical, Coords pos, int facing) {
-        Set<Coords> landingPositions = aero.getLandingCoords(vertical, pos, facing);
-        if (landingPositions.stream().map(c -> game.getBoard().getHex(c))
+    private void checkLandingTerrainEffects(IAero aero, boolean vertical, Coords touchdownPos, Coords finalPos, int facing) {
+        // Landing in a rough for rubble hex damages landing gear.
+        Set<Coords> landingPositions = aero.getLandingCoords(vertical, touchdownPos, facing);
+        if (landingPositions.stream().map(c -> game.getBoard().getHex(c)).filter(Objects::nonNull)
                 .anyMatch(h -> h.containsTerrain(Terrains.ROUGH) || h.containsTerrain(Terrains.RUBBLE))) {
             aero.setGearHit(true);
             Report r = new Report(9125);
             r.subject = ((Entity) aero).getId();
             addReport(r);
+        }
+        // Landing in water can destroy or immobilize the unit.
+        Hex hex = game.getBoard().getHex(finalPos);
+        if ((aero instanceof Aero) && hex.containsTerrain(Terrains.WATER) && !hex.containsTerrain(Terrains.ICE)
+                && (hex.terrainLevel(Terrains.WATER) > 0)
+                && !((Entity) aero).hasWorkingMisc(MiscType.F_FLOTATION_HULL)) {
+            if ((hex.terrainLevel(Terrains.WATER) > 1) || !(aero instanceof Dropship)) {
+                Report r = new Report(9702);
+                r.subject(((Entity) aero).getId());
+                r.addDesc((Entity) aero);
+                addReport(r);
+                addReport(destroyEntity((Entity) aero, "landing in deep water"));
+            }
         }
     }
 
@@ -6142,7 +6158,8 @@ public class GameManager implements IGameManager {
             rollTarget = a.checkLanding(md.getLastStepMovementType(), md.getFinalVelocity(),
                     md.getFinalCoords(), md.getFinalFacing(), false);
             attemptLanding(entity, rollTarget);
-            checkForLandingGearDamage(a, true, md.getFinalCoords(), md.getFinalFacing());
+            checkLandingTerrainEffects(a, true, md.getFinalCoords(),
+                    md.getFinalCoords().translated(md.getFinalFacing(), a.getLandingLength()), md.getFinalFacing());
             a.land();
             entity.setPosition(md.getFinalCoords().translated(md.getFinalFacing(),
                     a.getLandingLength()));
@@ -6160,7 +6177,7 @@ public class GameManager implements IGameManager {
             if (entity instanceof Dropship) {
                 applyDropShipLandingDamage(md.getFinalCoords(), (Dropship) a);
             }
-            checkForLandingGearDamage(a, true, md.getFinalCoords(), md.getFinalFacing());
+            checkLandingTerrainEffects(a, true, md.getFinalCoords(), md.getFinalCoords(), md.getFinalFacing());
             a.land();
             entity.setPosition(md.getFinalCoords());
             entity.setDone(true);


### PR DESCRIPTION
Fixes several issues related to aerospace units making landings:
1. Units making vertical landings only apply half the terrain modifier (TW, p. 87).
2. I added terrain modifiers for advanced terrain from TacOps.
3. When the landing path includes rough or rubble terrain, the landing unit takes damage (TW, p. 86, table).
4. A unit that lands in water of sufficient depth (2 for dropships, 1 for other units) is destroyed (TW p. 87, which refers to p. 82).
5. A dropship that lands in depth 1 water is immobile for the rest of the game (ibid).

I exempted LAMs and units with a flotation hull from water destruction.
Fixes #4743 