### PR TITLE
add a split pane lobby between player and unit panels

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -614,8 +614,12 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         rightSide.add(scrMekTable);
 
         panUnits.setLayout(new BoxLayout(panUnits, BoxLayout.LINE_AXIS));
-        panUnits.add(leftSide);
-        panUnits.add(rightSide);
+        JSplitPane sp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        sp.setDividerLocation(400);
+        sp.setDividerSize(10);
+        sp.setLeftComponent(leftSide);
+        sp.setRightComponent(rightSide);
+        panUnits.add(sp);
     }
 
     private void setupMapPanel() {


### PR DESCRIPTION
- add a split pane in lobby between player and unit panels, to help when using a very large GUI scale

![image](https://github.com/MegaMek/megamek/assets/116095479/f93f0577-7471-42da-88de-fabae323e12b)
