### PR TITLE
User file directory

### DIFF
--- a/megamek/docs/UserDirHelp.html
+++ b/megamek/docs/UserDirHelp.html
@@ -2,6 +2,8 @@
 
 <P>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. The files listed below will also be loaded from this directory (in addition to what is loaded from MegaMek's own data). The directory should be an absolute path such as D:/MyBTStuff (in other words, not relative to your MegaMek directory).</P>
 
+<P>Generally, all content from the user directory is added to the pre-defined content. In some cases, added content may replace pre-defined content when it has the same name or file path.</P>
+
 <P>How to place files within the user data directory:
 <UL>
     <LI><B>Fonts</B> can be placed anywhere in the user data directory (i.e., in the directory itself or in any subfolder)
@@ -15,6 +17,10 @@
     <LI><B>Unit fluff</B> images must be placed in &lt;user data directory&gt;/data/images/fluff/&lt;unit type&gt;/. To find the exact subfolders to use, go to your megamek folder and open /data/images/fluff/.
 
     <LI><B>Skin</B> definition files (.xml) can be placed anywhere in the user data directory
+
+    <LI><B>Rank Systems</B> may be defined in &lt;user data directory&gt;/data/universe/ranks.xml
+
+    <LI><B>Award</B> definition files (.xml) can be placed in &lt;user data directory&gt;/data/universe/awards
 </UL>
 
 <P>This is an example of a suitable directory structure with a few example files:
@@ -22,21 +28,26 @@
 D:/myBTStuff<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;Oxanium.ttf<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;Exo.ttf<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;/campaign_units<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;campaign_units/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;/data<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;data/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jura.ttf<BR>
-        MyMMSkin.xml
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/images<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/camo<BR>
+        MyMMSkin.xml<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;images/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myForceCamo.png<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/oldcamo<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;oldcamo/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo1.png<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo2.png<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/portraits<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myPortrait1.png<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/fluff<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/Mech<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;portraits/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minscandboo.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fluff/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Mech/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas.png<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/DropShip<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;DropShip/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Colossus.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;universe/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ranks.xml<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;awards/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MyAwards.xml<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AuriganAwards.xml<BR>

--- a/megamek/docs/UserDirHelp.html
+++ b/megamek/docs/UserDirHelp.html
@@ -1,0 +1,39 @@
+<HTML><H2>How to Use the User Data Directory</H2>
+
+<P>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. Fonts, units, camos, portraits and unit fluff images will also be loaded from this directory (in addition to what is loaded from MegaMek's own data). The directory should be an absolute path such as D:/MyBTStuff (in other words, not relative to your MegaMek directory).</P>
+
+<P>How to place files within the user data directory:
+<UL>
+    <LI><B>Fonts</B> can be placed anywhere in the user data directory (i.e., in the directory itself or in any subfolder)
+
+    <LI><B>Units</B> (.mtf and .blk files) can be placed anywhere in the user data directory
+
+    <LI><B>Camo</B> images must be placed in &lt;user data directory&gt;/data/images/camo/. In this subfolder, further subfolders can be used (optional).
+
+    <LI><B>Portrait</B> images must be placed in &lt;user data directory&gt;/data/images/portraits/. In this subfolder, further subfolders can be used (optional).
+
+    <LI><B>Unit fluff</B> images must be placed in &lt;user data directory&gt;/data/images/fluff/&lt;unit type&gt;/. To find the exact subfolders to use, go to your megamek folder and open /data/images/fluff/.
+</UL>
+
+<P>This is an example of a suitable directory structure with a few example files:
+<BR><BR>
+D:/myBTStuff<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;Oxanium.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;Exo.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;/campaign_units<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;/data<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jura.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/images<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/camo<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myForceCamo.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/oldcamo<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo1.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo2.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/portraits<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myPortrait1.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/fluff<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/Mech<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/DropShip<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Colossus.png<BR>

--- a/megamek/docs/UserDirHelp.html
+++ b/megamek/docs/UserDirHelp.html
@@ -1,6 +1,6 @@
 <HTML><H2>How to Use the User Data Directory</H2>
 
-<P>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. Fonts, units, camos, portraits and unit fluff images will also be loaded from this directory (in addition to what is loaded from MegaMek's own data). The directory should be an absolute path such as D:/MyBTStuff (in other words, not relative to your MegaMek directory).</P>
+<P>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. The files listed below will also be loaded from this directory (in addition to what is loaded from MegaMek's own data). The directory should be an absolute path such as D:/MyBTStuff (in other words, not relative to your MegaMek directory).</P>
 
 <P>How to place files within the user data directory:
 <UL>
@@ -13,6 +13,8 @@
     <LI><B>Portrait</B> images must be placed in &lt;user data directory&gt;/data/images/portraits/. In this subfolder, further subfolders can be used (optional).
 
     <LI><B>Unit fluff</B> images must be placed in &lt;user data directory&gt;/data/images/fluff/&lt;unit type&gt;/. To find the exact subfolders to use, go to your megamek folder and open /data/images/fluff/.
+
+    <LI><B>Skin</B> definition files (.xml) can be placed anywhere in the user data directory
 </UL>
 
 <P>This is an example of a suitable directory structure with a few example files:
@@ -24,6 +26,7 @@ D:/myBTStuff<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;/data<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jura.ttf<BR>
+        MyMMSkin.xml
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/images<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;/camo<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myForceCamo.png<BR>

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1215,6 +1215,7 @@ CommonSettingsDialog.locale.Spanish=Español
 CommonSettingsDialog.locale=Language/Sprache/\u042f\u0437\u044b\u043a:
 CommonSettingsDialog.logFileName=Game log filename:
 CommonSettingsDialog.userDir=User Files Directory:
+CommonSettingsDialog.userDir.tooltip=<html>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. Fonts, units, camos, portraits and fluff images will also be loaded from this directory.<BR>Note: Inside the user directory, use the directory structure of MM/MML/MHQ for camos, portraits and fluff images, i.e. data/images/camo, data/images/portraits and data/images/fluff/. <BR>Fonts and units can be placed anywhere in the user directory.
 CommonSettingsDialog.main=Main
 CommonSettingsDialog.audio=Audio
 CommonSettingsDialog.miniMap=Mini Map

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1214,6 +1214,7 @@ CommonSettingsDialog.locale.Russian=\u0420\u0443\u0441\u0441\u043a\u0438\u0439
 CommonSettingsDialog.locale.Spanish=Español
 CommonSettingsDialog.locale=Language/Sprache/\u042f\u0437\u044b\u043a:
 CommonSettingsDialog.logFileName=Game log filename:
+CommonSettingsDialog.userDir=User Files Directory:
 CommonSettingsDialog.main=Main
 CommonSettingsDialog.audio=Audio
 CommonSettingsDialog.miniMap=Mini Map

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -63,6 +63,8 @@ BotReadmeNagDialog.title=Please Read The Bot Documentation First
 BotReadmeNagDialog.text=Please read the Princess Notes.txt file in the docs/Bot Stuff folder before using the bot. \nNote: The bot does not support all game options. \nWould you like to read the AI documentation now?
 
 ### Unspecified Dialogs
+UserDirHelpDialog.title=How to Use the User Data Directory
+
 ## AlphaStrikeStatsDialog Class
 AlphaStrikeStatsDialog.title=Alpha Strike Conversion Results
 

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1216,6 +1216,7 @@ CommonSettingsDialog.locale=Language/Sprache/\u042f\u0437\u044b\u043a:
 CommonSettingsDialog.logFileName=Game log filename:
 CommonSettingsDialog.userDir=User Files Directory:
 CommonSettingsDialog.userDir.tooltip=<html>Use this directory for resources you want to share between different installs or versions of MegaMek, MegaMekLab and MekHQ. Fonts, units, camos, portraits and fluff images will also be loaded from this directory.<BR>Note: Inside the user directory, use the directory structure of MM/MML/MHQ for camos, portraits and fluff images, i.e. data/images/camo, data/images/portraits and data/images/fluff/. <BR>Fonts and units can be placed anywhere in the user directory.
+CommonSettingsDialog.userDir.chooser.title=Choose User Data Folder
 CommonSettingsDialog.main=Main
 CommonSettingsDialog.audio=Audio
 CommonSettingsDialog.miniMap=Mini Map

--- a/megamek/src/megamek/MMConstants.java
+++ b/megamek/src/megamek/MMConstants.java
@@ -49,6 +49,7 @@ public final class MMConstants extends SuiteConstants {
     public static final String GIVEN_NAME_MALE_FILE = "data/names/maleGivenNames.csv";
     public static final String SURNAME_FILE = "data/names/surnames.csv";
     public static final String BOT_README_FILE_PATH = "docs/Bot Stuff/Princess Notes.txt";
+    public static final String USER_DIR_README_FILE = "docs/UserDirHelp.html";
     public static final String SERIALKILLER_CONFIG_FILE = "mmconf/serialkiller.xml";
     public static final String USER_NAME_FACTIONS_DIRECTORY_PATH = "userdata/data/names/factions/";
     public static final String USER_CALLSIGN_FILE_PATH = "userdata/data/names/callsigns.csv";

--- a/megamek/src/megamek/client/ui/preferences/SuitePreferences.java
+++ b/megamek/src/megamek/client/ui/preferences/SuitePreferences.java
@@ -135,7 +135,6 @@ public class SuitePreferences {
                     LogManager.getLogger().error("Error reading node. " + getParserInformation(parser), e);
                 }
             }
-            LogManager.getLogger().info("Finished loading user preferences");
         } catch (FileNotFoundException ignored) {
 
         } catch (Exception e) {

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -648,7 +648,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             URL helpUrl = new URL(helpPath.toString());
 
             // Launch the help dialog.
-            HelpDialog helpDialog = new HelpDialog(Messages.getString("ClientGUI.skinningHelpPath.title"), helpUrl);
+            HelpDialog helpDialog = new HelpDialog(Messages.getString("ClientGUI.skinningHelpPath.title"), helpUrl, frame);
             helpDialog.setVisible(true);
         } catch (MalformedURLException ex) {
             LogManager.getLogger().error("", ex);

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -48,6 +48,8 @@ import javax.swing.filechooser.FileFilter;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 import java.util.*;
 
@@ -1404,11 +1406,22 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         JButton userDirChooser = new JButton("...");
         userDirChooser.addActionListener(e -> fileChooseUserDir(userDir, getFrame()));
         userDirChooser.setToolTipText(Messages.getString("CommonSettingsDialog.userDir.chooser.title"));
+        JButton userDirHelp = new JButton("Help");
+        try {
+            String helpTitle = Messages.getString("UserDirHelpDialog.title");
+            URL helpFile = new File(MMConstants.USER_DIR_README_FILE).toURI().toURL();
+            userDirHelp.addActionListener(e -> new HelpDialog(helpTitle, helpFile, getFrame()).setVisible(true));
+        } catch (MalformedURLException e) {
+            LogManager.getLogger().error("Could not find the user data directory readme file at "
+                    + MMConstants.USER_DIR_README_FILE);
+        }
         row = new ArrayList<>();
         row.add(userDirLabel);
         row.add(userDir);
         row.add(Box.createHorizontalStrut(10));
         row.add(userDirChooser);
+        row.add(Box.createHorizontalStrut(10));
+        row.add(userDirHelp);
         comps.add(row);
 
         addLineSpacer(comps);

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1396,8 +1396,10 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         addLineSpacer(comps);
 
         JLabel userDirLabel = new JLabel(Messages.getString("CommonSettingsDialog.userDir"));
-        userDir = new JTextField(15);
+        userDirLabel.setToolTipText(Messages.getString("CommonSettingsDialog.userDir.tooltip"));
+        userDir = new JTextField(20);
         userDir.setMaximumSize(new Dimension(250, 40));
+        userDir.setToolTipText(Messages.getString("CommonSettingsDialog.userDir.tooltip"));
         row = new ArrayList<>();
         row.add(userDirLabel);
         row.add(userDir);

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -44,6 +44,7 @@ import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.*;
+import javax.swing.filechooser.FileFilter;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.File;
@@ -1400,9 +1401,14 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         userDir = new JTextField(20);
         userDir.setMaximumSize(new Dimension(250, 40));
         userDir.setToolTipText(Messages.getString("CommonSettingsDialog.userDir.tooltip"));
+        JButton userDirChooser = new JButton("...");
+        userDirChooser.addActionListener(e -> fileChooseUserDir(userDir, getFrame()));
+        userDirChooser.setToolTipText(Messages.getString("CommonSettingsDialog.userDir.chooser.title"));
         row = new ArrayList<>();
         row.add(userDirLabel);
         row.add(userDir);
+        row.add(Box.createHorizontalStrut(10));
+        row.add(userDirChooser);
         comps.add(row);
 
         addLineSpacer(comps);
@@ -2945,5 +2951,17 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
     private void adaptToGUIScale() {
         UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
+    }
+
+    /** Shows a file chooser for selecting a user directory and sets the user dir if one was chosen. */
+    public static void fileChooseUserDir(JTextField userDirTextField, JFrame parent) {
+        JFileChooser userDirChooser = new JFileChooser(userDirTextField.getText());
+        userDirChooser.setDialogTitle(Messages.getString("CommonSettingsDialog.userDir.chooser.title"));
+        userDirChooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+        int returnVal = userDirChooser.showOpenDialog(parent);
+        if ((returnVal == JFileChooser.APPROVE_OPTION) && (userDirChooser.getSelectedFile() != null)
+                && userDirChooser.getSelectedFile().isDirectory()) {
+            userDirTextField.setText(userDirChooser.getSelectedFile().toString());
+        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -162,6 +162,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private final JCheckBox soundMuteOthersTurn = new JCheckBox(Messages.getString("CommonSettingsDialog.soundMuteOthersTurn"));
     private JTextField tfSoundMuteOthersFileName;
 
+    private JTextField userDir;
     private final JCheckBox keepGameLog = new JCheckBox(Messages.getString("CommonSettingsDialog.keepGameLog"));
     private JTextField gameLogFilename;
     private final JCheckBox stampFilenames = new JCheckBox(Messages.getString("CommonSettingsDialog.stampFilenames"));
@@ -1475,6 +1476,15 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         row.add(gameLogFilename);
         comps.add(row);
 
+        JLabel userDirLabel = new JLabel(Messages.getString("CommonSettingsDialog.logFileName"));
+        userDir = new JTextField(15);
+        userDir.setMaximumSize(new Dimension(250, 40));
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(DEPENDENT_INSET));
+        row.add(userDirLabel);
+        row.add(userDir);
+        comps.add(row);
+
         addSpacer(comps, 5);
         comps.add(checkboxEntry(stampFilenames, null));
 
@@ -1576,6 +1586,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             keepGameLog.setSelected(CP.keepGameLog());
             gameLogFilename.setEnabled(keepGameLog.isSelected());
             gameLogFilename.setText(CP.getGameLogFilename());
+            userDir.setText(GUIP.getUserDir());
             stampFilenames.setSelected(CP.stampFilenames());
             stampFormat.setEnabled(stampFilenames.isSelected());
             stampFormat.setText(CP.getStampFormat());
@@ -1996,6 +2007,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         CP.setKeepGameLog(keepGameLog.isSelected());
         CP.setGameLogFilename(gameLogFilename.getText());
+        GUIP.setUserDir(userDir.getText());
         CP.setStampFilenames(stampFilenames.isSelected());
         CP.setStampFormat(stampFormat.getText());
         CP.setReportKeywords(reportKeywordsTextPane.getText());

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1395,6 +1395,16 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         addLineSpacer(comps);
 
+        JLabel userDirLabel = new JLabel(Messages.getString("CommonSettingsDialog.userDir"));
+        userDir = new JTextField(15);
+        userDir.setMaximumSize(new Dimension(250, 40));
+        row = new ArrayList<>();
+        row.add(userDirLabel);
+        row.add(userDir);
+        comps.add(row);
+
+        addLineSpacer(comps);
+
         // UI Theme
         uiThemes = new JComboBox<>();
         uiThemes.setMaximumSize(new Dimension(400, uiThemes.getMaximumSize().height));
@@ -1474,15 +1484,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.add(gameLogFilenameLabel);
         row.add(gameLogFilename);
-        comps.add(row);
-
-        JLabel userDirLabel = new JLabel(Messages.getString("CommonSettingsDialog.logFileName"));
-        userDir = new JTextField(15);
-        userDir.setMaximumSize(new Dimension(250, 40));
-        row = new ArrayList<>();
-        row.add(Box.createRigidArea(DEPENDENT_INSET));
-        row.add(userDirLabel);
-        row.add(userDir);
         comps.add(row);
 
         addSpacer(comps, 5);
@@ -1586,7 +1587,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             keepGameLog.setSelected(CP.keepGameLog());
             gameLogFilename.setEnabled(keepGameLog.isSelected());
             gameLogFilename.setText(CP.getGameLogFilename());
-            userDir.setText(GUIP.getUserDir());
+            userDir.setText(CP.getUserDir());
             stampFilenames.setSelected(CP.stampFilenames());
             stampFormat.setEnabled(stampFilenames.isSelected());
             stampFormat.setText(CP.getStampFormat());
@@ -2007,7 +2008,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         CP.setKeepGameLog(keepGameLog.isSelected());
         CP.setGameLogFilename(gameLogFilename.getText());
-        GUIP.setUserDir(userDir.getText());
+        CP.setUserDir(userDir.getText());
         CP.setStampFilenames(stampFilenames.isSelected());
         CP.setStampFormat(stampFormat.getText());
         CP.setReportKeywords(reportKeywordsTextPane.getText());

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -2953,7 +2953,13 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 
-    /** Shows a file chooser for selecting a user directory and sets the user dir if one was chosen. */
+    /**
+     * Shows a file chooser for selecting a user directory and sets the given text field to the
+     * result if one was chosen. This is for use with settings dialogs (also used in MML and MHQ)
+     *
+     * @param userDirTextField The textfield showing the user dir for manual change
+     * @param parent The parent JFrame of the settings dialog
+     */
     public static void fileChooseUserDir(JTextField userDirTextField, JFrame parent) {
         JFileChooser userDirChooser = new JFileChooser(userDirTextField.getText());
         userDirChooser.setDialogTitle(Messages.getString("CommonSettingsDialog.userDir.chooser.title"));

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -331,10 +331,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String SBFSHEET_VALUEFONT = "SBFSheetValueFont";
     public static final String SUMMARY_FONT = "SummaryCardFont";
 
-    /** A user-specified directory, typically outside the MM directory, where content may be loaded from. */
-    public static final String USER_DIR = "UserDir";
-
-
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
     public static String RAT_BV_MIN = "RATBVMin";
@@ -726,8 +722,6 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(SBFSHEET_HEADERFONT, "");
         setDefault(SBFSHEET_VALUEFONT, "");
         setDefault(SUMMARY_FONT, "");
-
-        setDefault(USER_DIR, "");
     }
 
     public void setDefault(String name, Color color) {
@@ -1504,13 +1498,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getBoolean(BOARDEDIT_RNDDIALOG_START);
     }
 
-    public String getUserDir() {
-        return store.getString(USER_DIR);
-    }
 
-    public void setUserDir(String userDir) {
-        store.setValue(USER_DIR, userDir);
-    }
 
     public void setShadowMap(boolean state) {
         store.setValue(SHADOWMAP, state);

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -331,6 +331,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String SBFSHEET_VALUEFONT = "SBFSheetValueFont";
     public static final String SUMMARY_FONT = "SummaryCardFont";
 
+    /** A user-specified directory, typically outside the MM directory, where content may be loaded from. */
+    public static final String USER_DIR = "UserDir";
+
 
     // RAT dialog preferences
     public static String RAT_TECH_LEVEL = "RATTechLevel";
@@ -723,6 +726,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(SBFSHEET_HEADERFONT, "");
         setDefault(SBFSHEET_VALUEFONT, "");
         setDefault(SUMMARY_FONT, "");
+
+        setDefault(USER_DIR, "");
     }
 
     public void setDefault(String name, Color color) {
@@ -1497,6 +1502,14 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public boolean getBoardEdRndStart() {
         return store.getBoolean(BOARDEDIT_RNDDIALOG_START);
+    }
+
+    public String getUserDir() {
+        return store.getString(USER_DIR);
+    }
+
+    public void setUserDir(String userDir) {
+        store.setValue(USER_DIR, userDir);
     }
 
     public void setShadowMap(boolean state) {

--- a/megamek/src/megamek/client/ui/swing/HelpDialog.java
+++ b/megamek/src/megamek/client/ui/swing/HelpDialog.java
@@ -1,48 +1,53 @@
-/*  
-* MegaMek - Copyright (C) 2013-2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
-*/  
+/*
+ * Copyright (c) 2013-2020, 2023 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
 package megamek.client.ui.swing;
 
 import megamek.client.ui.swing.util.UIUtil;
 import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
 import java.net.URL;
 
 /**
+ * This is a basic help dialog that can display HTML pages and also reacts to hyperlink clicks.
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
- * @since 11/4/13 9:20 PM
+ * @author Simon (Juliez)
  */
 public class HelpDialog extends JDialog {
 
-    private static final long serialVersionUID = 1442198850518387690L;
-    
-    private static final int WIDTH = 600;
-    private static final int HEIGHT = 400;
+    protected static final String CLOSE_ACTION = "closeAction";
 
-    private URL helpUrl;
+    private static final int WIDTH = 800;
+    private static final int HEIGHT = 600;
 
-    public HelpDialog(String title, URL helpURL) {
-        setTitle(title);
-        getContentPane().setLayout(new BorderLayout());
-        this.helpUrl = helpURL;
+    public HelpDialog(String title, URL helpURL, JFrame parent) {
+        super(parent, title, true);
 
         JEditorPane mainView = new JEditorPane();
         mainView.setEditable(false);
         try {
-            mainView.setPage(helpUrl);
+            mainView.setPage(helpURL);
         } catch (Exception ex) {
             LogManager.getLogger().error("", ex);
             JOptionPane.showMessageDialog(this, ex.getMessage(), "ERROR", JOptionPane.ERROR_MESSAGE);
@@ -60,16 +65,20 @@ public class HelpDialog extends JDialog {
             }
         });
 
-        add(new JScrollPane(mainView));
-        setModalExclusionType(ModalExclusionType.TOOLKIT_EXCLUDE);
+        JScrollPane scrollPane = new JScrollPane(mainView);
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        scrollPane.setBorder(new EmptyBorder(10, 10, 10, 10));
+        add(scrollPane);
+        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
 
-        adaptToGUIScale();
+        // Escape keypress
+        final KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
+        getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, CLOSE_ACTION);
+        getRootPane().getInputMap(JComponent.WHEN_FOCUSED).put(escape, CLOSE_ACTION);
+        getRootPane().getActionMap().put(CLOSE_ACTION, new CloseAction(this));
+
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         setSize(WIDTH, HEIGHT);
         setLocationRelativeTo(null);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -912,7 +912,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             // Launch the help dialog.
             HelpDialog helpDialog = new HelpDialog(
                     Messages.getString("ClientGUI.skinningHelpPath.title"),
-                    helpUrl);
+                    helpUrl, frame);
             helpDialog.setVisible(true);
         } catch (MalformedURLException e) {
             LogManager.getLogger().error("", e);

--- a/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
@@ -75,9 +75,9 @@ public class MMStaticDirectoryManager {
                 portraitDirectory = new DirectoryItems(Configuration.portraitImagesDir(),
                         new ImageFileFactory());
 
-                File portraitUserDir = new File(PreferenceManager.getClientPreferences().getUserDir()
-                        + "/" + Configuration.portraitImagesDir());
-                if (portraitUserDir.isDirectory()) {
+                String userDir = PreferenceManager.getClientPreferences().getUserDir();
+                File portraitUserDir = new File(userDir + "/" + Configuration.portraitImagesDir());
+                if (!userDir.isBlank() && portraitUserDir.isDirectory()) {
                     DirectoryItems userDirPortraits = new DirectoryItems(portraitUserDir, new ImageFileFactory());
                     portraitDirectory.merge(userDirPortraits);
                 }
@@ -101,9 +101,9 @@ public class MMStaticDirectoryManager {
                 camouflageDirectory = new DirectoryItems(Configuration.camoDir(),
                         new ScaledImageFileFactory());
 
-                File camoUserDir = new File(PreferenceManager.getClientPreferences().getUserDir()
-                        + "/" + Configuration.camoDir());
-                if (camoUserDir.isDirectory()) {
+                String userDir = PreferenceManager.getClientPreferences().getUserDir();
+                File camoUserDir = new File(userDir + "/" + Configuration.camoDir());
+                if (!userDir.isBlank() && camoUserDir.isDirectory()) {
                     DirectoryItems userDirCamo = new DirectoryItems(camoUserDir, new ScaledImageFileFactory());
                     camouflageDirectory.merge(userDirCamo);
                 }

--- a/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
@@ -20,17 +20,21 @@ package megamek.client.ui.swing.tileset;
 
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.fileUtils.AbstractDirectory;
 import megamek.common.util.fileUtils.DirectoryItems;
 import megamek.common.util.fileUtils.ImageFileFactory;
 import megamek.common.util.fileUtils.ScaledImageFileFactory;
 import org.apache.logging.log4j.LogManager;
 
+import java.io.File;
+import java.util.Map;
+
 public class MMStaticDirectoryManager {
     //region Variable Declarations
     // Directories
-    private static AbstractDirectory portraitDirectory;
-    private static AbstractDirectory camouflageDirectory;
+    private static DirectoryItems portraitDirectory;
+    private static DirectoryItems camouflageDirectory;
     private static MechTileset mechTileset;
 
     // Re-parsing Prevention Variables: They are True at startup and when the specified directory
@@ -70,6 +74,13 @@ public class MMStaticDirectoryManager {
             try {
                 portraitDirectory = new DirectoryItems(Configuration.portraitImagesDir(),
                         new ImageFileFactory());
+
+                File portraitUserDir = new File(PreferenceManager.getClientPreferences().getUserDir()
+                        + "/" + Configuration.portraitImagesDir());
+                if (portraitUserDir.isDirectory()) {
+                    DirectoryItems userDirPortraits = new DirectoryItems(portraitUserDir, new ImageFileFactory());
+                    portraitDirectory.merge(userDirPortraits);
+                }
             } catch (Exception e) {
                 LogManager.getLogger().error("Could not parse the portraits directory!", e);
             }
@@ -89,6 +100,13 @@ public class MMStaticDirectoryManager {
             try {
                 camouflageDirectory = new DirectoryItems(Configuration.camoDir(),
                         new ScaledImageFileFactory());
+
+                File camoUserDir = new File(PreferenceManager.getClientPreferences().getUserDir()
+                        + "/" + Configuration.camoDir());
+                if (camoUserDir.isDirectory()) {
+                    DirectoryItems userDirCamo = new DirectoryItems(camoUserDir, new ScaledImageFileFactory());
+                    camouflageDirectory.merge(userDirCamo);
+                }
             } catch (Exception e) {
                 LogManager.getLogger().error("Could not parse the camo directory!", e);
             }

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -18,6 +18,7 @@ import megamek.common.*;
 import megamek.common.alphaStrike.ASCardDisplayable;
 import megamek.common.alphaStrike.ASUnitType;
 import megamek.common.annotations.Nullable;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.fileUtils.MegaMekFile;
 
 import javax.swing.*;
@@ -81,8 +82,15 @@ public class FluffImageHelper {
      * @return An image or {@code null}.
      */
     public static @Nullable Image loadFluffImageHeuristic(final Entity entity) {
+        var userDirPath = new File(PreferenceManager.getClientPreferences().getUserDir() + "/"
+                + Configuration.fluffImagesDir(), getImagePath(entity));
+        Image image = loadFluffImageHeuristic(userDirPath, entity.getModel(), entity.getChassis());
+        if (image != null) {
+            return image;
+        }
+
         var path = new MegaMekFile(Configuration.fluffImagesDir(), getImagePath(entity));
-        return loadFluffImageHeuristic(path, entity.getModel(), entity.getChassis());
+        return loadFluffImageHeuristic(path.getFile(), entity.getModel(), entity.getChassis());
     }
 
     /**
@@ -91,12 +99,19 @@ public class FluffImageHelper {
      * @return An image or null
      */
     public static @Nullable Image loadFluffImageHeuristic(final ASCardDisplayable element) {
+        var userDirPath = new File(PreferenceManager.getClientPreferences().getUserDir() + "/"
+                + Configuration.fluffImagesDir(), getImagePath(element));
+        Image image = loadFluffImageHeuristic(userDirPath, element.getModel(), element.getChassis());
+        if (image != null) {
+            return image;
+        }
+
         var path = new MegaMekFile(Configuration.fluffImagesDir(), getImagePath(element));
-        return loadFluffImageHeuristic(path, element.getModel(), element.getChassis());
+        return loadFluffImageHeuristic(path.getFile(), element.getModel(), element.getChassis());
     }
 
-    private static @Nullable Image loadFluffImageHeuristic(MegaMekFile path, String model, String chassis) {
-        File fluff_image_file = findFluffImage(path.getFile(), model, chassis);
+    private static @Nullable Image loadFluffImageHeuristic(File path, String model, String chassis) {
+        File fluff_image_file = findFluffImage(path, model, chassis);
         if (fluff_image_file != null) {
             return new ImageIcon(fluff_image_file.toString()).getImage();
         } else {

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -82,11 +82,13 @@ public class FluffImageHelper {
      * @return An image or {@code null}.
      */
     public static @Nullable Image loadFluffImageHeuristic(final Entity entity) {
-        var userDirPath = new File(PreferenceManager.getClientPreferences().getUserDir() + "/"
-                + Configuration.fluffImagesDir(), getImagePath(entity));
-        Image image = loadFluffImageHeuristic(userDirPath, entity.getModel(), entity.getChassis());
-        if (image != null) {
-            return image;
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        if (!userDir.isBlank()) {
+            var userDirPath = new File(userDir + "/" + Configuration.fluffImagesDir(), getImagePath(entity));
+            Image image = loadFluffImageHeuristic(userDirPath, entity.getModel(), entity.getChassis());
+            if (image != null) {
+                return image;
+            }
         }
 
         var path = new MegaMekFile(Configuration.fluffImagesDir(), getImagePath(entity));
@@ -99,11 +101,13 @@ public class FluffImageHelper {
      * @return An image or null
      */
     public static @Nullable Image loadFluffImageHeuristic(final ASCardDisplayable element) {
-        var userDirPath = new File(PreferenceManager.getClientPreferences().getUserDir() + "/"
-                + Configuration.fluffImagesDir(), getImagePath(element));
-        Image image = loadFluffImageHeuristic(userDirPath, element.getModel(), element.getChassis());
-        if (image != null) {
-            return image;
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        if (!userDir.isBlank()) {
+            var userDirPath = new File(userDir + "/" + Configuration.fluffImagesDir(), getImagePath(element));
+            Image image = loadFluffImageHeuristic(userDirPath, element.getModel(), element.getChassis());
+            if (image != null) {
+                return image;
+            }
         }
 
         var path = new MegaMekFile(Configuration.fluffImagesDir(), getImagePath(element));

--- a/megamek/src/megamek/client/ui/swing/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/swing/util/FontHandler.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.swing.util;
 
 import megamek.MMConstants;
+import megamek.client.ui.swing.CommonSettingsDialog;
 import megamek.common.preference.PreferenceManager;
 import org.apache.logging.log4j.LogManager;
 
@@ -116,25 +117,11 @@ public final class FontHandler {
      * @param directory the directory to parse
      */
     public static void parseFontsInDirectory(final File directory) {
-        final String[] filenames = directory.list();
-        if (filenames == null) {
-            LogManager.getLogger().warn(directory + " is not a directory!");
-            return;
-        }
-
-        for (final String filename : filenames) {
-            if (filename.toLowerCase().endsWith(MMConstants.TRUETYPE_FONT)) {
-                try (InputStream fis = new FileInputStream(directory.getPath() + '/' + filename)) {
-                    GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(
-                            Font.createFont(Font.TRUETYPE_FONT, fis));
-                } catch (Exception ex) {
-                    LogManager.getLogger().error("Failed to parse font", ex);
-                }
-            } else {
-                final File file = new File(directory, filename);
-                if (file.isDirectory()) {
-                    parseFontsInDirectory(file);
-                }
+        for (String fontFile : CommonSettingsDialog.filteredFilesWithSubDirs(directory, MMConstants.TRUETYPE_FONT)) {
+            try (InputStream fis = new FileInputStream(fontFile)) {
+                GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(Font.createFont(Font.TRUETYPE_FONT, fis));
+            } catch (Exception ex) {
+                LogManager.getLogger().error("Failed to parse font", ex);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/swing/util/FontHandler.java
@@ -19,6 +19,7 @@
 package megamek.client.ui.swing.util;
 
 import megamek.MMConstants;
+import megamek.common.preference.PreferenceManager;
 import org.apache.logging.log4j.LogManager;
 
 import java.awt.*;
@@ -78,7 +79,14 @@ public final class FontHandler {
     }
 
     private void initializeFonts() {
+        LogManager.getLogger().info("Loading fonts from " + MMConstants.FONT_DIRECTORY);
         parseFontsInDirectory(new File(MMConstants.FONT_DIRECTORY));
+
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        LogManager.getLogger().info("Loading fonts from " + userDir);
+        parseFontsInDirectory(userDir);
+
+        LogManager.getLogger().info("Loading fonts from Java's GraphicsEnvironment");
         for (String fontName : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()) {
             allFontNames.add(fontName);
             Font font = Font.decode(fontName);
@@ -95,9 +103,20 @@ public final class FontHandler {
      *
      * @param directory the directory to parse
      */
+    public static void parseFontsInDirectory(String directory) {
+        parseFontsInDirectory(new File(directory));
+    }
+
+    /**
+     * Searches the provided directory and all subdirectories and registers any truetype
+     * fonts from .ttf files it finds.
+     *
+     * @param directory the directory to parse
+     */
     public static void parseFontsInDirectory(final File directory) {
         final String[] filenames = directory.list();
         if (filenames == null) {
+            LogManager.getLogger().warn(directory + " is not a directory!");
             return;
         }
 

--- a/megamek/src/megamek/client/ui/swing/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/swing/util/FontHandler.java
@@ -83,8 +83,10 @@ public final class FontHandler {
         parseFontsInDirectory(new File(MMConstants.FONT_DIRECTORY));
 
         String userDir = PreferenceManager.getClientPreferences().getUserDir();
-        LogManager.getLogger().info("Loading fonts from " + userDir);
-        parseFontsInDirectory(userDir);
+        if (!userDir.isBlank()) {
+            LogManager.getLogger().info("Loading fonts from " + userDir);
+            parseFontsInDirectory(userDir);
+        }
 
         LogManager.getLogger().info("Loading fonts from Java's GraphicsEnvironment");
         for (String fontName : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()) {

--- a/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
@@ -141,7 +141,7 @@ public class SkinXMLHandler {
      * @return
      */
     public static boolean validSkinSpecFile(String fileName) {
-        File file = new MegaMekFile(Configuration.skinsDir(), fileName).getFile();
+        File file = new MegaMekFile(fileName).getFile();
         if (!file.exists() || !file.isFile()) {
             return false;
         }
@@ -181,10 +181,14 @@ public class SkinXMLHandler {
             return false;
         }
 
-        File file = new MegaMekFile(Configuration.skinsDir(), filename).getFile();
+        File file = new MegaMekFile(filename).getFile();
         if (!file.exists() || !file.isFile()) {
-            LogManager.getLogger().error("Cannot initialize skin based on a non-existent file with filename " + filename);
-            return false;
+            // for backwards compatibility, also check the skins filename as if it is only a relative path
+            file = new MegaMekFile(Configuration.skinsDir(), filename).getFile();
+            if (!file.exists() || !file.isFile()) {
+                LogManager.getLogger().error("Cannot initialize skin based on a non-existent file with filename " + filename);
+                return false;
+            }
         }
 
         // Build the XML document.

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -18,6 +18,7 @@ package megamek.common;
 import megamek.common.alphaStrike.ASUnitType;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.alphaStrike.conversion.ASConverter;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.*;
 import org.apache.logging.log4j.LogManager;
@@ -253,9 +254,17 @@ public class MechSummaryCache {
         boolean bNeedsUpdate = loadMechsFromDirectory(vMechs, sKnownFiles,
                 lLastCheck, Configuration.unitsDir(), ignoreUnofficial);
 
+        // load units from the MM internal user data dir
         File userDataUnits = new File(Configuration.userdataDir(), Configuration.unitsDir().toString());
         if (userDataUnits.isDirectory()) {
             bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, userDataUnits, ignoreUnofficial);
+        }
+
+        // load units from the external user data dir
+        File userDataUnits2 = new File(PreferenceManager.getClientPreferences().getUserDir(),
+                Configuration.unitsDir().toString());
+        if (userDataUnits2.isDirectory()) {
+            bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, userDataUnits2, ignoreUnofficial);
         }
 
         // save updated cache back to disk

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -261,9 +261,9 @@ public class MechSummaryCache {
         }
 
         // load units from the external user data dir
-        File userDataUnits2 = new File(PreferenceManager.getClientPreferences().getUserDir(),
-                "");
-        if (userDataUnits2.isDirectory()) {
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        File userDataUnits2 = new File(userDir, "");
+        if (!userDir.isBlank() && userDataUnits2.isDirectory()) {
             bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, userDataUnits2, ignoreUnofficial);
         }
 

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -262,7 +262,7 @@ public class MechSummaryCache {
 
         // load units from the external user data dir
         File userDataUnits2 = new File(PreferenceManager.getClientPreferences().getUserDir(),
-                Configuration.unitsDir().toString());
+                "");
         if (userDataUnits2.isDirectory()) {
             bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, userDataUnits2, ignoreUnofficial);
         }
@@ -766,6 +766,11 @@ public class MechSummaryCache {
                     // recursion is fun
                     bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles,
                             lLastCheck, f, ignoreUnofficial);
+                    continue;
+                }
+                if (!f.getName().toLowerCase().endsWith(".mtf") && !f.getName().toLowerCase().endsWith(".blk")
+                        && !f.getName().toLowerCase().endsWith(".hmp") && !f.getName().toLowerCase().endsWith(".hmv")
+                        && !f.getName().toLowerCase().endsWith(".mep") && !f.getName().toLowerCase().endsWith(".tdb")) {
                     continue;
                 }
                 if (f.getName().indexOf('.') == -1) {

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -60,6 +60,10 @@ public class ClientPreferences extends PreferenceStoreProxy {
     private static final String REPORTKEYWORDSDEFAULTS = "Needs\nRolls\nTakes\nHit\nFalls\nSkill Roll\nPilot Skill\nPhase\nDestroyed\nDamage";
     public static final String IP_ADDRESSES_IN_CHAT = "IPAddressesInChat";
     public static final String START_SEARCHLIGHTS_ON = "StartSearchlightsOn";
+
+    /** A user-specified directory, typically outside the MM directory, where content may be loaded from. */
+    public static final String USER_DIR = "UserDir";
+
     //endregion Variable Declarations
 
     //region Constructors
@@ -91,6 +95,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
         store.setDefault(REPORT_KEYWORDS, REPORTKEYWORDSDEFAULTS);
         store.setDefault(IP_ADDRESSES_IN_CHAT, false);
         store.setDefault(START_SEARCHLIGHTS_ON, true);
+        store.setDefault(USER_DIR, "");
         setLocale(store.getString(LOCALE));
         setMekHitLocLog();
     }
@@ -369,5 +374,18 @@ public class ClientPreferences extends PreferenceStoreProxy {
 
     public int getMapHeight() {
         return store.getInt(MAP_HEIGHT);
+    }
+
+    /** @return The absolute user directory path (usually outside of MM). Does not end in a slash or backslash. */
+    public String getUserDir() {
+        return store.getString(USER_DIR);
+    }
+
+    public void setUserDir(String userDir) {
+        // remove directory separators at the end
+        while (!userDir.isBlank() && (userDir.endsWith("/") || userDir.endsWith("\\"))) {
+            userDir = userDir.substring(0, userDir.length() - 1);
+        }
+        store.setValue(USER_DIR, userDir);
     }
 }

--- a/megamek/src/megamek/common/util/fileUtils/AbstractDirectory.java
+++ b/megamek/src/megamek/common/util/fileUtils/AbstractDirectory.java
@@ -150,8 +150,9 @@ public abstract class AbstractDirectory {
     //endregion Getters/Setters
 
     /**
-     * Adds the given directory's contents to this one's. Note: equally named items and categories oth
-     * other will replace those of this directory.
+     * Adds the given AbstractDirectory's contents to this one's. Note: equally named categories are integrated
+     * into one another, but for items in the exact same category (file path) and with the same name the
+     * item of other will replace the item in this AbstractDirectory.
      *
      * @param other The AbstractDirectory to merge into this one
      */

--- a/megamek/src/megamek/common/util/fileUtils/AbstractDirectory.java
+++ b/megamek/src/megamek/common/util/fileUtils/AbstractDirectory.java
@@ -148,4 +148,21 @@ public abstract class AbstractDirectory {
         return (entry == null) ? null : entry.getItem();
     }
     //endregion Getters/Setters
+
+    /**
+     * Adds the given directory's contents to this one's. Note: equally named items and categories oth
+     * other will replace those of this directory.
+     *
+     * @param other The AbstractDirectory to merge into this one
+     */
+    public void merge(AbstractDirectory other) {
+        getItems().putAll(other.getItems());
+        for (Map.Entry<String, AbstractDirectory> categoryEntry : other.getCategories().entrySet()) {
+            if (categories.containsKey(categoryEntry.getKey())) {
+                categories.get(categoryEntry.getKey()).merge(categoryEntry.getValue());
+            } else {
+                categories.put(categoryEntry.getKey(), categoryEntry.getValue());
+            }
+        }
+    }
 }


### PR DESCRIPTION
We have sort of a fixed user file directory within MM, but it seemed to me that having a freely settable directory outside of any MM install (wherever the user wants to set it, like D:/myMMStuff) where units, camos, fonts etc. can be kept and never need to be moved for a new MM install or between MHQ/MML/MM would be a better solution. This is what this PR adds. The directory can be set in the Client settings and is part of the ClientPreferences. There will be accompanying PRs for MML where the user dir can be set in the Options and MHQ where it can be set in the MekHQ options->misc options.

As things are now, fonts and units can be placed anywhere within the user dir as they can be identified by their extension. Images must be placed in subdirectories as they are in MM itself, i.e. in <userdir>/data/images/camo, data/images/portraits, data/images/fluff/<unittype>.

Typically, the user dir setting will only take effect after a restart.
