### PR TITLE
MTF file updates

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4181,18 +4181,8 @@ public abstract class Mech extends Entity {
 
         boolean standard = (getCockpitType() == Mech.COCKPIT_STANDARD)
                 && (getGyroType() == Mech.GYRO_STANDARD);
-        boolean fullHead = hasFullHeadEject();
-        if (hasMulId()) {
-            sb.append("Version:1.3").append(newLine);
-        } else if (standard && !fullHead) {
-            sb.append("Version:1.0").append(newLine);
-        } else if (!fullHead) {
-            sb.append("Version:1.1").append(newLine);
-        } else {
-            sb.append("Version:1.2").append(newLine);
-        }
-        sb.append(chassis).append(newLine);
-        sb.append(model).append(newLine);
+        sb.append(MtfFile.CHASSIS).append(chassis).append(newLine);
+        sb.append(MtfFile.MODEL).append(model).append(newLine);
         if (hasMulId()) {
             sb.append(MtfFile.MUL_ID).append(mulId);
         }

--- a/megamek/src/megamek/utilities/UnitFileMigrationTool.java
+++ b/megamek/src/megamek/utilities/UnitFileMigrationTool.java
@@ -19,6 +19,7 @@
 package megamek.utilities;
 
 import megamek.common.*;
+import megamek.common.loaders.MtfFile;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,36 +38,32 @@ public class UnitFileMigrationTool {
         MechSummaryCache cache = MechSummaryCache.getInstance(true);
         MechSummary[] units = cache.getAllMechs();
         for (MechSummary unit : units) {
-
-            /*
             File file = unit.getSourceFile();
-            if (UnitRoleHandler.getRoleFor(unit) == UnitRole.UNDETERMINED) {
-                continue;
-            }
-            if (file.toString().toLowerCase().endsWith(".blk")) {
+            if (file.toString().toLowerCase().endsWith(".mtf")) {
                 List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-                int line = 0;
-                boolean found = false;
-                for (; line < lines.size(); line++) {
-                    if (lines.get(line).toLowerCase().startsWith("</type>")) {
-                        found = true;
-                        break;
-                    }
-                }
-                if (found) {
-                    lines.add(line + 1, "");
-                    lines.add(line + 2, "<role>");
-                    lines.add(line + 3, UnitRoleHandler.getRoleFor(unit).toString());
-                    lines.add(line + 4, "</role>");
-//                    Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
-//                    System.out.println(lines);
+                if (lines.get(0).startsWith("Version:")) {
+                    lines.remove(0);
                 } else {
-                    System.out.println("type line not found for: " + unit.getName());
+                    System.out.println(unit + " doesnt have Version");
+                    continue;
                 }
+                if (!lines.get(0).contains(":")) {
+                    String chassis = lines.remove(0);
+                    lines.add(0, MtfFile.CHASSIS + chassis);
+                } else {
+                    System.out.println(unit + " doesnt have chassis without :");
+                    continue;
+                }
+                if (!lines.get(1).contains(":")) {
+                    String model = lines.remove(1);
+                    lines.add(1, MtfFile.MODEL + model);
+                } else {
+                    System.out.println(unit + " doesnt have model without :");
+                    continue;
+                }
+                    Files.write(file.toPath(), lines, StandardCharsets.UTF_8);
+//                System.out.println(lines);
             }
-*/
-
-
         }
     }
 }


### PR DESCRIPTION
This changes .MTF Mek files:
- The MTF Version is no longer used
- chassis and model are no longer expected as the first lines; instead they use the normal mtf format "chassis:Atlas" and "model:AS7-XY" and need not be the first lines

Old mtf files can still be read to keep backward compatibility for user-generated units. All units in the package are changed in the accompanying PR. This PR only has the code changes.

Notes for review:
- The UnitFileMigrationTool isnt important. I didnt want to lose the current version that migrated the mtf files so its included here
- A good part of the code changes in MTFFile.java is just moving things around