### PR TITLE
Don't display engine rating for SV engines

### DIFF
--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -450,7 +450,11 @@ public class Engine implements Serializable, ITechnology {
      */
     public String getShortEngineName() {
         if (engineType < TYPE_KEYS.length) {
-            return String.format("%d%s", engineRating, Messages.getString("Engine." + TYPE_KEYS[engineType]));
+            if (hasFlag(SUPPORT_VEE_ENGINE)) {
+                return String.format("%s", Messages.getString("Engine." + TYPE_KEYS[engineType])).trim();
+            } else {
+                return String.format("%d%s", engineRating, Messages.getString("Engine." + TYPE_KEYS[engineType]));
+            }
         } else {
             return Messages.getString("Engine.invalid");
         }

--- a/megamek/src/megamek/common/Engine.java
+++ b/megamek/src/megamek/common/Engine.java
@@ -451,7 +451,7 @@ public class Engine implements Serializable, ITechnology {
     public String getShortEngineName() {
         if (engineType < TYPE_KEYS.length) {
             if (hasFlag(SUPPORT_VEE_ENGINE)) {
-                return String.format("%s", Messages.getString("Engine." + TYPE_KEYS[engineType])).trim();
+                return Messages.getString("Engine." + TYPE_KEYS[engineType]).trim();
             } else {
                 return String.format("%d%s", engineRating, Messages.getString("Engine." + TYPE_KEYS[engineType]));
             }


### PR DESCRIPTION
Removes the engine rating (but not the engine type) from the mech summary and the record sheet for support vehicles as they don't use engine ratings.

old:
![image](https://github.com/MegaMek/megamek/assets/17069663/c77b3dfe-f69e-4e9f-8d10-fee4cad46dec)

new:
![image](https://github.com/MegaMek/megamek/assets/17069663/1e6391e9-55e9-4379-a224-3f277adabb09)
