### PR TITLE
null check for ghostTargetRoll

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -5187,7 +5187,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         }
 
         // if you failed your ghost target PSR, then it doesn't matter
-        if ((active && (getGhostTargetRollMoS() < 0)) || isShutDown()) {
+        if ((ghostTargetRoll == null) || (active && (getGhostTargetRollMoS() < 0)) || isShutDown()) {
             return false;
         }
         boolean hasGhost = false;


### PR DESCRIPTION
- null check for ghostTargetRoll



17:55:22,234 ERROR [megamek.client.bot.BotClient] {Princess Turn 3 Calc Thread}
megamek.client.bot.BotClient.calculateMyTurnWorker(BotClient.java:558) - 
java.lang.NullPointerException: Cannot invoke "megamek.common.Roll.getIntValue()" because "this.ghostTargetRoll" is null
	at megamek.common.Entity.getGhostTargetRollMoS(Entity.java:12134)
	at megamek.common.Entity.hasGhostTargets(Entity.java:5190)
	at megamek.common.Compute.getGhostTargetNumber(Compute.java:5347)
	at megamek.common.actions.WeaponAttackAction.compileTargetToHitMods(WeaponAttackAction.java:4085)
	at megamek.common.actions.WeaponAttackAction.toHitCalc(WeaponAttackAction.java:757)
	at megamek.common.actions.WeaponAttackAction.toHit(WeaponAttackAction.java:255)
	at megamek.common.Compute.getExpectedDamage(Compute.java:3028)
	at megamek.client.bot.princess.WeaponFireInfo.computeExpectedDamage(WeaponFireInfo.java:415)
	at megamek.client.bot.princess.WeaponFireInfo.initDamage(WeaponFireInfo.java:567)
	at megamek.client.bot.princess.WeaponFireInfo.<init>(WeaponFireInfo.java:171)
	at megamek.client.bot.princess.WeaponFireInfo.<init>(WeaponFireInfo.java:105)
	at megamek.client.bot.princess.FireControl.buildWeaponFireInfo(FireControl.java:1415)
	at megamek.client.bot.princess.FireControl.guessFullFiringPlan(FireControl.java:1540)
	at megamek.client.bot.princess.FireControl.guessBestFiringPlanUnderHeat(FireControl.java:2027)
	at megamek.client.bot.princess.FireControl.determineBestFiringPlan(FireControl.java:2102)
	at megamek.client.bot.princess.BasicPathRanker.initUnitTurn(BasicPathRanker.java:636)
	at megamek.client.bot.princess.Princess.continueMovementFor(Princess.java:1241)
	at megamek.client.bot.BotClient.calculateMyTurnWorker(BotClient.java:515)
	at megamek.client.bot.BotClient.calculateMyTurn(BotClient.java:484)
	at megamek.client.bot.BotClient$CalculateBotTurn.run(BotClient.java:62)
	at java.base/java.lang.Thread.run(Thread.java:833)