### PR TITLE
Fix for space station rotation

### DIFF
--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -82,9 +82,6 @@ public class Jumpship extends Aero {
     private int escapePodsLaunched = 0;
     private int lifeBoatsLaunched = 0;
 
-    // Battlestation
-    private boolean isBattleStation = false;
-
     // HPG
     private boolean hasHPG = false;
 
@@ -482,13 +479,8 @@ public class Jumpship extends Aero {
         return hasHPG;
     }
 
-    public void setBattleStation(boolean b) {
-        isBattleStation = b;
-
-    }
-
     public boolean isBattleStation() {
-        return isBattleStation;
+        return false;
     }
 
     public void setLF(boolean b) {

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -118,6 +118,11 @@ public class SpaceStation extends Jumpship {
     }
 
     @Override
+    public boolean isBattleStation() {
+        return designType == MILITARY;
+    }
+
+    @Override
     public double getBVTypeModifier() {
         return 0.7;
     }

--- a/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
@@ -147,11 +147,6 @@ public class BLKSpaceStationFile extends BLKFile implements IMechLoader {
             a.setModular(true);
         }
 
-        // BattleStation
-        if (dataFile.exists("Battlestation")) {
-            a.setBattleStation(true);
-        }
-
         // Grav Decks - two approaches
         // First, the old method, where a number of grav decks for each category is specified
         //  This doesn't allow us to specify precise size


### PR DESCRIPTION
Per SO, p. 63, (civilian) space stations can accumulate 0.2 thrust per turn and rotate one hexside when they have acquired a full point of thrust. Military space stations can rotate every turn. MM checks the isBattlestation field to make this determination. Though the loader checks for the field and sets it, it is not written to the blk file and none of the unit files have it. The military checkbox in MML sets the designType field, which was added later as part of implementation of sensor rules. Since the older isBattlestation field provides no additional information, I have removed it to standardize on the designType field.

Fixes #3861