### PR TITLE
#4876 Fix Unit Display General tab rendered blank when switching units.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -758,7 +758,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
         clientgui.getBoardView().setHighlightColor(GUIP.getMoveDefaultColor());
         clear();
 
-        updateButtons();
+        updateButtonsLater();
+
         clientgui.getBoardView().highlight(ce.getPosition());
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().cursor(null);
@@ -792,6 +793,21 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     private boolean isEnabled(MoveCommand c) {
         return buttons.get(c).isEnabled();
+    }
+
+    /**
+     * Sets buttons to their proper state, but lets Swing do this later after all the 
+     * current BoardView repaints and updates are complete.  This is done to prevent some
+     * buttons from painting correctly when the maps is zoomed way out. See Issue: #4444
+     */
+    private void updateButtonsLater() {
+        SwingUtilities.invokeLater(new Runnable() {
+
+			@Override
+			public void run() {
+				updateButtons();
+			 };
+        });
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -792,12 +792,15 @@ public class MovementDisplay extends ActionPhaseDisplay {
         return buttons.get(c).isEnabled();
     }
 
+    /**
+     * Signals Unit Display to update later on the AWT event stack.
+     * See Issue:#4876 and #4444.  This is done to prevent blank general tab when switching 
+     * units when the map is zoomed all the way out.
+     */
     private void updateUnitDisplayLater(Entity ce) {
         SwingUtilities.invokeLater(new Runnable() {
             @Override
             public void run() {
-                // Issue:#4876 moving the call to 'displayEntity' before boardview calls that invoke 'repaint()'
-                // this seems to prevent blank general tab when switching units when the map is zoomed all the way out.
                clientgui.getUnitDisplay().displayEntity(ce);
                clientgui.getUnitDisplay().showPanel("movement");
             }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -752,9 +752,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
         clientgui.setSelectedEntityNum(en);
         gear = MovementDisplay.GEAR_LAND;
 
-        // Issue:#4876 moving the call to 'displayEntity' before boardview calls that invoke 'repaint()'
-        // this seems to prevent blank general tab when switching units when the map is zoomed all the way out.
-        clientgui.getUnitDisplay().displayEntity(ce);
         clientgui.getBoardView().setHighlightColor(GUIP.getMoveDefaultColor());
         clear();
 
@@ -763,7 +760,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         clientgui.getBoardView().highlight(ce.getPosition());
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().cursor(null);
-        clientgui.getUnitDisplay().showPanel("movement");
+        updateUnitDisplayLater(ce);
         if (!clientgui.getBoardView().isMovingUnits()) {
             clientgui.getBoardView().centerOnHex(ce.getPosition());
         }
@@ -793,6 +790,18 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     private boolean isEnabled(MoveCommand c) {
         return buttons.get(c).isEnabled();
+    }
+
+    private void updateUnitDisplayLater(Entity ce) {
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                // Issue:#4876 moving the call to 'displayEntity' before boardview calls that invoke 'repaint()'
+                // this seems to prevent blank general tab when switching units when the map is zoomed all the way out.
+               clientgui.getUnitDisplay().displayEntity(ce);
+               clientgui.getUnitDisplay().showPanel("movement");
+            }
+        });
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -751,15 +751,17 @@ public class MovementDisplay extends ActionPhaseDisplay {
         cen = en;
         clientgui.setSelectedEntityNum(en);
         gear = MovementDisplay.GEAR_LAND;
-        Color walkColor = GUIP.getMoveDefaultColor();
-        clientgui.getBoardView().setHighlightColor(walkColor);
+
+        // Issue:#4876 moving the call to 'displayEntity' before boardview calls that invoke 'repaint()'
+        // this seems to prevent blank general tab when switching units when the map is zoomed all the way out.
+        clientgui.getUnitDisplay().displayEntity(ce);
+        clientgui.getBoardView().setHighlightColor(GUIP.getMoveDefaultColor());
         clear();
 
         updateButtons();
         clientgui.getBoardView().highlight(ce.getPosition());
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().cursor(null);
-        clientgui.getUnitDisplay().displayEntity(ce);
         clientgui.getUnitDisplay().showPanel("movement");
         if (!clientgui.getBoardView().isMovingUnits()) {
             clientgui.getBoardView().centerOnHex(ce.getPosition());


### PR DESCRIPTION
This is a proposed fix for #4876.  This code change moves the unit display select entity logic before BoardView setup and rendering methods.  I cannot 100% explain why this order of operations works, but it seems to be race condition in the Java Swing component repainting that occurs as methods like `BoardView.setHighlightColor()` trigger a `repaint()`.

It doesn't appear there are any side-effects to moving this call up in the order of operations as it appears all the other tabs update as expected as new units are selected in the movement phase.

Fixes #4876
Fixed #4444 