### PR TITLE
Additional Mtffile changes

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4176,8 +4176,8 @@ public abstract class Mech extends Entity {
         StringBuilder sb = new StringBuilder();
         String newLine = "\n";
 
-        sb.append(MtfFile.COMMENT).append("Saved from version ").append(SuiteConstants.VERSION);
-        sb.append(" on ").append(LocalDate.now()).append(newLine);
+        sb.append(MtfFile.GENERATOR).append(SuiteConstants.PROJECT_NAME)
+                .append(" ").append(SuiteConstants.VERSION).append(" on ").append(LocalDate.now()).append(newLine);
 
         boolean standard = (getCockpitType() == Mech.COCKPIT_STANDARD)
                 && (getGyroType() == Mech.GYRO_STANDARD);

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -93,6 +93,7 @@ public class MtfFile implements IMechLoader {
 
     public static final String COMMENT = "#";
     public static final String MTF_VERSION = "Version:";
+    public static final String GENERATOR = "Generator:";
     public static final String CHASSIS = "chassis:";
     public static final String MODEL = "model:";
     public static final String COCKPIT = "cockpit:";
@@ -507,7 +508,7 @@ public class MtfFile implements IMechLoader {
         while (r.ready()) {
             String line = r.readLine().trim();
 
-            if (line.isBlank() || line.startsWith(COMMENT)) {
+            if (line.isBlank() || line.startsWith(COMMENT) || line.startsWith(GENERATOR)) {
                 continue;
             }
 
@@ -519,7 +520,14 @@ public class MtfFile implements IMechLoader {
                 // Version 1.1: Added level 3 cockpit and gyro options.
                 // version 1.2: added full head ejection
                 // Version 1.3: Added MUL ID
-                chassis = readLineIgnoringComments(r);
+
+                String generatorOrChassis = readLineIgnoringComments(r);
+                if (generatorOrChassis.startsWith(GENERATOR)) {
+                    // Compatibility with SSW 0.7.6.1 - Generator: comes between Version and chassis
+                    chassis = readLineIgnoringComments(r);
+                } else {
+                    chassis = generatorOrChassis;
+                }
                 model = readLineIgnoringComments(r);
                 continue;
             }

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -92,7 +92,7 @@ public class MtfFile implements IMechLoader {
             {Mech.LOC_LT, Mech.LOC_RT, Mech.LOC_CT};
 
     public static final String COMMENT = "#";
-    public static final String MTF_VERSION = "Version:";
+    public static final String MTF_VERSION = "version:";
     public static final String GENERATOR = "generator:";
     public static final String CHASSIS = "chassis:";
     public static final String MODEL = "model:";
@@ -512,7 +512,7 @@ public class MtfFile implements IMechLoader {
                 continue;
             }
 
-            if (line.startsWith(MTF_VERSION)) {
+            if (line.toLowerCase().startsWith(MTF_VERSION)) {
                 // Reading the version, chassis and model as the first three lines without header is kept
                 // for backward compatibility for user-generated units. However the version is no longer checked
                 // for correct values as that makes no difference so long as the unit can be loaded

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -93,7 +93,7 @@ public class MtfFile implements IMechLoader {
 
     public static final String COMMENT = "#";
     public static final String MTF_VERSION = "Version:";
-    public static final String GENERATOR = "Generator:";
+    public static final String GENERATOR = "generator:";
     public static final String CHASSIS = "chassis:";
     public static final String MODEL = "model:";
     public static final String COCKPIT = "cockpit:";
@@ -522,7 +522,7 @@ public class MtfFile implements IMechLoader {
                 // Version 1.3: Added MUL ID
 
                 String generatorOrChassis = readLineIgnoringComments(r);
-                if (generatorOrChassis.startsWith(GENERATOR)) {
+                if (generatorOrChassis.toLowerCase().startsWith(GENERATOR)) {
                     // Compatibility with SSW 0.7.6.1 - Generator: comes between Version and chassis
                     chassis = readLineIgnoringComments(r);
                 } else {


### PR DESCRIPTION
I noticed MegaMek/megameklab#1061 somewhat late. From the suggestions there, this PR adjusts MTF files to use the generator: keyword to output the MM version (instead of a comment line) and makes it compatible with SSW mtf files.

Fixes MegaMek/megameklab#1061