### PR TITLE
JumpShip movement fix

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2490,6 +2490,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
             setAccNEnabled(false);
         }
 
+        // Disable accn/decn if a jumpship has changed facing
+        if ((a instanceof Jumpship) && ((Jumpship) a).hasStationKeepingDrive()
+                && (cmd.contains(MoveStepType.TURN_LEFT) || cmd.contains(MoveStepType.TURN_RIGHT))) {
+            setDecNEnabled(false);
+            setAccNEnabled(false);
+        }
+
         // if in atmosphere, limit acceleration to 2x safe thrust
         if (!clientgui.getClient().getGame().getBoard().inSpace()
                 && (vel == (2 * ce.getWalkMP()))) {

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1600,6 +1600,8 @@ public final class UnitToolTip {
                 if (jumpMPModified > 0) {
                     sMove += "/" + jumpMPModified;
                 }
+            } else if ((entity instanceof Jumpship) && ((Jumpship) entity).hasStationKeepingDrive()) {
+                sMove += String.format("%s%1.1f", DOT_SPACER, ((Jumpship) entity).getAccumulatedThrust());
             }
 
             sMove += DOT_SPACER;

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -1958,6 +1958,13 @@ public class MoveStep implements Serializable {
                         && (velocity != 0) && (getNTurns() > 1)) {
                     return;
                 }
+
+                // Jumpships cannot change velocity and use attitude jets in the same turn.
+                if ((a instanceof Jumpship) && ((Jumpship) a).hasStationKeepingDrive()
+                        && (prev.getMovementType(false) == EntityMovementType.MOVE_OVER_THRUST)
+                        && ((type == MoveStepType.TURN_LEFT) || (type == MoveStepType.TURN_RIGHT))) {
+                    return;
+                }
             }
 
             // atmosphere has its own rules about turning


### PR DESCRIPTION
Per StratOps, pp 51-2, JumpShips can accumulate 0.2 thrust per turn, and when it totals 1 they can spend that thrust as other aerospace units do. They also have attitude jets that allow them to change facing by one hexside per turn. But they do not accumulate any thrust on the same turn the attitude jets are used, and cannot use the attitude jets on the same turn that previously accumulated thrust is used.

MM handles the lack of accumulation when the jets are used, but allows a facing change the same turn that thrust is expended. This update fixes that. It also shows the amount of accumulated thrust on the unit tooltip, which also shows on the summary tab of the unit display.

Fixes #4807