### PR TITLE
Fix Immelman and Split-S maneuvers

### DIFF
--- a/megamek/src/megamek/client/commands/MoveCommand.java
+++ b/megamek/src/megamek/client/commands/MoveCommand.java
@@ -16,10 +16,7 @@ package megamek.client.commands;
 
 import megamek.client.Client;
 import megamek.client.ui.swing.MovementDisplay;
-import megamek.common.Coords;
-import megamek.common.Entity;
-import megamek.common.EntityMovementMode;
-import megamek.common.MovePath;
+import megamek.common.*;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.options.OptionsConstants;
 
@@ -164,7 +161,7 @@ public class MoveCommand extends ClientCommand {
     private void currentMove(Coords dest) {
         if (dest != null) {
             if (gear == GEAR_TURN) {
-                cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), false);
+                cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), false, ManeuverType.MAN_NONE);
             } else if (gear == GEAR_LAND || gear == GEAR_JUMP) {
                 cmd.findPathTo(dest, MoveStepType.FORWARDS);
             } else if (gear == GEAR_BACKUP) {

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -987,14 +987,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
         updateMove();
     }
 
-    private void addStepToMovePath(MoveStepType moveStep, boolean noCost,  boolean isManeuver) {
-        cmd.addStep(moveStep, noCost, isManeuver);
+    private void addStepToMovePath(MoveStepType moveStep, boolean noCost,  boolean isManeuver, int maneuverType) {
+        cmd.addStep(moveStep, noCost, isManeuver, maneuverType);
         updateMove();
     }
 
-    private void addStepsToMovePath(boolean noCost, boolean isManeuver, MoveStepType ... moveSteps) {
+    private void addStepsToMovePath(boolean noCost, boolean isManeuver, int maneuverType, MoveStepType ... moveSteps) {
         for (MoveStepType moveStep : moveSteps) {
-            cmd.addStep(moveStep, noCost, isManeuver);
+            cmd.addStep(moveStep, noCost, isManeuver, maneuverType);
         }
         updateMove();
     }
@@ -1747,7 +1747,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     private void currentMove(Coords dest) {
         if (shiftheld || (gear == GEAR_TURN)) {
-            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), false);
+            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), false, ManeuverType.MAN_NONE);
         } else if ((gear == GEAR_JUMP)
                    && (ce().getJumpType() == Mech.JUMP_BOOSTER)) {
             // Jumps with mechanical jump boosters are special
@@ -1836,19 +1836,19 @@ public class MovementDisplay extends ActionPhaseDisplay {
         } else if (gear == GEAR_RAM) {
             cmd.findPathTo(dest, MoveStepType.FORWARDS);
         } else if (gear == GEAR_IMMEL) {
-            addStepsToMovePath(true, true,
+            addStepsToMovePath(true, true, ManeuverType.MAN_IMMELMAN,
                     MoveStepType.UP,
                     MoveStepType.UP,
                     MoveStepType.DEC,
                     MoveStepType.DEC);
-            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), true);
+            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), true, ManeuverType.MAN_IMMELMAN);
             gear = GEAR_LAND;
         } else if (gear == GEAR_SPLIT_S) {
-            addStepsToMovePath(true, true,
+            addStepsToMovePath(true, true, ManeuverType.MAN_SPLIT_S,
                     MoveStepType.DOWN,
                     MoveStepType.DOWN,
                     MoveStepType.ACC);
-            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), true);
+            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), true, ManeuverType.MAN_SPLIT_S);
             gear = GEAR_LAND;
         }
         if (gear == GEAR_LONGEST_WALK || gear == GEAR_LONGEST_RUN) {
@@ -4244,13 +4244,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
         cmd.addManeuver(type);
         switch (type) {
             case ManeuverType.MAN_HAMMERHEAD:
-                addStepToMovePath(MoveStepType.YAW, true, true);
+                addStepToMovePath(MoveStepType.YAW, true, true, type);
                 return true;
             case ManeuverType.MAN_HALF_ROLL:
-                addStepToMovePath(MoveStepType.ROLL, true, true);
+                addStepToMovePath(MoveStepType.ROLL, true, true, type);
                 return true;
             case ManeuverType.MAN_BARREL_ROLL:
-                addStepToMovePath(MoveStepType.DEC, true, true);
+                addStepToMovePath(MoveStepType.DEC, true, true, type);
                 return true;
             case ManeuverType.MAN_IMMELMAN:
                 gear = MovementDisplay.GEAR_IMMEL;
@@ -4269,7 +4269,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     vel = last.getVelocityLeft();
                 }
                 while (vel > 0) {
-                    addStepToMovePath(MoveStepType.DEC, true, true);
+                    addStepToMovePath(MoveStepType.DEC, true, true, type);
                     vel--;
                 }
                 addStepToMovePath(MoveStepType.UP);
@@ -4279,13 +4279,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 // See Total Warfare pg 85
                 if (clientgui.getClient().getGame().getBoard().getType() == Board.T_GROUND) {
                     for (int i = 0; i < 8; i++) {
-                        addStepToMovePath(MoveStepType.LATERAL_LEFT, true, true);
+                        addStepToMovePath(MoveStepType.LATERAL_LEFT, true, true, type);
                     }
                     for (int i = 0; i < 8; i++) {
-                        addStepToMovePath(MoveStepType.FORWARDS, true, true);
+                        addStepToMovePath(MoveStepType.FORWARDS, true, true, type);
                     }
                 } else {
-                    addStepToMovePath(MoveStepType.LATERAL_LEFT, true, true);
+                    addStepToMovePath(MoveStepType.LATERAL_LEFT, true, true, type);
                 }
                 return true;
             case ManeuverType.MAN_SIDE_SLIP_RIGHT:
@@ -4293,17 +4293,17 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 // See Total Warfare pg 85
                 if (clientgui.getClient().getGame().getBoard().getType() == Board.T_GROUND) {
                     for (int i = 0; i < 8; i++) {
-                        addStepToMovePath(MoveStepType.LATERAL_RIGHT, true, true);
+                        addStepToMovePath(MoveStepType.LATERAL_RIGHT, true, true, type);
                     }
                     for (int i = 0; i < 8; i++) {
-                        addStepToMovePath(MoveStepType.FORWARDS, true, true);
+                        addStepToMovePath(MoveStepType.FORWARDS, true, true, type);
                     }
                 } else {
-                    addStepToMovePath(MoveStepType.LATERAL_RIGHT, true, true);
+                    addStepToMovePath(MoveStepType.LATERAL_RIGHT, true, true, type);
                 }
                 return true;
             case ManeuverType.MAN_LOOP:
-                addStepToMovePath(MoveStepType.LOOP, true, true);
+                addStepToMovePath(MoveStepType.LOOP, true, true, type);
                 return true;
             default:
                 return false;

--- a/megamek/src/megamek/common/ManeuverType.java
+++ b/megamek/src/megamek/common/ManeuverType.java
@@ -87,13 +87,13 @@ public class ManeuverType {
                         MovePath tmpMp = mp.clone();                    
                         for (int i = 0; i < 8; i++) {
                             if (type == MAN_SIDE_SLIP_LEFT) {
-                                tmpMp.addStep(MoveStepType.LATERAL_LEFT, true, true);
+                                tmpMp.addStep(MoveStepType.LATERAL_LEFT, true, true, type);
                             } else {
-                                tmpMp.addStep(MoveStepType.LATERAL_RIGHT, true, true);
+                                tmpMp.addStep(MoveStepType.LATERAL_RIGHT, true, true, type);
                             }
                         }
                         for (int i = 0; i < 8; i++) {
-                            tmpMp.addStep(MoveStepType.FORWARDS, true, true);
+                            tmpMp.addStep(MoveStepType.FORWARDS, true, true, type);
                         }                    
                         return tmpMp.getLastStep().isLegal(tmpMp);
                     } else {

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -567,10 +567,10 @@ public class MovePath implements Cloneable, Serializable {
                 step = new MoveStep(this, step.getType(), step.getBraceLocation());
             } else if (!step.getLaunched().isEmpty()) {
                 step = new MoveStep(this, step.getType(), step.getLaunched());
-            } else if (step.getManeuverType() != ManeuverType.MAN_NONE) {
-                step = new MoveStep(this, step.getType(), -1, -1, step.getManeuverType());
             } else if (step.isManeuver()) {
                 step = new MoveStep(this, step.getType(), step.hasNoCost(), step.isManeuver(), step.getManeuverType());
+            } else if (step.getManeuverType() != ManeuverType.MAN_NONE) {
+                step = new MoveStep(this, step.getType(), -1, -1, step.getManeuverType());
             } else if (step.hasNoCost()) {
                 step = new MoveStep(this, step.getType(), step.hasNoCost());
             } else if (null != step.getMinefield()) {

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -206,8 +206,8 @@ public class MovePath implements Cloneable, Serializable {
         return addStep(new MoveStep(this, type, noCost));
     }
 
-    public MovePath addStep(final MoveStepType type, final boolean noCost, final boolean isManeuver) {
-        return addStep(new MoveStep(this, type, noCost, isManeuver));
+    public MovePath addStep(final MoveStepType type, final boolean noCost, final boolean isManeuver, final int maneuverType) {
+        return addStep(new MoveStep(this, type, noCost, isManeuver, maneuverType));
     }
 
     public MovePath addStep(final MoveStepType type, final Minefield mf) {
@@ -570,7 +570,7 @@ public class MovePath implements Cloneable, Serializable {
             } else if (step.getManeuverType() != ManeuverType.MAN_NONE) {
                 step = new MoveStep(this, step.getType(), -1, -1, step.getManeuverType());
             } else if (step.isManeuver()) {
-                step = new MoveStep(this, step.getType(), step.hasNoCost(), step.isManeuver());
+                step = new MoveStep(this, step.getType(), step.hasNoCost(), step.isManeuver(), step.getManeuverType());
             } else if (step.hasNoCost()) {
                 step = new MoveStep(this, step.getType(), step.hasNoCost());
             } else if (null != step.getMinefield()) {
@@ -1440,11 +1440,12 @@ public class MovePath implements Cloneable, Serializable {
         while (!getFinalCoords().equals(subDest)) {
             // adjust facing
             rotatePathfinder((getFinalCoords().direction(subDest) + (step == MoveStepType.BACKWARDS ? 3 : 0)) % 6,
-                    false);
+                    false, ManeuverType.MAN_NONE);
             // step forwards
             addStep(step);
         }
-        rotatePathfinder((getFinalCoords().direction(dest) + (step == MoveStepType.BACKWARDS ? 3 : 0)) % 6, false);
+        rotatePathfinder((getFinalCoords().direction(dest) + (step == MoveStepType.BACKWARDS ? 3 : 0)) % 6,
+                false, ManeuverType.MAN_NONE);
         if (!dest.equals(getFinalCoords())) {
             addStep(type);
         }
@@ -1553,10 +1554,10 @@ public class MovePath implements Cloneable, Serializable {
     /**
      * Rotate from the current facing to the destination facing.
      */
-    public void rotatePathfinder(final int destFacing, final boolean isManeuver) {
+    public void rotatePathfinder(final int destFacing, final boolean isManeuver, int maneuverType) {
         while (getFinalFacing() != destFacing) {
             final MoveStepType stepType = getDirection(getFinalFacing(), destFacing);
-            addStep(stepType, isManeuver, isManeuver);
+            addStep(stepType, isManeuver, isManeuver, maneuverType);
         }
     }
 

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -292,10 +292,11 @@ public class MoveStep implements Serializable {
     }
 
     public MoveStep(MovePath path, MoveStepType type, boolean noCost,
-                    boolean isManeuver) {
+                    boolean isManeuver, int maneuverType) {
         this(path, type);
         this.noCost = noCost;
         maneuver = isManeuver;
+        this.maneuverType = maneuverType;
     }
 
     public MoveStep(MovePath path, MoveStepType type, int recovery,


### PR DESCRIPTION
This fixes a bug I introduced in #4663. The change assumes that the maneuver type is set in the previous step, but it was only being set in the movement step and not the subsequent steps that implement the effects of the maneuver. I've changed it to include the maneuver type with all steps that are part of the maneuver, and this time I tested every maneuver type to make sure it's working.

Fixes #4791.