### PR TITLE
Fix entity sprint MP calculation

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2837,7 +2837,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * Returns sprint MP without considering MASC
      */
     public int getSprintMPwithoutMASC() {
-        return getRunMPwithoutMASC();
+        return getSprintMP(MPCalculationSetting.NO_MASC);
     }
 
     /**


### PR DESCRIPTION
The call to Entity::getSprintMPWithoutMASC is returning the run MP, leading to the assumption later on that any unit that exceeds run must be using a supercharger.

Fixes #4857