### PR TITLE
Fix report of hit for ultra ACs in single mode or with the unofficial fire twice option

### DIFF
--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -108,11 +108,11 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
             return 1;
         }
 
-        bSalvo = true;
-
         if (howManyShots == 1 || twoRollsUltra) {
             return 1;
         }
+
+        bSalvo = true;
 
         int nMod = getClusterModifiers(true);
 


### PR DESCRIPTION
When a weapon is fired the round report will either show "needs x, rolls y : hits [location]" or "needs x, rolls y : misses". For ultra autocannons firing a single shot it shows a miss, but not a hit. This is because the bSalvo field is set to true regardless of the number of shots fired. Moving the assignment until after the check for a single shot or the unofficial option that has it fire twice instead of making a cluster roll has it report normally.

In ultra mode it will report "x shot(s) hit", which is unaffected by the change.

Fixes #4904