### PR TITLE
Add Revenant UBM-1A to data

### DIFF
--- a/megamek/data/mechfiles/mechs/Jihad Final Reckoning/Revenant UBM-1A.mtf
+++ b/megamek/data/mechfiles/mechs/Jihad Final Reckoning/Revenant UBM-1A.mtf
@@ -1,0 +1,156 @@
+Version:1.3
+Revenant
+UBM-1A
+mul id:4911
+Config:Quad
+techbase:Inner Sphere
+era:3075
+source:Jihad: Final Reckoning
+rules level:3
+
+mass:30
+engine:180 Fusion Engine(IS)
+structure:IS Endo Steel
+myomer:Standard
+
+heat sinks:10 IS Double
+nocrit:SmartRoboticControlSystem:None
+walk mp:6
+jump mp:0
+
+armor:Standard(Inner Sphere)
+FLL armor:11
+FRL armor:11
+LT armor:10
+RT armor:10
+CT armor:12
+HD armor:6
+RLL armor:11
+RRL armor:11
+RTL armor:4
+RTR armor:4
+RTC armor:6
+
+Weapons:8
+ER Medium Laser, Left Torso
+Light Machine Gun, Left Torso
+Light Machine Gun, Left Torso
+ER Medium Laser, Right Torso
+Light Machine Gun, Right Torso
+Light Machine Gun, Right Torso
+Medium Pulse Laser, Left Torso
+Medium Pulse Laser, Right Torso
+
+Front Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+IS Endo Steel
+IS Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Front Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+IS Endo Steel
+IS Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISMediumPulseLaser
+ISERMediumLaser
+Light Machine Gun
+Light Machine Gun
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+IS Endo Steel
+-Empty-
+
+Right Torso:
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISDoubleHeatSink
+ISMediumPulseLaser
+ISERMediumLaser
+Light Machine Gun
+Light Machine Gun
+IS Endo Steel
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+IS Light Machine Gun Ammo - Full
+-Empty-
+
+Head:
+Life Support
+Sensors
+Cockpit
+IS Endo Steel
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Rear Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+IS Endo Steel
+IS Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Rear Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+IS Endo Steel
+IS Endo Steel
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+


### PR DESCRIPTION
This was based on the 2R file, but modified:

- removed 1 ton of armor
- removed small cockpit
- removed Remote Drone Control System
- removed two IS ER Medium Lasers
- removed two half-ton LMG ammo
- added regular cockpit
- added Smart Robotic Control System
- added two IS Medium Pulse Lasers
- added one ton of LMG ammo in CT
- modified Model, MUL ID, Era, and source

New mek loads fine and is usable by Princess.
Note: the expected BV is 784, PV is 25.  MegaMek produces nearly these values (785 / 25), which may be due to incorrectly rounding the raw BV of 784.7 naturally, but I'm not sure.

Close #4855