### PR TITLE
HTML tags in fluff: correction for CI ftlh template

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/conv_infantry.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/conv_infantry.ftlh
@@ -7,6 +7,7 @@
   <font size="+1"><b>${fullName}</b></font>
 
 <#if includeFluff>
+	<#noautoesc>
 	<#if fluffOverview??>
 	<p>
 	<b>Overview</b><br/>
@@ -34,6 +35,7 @@
 	${fluffHistory}
 	</p>
 	</#if>
+	</#noautoesc>
 </#if>
 
 	<p>


### PR DESCRIPTION
When allowing HTML tags in unit fluff I forgot to adapt the TRO View ftlh template for infantry. 