### PR TITLE
Fix for #4892: failure loading files that contain infantryWeaponMounted objects

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -53,7 +53,6 @@ public class SerializationHelper {
                 megamek.common.Game.class,
                 megamek.common.Hex.class,
                 megamek.common.Minefield.class,
-                megamek.common.Mounted.class,
                 megamek.common.PilotingRollData.class,
                 megamek.common.Player.class,
                 megamek.common.Sensor.class,
@@ -75,6 +74,7 @@ public class SerializationHelper {
         xStream.allowTypeHierarchy(megamek.common.GameTurn.class);
         xStream.allowTypeHierarchy(megamek.common.ITechnology.class);
         xStream.allowTypeHierarchy(megamek.common.Transporter.class);
+        xStream.allowTypeHierarchy(megamek.common.Mounted.class);
         xStream.allowTypeHierarchy(megamek.common.actions.EntityAction.class);
         xStream.allowTypeHierarchy(megamek.common.icons.AbstractIcon.class);
         xStream.allowTypeHierarchy(megamek.common.options.AbstractOptions.class);


### PR DESCRIPTION
Ran into an issue where new save games could not be loaded back into current code.
It appears that something has changed in how we save infantry units.
Based on recommendation from other contributors, fix is to move `megamek.common.Mounted.class` into xStream.allowTypeHierarchy() call, as `infantryWeaponMounted` type is a subclass of this type.

Close #4892