### PR TITLE
FixedWingSupport: automatically set SI when walk MPs are set

### DIFF
--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -320,4 +320,10 @@ public class FixedWingSupport extends ConvFighter {
     public boolean isAerospaceSV() {
         return true;
     }
+
+    @Override
+    public void setOriginalWalkMP(int walkMP) {
+        super.setOriginalWalkMP(walkMP);
+        autoSetSI();
+    }
 }

--- a/megamek/src/megamek/common/loaders/BLKFixedWingSupportFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFixedWingSupportFile.java
@@ -143,7 +143,6 @@ public class BLKFixedWingSupportFile extends BLKFile implements IMechLoader {
 
         a.autoSetInternal();
         a.recalculateTechAdvancement();
-        a.autoSetSI();
         // This is not working right for arrays for some reason
         a.autoSetThresh();
 


### PR DESCRIPTION
In FixedWingS, the SI value is always equal to the walk MP (safe thrust). This adds an override that sets SI automatically in FWS. This affects unit loading everywhere as well as unit building in MML.

Fixes MegaMek/megameklab#1320