### PR TITLE
Handle artillery strike against offboard unit that has disengaged.

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -302,6 +302,7 @@
 3145=, the shot is an automatic hit (<data>), 
 3150=\ needs <data>, 
 3155=rolls <data> : 
+3158=<data> lands, but the offboard target is gone.
 3160=<font color='C00000'>THE AUTOCANNON JAMS</font>; 
 3161=<font color='C00000'>THE DAMN THING JAMS</font>; 
 3162=<font color='C00000'>THE DAMN THING EXPLODES</font>;

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -136,6 +136,15 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             aaa.decrementTurnsTilHit();
             return true;
         }
+        // Offboard shots are targeted at an entity rather than a hex. If null, the target has disengaged.
+        if (target == null) {
+            Report r = new Report(3158);
+            r.indent();
+            r.subject = subjectId;
+            r.add(wtype.getName());
+            vPhaseReport.add(r);
+            return true;
+        }
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();
         Coords targetPos = target.getPosition();
         final int playerId = aaa.getPlayerId();

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -102,6 +102,15 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             return true;
         }
 
+        // Offboard shots are targeted at an entity rather than a hex. If null, the target has disengaged.
+        if (target == null) {
+            Report r = new Report(3158);
+            r.indent();
+            r.subject = subjectId;
+            r.add(wtype.getName());
+            vPhaseReport.add(r);
+            return true;
+        }
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();
 
         Coords targetPos = target.getPosition();


### PR DESCRIPTION
Another issue with offboard artillery disengagement. I thought we had already fixed this one.
When the round lands, report the missing target instead of choking.

Fixes #4794.