### PR TITLE
Fix for 3095 - no +1 TMM for jumping WiGE

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2534,20 +2534,30 @@ public class Compute {
             return toHit;
         }
 
+        // Compile various state information to determine if the entity jumped, "jumped", or is VTOL
+        // Airborne non-ASF vehicles like WiGE can get +1 TMM for jumping _or_ being airborne, but not both.
+        // Non-flying WiGE _can_ get +1 TMM for jumping.
+        // See TW: pg. 307, "Attack Modifiers Table"
+        boolean jumped = !entity.isAirborneVTOLorWIGE()
+                        && (
+                            (entity.moved == EntityMovementType.MOVE_JUMP)
+                            || (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
+                            || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
+                            || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT)
+                        );
+
+        boolean isVTOL = (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
+                        || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
+                        || (entity.getMovementMode() == EntityMovementMode.VTOL)
+                        || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT);
+
         ToHitData toHit = Compute
                 .getTargetMovementModifier(
                         entity.delta_distance,
-                        (entity.getMovementMode() != EntityMovementMode.WIGE)
-                        && ((entity.moved == EntityMovementType.MOVE_JUMP)
-                                || (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
-                                || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
-                                || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT)),
-
-                        (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
-                        || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
-                        || (entity.getMovementMode() == EntityMovementMode.VTOL)
-                        || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT),
+                        jumped,
+                        isVTOL,
                         game);
+
         if (entity.moved != EntityMovementType.MOVE_JUMP
                 && entity.delta_distance > 0
                 && entity instanceof Mech && ((Mech) entity).getCockpitType() == Mech.COCKPIT_DUAL

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -12488,6 +12488,7 @@ public class GameManager implements IGameManager {
                 && (entity.getMovementMode() != EntityMovementMode.HYDROFOIL)
                 && (entity.getMovementMode() != EntityMovementMode.NAVAL)
                 && (entity.getMovementMode() != EntityMovementMode.SUBMARINE)
+                && (entity.getMovementMode() != EntityMovementMode.WIGE)
                 && (entity.getMovementMode() != EntityMovementMode.INF_UMU)) {
             vPhaseReport.addAll(destroyEntity(entity, "a watery grave", false));
         } else if ((waterDepth > 0)
@@ -27866,6 +27867,7 @@ public class GameManager implements IGameManager {
                 && (entity.getMovementMode() != EntityMovementMode.HYDROFOIL)
                 && (entity.getMovementMode() != EntityMovementMode.NAVAL)
                 && (entity.getMovementMode() != EntityMovementMode.SUBMARINE)
+                && (entity.getMovementMode() != EntityMovementMode.WIGE)
                 && (entity.getMovementMode() != EntityMovementMode.INF_UMU)) {
             vPhaseReport.addAll(destroyEntity(entity, "a watery grave", false));
             return vPhaseReport;
@@ -33718,8 +33720,7 @@ public class GameManager implements IGameManager {
         // which for these particular purposes may or may not be the intent of
         // the rules in all cases.
         // Immobile hovercraft on water sink...
-        if (!te.isOffBoard() && (((te.getMovementMode() == EntityMovementMode.HOVER)
-                || ((te.getMovementMode() == EntityMovementMode.WIGE) && (te.getElevation() == 0)))
+        if (!te.isOffBoard() && (te.getMovementMode() == EntityMovementMode.HOVER
                 && (te.isMovementHitPending() || (te.getWalkMP() <= 0))
                 // HACK: Have to check for *pending* hit here and below.
                 && (game.getBoard().getHex(te.getPosition()).terrainLevel(Terrains.WATER) > 0)


### PR DESCRIPTION
Fixes issue #3095, but only for non-airborne WiGE that jump. Airborne jumping WiGE are already getting a +1 TMM from being airborne and these are not cumulative with each other _(TW pg 307, ATTACK MODIFIERS TABLE)_.

Also fixes an issue where immobile / crashing WiGE are treated as other land vehicles and sink immediately; according to _TW pg 55_ they float and treat water as clear terrain, acting as naval vessels when landed on water, and so do not sink due to being immobile _(q.v.)_.

Close #3095.