### PR TITLE
Show cockpit type on MechView even for standard.

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -3902,6 +3902,16 @@ public abstract class Mech extends Entity {
     }
 
     public String getCockpitTypeString() {
+        if (isIndustrial()) {
+            switch (getCockpitType()) {
+                case COCKPIT_STANDARD:
+                    return Mech.getCockpitTypeString(COCKPIT_INDUSTRIAL) + " (Adv. FCS)";
+                case COCKPIT_PRIMITIVE:
+                    return Mech.getCockpitTypeString(COCKPIT_PRIMITIVE_INDUSTRIAL) + " (Adv. FCS)";
+                case COCKPIT_SUPERHEAVY:
+                    return Mech.getCockpitTypeString(COCKPIT_SUPERHEAVY_INDUSTRIAL) + " (Adv. FCS)";
+            }
+        }
         return Mech.getCockpitTypeString(getCockpitType());
     }
 

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -418,10 +418,8 @@ public class MechView {
             }
             sBasic.add(new LabeledElement(Messages.getString("MechView.HeatSinks"), hsString.toString()));
             
-            if (a.getCockpitType() != Mech.COCKPIT_STANDARD) {
-                sBasic.add(new LabeledElement(Messages.getString("MechView.Cockpit"),
-                        a.getCockpitTypeString()));
-            }
+            sBasic.add(new LabeledElement(Messages.getString("MechView.Cockpit"),
+                    a.getCockpitTypeString()));
         }
 
         if (isMech) {
@@ -437,13 +435,10 @@ public class MechView {
                         .append(" damaged)").append(warningEnd());
             }
             sBasic.add(new LabeledElement(aMech.getHeatSinkTypeName() + "s", hsString.toString()));
-            if ((aMech.getCockpitType() != Mech.COCKPIT_STANDARD)
-                    || aMech.hasArmoredCockpit()) {
-                sBasic.add(new LabeledElement(Messages.getString("MechView.Cockpit"),
-                        aMech.getCockpitTypeString()
-                                + (aMech.hasArmoredCockpit() ? " (armored)" : "")));
-                                
-            }
+            sBasic.add(new LabeledElement(Messages.getString("MechView.Cockpit"),
+                    aMech.getCockpitTypeString()
+                            + (aMech.hasArmoredCockpit() ? " (armored)" : "")));
+
             String gyroString = aMech.getGyroTypeString();
             if (aMech.getGyroHits() > 0) {
                 gyroString += " " + warningStart() + "(" + aMech.getGyroHits()


### PR DESCRIPTION
Shows the cockpit type on the MechView even for for standard. Industrial mechs set to the non-industrial version to indicate advanced fire control will show as the industrial type that they canonically have with " (Adv. FCS)" added.

Closes #4907