### PR TITLE
Allow HTML tags in the TROView fluff

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/fluff.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/fluff.ftlh
@@ -24,6 +24,7 @@
 <b>Cost:</b> ${cost} C-bills<br/>
 </p>
 	
+<#noautoesc>
 <#if fluffOverview??>
 <p>
 <b>Overview</b><br/>
@@ -51,3 +52,4 @@ ${fluffDeployment}
 ${fluffHistory}
 </p>
 </#if>
+</#noautoesc>


### PR DESCRIPTION
When I added HTML tag processing to the MechView a few days ago I missed handling the tags in the TRO View. Unfortunately tags get processed (auto-escaped) by the template engine so that they appear as plain text in the result. I did not want to introduce some crazy processing where I replace the tags by some artificial markup or re-engineer the auto-escaped tags. So it was either remove tags entirely before processing (making the tags ineffective in the TRO view) or removing the auto-escaping. I opted for removing the auto-escaping. It seemed to have no negative effects with " and ' characters (see Atlas AS7-D) and I don't expect `<` or `>` to appear in the fluff text which would throw the TRO view off.
This PR has no visible effect as long as no HTML tags appear in the fluff.