### PR TITLE
Ba manipulator size

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -455,10 +455,9 @@ public class MiscType extends EquipmentType {
 
     @Override
     public Double variableStepSize() {
-        if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO)) {
+        if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO) || hasFlag(F_CARGOLIFTER)) {
             return 0.5;
-        }
-        if (hasFlag(F_LADDER)) {
+        } else if (hasFlag(F_LADDER)) {
             return 20.0;
         }
         return super.variableStepSize();

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -188,29 +188,25 @@ public class TestBattleArmor extends TestEntity {
          * The type, corresponding to types defined in
          * <code>EquipmentType</code>.
          */
-        public int type;
+        public final int type;
 
         /**
          * The name of this manipulator
          */
-        public String internalName;
+        public final String internalName;
 
-        public String displayName;
+        public final String displayName;
 
         /**
          * Denotes whether this armor is Clan or not.
          */
-        public boolean pairMounted;
+        public final boolean pairMounted;
 
         BAManipulator(int t, boolean p) {
             type = t;
             internalName = BattleArmor.MANIPULATOR_TYPE_STRINGS[t];
             displayName = BattleArmor.MANIPULATOR_NAME_STRINGS[t];
             pairMounted = p;
-        }
-
-        public static int getNumBAArmors() {
-            return values().length;
         }
 
         /**


### PR DESCRIPTION
A small change dealing with #4833, setting the step size of BA cargo lifter manipulators to 0.5 tons, for use by MML.

Also made some changes to TestBattleArmor's internal BAManipulator enum class, making the fields immutable and removing an unused method.