### PR TITLE
Fix #4795 Sensor Range Bands Not Showing Until Movement Begins.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -780,7 +780,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
             setStatusBarText(yourTurnMsg);
         }
         clientgui.getBoardView().clearFieldOfFire();
-        clientgui.getBoardView().clearSensorsRanges();
         computeMovementEnvelope(ce);
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6424,13 +6424,8 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     // prepares the sprites for visual and sensor ranges
     public void setSensorRange(Entity entity, Coords c) {
-        if (entity == null || c == null) {
-            clearSensorsRanges();
-            return;
-        }
-
-        // Do not display anything for offboard units
-        if (entity.isOffBoard()) {
+        // Do not calculate anything for offboard units
+        if (entity == null || c == null || entity.isOffBoard()) {
             clearSensorsRanges();
             return;
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6424,7 +6424,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     // prepares the sprites for visual and sensor ranges
     public void setSensorRange(Entity entity, Coords c) {
-        if (entity == null || c == null || !GUIP.getShowSensorRange()) {
+        if (entity == null || c == null) {
             clearSensorsRanges();
             return;
         }


### PR DESCRIPTION
Fixes #4795 - Whenever a unit is selected in the movement phase, the `MovementDisplay::selectEntity()` call clears the sensor ranges.  This fix removes the call to clear the sensor ranges when an entity is selected allowing the sensor range sprite to be drawn be default when the feature is enabled.

Additionally, if a player would toggle off sensor ranges and then select a new entity, the ranges would be cleared due to the feature being toggled off - causing the sensors range to not display when the sensor range is toggled back on. (at least until some event triggers the re-calculation of the ranges.)

