### PR TITLE
VTOL infantry fixes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -813,7 +813,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         setWalkEnabled(!ce.isImmobile() && ((ce.getWalkMP() > 0) || (ce.getRunMP() > 0))
                 && !ce.isStuck());
-        setJumpEnabled(!isAero && !ce.isImmobile() && !ce.isProne() && (ce.getJumpMP() > 0)
+        setJumpEnabled(!isAero && !ce.isImmobile() && !ce.isProne()
+                // Conventional infantry also uses jump MP for VTOL and UMU MP
+                && ((ce.getJumpMP() > 0) && (!ce.isConventionalInfantry() || ce.getMovementMode().isJumpInfantry()))
                 && !(ce.isStuck() && !ce.canUnstickByJumping()));
         setSwimEnabled(!isAero && !ce.isImmobile() && (ce.getActiveUMUCount() > 0)
                 && ce.isUnderwater());

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1670,7 +1670,7 @@ public class Infantry extends Entity {
 
     @Override
     public String getMovementModeAsString() {
-        if (!hasETypeFlag(Entity.ETYPE_BATTLEARMOR)) {
+        if (isConventionalInfantry() && (mount == null)) {
             if (getMovementMode().isVTOL()) {
                 return hasMicrolite() ? "Microlite" : "Microcopter";
             }

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -2970,7 +2970,8 @@ public class MoveStep implements Serializable {
         // 0 MP infantry units can move 1 hex
         if (isInfantry
                 && (cachedEntityState.getWalkMP() == 0)
-                && (moveMode != EntityMovementMode.SUBMARINE)
+                && !moveMode.isSubmarine()
+                && !moveMode.isVTOL()
                 && getEntity().getPosition().equals(prev)
                 && (getEntity().getPosition().distance(getPosition()) == 1)
                 && (!isJumping())) {

--- a/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
@@ -106,9 +106,15 @@ public class InfantryPathFinder {
         // we've visited this hex already
         // we are walking and at or past our movement mp
         // we are jumping and at or past our jump mp
-        if (visitedCoords.contains(startingPath.getFinalCoords()) ||
-                (!startingPath.isJumping() && (startingPath.getMpUsed() >= startingPath.getEntity().getRunMP()))||
-                (startingPath.isJumping() && (startingPath.getMpUsed() >= startingPath.getEntity().getJumpMP()))) {
+        int mp;
+        if (startingPath.isJumping() || startingPath.getEntity().getMovementMode().isVTOL()) {
+            mp = startingPath.getEntity().getJumpMP();
+        } else if (startingPath.getEntity().hasUMU()) {
+            mp = startingPath.getEntity().getActiveUMUCount();
+        } else {
+            mp = startingPath.getEntity().getRunMP();
+        }
+        if (visitedCoords.contains(startingPath.getFinalCoords()) || (startingPath.getMpUsed() >= mp)) {
             return retval;
         }
         


### PR DESCRIPTION
Fixes four issues with VTOL infantry movement:
1. Disables the jump button on the movement panel. The jump button gets enabled because infantry use jump MP for VTOL or underwater movement.
2. getMovementModeAsString() returns VTOL for beast-mounted VTOL infantry rather than trying to assign it a mechanized VTOL movement type.
3. Allows VTOL infantry with 0 ground movement to move horizontally after changing elevation. Spending MP before the first move to a new hex is treating it like 0* MP foot infantry and disallowing further movement after spending MP.
4. Use VTOL or UMU mp instead of ground MP as appropriate when Princess calculates possible paths for infantry.

Fixes #4901.