### PR TITLE
dont set gm to an observer when they have no units

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -536,7 +536,7 @@ public class GameManager implements IGameManager {
     public void checkForObservers() {
         for (Enumeration<Player> e = getGame().getPlayers(); e.hasMoreElements(); ) {
             Player p = e.nextElement();
-            p.setObserver((getGame().getEntitiesOwnedBy(p) < 1) && !getGame().getPhase().isLounge());
+            p.setObserver((!p.isGameMaster()) && (getGame().getEntitiesOwnedBy(p) < 1) && !getGame().getPhase().isLounge());
         }
     }
 


### PR DESCRIPTION
- don't set gm to an observer when they have no units left.  
- this fixes an issue when using the gm done option and the gm has no units.  causing the report phases to automatically skip,  since there is no one set to check for done.