### PR TITLE
Fix test for aerospace units that don't require fuel

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4110,7 +4110,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
 
         IAero aero = (IAero) ce;
-        if ((aero.getCurrentFuel() < 1) && !(ce.hasEngine() && ce.getEngine().isSolar())) {
+        if ((aero.getCurrentFuel() < 1) && aero.requiresFuel()) {
             disableButtons();
             butDone.setEnabled(true);
             getBtn(MoveCommand.MOVE_NEXT).setEnabled(true);

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -135,12 +135,11 @@ public class FixedWingSupport extends ConvFighter {
      * @return The mass of each point of fuel in kg.
      */
     public int kgPerFuelPoint() {
+        if (!requiresFuel()) {
+            return 0;
+        }
         int kg = KG_PER_FUEL_POINT[getWeightClass() - EntityWeightClass.WEIGHT_SMALL_SUPPORT][getEngineTechRating()];
         if (hasPropChassisMod() || getMovementMode().equals(EntityMovementMode.AIRSHIP)) {
-            if (getEngine().isFusion() || (getEngine().getEngineType() == Engine.FISSION)
-                    || (getEngine().getEngineType() == Engine.SOLAR)) {
-                return 0;
-            }
             kg = (int) Math.ceil(kg * 0.75);
         }
         return kg;
@@ -155,6 +154,13 @@ public class FixedWingSupport extends ConvFighter {
     @Override
     public double getFuelPointsPerTon() {
         return 1000.0 / kgPerFuelPoint();
+    }
+
+    @Override
+    public boolean requiresFuel() {
+        return !(((hasPropChassisMod() || getMovementMode().isAirship()))
+                && hasEngine() && (getEngine().isFusion() || (getEngine().getEngineType() == Engine.FISSION)
+                || (getEngine().getEngineType() == Engine.SOLAR)));
     }
 
     private static final TechAdvancement TA_FIXED_WING_SUPPORT = new TechAdvancement(TECH_BASE_ALL)

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -146,6 +146,10 @@ public interface IAero {
 
     double getFuelPointsPerTon();
 
+    default boolean requiresFuel() {
+        return true;
+    }
+
     // Capital fighters
     int getCapArmor();
 


### PR DESCRIPTION
Currently the check for an aerospace unit that has run out of fuel exempts those with solar engines. The rules in TM, p. 129 state that this only applies to fixed wing and airship support vehicles with the prop chassis mod, and it also includes fission and fusion engines.

Fixes #4821