### PR TITLE
Allow jdialog to be a parent rather than just jframe

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
@@ -76,6 +76,15 @@ public abstract class AbstractButtonDialog extends AbstractDialog {
         super(frame, modal, resources, name, title);
         setResult(DialogResult.CANCELLED); // Default result is cancelled
     }
+
+    /**
+     * This constructor is provided for uses cases where this dialog needs another dialog as a parent.
+     */
+    protected AbstractButtonDialog(final JDialog dialog, final JFrame frame, final boolean modal, final ResourceBundle resources,
+                                   final String name, final String title) {
+        super(dialog, frame, modal, resources, name, title);
+        setResult(DialogResult.CANCELLED); // Default result is cancelled
+    }
     //endregion Constructors
 
     //region Getters/Setters

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractDialog.java
@@ -85,6 +85,29 @@ public abstract class AbstractDialog extends JDialog implements WindowListener {
         setFrame(frame);
         this.resources = resources;
     }
+
+    /**
+     * This allows Swing to create the dialog with another dialog as the parent. Which dialog swing renders on top
+     * is somewhat undefined, depending on the window manager. This can cause problems in the case of modal dialogs
+     * that show up behind other dialogs and you cannot get to them.
+     *
+     * @param dialog Owning dialog, for dialogs on dialogs
+     * @param frame Owning frame
+     * @param modal if this dialog is modal
+     * @param resources the resource bundle for this dialog
+     * @param name the dialog's name
+     * @param title the dialog's title resource key. This is required for accessibility reasons, and
+     *              the method will error out if it isn't valid.
+     */
+    protected AbstractDialog(final JDialog dialog, JFrame frame, final boolean modal, final ResourceBundle resources,
+                             final String name, final String title) {
+        super(dialog, modal);
+        setTitle(resources.getString(title));
+        setName(name);
+        setFrame(frame);
+        this.resources = resources;
+    }
+
     //endregion Constructors
 
     //region Getters/Setters

--- a/megamek/src/megamek/client/ui/baseComponents/AbstractValidationButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractValidationButtonDialog.java
@@ -82,6 +82,16 @@ public abstract class AbstractValidationButtonDialog extends AbstractButtonDialo
         super(frame, modal, resources, name, title);
         setState(ValidationState.PENDING);
     }
+
+    /**
+     * Allows a dialog to be passed in as the owner
+     */
+    protected AbstractValidationButtonDialog(final JDialog owner, final JFrame frame, final boolean modal,
+                                             final ResourceBundle resources, final String name,
+                                             final String title) {
+        super(owner, frame, modal, resources, name, title);
+        setState(ValidationState.PENDING);
+    }
     //endregion Constructors
 
     //region Getters/Setters


### PR DESCRIPTION
Motivation:
In MekHq, the campaign creation user interface wasn't showing up.   After tracking this down, the modal campaign dialog was coming up behind the original dialog that spawned it.

Without rearranging things too much, a straight-forward fix appeared to be to make sure that the modal dialog had the owner of the JDialog that created it, not the owning JFrame.

I am guessing that this works ok on some platforms so it's not an issue for some. I'm also guessing that this is the case because which JDialog is rendered in front is arbitrary if they have the same JFrame. Regardless, this feels like a fairly benign change.

Change Description:
The 'megamek' changes are just to allow a JDialog to be the parent of another JDialog in the abstract classes... Something Swing already supports. The real functional change will be in mekhq.