### PR TITLE
MechSummaryCache BV calculation: ignore pilot skill to ignore saved a…

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -416,7 +416,7 @@ public class MechSummaryCache {
             ms.setTWweight(e.getWeight());
             ms.setSuitWeight(((BattleArmor) e).getTrooperWeight());
         }
-        ms.setBV(e.calculateBattleValue());
+        ms.setBV(e.calculateBattleValue(true, true));
         ms.setLevel(TechConstants.T_SIMPLE_LEVEL[e.getTechLevel()]);
         ms.setAdvancedYear(e.getProductionDate(e.isClan()));
         ms.setStandardYear(e.getCommonDate(e.isClan()));


### PR DESCRIPTION
This makes the MechSummaryCache calculate BV without factoring in C3 and pilot skill. This should have no effect on anything as the MSC always uses clean units with base skill and (obviously) without C3 connections. It will however affect some conventional infantry units that have an anti-mek skill saved in their unit file which has BV being calculated not for 4/5 but 4/6 skill or other values instead. This affects unit export as it uses MSC data.