### PR TITLE
Weight calculation

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11073,6 +11073,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         return engine;
     }
 
+    /** @return The type of engine if it has an engine, or Engine.NONE, if it has no engine. */
+    public int getEngineType() {
+        return hasEngine() ? getEngine().getEngineType() : Engine.NONE;
+    }
+
     public boolean hasEngine() {
         return (null != engine);
     }

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -1071,7 +1071,7 @@ public class TestAdvancedAerospace extends TestAero {
     }
     
     @Override
-    public double calculateWeight() {
+    public double calculateWeightExact() {
         double weight = 0;
         weight += getWeightStructure();
         weight += getWeightEngine();

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -1070,7 +1070,7 @@ public class TestAero extends TestEntity {
     }
 
     @Override
-    public double calculateWeight() {
+    public double calculateWeightExact() {
         double weight = 0;
         weight += getWeightEngine();
         weight += getWeightControls();

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1348,7 +1348,7 @@ public class TestBattleArmor extends TestEntity {
     }
 
     @Override
-    public double calculateWeight() {
+    public double calculateWeightExact() {
         double totalWeight = 0.0;
         for (int i = 0; i < ba.getTroopers(); i++) {
             totalWeight += calculateWeight(i);

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1689,6 +1689,14 @@ public abstract class TestEntity implements TestEntityOption {
         return usesKgStandard(getEntity());
     }
 
+
+    public int totalCritSlotCount() {
+        int slotCount = 0;
+        for (int i = 0; i < getEntity().locations(); i++) {
+            slotCount += getEntity().getNumberOfCriticals(i);
+        }
+        return slotCount;
+    }
 } // End class TestEntity
 
 class Armor {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -860,7 +860,32 @@ public abstract class TestEntity implements TestEntityOption {
         return heat;
     }
 
+    /**
+     * According to TM, unit weights are to be rounded up to the nearest half ton or kilo. This method
+     * returns the rounded weight.
+     *
+     * @return The weight of the unit, rounded up according to TM, p.22.
+     */
     public double calculateWeight() {
+        double weight = calculateWeightExact();
+        // If the unit used kg standard, we just need to get rid of floating-point math anomalies.
+        // Otherwise accumulated kg-scale equipment needs to be rounded up to the nearest half-ton.
+        weight = round(weight, Ceil.KILO);
+        if (usesKgStandard()) {
+            return weight;
+        } else {
+            return ceil(weight, Ceil.HALFTON);
+        }
+    }
+
+    /**
+     * According to TM p.22, unit weights are to be rounded up to the nearest half ton or kilo, but in MML
+     * for construction at least we should be able to show the exact weight. This method returns the unrounded
+     * weight.
+     *
+     * @return The unrounded weight of the unit.
+     */
+    public double calculateWeightExact() {
         double weight = 0;
         weight += getWeightEngine();
         weight += getWeightStructure();
@@ -877,14 +902,7 @@ public abstract class TestEntity implements TestEntityOption {
         weight += getWeightCarryingSpace();
 
         weight += getArmoredComponentWeight();
-        // If the unit used kg standard, we just need to get rid of floating-point math anomalies.
-        // Otherwise accumulated kg-scale equipment needs to be rounded up to the nearest half-ton.
-        weight = round(weight, Ceil.KILO);
-        if (usesKgStandard()) {
-            return weight;
-        } else {
-            return ceil(weight, Ceil.HALFTON);
-        }
+        return weight;
     }
 
     public String printWeightCalculation() {

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -287,10 +287,9 @@ public class TestInfantry extends TestEntity {
     public double getWeightPowerAmp() {
         return 0;
     }
-    
+
     @Override
-    public double calculateWeight() {
+    public double calculateWeightExact() {
         return infantry.getWeight();
     }
-    
 }

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -244,9 +244,9 @@ public class TestProtomech extends TestEntity {
     @Override
     public double calculateWeight() {
         // Deal with some floating point precision issues
-        return round(super.calculateWeight(), Ceil.KILO);
+        return round(super.calculateWeightExact(), Ceil.KILO);
     }
-    
+
     @Override
     public double getWeightAllocatedArmor() {
         ProtomechArmor armor = ProtomechArmor.getArmor(proto);

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -808,7 +808,7 @@ public class TestSmallCraft extends TestAero {
     }
     
     @Override
-    public double calculateWeight() {
+    public double calculateWeightExact() {
         double weight = 0;
         weight += getWeightStructure();
         weight += getWeightEngine();

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -720,7 +720,7 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public double calculateWeightExact() {
-        return super.calculateWeight() + getFuelTonnage();
+        return super.calculateWeightExact() + getFuelTonnage();
     }
 
     @Override

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -715,7 +715,12 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public double calculateWeight() {
-        return ceilWeight(super.calculateWeight() + getFuelTonnage());
+        return ceilWeight(calculateWeightExact());
+    }
+
+    @Override
+    public double calculateWeightExact() {
+        return super.calculateWeight() + getFuelTonnage();
     }
 
     @Override


### PR DESCRIPTION
MML shows a weight value that is rounded to half tons, as per TM p22. During construction the shown value should be accurate, as e.g. Clan MGs only weigh only 0.25t. This PR adds methods so that an exact value can be obtained. The standard method still returns the rounded value, now also for units other than Meks and tanks.

An MML PR changes the weight display accordingly.

Converted to draft as there's an error in SV weight calculation