### PR TITLE
Check for available bay when recovering aero instead of using the first

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8172,22 +8172,27 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         // find those that can load the unit.
         // load the unit into the best match.
         if (unit.getElevation() == getElevation()) {
-            for (Transporter nextbay : transports) {
-                if ((nextbay instanceof DockingCollar) && nextbay.canLoad(unit)) {
-                    ((DockingCollar) nextbay).recover(unit);
-                    return;
+            if (unit.isDropShip()) {
+                for (Transporter nextbay : transports) {
+                    if ((nextbay instanceof DockingCollar) && nextbay.canLoad(unit)) {
+                        ((DockingCollar) nextbay).recover(unit);
+                        return;
+                    }
                 }
-            }
-            for (Bay nextbay : getTransportBays()) {
-                if ((nextbay instanceof ASFBay) && nextbay.canLoad(unit)) {
-                    ((ASFBay) nextbay).recover(unit);
-                    return;
+            } else {
+                if (unit.isFighter()) {
+                    for (Bay nextbay : getTransportBays()) {
+                        if ((nextbay instanceof ASFBay) && nextbay.canLoad(unit)) {
+                            ((ASFBay) nextbay).recover(unit);
+                            return;
+                        }
+                    }
                 }
-            }
-            for (Bay nextbay : getTransportBays()) {
-                if ((nextbay instanceof SmallCraftBay) && nextbay.canLoad(unit)) {
-                    ((SmallCraftBay) nextbay).recover(unit);
-                    return;
+                for (Bay nextbay : getTransportBays()) {
+                    if ((nextbay instanceof SmallCraftBay) && nextbay.canLoad(unit)) {
+                        ((SmallCraftBay) nextbay).recover(unit);
+                        return;
+                    }
                 }
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8171,42 +8171,27 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         // Walk through this entity's transport components;
         // find those that can load the unit.
         // load the unit into the best match.
-        int choice = 0;
-        for (Transporter nextbay : transports) {
-            if (nextbay.canLoad(unit) && (unit.getElevation() == getElevation())) {
-                if (nextbay instanceof DockingCollar) {
-                    choice = 3;
-                }
-                if (nextbay instanceof ASFBay) {
-                    choice = 2;
-                }
-                if (nextbay instanceof SmallCraftBay) {
-                    choice = 1;
-                }
-            }
-        }
-        if (choice == 3) {
+        if (unit.getElevation() == getElevation()) {
             for (Transporter nextbay : transports) {
-                while (nextbay instanceof DockingCollar) {
+                if ((nextbay instanceof DockingCollar) && nextbay.canLoad(unit)) {
                     ((DockingCollar) nextbay).recover(unit);
                     return;
                 }
             }
-        } else if (choice == 2) {
             for (Bay nextbay : getTransportBays()) {
-                while (nextbay instanceof ASFBay) {
+                if ((nextbay instanceof ASFBay) && nextbay.canLoad(unit)) {
                     ((ASFBay) nextbay).recover(unit);
                     return;
                 }
             }
-        } else if (choice == 1) {
             for (Bay nextbay : getTransportBays()) {
-                while (nextbay instanceof SmallCraftBay) {
+                if ((nextbay instanceof SmallCraftBay) && nextbay.canLoad(unit)) {
                     ((SmallCraftBay) nextbay).recover(unit);
                     return;
                 }
             }
         }
+        throw new IllegalArgumentException(getDisplayName() + " does not have a bay that can load" + unit.getDisplayName());
     }
 
 


### PR DESCRIPTION
Fixes a logic error in Entity::recover. After checking to see what type of bay is available that can hold the recovered unit, it attempts to load it into the first type of that bay whether that is the one with the capacity or not. This change also attempts to put fighters into fighter bays first, only checking small craft bays if none is available.

Fixes #4806.