### PR TITLE
Berserk v2 Cleanup

### DIFF
--- a/megamek/mmconf/princessBehaviors.xml
+++ b/megamek/mmconf/princessBehaviors.xml
@@ -105,22 +105,7 @@
     <strategicBuildingTargets/>
   </behavior>
   <behavior>
-    <name>BERSERK</name>
-    <destinationEdge>NONE</destinationEdge>
-    <retreatEdge>NEAREST</retreatEdge>
-    <forcedWithdrawal>false</forcedWithdrawal>
-    <goHome>false</goHome>
-    <autoFlee>false</autoFlee>
-    <fallShameIndex>2</fallShameIndex>
-    <hyperAggressionIndex>10</hyperAggressionIndex>
-    <selfPreservationIndex>3</selfPreservationIndex>
-    <herdMentalityIndex>5</herdMentalityIndex>
-    <braveryIndex>2</braveryIndex>
-    <verbosity>WARNING</verbosity>
-    <strategicBuildingTargets/>
-  </behavior>
-  <behavior>
-    <name>BERSERK v2 ANGRY HORDE</name>
+    <name>BERSERK v2</name>
     <destinationEdge>NONE</destinationEdge>
     <retreatEdge>NEAREST</retreatEdge>
     <forcedWithdrawal>false</forcedWithdrawal>


### PR DESCRIPTION
Fixes confusing Berserk settings.  Renames Berserk v2 Angry Horde to Berserk v2 and deletes the Original Berserk.  With the new aggression settings, Origianl Berserk was much worse because she would suicide mechs based on speed.  Berserk v2 Angry Horde is much better and deadlier, and is now renamed to just Berserk v2 to avoid confusion.  

All of that is another way of saying:  There is now just a single Berserk setting - the good one.