### PR TITLE
MekView updates

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4459,6 +4459,12 @@ CASCardPanel.conversionReport=Conversion Report
 CASCardPanel.font=Font:
 CASCardPanel.cardSize=Card Size:
 
+#ConfigurableMechViewPanel
+CMVPanel.copyHTML=Copy as HTML
+CMVPanel.copyText=Copy as Text
+CMVPanel.MUL=Open MUL
+CMVPanel.font=Font:
+
 #Gamemaster Menu Text
 Gamemaster.Gamemaster=Gamemaster
 Gamemaster.EditDamage=Edit Damage

--- a/megamek/src/megamek/MMConstants.java
+++ b/megamek/src/megamek/MMConstants.java
@@ -25,6 +25,7 @@ public final class MMConstants extends SuiteConstants {
     //region General Constants
     public static final String PROJECT_NAME = "MegaMek";
     public static final String MUL_URL_PREFIX = "http://www.masterunitlist.info/Unit/Details/";
+    public static final String BT_URL_SHRAPNEL = "https://bg.battletech.com/shrapnel/";
     //endregion General Constants
 
     //region GUI Constants

--- a/megamek/src/megamek/MMConstants.java
+++ b/megamek/src/megamek/MMConstants.java
@@ -26,6 +26,8 @@ public final class MMConstants extends SuiteConstants {
     public static final String PROJECT_NAME = "MegaMek";
     public static final String MUL_URL_PREFIX = "http://www.masterunitlist.info/Unit/Details/";
     public static final String BT_URL_SHRAPNEL = "https://bg.battletech.com/shrapnel/";
+    /** When this text is found in the source field, the Mek View will display a link to {@link #BT_URL_SHRAPNEL} */
+    public static final String SOURCE_TEXT_SHRAPNEL = "Shrapnel";
     //endregion General Constants
 
     //region GUI Constants

--- a/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
@@ -28,7 +28,10 @@ import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 
-/** A dialog showing the unit readout for a given unit. */
+/**
+ * A dialog showing the unit readout for a given unit. It shows an {@link EntityViewPane} with the entity summary,
+ * TRO and AS card panels within a TabbedPane.
+ */
 public class EntityReadoutDialog extends AbstractDialog {
 
     private final Entity entity;

--- a/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
@@ -25,6 +25,7 @@ import megamek.client.ui.baseComponents.AbstractDialog;
 import megamek.client.ui.panes.EntityViewPane;
 import megamek.client.ui.preferences.JTabbedPanePreference;
 import megamek.client.ui.preferences.PreferencesNode;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 
 /** A dialog showing the unit readout for a given unit. */
@@ -56,5 +57,14 @@ public class EntityReadoutDialog extends AbstractDialog {
     protected void setCustomPreferences(final PreferencesNode preferences) throws Exception {
         super.setCustomPreferences(preferences);
         preferences.manage(new JTabbedPanePreference(entityView));
+    }
+
+    @Override
+    public void setVisible(boolean visible) {
+        if (visible) {
+            UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
+        }
+
+        super.setVisible(visible);
     }
 }

--- a/megamek/src/megamek/client/ui/panes/ConfigurableMechViewPanel.java
+++ b/megamek/src/megamek/client/ui/panes/ConfigurableMechViewPanel.java
@@ -32,6 +32,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
+import java.util.Locale;
 
 /**
  * This class wraps the MechView / MechViewPanel and gives it a toolbar to choose font, open the MUL
@@ -56,8 +57,11 @@ public class ConfigurableMechViewPanel extends JPanel {
         setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
 
         fontChooser.addItem("");
-        for (String family : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()) {
-            fontChooser.addItem(family);
+        for (String family : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames(Locale.US)) {
+            Font f = Font.decode(family);
+            if (f.canDisplayUpTo("anzANZ150/[]") == -1) {
+                fontChooser.addItem(family);
+            }
         }
         fontChooser.addActionListener(ev -> updateFont());
         fontChooser.setSelectedItem(GUIPreferences.getInstance().getSummaryFont());

--- a/megamek/src/megamek/client/ui/panes/ConfigurableMechViewPanel.java
+++ b/megamek/src/megamek/client/ui/panes/ConfigurableMechViewPanel.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.panes;
+
+import megamek.MMConstants;
+import megamek.client.ui.Messages;
+import megamek.client.ui.WrapLayout;
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.MechViewPanel;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.Entity;
+import megamek.common.MechView;
+import megamek.common.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+
+/**
+ * This class wraps the MechView / MechViewPanel and gives it a toolbar to choose font, open the MUL
+ * and copy the contents.
+ */
+public class ConfigurableMechViewPanel extends JPanel {
+
+    private final JComboBox<String> fontChooser = new JComboBox<>();
+    private final JButton copyHtmlButton = new JButton(Messages.getString("CMVPanel.copyHTML"));
+    private final JButton copyTextButton = new JButton(Messages.getString("CMVPanel.copyText"));
+    private final JButton mulButton = new JButton(Messages.getString("CMVPanel.MUL"));
+    private final MechViewPanel mechViewPanel = new MechViewPanel();
+    private int mulId;
+    private Entity entity;
+
+    /**
+     * Constructs a panel with the given unit to display.
+     *
+     * @param entity The Entity to display
+     */
+    public ConfigurableMechViewPanel(@Nullable Entity entity) {
+        setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
+
+        fontChooser.addItem("");
+        for (String family : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()) {
+            fontChooser.addItem(family);
+        }
+        fontChooser.addActionListener(ev -> updateFont());
+        fontChooser.setSelectedItem(GUIPreferences.getInstance().getSummaryFont());
+
+        copyHtmlButton.addActionListener(ev -> copyToClipboard(true));
+        copyTextButton.addActionListener(ev -> copyToClipboard(false));
+
+        mulButton.addActionListener(ev -> UIUtil.showMUL(mulId, this));
+        mulButton.setToolTipText("Show the Master Unit List entry for this unit. Opens a browser window.");
+
+        var chooserLine = new UIUtil.FixedYPanel(new WrapLayout(FlowLayout.LEFT, 15, 10));
+        JPanel fontChooserPanel = new JPanel();
+        fontChooserPanel.add(new JLabel(Messages.getString("CMVPanel.font")));
+        fontChooserPanel.add(fontChooser);
+        chooserLine.add(fontChooserPanel);
+        chooserLine.add(copyHtmlButton);
+        chooserLine.add(copyTextButton);
+        chooserLine.add(mulButton);
+
+        add(chooserLine);
+        add(mechViewPanel);
+        setEntity(entity);
+    }
+
+    /** Construct a new panel without a unit to display. */
+    public ConfigurableMechViewPanel() {
+        this(null);
+    }
+
+    /**
+     * Set the panel to display the given element.
+     *
+     * @param entity The Entity to display
+     */
+    public void setEntity(@Nullable Entity entity) {
+        this.entity = entity;
+        mulId = (entity != null) ? entity.getMulId() : -1;
+        mulButton.setEnabled(mulId > 0);
+        copyTextButton.setEnabled(entity != null);
+        copyHtmlButton.setEnabled(entity != null);
+        if (entity != null) {
+            mechViewPanel.setMech(entity, GUIPreferences.getInstance().getSummaryFont());
+        } else {
+            mechViewPanel.reset();
+        }
+    }
+
+    /** Set the card to use a newly selected font. */
+    private void updateFont() {
+        if (entity != null) {
+            String selectedItem = (String) fontChooser.getSelectedItem();
+            if ((selectedItem == null) || selectedItem.isBlank()) {
+                mechViewPanel.setMech(entity, MMConstants.FONT_SANS_SERIF);
+                GUIPreferences.getInstance().setSummaryFont("");
+            } else {
+                mechViewPanel.setMech(entity, selectedItem);
+                GUIPreferences.getInstance().setSummaryFont(selectedItem);
+            }
+        }
+    }
+
+    public void reset() {
+        mechViewPanel.reset();
+    }
+
+    private void copyToClipboard(boolean asHtml) {
+        if (entity != null) {
+            MechView mechView = new MechView(entity, false, false, asHtml);
+            StringSelection stringSelection = new StringSelection(mechView.getMechReadout());
+            Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+            clipboard.setContents(stringSelection, null);
+        }
+    }
+}

--- a/megamek/src/megamek/client/ui/panes/EntityViewPane.java
+++ b/megamek/src/megamek/client/ui/panes/EntityViewPane.java
@@ -30,24 +30,19 @@ import megamek.common.templates.TROView;
 import javax.swing.*;
 
 /**
- * The EntityViewPane displays the Entity Summary and the TRO panels within a Tabbed Pane.
+ * The EntityViewPane displays the entity summary, TRO and AS card panels within a TabbedPane.
  */
 public class EntityViewPane extends AbstractTabbedPane {
-    //region Variable Declarations
     private ConfigurableMechViewPanel entityPanel;
     private MechViewPanel troPanel;
     private final ConfigurableASCardPanel cardPanel = new ConfigurableASCardPanel(getFrame());
-    //endregion Variable Declarations
 
-    //region Constructors
     public EntityViewPane(final JFrame frame, final @Nullable Entity entity) {
         super(frame, "EntityViewPane");
         initialize();
         updateDisplayedEntity(entity);
     }
-    //endregion Constructors
 
-    //region Getters/Setters
     public ConfigurableMechViewPanel getEntityPanel() {
         return entityPanel;
     }
@@ -63,9 +58,7 @@ public class EntityViewPane extends AbstractTabbedPane {
     public void setTROPanel(final MechViewPanel troPanel) {
         this.troPanel = troPanel;
     }
-    //endregion Getters/Setters
 
-    //region Initialization
     /**
      * This purposefully does not set preferences, as it may be used on differing panes for
      * differing uses and thus you don't want to remember the selected tab between the different
@@ -83,14 +76,13 @@ public class EntityViewPane extends AbstractTabbedPane {
 
         addTab("AS Card", cardPanel);
     }
-    //endregion Initialization
 
     /**
-     * This updates the pane's currently displayed entity
-     * @param entity the entity to update to, or null if the panels are to be reset.
+     * Updates the pane's currently displayed entity.
+     *
+     * @param entity the entity to update to, or null if the panels are to be emptied.
      */
     public void updateDisplayedEntity(final @Nullable Entity entity) {
-        // Null entity, which means to reset the panels
         if (entity == null) {
             getEntityPanel().reset();
             getTROPanel().reset();

--- a/megamek/src/megamek/client/ui/panes/EntityViewPane.java
+++ b/megamek/src/megamek/client/ui/panes/EntityViewPane.java
@@ -34,7 +34,7 @@ import javax.swing.*;
  */
 public class EntityViewPane extends AbstractTabbedPane {
     //region Variable Declarations
-    private MechViewPanel entityPanel;
+    private ConfigurableMechViewPanel entityPanel;
     private MechViewPanel troPanel;
     private final ConfigurableASCardPanel cardPanel = new ConfigurableASCardPanel(getFrame());
     //endregion Variable Declarations
@@ -48,11 +48,11 @@ public class EntityViewPane extends AbstractTabbedPane {
     //endregion Constructors
 
     //region Getters/Setters
-    public MechViewPanel getEntityPanel() {
+    public ConfigurableMechViewPanel getEntityPanel() {
         return entityPanel;
     }
 
-    public void setEntityPanel(final MechViewPanel entityPanel) {
+    public void setEntityPanel(final ConfigurableMechViewPanel entityPanel) {
         this.entityPanel = entityPanel;
     }
 
@@ -73,7 +73,7 @@ public class EntityViewPane extends AbstractTabbedPane {
      */
     @Override
     protected void initialize() {
-        setEntityPanel(new MechViewPanel());
+        setEntityPanel(new ConfigurableMechViewPanel());
         getEntityPanel().setName("entityPanel");
         addTab(resources.getString("Summary.title"), getEntityPanel());
 
@@ -95,7 +95,7 @@ public class EntityViewPane extends AbstractTabbedPane {
             getEntityPanel().reset();
             getTROPanel().reset();
         } else {
-            getEntityPanel().setMech(entity, false);
+            getEntityPanel().setEntity(entity);
             getTROPanel().setMech(entity, TROView.createView(entity, true));
         }
         if (ASConverter.canConvert(entity)) {

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -328,6 +328,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String AS_CARD_SIZE = "AsCardSize";
     public static final String SBFSHEET_HEADERFONT = "SBFSheetHeaderFont";
     public static final String SBFSHEET_VALUEFONT = "SBFSheetValueFont";
+    public static final String SUMMARY_FONT = "SummaryCardFont";
+
 
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
@@ -718,6 +720,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(AS_CARD_SIZE, 0.75f);
         setDefault(SBFSHEET_HEADERFONT, "");
         setDefault(SBFSHEET_VALUEFONT, "");
+        setDefault(SUMMARY_FONT, "");
     }
 
     public void setDefault(String name, Color color) {
@@ -1436,6 +1439,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public String getAsCardFont() {
         return store.getString(AS_CARD_FONT);
+    }
+
+    public String getSummaryFont() {
+        return store.getString(SUMMARY_FONT);
     }
 
     public String getSbfSheetHeaderFont() {
@@ -2209,6 +2216,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setAsCardFont(String asCardFont) {
         store.setValue(AS_CARD_FONT, asCardFont);
+    }
+
+    public void setSummaryFont(String summaryFont) {
+        store.setValue(SUMMARY_FONT, summaryFont);
     }
 
     public void setAsCardSize(float size) {

--- a/megamek/src/megamek/client/ui/swing/MechViewPanel.java
+++ b/megamek/src/megamek/client/ui/swing/MechViewPanel.java
@@ -20,6 +20,7 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.swing.util.FluffImageHelper;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.util.UIUtil.FixedXPanel;
 import megamek.common.Entity;
 import megamek.common.MechView;
@@ -60,18 +61,13 @@ public class MechViewPanel extends JPanel {
         txtMek.setMinimumSize(new Dimension(width, height));
         txtMek.setPreferredSize(new Dimension(width, height));
         txtMek.addHyperlinkListener(e -> {
-            try {
-                if (HyperlinkEvent.EventType.ACTIVATED == e.getEventType()) {
-                    if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                        Desktop.getDesktop().browse(e.getURL().toURI());
-                    }
-                }
-            } catch (Exception ex) {
-                LogManager.getLogger().error("", ex);
-                JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
+            if (HyperlinkEvent.EventType.ACTIVATED == e.getEventType()) {
+                UIUtil.browse(e.getURL().toString(), this);
             }
         });
         scrMek = new JScrollPane(txtMek);
+        scrMek.getVerticalScrollBar().setUnitIncrement(16);
+
         if (noBorder) {
             scrMek.setBorder(null);
         }
@@ -104,6 +100,12 @@ public class MechViewPanel extends JPanel {
         setFluffImage(entity);
     }
 
+    public void setMech(Entity entity, MechView mechView, String fontName) {
+        txtMek.setText(mechView.getMechReadout(fontName));
+        txtMek.setCaretPosition(0);
+        setFluffImage(entity);
+    }
+
     public void setMech(Entity entity, TROView troView) {
         txtMek.setText(troView.processTemplate());
         txtMek.setCaretPosition(0);
@@ -113,6 +115,11 @@ public class MechViewPanel extends JPanel {
     public void setMech(Entity entity, boolean useAlternateCost) {
         MechView mechView = new MechView(entity, false, useAlternateCost);
         setMech(entity, mechView);
+    }
+
+    public void setMech(Entity entity, String fontName) {
+        MechView mechView = new MechView(entity, false, false);
+        setMech(entity, mechView, fontName);
     }
 
     private void setFluffImage(Entity entity) {

--- a/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
+++ b/megamek/src/megamek/client/ui/swing/alphaStrike/ConfigurableASCardPanel.java
@@ -19,23 +19,20 @@
 package megamek.client.ui.swing.alphaStrike;
 
 import megamek.MMConstants;
+import megamek.client.ui.Messages;
 import megamek.client.ui.WrapLayout;
 import megamek.client.ui.dialogs.ASConversionInfoDialog;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.UIUtil;
-import megamek.client.ui.Messages;
 import megamek.common.alphaStrike.ASCardDisplayable;
 import megamek.common.alphaStrike.ASStatsExporter;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.alphaStrike.cardDrawer.ASCardPrinter;
 import megamek.common.annotations.Nullable;
-import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
-import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.datatransfer.*;
-import java.net.URL;
 import java.util.List;
 
 /**
@@ -87,13 +84,12 @@ public class ConfigurableASCardPanel extends JPanel {
         copyStatsButton.addActionListener(ev -> copyStats());
         printButton.addActionListener(ev -> printCard());
 
-        mulButton.addActionListener(ev -> showMUL());
+        mulButton.addActionListener(ev -> UIUtil.showMUL(mulId, this));
         mulButton.setToolTipText("Show the Master Unit List entry for this unit. Opens a browser window.");
 
         conversionButton.addActionListener(e -> showConversionReport());
 
         var chooserLine = new UIUtil.FixedYPanel(new WrapLayout(FlowLayout.LEFT, 15, 10));
-        chooserLine.setBorder(new EmptyBorder(10, 15, 10, 15));
         JPanel fontChooserPanel = new JPanel();
         fontChooserPanel.add(new JLabel(Messages.getString("CASCardPanel.font")));
         fontChooserPanel.add(fontChooser);
@@ -109,7 +105,6 @@ public class ConfigurableASCardPanel extends JPanel {
         chooserLine.add(conversionButton);
 
         var cardLine = new JScrollPane(cardPanel);
-        cardPanel.setBorder(new EmptyBorder(5, 65, 0, 0));
         cardLine.getVerticalScrollBar().setUnitIncrement(16);
 
         add(chooserLine);
@@ -155,17 +150,6 @@ public class ConfigurableASCardPanel extends JPanel {
         if (sizeChooser.getSelectedItem() != null) {
             cardPanel.setScale((Float) sizeChooser.getSelectedItem());
             GUIPreferences.getInstance().setAsCardSize((Float) sizeChooser.getSelectedItem());
-        }
-    }
-
-    private void showMUL() {
-        try {
-            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
-                Desktop.getDesktop().browse(new URL(MMConstants.MUL_URL_PREFIX + mulId).toURI());
-            }
-        } catch (Exception ex) {
-            LogManager.getLogger().error("", ex);
-            JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -22,6 +22,7 @@ import megamek.client.ui.swing.MMToggleButton;
 import megamek.common.Player;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.ImageUtil;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import javax.swing.border.Border;
@@ -35,6 +36,7 @@ import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.MouseEvent;
 import java.awt.image.ImageObserver;
+import java.net.URL;
 import java.util.List;
 import java.util.*;
 import java.util.stream.Stream;
@@ -59,6 +61,21 @@ public final class UIUtil {
     public static final String DOT_SPACER = " \u2B1D ";
     public static final String BOT_MARKER = " \u259A ";
 
+
+    public static void showMUL(int mulId, Component parent) {
+        browse(MMConstants.MUL_URL_PREFIX + mulId, parent);
+    }
+
+    public static void browse(String url, Component parent) {
+        try {
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                Desktop.getDesktop().browse(new URL(url).toURI());
+            }
+        } catch (Exception ex) {
+            LogManager.getLogger().error("", ex);
+            JOptionPane.showMessageDialog(parent, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
+        }
+    }
 
     public static String repeat(String str, int count) {
         return String.valueOf(str).repeat(Math.max(0, count));
@@ -1355,7 +1372,6 @@ public final class UIUtil {
         y = Math.min(y, h - vh);
         return y;
     }
-
 
     private UIUtil() { }
 }

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -17,16 +17,13 @@ import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.UIUtil;
-import megamek.codeUtilities.StringUtility;
 import megamek.common.annotations.Nullable;
 import megamek.common.eras.Era;
 import megamek.common.eras.Eras;
 import megamek.common.options.*;
-import megamek.common.util.StringUtil;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-import java.awt.*;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.*;
@@ -284,7 +281,7 @@ public class MechView {
                 dFormatter.format(cost) + " C-bills"));
         String source = entity.getSource();
         if (!source.isBlank()) {
-            if (source.contains("Shrapnel")) {
+            if (source.contains(MMConstants.SOURCE_TEXT_SHRAPNEL)) {
                 sHead.add(new HyperLinkElement(Messages.getString("MechView.Source"), MMConstants.BT_URL_SHRAPNEL, source));
             } else {
                 sHead.add(new LabeledElement(Messages.getString("MechView.Source"), source));

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -15,16 +15,22 @@ package megamek.common;
 
 import megamek.MMConstants;
 import megamek.client.ui.Messages;
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.codeUtilities.StringUtility;
+import megamek.common.annotations.Nullable;
 import megamek.common.eras.Era;
 import megamek.common.eras.Eras;
 import megamek.common.options.*;
+import megamek.common.util.StringUtil;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
+import java.awt.*;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.*;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -76,7 +82,7 @@ public class MechView {
     private List<ViewElement> sLoadout = new ArrayList<>();
     private List<ViewElement> sFluff = new ArrayList<>();
     
-    private boolean html;
+    private final boolean html;
 
     /**
      * Compiles information about an {@link Entity} useful for showing a summary of its abilities.
@@ -147,20 +153,35 @@ public class MechView {
         isJumpship = entity instanceof Jumpship;
         isSpaceStation = entity instanceof SpaceStation;
 
-        sLoadout.addAll(getWeapons(showDetail));
-        sLoadout.add(new SingleLine());
+        List<ViewElement> weapons = getWeapons(showDetail);
+        if (!weapons.isEmpty()) {
+            sLoadout.add(new SingleLine());
+            sLoadout.addAll(getWeapons(showDetail));
+        }
+
         if ((!entity.usesWeaponBays() || !showDetail) && !entity.getAmmo().isEmpty()) {
+            sLoadout.add(new SingleLine());
             sLoadout.add(getAmmo());
-            sLoadout.add(new SingleLine());
         }
+
         if (entity instanceof IBomber) {
-            sLoadout.addAll(getBombs());
-            sLoadout.add(new SingleLine());
+            List<ViewElement> bombs = getBombs();
+            if (!bombs.isEmpty()) {
+                sLoadout.add(new SingleLine());
+                sLoadout.addAll(getBombs());
+            }
         }
-        sLoadout.addAll(getMisc()); // has to occur before basic is processed
-        sLoadout.add(new SingleLine());
-        sLoadout.add(getFailed());
-        sLoadout.add(new SingleLine());
+
+        List<ViewElement> miscEquipment = getMisc();
+        if (!miscEquipment.isEmpty()) {
+            sLoadout.addAll(getMisc()); // has to occur before basic is processed
+        }
+
+        ViewElement failedEquipment = getFailed();
+        if (!(failedEquipment instanceof EmptyElement)) {
+            sLoadout.add(new SingleLine());
+            sLoadout.add(failedEquipment);
+        }
 
         if (isInf) {
             Infantry inf = (Infantry) entity;
@@ -261,18 +282,16 @@ public class MechView {
         }
         sHead.add(new LabeledElement(Messages.getString("MechView.Cost"),
                 dFormatter.format(cost) + " C-bills"));
-        if (entity.hasMulId()) {
-            sHead.add(new HyperLinkElement(MMConstants.MUL_URL_PREFIX + entity.getMulId(),
-                    Messages.getString("MechView.Source")));
-            if (!entity.getSource().isEmpty()) {
-                sHead.add(new LabeledElement("", entity.getSource()));
+        String source = entity.getSource();
+        if (!source.isBlank()) {
+            if (source.contains("Shrapnel")) {
+                sHead.add(new HyperLinkElement(Messages.getString("MechView.Source"), MMConstants.BT_URL_SHRAPNEL, source));
             } else {
-                sHead.add(new LabeledElement("", Messages.getString("MechView.Unknown")));
+                sHead.add(new LabeledElement(Messages.getString("MechView.Source"), source));
             }
         } else {
-            if (!entity.getSource().isEmpty()) {
-                sHead.add(new LabeledElement(Messages.getString("MechView.Source"), entity.getSource()));
-            }
+            sHead.add(new LabeledElement(Messages.getString("MechView.Source"),
+                    Messages.getString("MechView.Unknown")));
         }
 
         UnitRole role = UnitRoleHandler.getRoleFor(entity);
@@ -466,7 +485,6 @@ public class MechView {
                 sBasic.addAll(getInternalAndArmor());
             }
         }
-        sBasic.add(new SingleLine());
 
         Game game = entity.getGame();
 
@@ -526,23 +544,22 @@ public class MechView {
             }
         }
 
-        sFluff.add(new SingleLine());
         if (!entity.getFluff().getOverview().isEmpty()) {
+            sFluff.add(new SingleLine());
             sFluff.add(new LabeledElement("Overview", entity.getFluff().getOverview()));
         }
-        sFluff.add(new SingleLine());        
         if (!entity.getFluff().getCapabilities().isEmpty()) {
+            sFluff.add(new SingleLine());
             sFluff.add(new LabeledElement("Capabilities", entity.getFluff().getCapabilities()));
         }
-        sFluff.add(new SingleLine());        
         if (!entity.getFluff().getDeployment().isEmpty()) {
+            sFluff.add(new SingleLine());
             sFluff.add(new LabeledElement("Deployment", entity.getFluff().getDeployment()));
         }
-        sFluff.add(new SingleLine());        
         if (!entity.getFluff().getHistory().isEmpty()) {
+            sFluff.add(new SingleLine());
             sFluff.add(new LabeledElement("History", entity.getFluff().getHistory()));
         }
-        sFluff.add(new SingleLine());
     }
 
     private String eraText(int startYear, int endYear) {
@@ -611,10 +628,19 @@ public class MechView {
      * @return A summary including all four sections. 
      */
     public String getMechReadout() {
-        String docStart = html?
-                "<div style=\"font:12pt monospaced\">" : "";
-        String docEnd = html?
-                "</div>" : "";
+        return getMechReadout(null);
+    }
+
+    /**
+     * @return A summary including all four sections.
+     */
+    public String getMechReadout(@Nullable String fontName) {
+        String docStart = "";
+        String docEnd = "";
+        if (html && (fontName != null)) {
+            docStart = "<div style=\"font-family:" + fontName + ";\">";
+            docEnd = "</div>";
+        }
         return docStart + getMechReadoutHead()
                 + getMechReadoutBasic() + getMechReadoutLoadout()
                 + getMechReadoutFluff() + docEnd;
@@ -668,8 +694,8 @@ public class MechView {
         if (!(isInf && !isBA)) {
             TableElement locTable = new TableElement(5);
             locTable.setColNames("", "Internal", "Armor", "", ""); // last two columns are patchwork armor and location damage
-            locTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_RIGHT,
-                    TableElement.JUSTIFIED_RIGHT, TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_LEFT);
+            locTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
+                    TableElement.JUSTIFIED_CENTER, TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_LEFT);
             for (int loc = 0; loc < entity.locations(); loc++) {
                 // Skip empty sections.
                 if (entity.getInternal(loc) == IArmorState.ARMOR_NA) {
@@ -760,7 +786,7 @@ public class MechView {
         if (!entity.isCapitalFighter()) {
             TableElement locTable = new TableElement(3);
             locTable.setColNames("", "Armor", "");
-            locTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_RIGHT,
+            locTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
                     TableElement.JUSTIFIED_LEFT);
             for (int loc = 0; loc < entity.locations(); loc++) {
 
@@ -838,9 +864,9 @@ public class MechView {
         }
         
         TableElement wpnTable = new TableElement(4);
-        wpnTable.setColNames("Weapons", "Loc", "Heat", entity.isOmni() ? "Omni" : "");
+        wpnTable.setColNames("Weapons  ", "  Loc  ", "  Heat  ", entity.isOmni() ? "  Omni  " : "");
         wpnTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
-                TableElement.JUSTIFIED_CENTER, TableElement.JUSTIFIED_LEFT);
+                TableElement.JUSTIFIED_CENTER, TableElement.JUSTIFIED_CENTER);
         for (Mounted mounted : entity.getWeaponList()) {
             String[] row = { mounted.getDesc(), entity.joinLocationAbbr(mounted.allLocations(), 3), "", "" };
             WeaponType wtype = (WeaponType) mounted.getType();
@@ -886,9 +912,9 @@ public class MechView {
             }
             if (mounted.isDestroyed()) {
                 if (mounted.isRepairable()) {
-                    wpnTable.addRowWithBgColor("yellow", row);
+                    wpnTable.addRowWithColor("yellow", row);
                 } else {
-                    wpnTable.addRowWithBgColor("red", row);
+                    wpnTable.addRowWithColor("red", row);
                 }
             } else {
                 wpnTable.addRow(row);
@@ -914,9 +940,9 @@ public class MechView {
                     }
                     if (m.isDestroyed()) {
                         if (m.isRepairable()) {
-                            wpnTable.addRowWithBgColor("yellow", row);
+                            wpnTable.addRowWithColor("yellow", row);
                         } else {
-                            wpnTable.addRowWithBgColor("red", row);
+                            wpnTable.addRowWithColor("red", row);
                         }
                     } else {
                         wpnTable.addRow(row);
@@ -935,9 +961,9 @@ public class MechView {
                     if (mounted.getLocation() != Entity.LOC_NONE) {
                         row = new String[] { m.getName(), String.valueOf(m.getBaseShotsLeft()), "", "" };
                         if (m.isDestroyed()) {
-                            wpnTable.addRowWithBgColor("red", row);
+                            wpnTable.addRowWithColor("red", row);
                         } else if (m.getUsableShotsLeft() < 1) {
-                            wpnTable.addRowWithBgColor("yellow", row);
+                            wpnTable.addRowWithColor("yellow", row);
                         } else {
                             wpnTable.addRow(row);
                         }
@@ -953,7 +979,7 @@ public class MechView {
         TableElement ammoTable = new TableElement(4);
         ammoTable.setColNames("Ammo", "Loc", "Shots", entity.isOmni() ? "Omni" : "");
         ammoTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
-                TableElement.JUSTIFIED_RIGHT, TableElement.JUSTIFIED_LEFT);
+                TableElement.JUSTIFIED_CENTER, TableElement.JUSTIFIED_CENTER);
 
         for (Mounted mounted : entity.getAmmo()) {
             // Ignore ammo for one-shot launchers
@@ -977,9 +1003,9 @@ public class MechView {
             }
 
             if (mounted.isDestroyed()) {
-                ammoTable.addRowWithBgColor("red", row);
+                ammoTable.addRowWithColor("red", row);
             } else if (mounted.getUsableShotsLeft() < 1) {
-                ammoTable.addRowWithBgColor("yellow", row);
+                ammoTable.addRowWithColor("yellow", row);
             } else {
                 ammoTable.addRow(row);
             }
@@ -1000,9 +1026,9 @@ public class MechView {
                     shotsLeft += current.getUsableShotsLeft();
                 }
                 if (mounted.isDestroyed()) {
-                    ammoTable.addRowWithBgColor("red", row);
+                    ammoTable.addRowWithColor("red", row);
                 } else if (shotsLeft < 1) {
-                    ammoTable.addRowWithBgColor("yellow", row);
+                    ammoTable.addRowWithColor("yellow", row);
                 } else {
                     ammoTable.addRow(row);
                 }
@@ -1010,8 +1036,6 @@ public class MechView {
         }
         return ammoTable;
     }
-    
-    
 
     private List<ViewElement> getBombs() {
         List<ViewElement> retVal = new ArrayList<>();
@@ -1031,7 +1055,7 @@ public class MechView {
         TableElement miscTable = new TableElement(3);
         miscTable.setColNames("Equipment", "Loc", entity.isOmni() ? "Omni" : "");
         miscTable.setJustification(TableElement.JUSTIFIED_LEFT, TableElement.JUSTIFIED_CENTER,
-                TableElement.JUSTIFIED_LEFT);
+                TableElement.JUSTIFIED_CENTER);
         int nEquip = 0;
         for (Mounted mounted : entity.getMisc()) {
             String name = mounted.getName();
@@ -1066,25 +1090,30 @@ public class MechView {
             }
 
             if (mounted.isDestroyed()) {
-                miscTable.addRowWithBgColor("red", row);
+                miscTable.addRowWithColor("red", row);
             } else {
                 miscTable.addRow(row);
             }
         }
 
         if (nEquip > 0) {
+            retVal.add(new SingleLine());
             retVal.add(miscTable);
         }
 
-        retVal.add(new SingleLine());
-        String capacity = entity.getUnusedString(html);
-        if (!StringUtility.isNullOrBlank(capacity)) {
-            // The entries have already been formatted into a list, but we're still going to
-            // format it as a list to get the items under the label.
-            ItemList list = new ItemList(Messages.getString("MechView.CarryingCapacity"));
-            list.addItem(capacity);
-            retVal.add(list);
+        String transportersString = entity.getUnusedString(html);
+        if (!transportersString.isBlank()) {
             retVal.add(new SingleLine());
+            // Reformat the list to a table to keep the formatting similar between blocks
+            TableElement transportTable = new TableElement(1);
+            transportTable.setColNames(Messages.getString("MechView.CarryingCapacity"));
+            transportTable.setJustification(TableElement.JUSTIFIED_LEFT);
+            String separator = html ? "<br>" : "\r\n";
+            String[] transportersLines = transportersString.split(separator);
+            for (String line : transportersLines) {
+                transportTable.addRow(line);
+            }
+            retVal.add(transportTable);
         }
 
         if (isSmallCraft || isJumpship) {
@@ -1108,6 +1137,7 @@ public class MechView {
             if (a.getNBattleArmor() > 0) {
                 crewTable.addRow(Messages.getString("MechView.BAMarines"), String.valueOf(a.getNBattleArmor()));
             }
+            retVal.add(new SingleLine());
             retVal.add(crewTable);
         }
         if (isVehicle && ((Tank) entity).getExtraCrewSeats() > 0) {
@@ -1140,15 +1170,13 @@ public class MechView {
             }
         }
         if (percentRemaining < 0) {
-            return "<span style='color:white;background-color:black'>X</span>";
+            return "<FONT " + UIUtil.colorString(GUIPreferences.getInstance().getWarningColor()) + ">X</FONT>";
         } else if (percentRemaining <= .25) {
-            return "<span style='color:white;background-color:red'>" + armor + "</span>";
-        } else if (percentRemaining <= .75) {
-            return "<span style='color:black;background-color:yellow'>" + armor + "</span>";
+            return "<FONT " + UIUtil.colorString(GUIPreferences.getInstance().getWarningColor()) + ">" + armor + "</FONT>";
         } else if (percentRemaining < 1.00) {
-            return "<span style='color:black;background-color:green'>" + armor + "</span>";
+            return "<FONT " + UIUtil.colorString(GUIPreferences.getInstance().getCautionColor()) + ">" + armor + "</FONT>";
         } else {
-            return "<span style='color:black;background-color:white'>" + armor + "</span>";
+            return armor;
         }
     }
 
@@ -1184,12 +1212,16 @@ public class MechView {
         
         @Override
         public String toPlainText() {
-            return label + ": " + value + "\n";
+            String htmlCleanedText = value.replaceAll("<[Bb][Rr]> *", "\n")
+                    .replaceAll("<[Pp]> *", "\n\n")
+                    .replaceAll("</[Pp]> *", "\n")
+                    .replaceAll("<[^>]*>", "");
+            return label + ": " + htmlCleanedText + "\n";
         }
         
         @Override
         public String toHTML() {
-            return "<b>" + label + "</b>: " + value + "<br/>\n";
+            return "<b>" + label + "</b>: " + value + "<br>";
         }
     }
     
@@ -1209,7 +1241,7 @@ public class MechView {
         private final String[] colNames;
         private final List<String[]> data = new ArrayList<>();
         private final Map<Integer,Integer> colWidth = new HashMap<>();
-        private final Map<Integer,String> bgColors = new HashMap<>();
+        private final Map<Integer,String> colors = new HashMap<>();
         
         TableElement(int colCount) {
             justification = new int[colCount];
@@ -1240,9 +1272,9 @@ public class MechView {
             }
         }
         
-        void addRowWithBgColor(String color, String... row) {
+        void addRowWithColor(String color, String... row) {
             addRow(row);
-            bgColors.put(data.size() - 1, color);
+            colors.put(data.size() - 1, color);
         }
         
         private String leftPad(String s, int fieldSize) {
@@ -1289,9 +1321,7 @@ public class MechView {
             sb.append("\n");
             if (colNames.length > 0) {
                 int w = sb.length() - 1;
-                for (int i = 0; i < w; i++) {
-                    sb.append("-");
-                }
+                sb.append("-".repeat(Math.max(0, w)));
                 sb.append("\n");
             }
             for (String[] row : data) {
@@ -1319,13 +1349,20 @@ public class MechView {
                     } else {
                         sb.append("<th align=\"left\">");
                     }
-                    sb.append(colNames[col]).append("</th>");
+                    if (justification[col] != JUSTIFIED_LEFT) {
+                        sb.append("&nbsp;&nbsp;");
+                    }
+                    sb.append(colNames[col]);
+                    if (justification[col] != JUSTIFIED_RIGHT) {
+                        sb.append("&nbsp;&nbsp;");
+                    }
+                    sb.append("</th>");
                 }
                 sb.append("</tr>\n");
             }
             for (int r = 0; r < data.size(); r++) {
-                if (bgColors.containsKey(r)) {
-                    sb.append("<tr bgcolor=\"").append(bgColors.get(r)).append("\">");
+                if (colors.containsKey(r)) {
+                    sb.append("<tr color=\"").append(colors.get(r)).append("\">");
                 } else {
                     sb.append("<tr>");
                 }
@@ -1338,7 +1375,14 @@ public class MechView {
                     } else {
                         sb.append("<td align=\"left\">");
                     }
-                    sb.append(row[col]).append("</td>");
+                    if (justification[col] != JUSTIFIED_LEFT) {
+                        sb.append("&nbsp;&nbsp;");
+                    }
+                    sb.append(row[col]);
+                    if (justification[col] != JUSTIFIED_RIGHT) {
+                        sb.append("&nbsp;&nbsp;");
+                    }
+                    sb.append("</td>");
                 }
                 sb.append("</tr>\n");
             }
@@ -1368,9 +1412,7 @@ public class MechView {
             StringBuilder sb = new StringBuilder();
             if (null != heading) {
                 sb.append(heading).append("\n");
-                for (int i = 0; i < heading.length(); i++) {
-                    sb.append("-");
-                }
+                sb.append("-".repeat(heading.length()));
                 sb.append("\n");
             }
             for (String item : data) {
@@ -1423,22 +1465,32 @@ public class MechView {
      */
     private static class HyperLinkElement implements ViewElement {
 
+        private final String label;
         private final String address;
         private final String displayText;
 
         HyperLinkElement(String address, String displayText) {
+            label = "";
+            this.address = address;
+            this.displayText = displayText;
+        }
+
+        HyperLinkElement(String label, String address, String displayText) {
+            this.label = (label == null) ? "" : label;
             this.address = address;
             this.displayText = displayText;
         }
 
         @Override
         public String toPlainText() {
-            return displayText;
+            String result = label.isBlank() ? "" : label + ": ";
+            return result + displayText + "\n";
         }
 
         @Override
         public String toHTML() {
-            return "<A HREF=" + address + ">" + displayText + "</A>";
+            String result = label.isBlank() ? "" : "<B>" + label + "</B>: ";
+            return result + "<A HREF=" + address + ">" + displayText + "</A><BR>";
         }
     }
     

--- a/megamek/src/megamek/utilities/RATGeneratorEditor.java
+++ b/megamek/src/megamek/utilities/RATGeneratorEditor.java
@@ -16,6 +16,7 @@ package megamek.utilities;
 import megamek.MMConstants;
 import megamek.client.ratgenerator.*;
 import megamek.client.ratgenerator.FactionRecord.TechCategory;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.util.UIUtil.FixedXPanel;
 import megamek.client.ui.swing.util.UIUtil.FixedYPanel;
 import megamek.common.Configuration;
@@ -266,7 +267,7 @@ public class RATGeneratorEditor extends JFrame {
         });
         unitSearchPanel.add(Box.createHorizontalStrut(15));
         unitSearchPanel.add(butMUL);
-        butMUL.addActionListener(e -> showMUL());
+        butMUL.addActionListener(e -> UIUtil.showMUL(currentMulId, this));
 
         tblMasterUnitList.setModel(masterUnitListModel);
         masterUnitListSorter = new TableRowSorter<>(masterUnitListModel);
@@ -308,18 +309,6 @@ public class RATGeneratorEditor extends JFrame {
         factionEditSide.add(Box.createVerticalStrut(5));
         factionEditSide.add(createUnitChassisEditor());
         return new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, unitContainer, factionEditSide);
-    }
-
-    private void showMUL() {
-        try {
-            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
-                    && currentMulId > 0) {
-                Desktop.getDesktop().browse(new URL(MMConstants.MUL_URL_PREFIX + currentMulId).toURI());
-            }
-        } catch (Exception ex) {
-            LogManager.getLogger().error("", ex);
-            JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
-        }
     }
 
     private JComponent createCopyBetweenButtonPanel() {


### PR DESCRIPTION
Some updates to the unit summary:

- adds a toolbar like on the AS Card that allows font configuration and copying the info as text or html
- removes some background coloring that wasnt compatible with dark look and feel, now damage is colored in the configurable warning color aka red and caution color aka yellow
- scrolling should be smoother (smaller increment)
- the tables (armor, weapons etc) now have a little space between columns, most columns are centered
- unnecessary empty lines between text blocks have been removed
- html tags in the fluff text are removed for text export, so simple html tags like `<P>, <BR>, <B> and <I>` can be used to add line breaks and formatting
- the MUL link from the "Source:" text has been removed, there's now a button
- instead, when the source is Shrapnel, a link to the Shrapnel website on bg.battletech.com is present
- in the lobby, the summary scales correctly according to GUI scaling (override on SetVisible)

![image](https://github.com/MegaMek/megamek/assets/17069663/f8f916b3-36b8-4a0b-84da-0b69e8eb8108)
