### PR TITLE
Fix 4830 wige jumps to bottom of water hex

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -70,7 +70,7 @@ public class SharedUtility {
         // iterate through steps
         for (final Enumeration<MoveStep> i = md.getSteps(); i.hasMoreElements();) {
             final MoveStep step = i.nextElement();
-            
+
             // stop for illegal movement
             if (step.getMovementType(md.isEndStep(step)) == EntityMovementType.MOVE_ILLEGAL) {
                 break;
@@ -103,7 +103,7 @@ public class SharedUtility {
                         step.getVelocity(), curPos, curFacing, false);
                 checkNag(rollTarget, nagReport, psrList);
             }
-            
+
             if (step.getType() == MoveStepType.VLAND) {
                 rollTarget = ((IAero) entity).checkLanding(moveType,
                         step.getVelocity(), curPos, curFacing, true);
@@ -111,7 +111,7 @@ public class SharedUtility {
             }
 
             // Check for Ejecting
-            if (step.getType() == MoveStepType.EJECT 
+            if (step.getType() == MoveStepType.EJECT
                     && (entity.isFighter())) {
                 rollTarget = GameManager.getEjectModifiers(game, entity, 0, false);
                 checkNag(rollTarget, nagReport, psrList);
@@ -150,7 +150,7 @@ public class SharedUtility {
         }
         return psrList;
     }
-    
+
     /**
      * Checks to see if piloting skill rolls are needed for the currently
      * selected movement. This code is basically a simplified version of
@@ -387,10 +387,10 @@ public class SharedUtility {
                     }
                 }
             }
-            
+
             // Sheer Cliffs, TO p.39
             // Roads over cliffs cancel the cliff effects for units that move on roads
-            boolean vehicleAffectedByCliff = entity instanceof Tank 
+            boolean vehicleAffectedByCliff = entity instanceof Tank
                     && !entity.isAirborneVTOLorWIGE();
             boolean quadveeVehMode = entity instanceof QuadVee
                     && entity.getConversionMode() == QuadVee.CONV_MODE_VEHICLE;
@@ -399,12 +399,12 @@ public class SharedUtility {
                     && !entity.isAero();
             // Cliffs should only exist towards 1 or 2 level drops, check just to make sure
             // Everything that does not have a 1 or 2 level drop shouldn't be handled as a cliff
-            int stepHeight = curElevation + curHex.getLevel() 
+            int stepHeight = curElevation + curHex.getLevel()
                     - (lastElevation + prevHex.getLevel());
-            boolean isUpCliff = !lastPos.equals(curPos) 
+            boolean isUpCliff = !lastPos.equals(curPos)
                     && curHex.hasCliffTopTowards(prevHex)
                     && (stepHeight == 1 || stepHeight == 2);
-            boolean isDownCliff = !lastPos.equals(curPos) 
+            boolean isDownCliff = !lastPos.equals(curPos)
                     && prevHex.hasCliffTopTowards(curHex)
                     && (stepHeight == -1 || stepHeight == -2);
 
@@ -492,13 +492,13 @@ public class SharedUtility {
                     checkNag(rollTarget, nagReport, psrList);
                 }
             }
-            
+
             if (step.isTurning()) {
                 rollTarget = entity.checkTurnModeFailure(overallMoveType,
                         prevStep == null? 0 : prevStep.getNStraight(), md.getMpUsed(), curPos);
                 checkNag(rollTarget, nagReport, psrList);
             }
-            
+
             if (step.getType() == MoveStepType.BOOTLEGGER) {
                 rollTarget = entity.getBasePilotingRoll(overallMoveType);
                 entity.addPilotingModifierForTerrain(rollTarget);
@@ -531,7 +531,7 @@ public class SharedUtility {
 
         rollTarget = entity.checkUsingOverdrive(overallMoveType);
         checkNag(rollTarget, nagReport, psrList);
-            
+
         rollTarget = entity.checkGunningIt(overallMoveType);
         checkNag(rollTarget, nagReport, psrList);
 
@@ -557,7 +557,7 @@ public class SharedUtility {
                     nagReport.append(Messages.getString("MovementDisplay.IceLanding"));
                 }
             } else if (!(prevStep.climbMode() && hex.containsTerrain(Terrains.BRIDGE))) {
-                if (!entity.getMovementMode().isHover()) {
+                if (!entity.getMovementMode().isHoverOrWiGE()) {
                     rollTarget = entity.checkWaterMove(waterLevel, overallMoveType);
                     checkNag(rollTarget, nagReport, psrList);
                 }
@@ -822,7 +822,7 @@ public class SharedUtility {
                 for (Entity ent : game.getEntitiesVector(left)) {
                     leftTonnage += ent.getWeight();
                 }
-                
+
                 double rightTonnage = 0;
                 for (Entity ent : game.getEntitiesVector(right)) {
                     rightTonnage += ent.getWeight();

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -1618,7 +1618,7 @@ public class MovePath implements Cloneable, Serializable {
 
     /**
      * Airborne WiGEs that move less than five hexes (four for glider protomech) in a movement phase must
-     * land unless it has taken off in the same phase or it is a LAM or glider ProtoMech that is using hover
+     * land unless it has taken off in the same phase, jumped, or it is a LAM or glider ProtoMech that is using hover
      * movement.
      *
      * @param includeMovePathHexes  Whether to include the hexes plotted in this MovePath in the total distance
@@ -1639,6 +1639,10 @@ public class MovePath implements Cloneable, Serializable {
             } else {
                 return getEntity().isAirborneVTOLorWIGE();
             }
+        }
+        // A WiGE that jumped A) has to have been flying and B) cannot land this turn.
+        if (isJumping()) {
+            return false;
         }
         // If movement has been interrupted (such as by a sideslip) and remaining movement points have
         // been spent, this MovePath only contains the hexes moved after the interruption. The hexes already
@@ -1854,12 +1858,12 @@ public class MovePath implements Cloneable, Serializable {
     }
 
     /**
-     * Worker function that counts the number of steps of the given type 
+     * Worker function that counts the number of steps of the given type
      * at the end of the given path before another step type occurs.
      */
     public int getEndStepCount(MoveStepType stepType) {
         int stepCount = 0;
-        
+
         for (int index = getStepVector().size() - 1; index >= 0; index--) {
             if (getStepVector().get(index).getType() == stepType) {
                 stepCount++;
@@ -1867,10 +1871,10 @@ public class MovePath implements Cloneable, Serializable {
                 break;
             }
         }
-        
+
         return stepCount;
     }
-    
+
     /**
      * Debugging method that calculates a destruction-aware move path to the destination coordinates
      */

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -557,12 +557,21 @@ public class MoveStep implements Serializable {
                     .getBoard().getHex(entity.getPosition()).getLevel()) - hex.getLevel();
             int building = hex.terrainLevel(Terrains.BLDG_ELEV);
             int depth = -hex.depth(true);
-            // need to adjust depth for potential ice over water
-            if ((hex.containsTerrain(Terrains.ICE) && hex
-                    .containsTerrain(Terrains.WATER))
-                    || (entity.getMovementMode() == EntityMovementMode.HOVER)) {
-                depth = 0;
+
+            // Set depth to 0 (surface level in several cases:
+            // 1. Jumping onto ice-covered water hex,
+            // 2. Jumping onto water with Hover move mode,
+            // 3. Jumping onto water with WiGE move mode
+            if (hex.containsTerrain(Terrains.WATER)) {
+                if (
+                    hex.containsTerrain(Terrains.ICE) ||
+                    entity.getMovementMode() == EntityMovementMode.HOVER ||
+                    entity.getMovementMode() == EntityMovementMode.WIGE
+                ) {
+                  depth = 0;
+                }
             }
+
             // grounded DropShips are treated as level 10 buildings for purposes
             // of jumping over
             boolean grdDropship = false;

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -558,7 +558,7 @@ public class MoveStep implements Serializable {
             int building = hex.terrainLevel(Terrains.BLDG_ELEV);
             int depth = -hex.depth(true);
 
-            // Set depth to 0 (surface level in several cases:
+            // Set depth to 0 (surface level) in several cases:
             // 1. Jumping onto ice-covered water hex,
             // 2. Jumping onto water with Hover move mode,
             // 3. Jumping onto water with WiGE move mode
@@ -591,7 +591,14 @@ public class MoveStep implements Serializable {
                 // infantry can jump into a building
                 setElevation(Math.max(depth, Math.min(building, maxElevation)));
             } else {
-                setElevation(Math.max(depth, building));
+                int subDepth = Math.max(depth, building);
+                // Put jumping Hover or WiGE at their elevation above the substrate level,
+                // or they get implicitly landed (which affects their movement next turn)
+                if (entity.getMovementMode().isHoverOrWiGE()) {
+                    setElevation(elevation + subDepth);
+                } else {
+                    setElevation(subDepth);
+                }
             }
             if (climbMode()
                     && (maxElevation >= hex.terrainLevel(Terrains.BRIDGE_ELEV))) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -8747,7 +8747,7 @@ public class GameManager implements IGameManager {
                     }
                 }
             } else if (!(prevStep.climbMode() && curHex.containsTerrain(Terrains.BRIDGE))
-                    && !(entity.getMovementMode() == EntityMovementMode.HOVER)) {
+                    && !(entity.getMovementMode().isHoverOrWiGE())) {
                 rollTarget = entity.checkWaterMove(waterLevel, overallMoveType);
                 if (rollTarget.getValue() != TargetRoll.CHECK_FALSE) {
                     // For falling elevation, Entity must not on hex surface


### PR DESCRIPTION
This should fix a few problems with WiGE jump jets in MM:
1. WiGE jumps to one elevation above the terrain _beneath_ the water level,
2. MM Prompts for a PSR when a WiGE jumps into a water hex, but does not prompt Hovers or WiGEs entering normally.
3. WiGE not getting set to an elevation that's high enough to be considered "flying",
4. MM prompting for automatic landing if the WiGE doesn't jump 5+ hexes (a WiGE _may not_ land in a turn it jumps)

Vehicle jump damage checks appear to otherwise be correct.

Ran MM verification tests and tested with both player- and Princess-controlled vehicles.

Close #4830 