### PR TITLE
Don't give active probe advantage to target in woods when using woods cover option.

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4433,10 +4433,11 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BAP) && !isIndirect && (te != null)
                 && ae.hasBAP() && (ae.getBAPRange() >= Compute.effectiveDistance(game, ae, te))
                 && !ComputeECM.isAffectedByECM(ae, ae.getPosition(), te.getPosition())
-                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS)
-                        || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE)
-                        || (los.getLightWoods() > 0) || (los.getHeavyWoods() > 0) || (los.getUltraWoods() > 0))
-                || ae.hasNetworkBAP()) {
+                && (!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER) &&
+                        (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS)
+                        || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE)))
+                    || (los.getLightWoods() > 0) || (los.getHeavyWoods() > 0) || (los.getUltraWoods() > 0)
+                    || ae.hasNetworkBAP()) {
             if (ae.hasBAP()) {
                 // If you want the bonus, the entity with the BAP should fire first.
                 // Not sure how to get around this


### PR DESCRIPTION
The woods cover rule from TacOps reduces damage to a unit in woods rather than giving a to-hit modifier. When using this with the TacOps probe rule, which reduces the modifier for woods by one, the reduction should only apply to intervening woods, and not woods the target is standing in.

Fixes #4927