### PR TITLE
Add fluff info to MechCacheCSVTool output

### DIFF
--- a/megamek/src/megamek/common/templates/TROView.java
+++ b/megamek/src/megamek/common/templates/TROView.java
@@ -196,7 +196,7 @@ public class TROView {
      * @return The fluff display name, which consists of the manufacturer and the
      *         model separated by a space. If either is missing it is left out.
      */
-    protected String formatSystemFluff(EntityFluff.System system, EntityFluff fluff, Supplier<String> altText) {
+    public static String formatSystemFluff(EntityFluff.System system, EntityFluff fluff, Supplier<String> altText) {
         final StringJoiner sj = new StringJoiner(" ");
         if (!fluff.getSystemManufacturer(system).isBlank()) {
             sj.add(fluff.getSystemManufacturer(system));

--- a/megamek/src/megamek/utilities/MechCacheCSVTool.java
+++ b/megamek/src/megamek/utilities/MechCacheCSVTool.java
@@ -22,6 +22,9 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
+
+import megamek.codeUtilities.ObjectUtility;
+import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.templates.TROView;
@@ -219,7 +222,13 @@ public final class MechCacheCSVTool {
                     csvLine.append(entity.getFluff().getOverview().isBlank() ? "no" : "yes").append(DELIM);
                     csvLine.append(entity.getFluff().getDeployment().isBlank() ? "no" : "yes").append(DELIM);
                     csvLine.append(entity.getFluff().getHistory().isBlank() ? "no" : "yes").append(DELIM);
-                    csvLine.append(entity.getFluff().getNotes().isBlank() ? "no" : "yes").append(DELIM);
+
+                    String notes = entity.getFluff().getNotes();
+                    if (!StringUtility.isNullOrBlank(notes)) {
+                        csvLine.append(notes);
+                    } else {
+                        csvLine.append("--");
+                    }
                 }
 
                 csvLine.append("\n");

--- a/megamek/src/megamek/utilities/MechCacheCSVTool.java
+++ b/megamek/src/megamek/utilities/MechCacheCSVTool.java
@@ -159,8 +159,9 @@ public final class MechCacheCSVTool {
                 }
                 for (int i = 0; i < armorType.size(); i++) {
                     csvLine.append(EquipmentType.getArmorTypeName(armorType.get(i),
-                            TechConstants.isClan(armorTech.get(i)))).append(DELIM);
+                            TechConstants.isClan(armorTech.get(i)))).append(",");
                 }
+                csvLine.append(DELIM);
 
                 // Equipment Names
                 List<String> equipmentNames = new ArrayList<>();

--- a/megamek/src/megamek/utilities/MechCacheCSVTool.java
+++ b/megamek/src/megamek/utilities/MechCacheCSVTool.java
@@ -18,12 +18,14 @@
  */
 package megamek.utilities;
 
-import java.io.BufferedWriter;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Vector;
 import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.templates.TROView;
+
 import java.util.stream.Stream;
 
 /**
@@ -33,19 +35,27 @@ import java.util.stream.Stream;
  * @author arlith
  * @author Simon (Juliez)
  */
-public class MechCacheCSVTool {
+public final class MechCacheCSVTool {
+
+    // Excel import works better with the .txt extension instead of .csv
+    private static final String FILE_NAME = "Units.txt";
+    private static final String DELIM = "|";
+
+    private static final List<String> HEADERS = List.of("Chassis", "Model", "MUL ID", "Combined", "Clan",
+            "Source", "File Location", "Weight", "Intro Date", "Experimental year", "Advanced year",
+            "Standard year", "Extinct Year", "Unit Type", "Role", "BV", "Cost", "Rules", "Engine Name",
+            "Internal Structure", "Myomer", "Cockpit Type", "Gyro Type", "Armor Types", "Equipment",
+            "Manufacturer", "Factory", "Targeting", "Comms", "Armor", "JJ", "Engine", "Chassis", "Capabilities",
+            "Overview", "History", "Deployment", "Notes");
 
     public static void main(String... args) {
-        try (PrintWriter pw = new PrintWriter("Units.csv"); // TODO : Remove inline filename
+        try (PrintWriter pw = new PrintWriter(FILE_NAME);
              BufferedWriter bw = new BufferedWriter(pw)) {
             MechSummaryCache cache = MechSummaryCache.getInstance(true);
             MechSummary[] units = cache.getAllMechs();
 
             StringBuilder csvLine = new StringBuilder();
-
-            csvLine.append("Chassis,Model,MUL ID,Combined,Clan,Source,File Location,Weight,Intro Date,Experimental year,Advanced year," +
-                    "Standard year,Extinct Year,Unit Type,Role,BV,Cost,Rules,Engine Name,Internal Structure,Myomer," +
-                    "Cockpit Type,Gyro Type,Armor Types,Equipment (multiple entries)\n");
+            csvLine.append(String.join(DELIM, HEADERS)).append("\n");
             bw.write(csvLine.toString());
 
             for (MechSummary unit : units) {
@@ -54,77 +64,77 @@ public class MechCacheCSVTool {
                 }
 
                 csvLine = new StringBuilder();
-                csvLine.append(unit.getChassis()).append(",");
-                csvLine.append(unit.getModel()).append(",");
-                csvLine.append(unit.getMulId()).append(",");
-                csvLine.append(unit.getChassis()).append(" ").append(unit.getModel()).append(",");
-                csvLine.append(unit.isClan()).append(",");
-                csvLine.append(unit.getSource()).append(",");
-                csvLine.append(unit.getSourceFile()).append(",");
-                csvLine.append(unit.getTons()).append(",");
-                csvLine.append(unit.getYear()).append(",");
+                csvLine.append(unit.getChassis()).append(DELIM);
+                csvLine.append(unit.getModel()).append(DELIM);
+                csvLine.append(unit.getMulId()).append(DELIM);
+                csvLine.append(unit.getChassis()).append(" ").append(unit.getModel()).append(DELIM);
+                csvLine.append(unit.isClan()).append(DELIM);
+                csvLine.append(unit.getSource()).append(DELIM);
+                csvLine.append(unit.getSourceFile()).append(DELIM);
+                csvLine.append(unit.getTons()).append(DELIM);
+                csvLine.append(unit.getYear()).append(DELIM);
 
                 // Experimental Tech Year
                 if (unit.getAdvancedTechYear() > unit.getYear()) {
                     csvLine.append(unit.getYear());
                 }
-                csvLine.append(",");
+                csvLine.append(DELIM);
 
                 // Advanced Tech Year
                 if (unit.getAdvancedTechYear() > 0) {
                     csvLine.append(unit.getAdvancedTechYear());
                 }
-                csvLine.append(",");
+                csvLine.append(DELIM);
 
                 // Standard Tech Year
                 if (unit.getStandardTechYear() > 0) {
                     csvLine.append(unit.getStandardTechYear());
                 }
-                csvLine.append(",");
-                
+                csvLine.append(DELIM);
+
                 // Extinct Tech Year
-               	csvLine.append(unit.getExtinctRange()).append(",");
-               	// Unit Type.
-                csvLine.append(unit.getFullAccurateUnitType()).append(",");
+                csvLine.append(unit.getExtinctRange()).append(DELIM);
+                // Unit Type.
+                csvLine.append(unit.getFullAccurateUnitType()).append(DELIM);
                 // Unit Role
-                csvLine.append(UnitRoleHandler.getRoleFor(unit)).append(",");
+                csvLine.append(UnitRoleHandler.getRoleFor(unit)).append(DELIM);
                 // Unit BV
-                csvLine.append(unit.getBV()).append(",");
+                csvLine.append(unit.getBV()).append(DELIM);
                 // Unit Dry Cost
-                csvLine.append(unit.getDryCost()).append(",");
+                csvLine.append(unit.getDryCost()).append(DELIM);
                 // Unit Tech Level
-                csvLine.append(unit.getLevel()).append(",");
+                csvLine.append(unit.getLevel()).append(DELIM);
                 //Engine Type
-                csvLine.append(unit.getEngineName()).append(",");
+                csvLine.append(unit.getEngineName()).append(DELIM);
 
                 // Internals Type
                 if (unit.getInternalsType() >= 0) {
                     String isString = unit.isClan() ? "Clan " : "IS ";
-                    isString += EquipmentType.structureNames[unit.getInternalsType()] + ",";
+                    isString += EquipmentType.structureNames[unit.getInternalsType()] + DELIM;
                     csvLine.append(isString);
                 } else if (unit.getInternalsType() < 0) {
-                    csvLine.append("Not Applicable,");
+                    csvLine.append("Not Applicable").append(DELIM);
                 }
 
                 // Myomer type
-                csvLine.append(unit.getMyomerName()).append(",");
+                csvLine.append(unit.getMyomerName()).append(DELIM);
 
                 // Cockpit Type
                 if ((unit.getCockpitType() >= 0) && (unit.getCockpitType() < Mech.COCKPIT_STRING.length)) {
                     if (unit.getUnitType().equals("Mek")) {
-                        csvLine.append(Mech.COCKPIT_STRING[unit.getCockpitType()]).append(",");
+                        csvLine.append(Mech.COCKPIT_STRING[unit.getCockpitType()]).append(DELIM);
                     } else {
-                        csvLine.append(Aero.COCKPIT_STRING[unit.getCockpitType()]).append(",");
+                        csvLine.append(Aero.COCKPIT_STRING[unit.getCockpitType()]).append(DELIM);
                     }
                 } else {
-                    csvLine.append("Not Applicable,");
+                    csvLine.append("Not Applicable").append(DELIM);
                 }
 
                 // Gyro Type
                 if (unit.getGyroType() >= 0) {
-                    csvLine.append(Mech.GYRO_STRING[unit.getGyroType()]).append(",");
+                    csvLine.append(Mech.GYRO_STRING[unit.getGyroType()]).append(DELIM);
                 } else if (unit.getGyroType() < 0) {
-                    csvLine.append("Not Applicable,");
+                    csvLine.append("Not Applicable").append(DELIM);
                 }
 
                 // Armor type - prints different armor types on the unit
@@ -149,10 +159,11 @@ public class MechCacheCSVTool {
                 }
                 for (int i = 0; i < armorType.size(); i++) {
                     csvLine.append(EquipmentType.getArmorTypeName(armorType.get(i),
-                            TechConstants.isClan(armorTech.get(i)))).append(",");
+                            TechConstants.isClan(armorTech.get(i)))).append(DELIM);
                 }
 
                 // Equipment Names
+                List<String> equipmentNames = new ArrayList<>();
                 for (String name : unit.getEquipmentNames()) {
                     // Ignore armor critical
                     if (Stream.of(EquipmentType.armorNames).anyMatch(name::contains)) {
@@ -169,9 +180,47 @@ public class MechCacheCSVTool {
                             .anyMatch(name::contains)) {
                         continue;
                     }
-
-                    csvLine.append(name).append(",");
+                    equipmentNames.add(name);
                 }
+                csvLine.append(String.join(",", equipmentNames)).append(DELIM);
+
+                Entity entity = loadEntity(unit.getSourceFile(), unit.getEntryName());
+                if ((entity != null)) {
+
+                    if (!entity.getFluff().getManufacturer().isBlank()) {
+                        csvLine.append(entity.getFluff().getManufacturer());
+                    } else {
+                        csvLine.append("--");
+                    }
+                    csvLine.append(DELIM);
+
+                    if (!entity.getFluff().getPrimaryFactory().isBlank()) {
+                        csvLine.append(entity.getFluff().getPrimaryFactory());
+                    } else {
+                        csvLine.append("--");
+                    }
+                    csvLine.append(DELIM);
+
+                    csvLine.append(TROView.formatSystemFluff(EntityFluff.System.TARGETING, entity.getFluff(),
+                            () -> "--")).append(DELIM);
+                    csvLine.append(TROView.formatSystemFluff(EntityFluff.System.COMMUNICATIONS, entity.getFluff(),
+                            () -> "--")).append(DELIM);
+                    csvLine.append(TROView.formatSystemFluff(EntityFluff.System.ARMOR, entity.getFluff(),
+                            () -> "--")).append(DELIM);
+                    csvLine.append(TROView.formatSystemFluff(EntityFluff.System.JUMPJET, entity.getFluff(),
+                            () -> "--")).append(DELIM);
+                    csvLine.append(TROView.formatSystemFluff(EntityFluff.System.ENGINE, entity.getFluff(),
+                            () -> "--")).append(DELIM);
+                    csvLine.append(TROView.formatSystemFluff(EntityFluff.System.CHASSIS, entity.getFluff(),
+                            () -> "--")).append(DELIM);
+
+                    csvLine.append(entity.getFluff().getCapabilities().isBlank() ? "no" : "yes").append(DELIM);
+                    csvLine.append(entity.getFluff().getOverview().isBlank() ? "no" : "yes").append(DELIM);
+                    csvLine.append(entity.getFluff().getDeployment().isBlank() ? "no" : "yes").append(DELIM);
+                    csvLine.append(entity.getFluff().getHistory().isBlank() ? "no" : "yes").append(DELIM);
+                    csvLine.append(entity.getFluff().getNotes().isBlank() ? "no" : "yes").append(DELIM);
+                }
+
                 csvLine.append("\n");
                 bw.write(csvLine.toString());
             }
@@ -181,5 +230,16 @@ public class MechCacheCSVTool {
             System.out.println("IOException: " + e.getMessage());
             e.printStackTrace();
         }
+    }
+
+    public static @Nullable Entity loadEntity(File f, String entityName) {
+        try {
+            return new MechFileParser(f, entityName).getEntity();
+        } catch (megamek.common.loaders.EntityLoadingException e) {
+            return null;
+        }
+    }
+
+    private MechCacheCSVTool() {
     }
 }


### PR DESCRIPTION
As the title says. Requested by @HammerGS 

Also allows to easily change the column delimiter. It is no longer strictly an output of the MechSummaryCache as the fluff info needs to be loaded from each unit's file.