### PR TITLE
ProtoMek max armor values

### DIFF
--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -780,7 +780,7 @@ public class TestProtomech extends TestEntity {
                 || (location == Protomech.LOC_RARM)) {
             if (proto.isQuad()) {
                 return 0;
-            } else if (proto.getWeight() < 3) {
+            } else if (proto.getWeight() < 6) {
                 return 2;
             } else if (proto.getWeight() < 10) {
                 return 4;
@@ -789,15 +789,6 @@ public class TestProtomech extends TestEntity {
             }
         } else if (location == Protomech.LOC_BODY) {
             return 0;
-        } else if (proto.isQuad()) {
-            switch ((int) proto.getWeight()) {
-                case 3:
-                    return 12;
-                case 4:
-                case 5:
-                    return 14;
-                // else drop through
-            }
         }
         return proto.getOInternal(location) * 2;
     }


### PR DESCRIPTION
Corrects ProtoMek maximum armor values. The original IO errata v1.21 note the error in the expanded protomek armor table, but the newer IO:AE errata seem to have forgotten. Looking at the table it still looks very much like an error. This PR corrects it.

@HammerGS could you give this a look; I feel the new IO:AE errata v3.01 should list this (taken from the old IO v1.21 errata):

![image](https://github.com/MegaMek/megamek/assets/17069663/09037e8f-30ed-438a-9e62-35bdb9edabd6)

Fixes MegaMek/megameklab#1345
Fixes MegaMek/megameklab#1154