### PR TITLE
add illumination indicator to the hextooltip and unittooltip

### DIFF
--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -484,7 +484,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(BOARD_MOVE_FONT_STYLE, Font.BOLD);
         store.setDefault(BOARD_ATTACK_ARROW_TRANSPARENCY, 0x80);
         store.setDefault(BOARD_ECM_TRANSPARENCY, 0x80);
-        store.setDefault(BOARD_DARKEN_MAP_AT_NIGHT, false);
+        store.setDefault(BOARD_DARKEN_MAP_AT_NIGHT, true);
         store.setDefault(BOARD_TRANSLUCENT_HIDDEN_UNITS, true);
         setDefault(BOARD_TMM_PIP_MODE, 2); // show pips with colors based on move type
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5449,7 +5449,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         // Hex Terrain
         if (GUIP.getShowMapHexPopup() && (mhex != null)) {
             StringBuffer sbTerrain = new StringBuffer();
-            appendTerrainTooltip(sbTerrain, mhex);
+            appendTerrainTooltip(sbTerrain, mhex, game);
             String sTrerain = sbTerrain.toString();
 
             // Distance from the selected unit and a planned movement end point
@@ -5750,11 +5750,11 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     /**
      * Appends HTML describing the terrain of a given hex
      */
-    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex) {
+    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex, Game game) {
         if (mhex == null) {
             return;
         }
-        txt.append(HexTooltip.getTerrainTip(mhex));
+        txt.append(HexTooltip.getTerrainTip(mhex, game));
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5449,7 +5449,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         // Hex Terrain
         if (GUIP.getShowMapHexPopup() && (mhex != null)) {
             StringBuffer sbTerrain = new StringBuffer();
-            appendTerrainTooltip(sbTerrain, mhex, game);
+            appendTerrainTooltip(sbTerrain, mhex);
             String sTrerain = sbTerrain.toString();
 
             // Distance from the selected unit and a planned movement end point
@@ -5750,7 +5750,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
     /**
      * Appends HTML describing the terrain of a given hex
      */
-    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex, Game game) {
+    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex) {
         if (mhex == null) {
             return;
         }

--- a/megamek/src/megamek/client/ui/swing/tooltip/HexTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/HexTooltip.java
@@ -20,13 +20,13 @@ import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.BasementType;
+import megamek.common.enums.IlluminationLevel;
 
 import java.util.Vector;
 
 import static megamek.client.ui.swing.tooltip.TipUtil.BUILDING_BGCOLOR;
 import static megamek.client.ui.swing.tooltip.TipUtil.LIGHT_BGCOLOR;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-import static megamek.client.ui.swing.util.UIUtil.uiBlack;
+import static megamek.client.ui.swing.util.UIUtil.*;
 
 public final class HexTooltip {
 
@@ -155,6 +155,7 @@ public final class HexTooltip {
                 result.append("<BR>");
             }
         }
+
         return result.toString();
     }
 
@@ -187,17 +188,19 @@ public final class HexTooltip {
         return result;
     }
 
-    public static String getTerrainTip(Hex mhex)
+    public static String getTerrainTip(Hex mhex, Game game)
     {
         Coords mcoords = mhex.getCoords();
+        String illuminated = IlluminationLevel.getIlluminationLevelIndicator(game, mcoords);
         String result = "";
-        StringBuilder sTerrain = new StringBuilder(Messages.getString("BoardView1.Tooltip.Hex", mcoords.getBoardNum(), mhex.getLevel()) + "<BR>");
+        StringBuilder sTerrain = new StringBuilder(Messages.getString("BoardView1.Tooltip.Hex", mcoords.getBoardNum(), mhex.getLevel()) + illuminated + "<BR>");
 
         // cycle through the terrains and report types found
         for (int terType: mhex.getTerrainTypes()) {
             int tf = mhex.getTerrain(terType).getTerrainFactor();
             int ttl = mhex.getTerrain(terType).getLevel();
             String name = Terrains.getDisplayName(terType, ttl);
+
             if (name != null) {
                 String msg_tf =  Messages.getString("BoardView1.Tooltip.TF");
                 name += (tf > 0) ? " (" + msg_tf + ": " + tf + ')' : "";

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1369,9 +1369,10 @@ public final class UnitToolTip {
             }
         }
 
+        String illuminated = entity.isIlluminated() ?  DOT_SPACER +"\uD83D\uDCA1" : "";
         String searchLight = entity.isUsingSearchlight() ? DOT_SPACER +"\uD83D\uDD26" : "";
         searchLight += entity.usedSearchlight() ? " \u2580\u2580" : "";
-        result += guiScaledFontHTML(uiYellow()) + searchLight + "</FONT>";
+        result += guiScaledFontHTML(uiYellow()) + illuminated + searchLight + "</FONT>";
 
         // Gun Emplacement Status
         if (isGunEmplacement) {
@@ -1505,9 +1506,8 @@ public final class UnitToolTip {
             }
         }
 
-        // Coloring and italic to make these transient entries stand out
+        // Coloring to make these transient entries stand out
         result = guiScaledFontHTML(uiLightViolet()) + result + "</FONT>";
-        result = "<I>" + result + "</I>";
 
         return new StringBuilder().append(result);
     }

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -1370,9 +1370,16 @@ public final class UnitToolTip {
         }
 
         String illuminated = entity.isIlluminated() ?  DOT_SPACER +"\uD83D\uDCA1" : "";
-        String searchLight = entity.isUsingSearchlight() ? DOT_SPACER +"\uD83D\uDD26" : "";
-        searchLight += entity.usedSearchlight() ? " \u2580\u2580" : "";
-        result += guiScaledFontHTML(uiYellow()) + illuminated + searchLight + "</FONT>";
+        result += guiScaledFontHTML(uiYellow()) + illuminated + "</FONT>";
+
+        if (entity.hasSearchlight()) {
+            String searchLight = entity.isUsingSearchlight() ? DOT_SPACER + "\uD83D\uDD26" : "";
+            searchLight += entity.usedSearchlight() ? " \u2580\u2580" : "";
+            result += guiScaledFontHTML(uiYellow()) + searchLight + "</FONT>";
+        } else {
+            String searchLight = "\uD83D\uDD26";
+            result += guiScaledFontHTML(GUIP.getWarningColor()) + DOT_SPACER + searchLight + "</FONT>";
+        }
 
         // Gun Emplacement Status
         if (isGunEmplacement) {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -146,7 +146,7 @@ public class SummaryPanel extends PicMap {
             Hex mhex = entity.getGame().getBoard().getHex(entity.getPosition());
             if (bv != null && mhex != null) {
                 StringBuffer sb = new StringBuffer();
-                bv.appendTerrainTooltip(sb, mhex, entity.getGame());
+                bv.appendTerrainTooltip(sb, mhex);
                 col = "<TD>" + sb + "</TD>";
                 row = "<TR>" + col + "</TR>";
                 hexTxt.append("<TABLE BORDER=0 BGCOLOR=" + TERRAIN_BGCOLOR + " width=100%>" + row + "</TABLE>");

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -146,7 +146,7 @@ public class SummaryPanel extends PicMap {
             Hex mhex = entity.getGame().getBoard().getHex(entity.getPosition());
             if (bv != null && mhex != null) {
                 StringBuffer sb = new StringBuffer();
-                bv.appendTerrainTooltip(sb, mhex);
+                bv.appendTerrainTooltip(sb, mhex, entity.getGame());
                 col = "<TD>" + sb + "</TD>";
                 row = "<TR>" + col + "</TR>";
                 hexTxt.append("<TABLE BORDER=0 BGCOLOR=" + TERRAIN_BGCOLOR + " width=100%>" + row + "</TABLE>");

--- a/megamek/src/megamek/common/enums/IlluminationLevel.java
+++ b/megamek/src/megamek/common/enums/IlluminationLevel.java
@@ -25,6 +25,8 @@ import megamek.common.Terrains;
 
 import java.util.Objects;
 
+import static megamek.client.ui.swing.util.UIUtil.*;
+
 public enum IlluminationLevel {
     //region Enum Declarations
     NONE,
@@ -87,5 +89,18 @@ public enum IlluminationLevel {
                 .anyMatch(adjacent -> adjacent.containsTerrain(Terrains.FIRE));
 
         return neighbouringFire ? IlluminationLevel.FIRE : IlluminationLevel.NONE;
+    }
+
+    public static  String getIlluminationLevelIndicator(final Game game, final Coords coords) {
+        switch (IlluminationLevel.determineIlluminationLevel(game, coords)) {
+            case FIRE:
+                return DOT_SPACER + guiScaledFontHTML(uiYellow()) + " \uD83D\uDD25" + "</FONT>";
+            case FLARE:
+                return DOT_SPACER + guiScaledFontHTML(uiYellow()) + " \uD83C\uDF86" + "</FONT>";
+            case SEARCHLIGHT:
+                return DOT_SPACER + guiScaledFontHTML(uiYellow()) + " \uD83D\uDD26" + "</FONT>";
+            default:
+                return "";
+        }
     }
 }

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -50,6 +50,7 @@ public class SerializationHelper {
                 megamek.common.CompositeTechLevel.DateRange.class,
                 megamek.common.CriticalSlot.class,
                 megamek.common.EquipmentMode.class,
+                megamek.common.Flare.class,
                 megamek.common.Game.class,
                 megamek.common.Hex.class,
                 megamek.common.Minefield.class,


### PR DESCRIPTION
- add illumination  spotlight, fire, flare indicator to the hex tooltip
- add unit illuminated by spotlight indicator to the unit tooltip
- helpful if you dont have the darken map at night client setting turned on
- add search light destroyed indicator to the unit tooltip
- set dark map at night to true by default

![image](https://github.com/MegaMek/megamek/assets/116095479/93a159de-bf31-46ec-999c-5977f0fd1261)
![image](https://github.com/MegaMek/megamek/assets/116095479/bbcadf07-68fc-4a01-b943-0f0b918d6b34)
![image](https://github.com/MegaMek/megamek/assets/116095479/dda5ffc5-fa49-4f56-9265-0f9e3ae31ec7)
![image](https://github.com/MegaMek/megamek/assets/116095479/8222088c-6044-4dd8-946c-ae3a977a9d18)

