### PR TITLE
Weapon sorting (for MML)

### DIFF
--- a/megamek/src/megamek/common/weapons/artillery/LongTomCannon.java
+++ b/megamek/src/megamek/common/weapons/artillery/LongTomCannon.java
@@ -35,6 +35,7 @@ public class LongTomCannon extends ArtilleryCannonWeapon {
         addLookupName("CLLongTomCannon");
         addLookupName("CLLongTomArtilleryCannon");
         addLookupName("CL Long Tom Cannon");
+        sortingName = "Cannon Arty Long Tom";
         heat = 20;
         rackSize = 20;
         ammoType = AmmoType.T_LONG_TOM_CANNON;

--- a/megamek/src/megamek/common/weapons/artillery/SniperCannon.java
+++ b/megamek/src/megamek/common/weapons/artillery/SniperCannon.java
@@ -35,6 +35,7 @@ public class SniperCannon extends ArtilleryCannonWeapon {
         addLookupName("CLSniper Cannon");
         addLookupName("CLSniperArtilleryCannon");
         addLookupName("CL Sniper Cannon");
+        sortingName = "Cannon Arty Sniper";
         heat = 10;
         rackSize = 10;
         ammoType = AmmoType.T_SNIPER_CANNON;

--- a/megamek/src/megamek/common/weapons/artillery/ThumperCannon.java
+++ b/megamek/src/megamek/common/weapons/artillery/ThumperCannon.java
@@ -35,6 +35,7 @@ public class ThumperCannon extends ArtilleryCannonWeapon {
         addLookupName("CLThumper Cannon");
         addLookupName("CLThumperArtilleryCannon");
         addLookupName("CL Thumper Cannon");
+        sortingName = "Cannon Arty Thumper";
         heat = 5;
         rackSize = 5;
         ammoType = AmmoType.T_THUMPER_CANNON;

--- a/megamek/src/megamek/common/weapons/flamers/ISVehicleFlamer.java
+++ b/megamek/src/megamek/common/weapons/flamers/ISVehicleFlamer.java
@@ -33,6 +33,7 @@ public class ISVehicleFlamer extends VehicleFlamerWeapon {
         this.addLookupName("CLVehicleFlamer");
         this.addLookupName("Clan Vehicle Flamer");
         this.addLookupName("Vehicle Flamer");
+        sortingName = "Flamer V";
         this.heat = 3;
         this.damage = 2;
         this.infDamageClass = WeaponType.WEAPON_BURST_4D6;

--- a/megamek/src/megamek/common/weapons/gaussrifles/CLAPGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/CLAPGaussRifle.java
@@ -28,6 +28,7 @@ public class CLAPGaussRifle extends GaussWeapon {
         name = "AP Gauss Rifle";
         setInternalName("CLAPGaussRifle");
         addLookupName("Clan AP Gauss Rifle");
+        sortingName = "Gauss X";
         heat = 1;
         damage = 3;
         infDamageClass = WeaponType.WEAPON_BURST_2D6;

--- a/megamek/src/megamek/common/weapons/lasers/CLImprovedLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLImprovedLaserLarge.java
@@ -28,6 +28,7 @@ public class CLImprovedLaserLarge extends LaserWeapon {
         this.setInternalName(this.name);
         this.addLookupName("Improved Large Laser");
         this.addLookupName("ImpLargeLaser");
+        sortingName = "Laser Imp D";
         this.heat = 8;
         this.damage = 8;
         this.shortRange = 5;

--- a/megamek/src/megamek/common/weapons/lasers/CLImprovedPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLImprovedPulseLaserLarge.java
@@ -28,6 +28,7 @@ public class CLImprovedPulseLaserLarge extends PulseLaserWeapon {
         setInternalName("ImprovedLargePulseLaser");
         addLookupName("Improved Pulse Large Laser");
         addLookupName("ImpLargePulseLaser");
+        sortingName = "Laser Pulse Imp D";
         heat = 10;
         damage = 9;
         toHitModifier = -2;

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserLarge.java
@@ -29,7 +29,7 @@ public class ISERLaserLarge extends LaserWeapon {
         name = "ER Large Laser";
         setInternalName("ISERLargeLaser");
         addLookupName("IS ER Large Laser");
-        sortingName = "ER Laser D";
+        sortingName = "Laser ER D";
         heat = 12;
         damage = 8;
         shortRange = 7;

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserMedium.java
@@ -25,7 +25,7 @@ public class ISERLaserMedium extends LaserWeapon {
         name = "ER Medium Laser";
         setInternalName("ISERMediumLaser");
         addLookupName("IS ER Medium Laser");
-        sortingName = "ER Laser C";
+        sortingName = "Laser ER C";
         heat = 5;
         damage = 5;
         shortRange = 4;

--- a/megamek/src/megamek/common/weapons/lasers/ISERLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISERLaserSmall.java
@@ -25,7 +25,7 @@ public class ISERLaserSmall extends LaserWeapon {
         name = "ER Small Laser";
         setInternalName("ISERSmallLaser");
         addLookupName("IS ER Small Laser");
-        sortingName = "ER Laser B";
+        sortingName = "Laser ER B";
         heat = 2;
         damage = 3;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/lasers/ISLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISLaserLarge.java
@@ -26,7 +26,7 @@ public class ISLaserLarge extends LaserWeapon {
         setInternalName(this.name);
         addLookupName("IS Large Laser");
         addLookupName("ISLargeLaser");
-        sortingName = "Laser D";
+        sortingName = "Laser AA D";
         heat = 8;
         damage = 8;
         shortRange = 5;

--- a/megamek/src/megamek/common/weapons/lasers/ISLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISLaserMedium.java
@@ -26,7 +26,7 @@ public class ISLaserMedium extends LaserWeapon {
         setInternalName(this.name);
         addLookupName("IS Medium Laser");
         addLookupName("ISMediumLaser");
-        sortingName = "Laser C";
+        sortingName = "Laser AA C";
         heat = 3;
         damage = 5;
         shortRange = 3;

--- a/megamek/src/megamek/common/weapons/lasers/ISLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/ISLaserSmall.java
@@ -29,7 +29,7 @@ public class ISLaserSmall extends LaserWeapon {
         addLookupName("ClSmall Laser");
         addLookupName("CL Small Laser");
         addLookupName("CLSmallLaser");
-        sortingName = "Laser B";
+        sortingName = "Laser AA B";
         heat = 1;
         damage = 3;
         shortRange = 1;

--- a/megamek/src/megamek/common/weapons/ppc/CLERPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/CLERPPC.java
@@ -25,6 +25,7 @@ public class CLERPPC extends PPCWeapon {
         this.name = "ER PPC";
         this.setInternalName("CLERPPC");
         this.addLookupName("Clan ER PPC");
+        sortingName = "PPC ER";
         this.heat = 15;
         this.damage = 15;
         this.shortRange = 7;

--- a/megamek/src/megamek/common/weapons/ppc/ISERPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISERPPC.java
@@ -25,7 +25,7 @@ public class ISERPPC extends PPCWeapon {
         name = "ER PPC";
         setInternalName("ISERPPC");
         addLookupName("IS ER PPC");
-        sortingName = "PPC Y";
+        sortingName = "PPC ER";
         heat = 15;
         damage = 10;
         shortRange = 7;

--- a/megamek/src/megamek/common/weapons/ppc/ISKinsSlaughterPPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISKinsSlaughterPPC.java
@@ -25,6 +25,7 @@ public class ISKinsSlaughterPPC extends PPCWeapon {
         this.name = "Kinslaughter H ER PPC";
         this.setInternalName("ISKinHERPPC");
         this.addLookupName("IS Kinslaughter H ER PPC");
+        sortingName = "PPC ER Kins";
         this.heat = 13;
         this.damage = 10;
         this.shortRange = 4;

--- a/megamek/src/megamek/common/weapons/ppc/ISSnubNosePPC.java
+++ b/megamek/src/megamek/common/weapons/ppc/ISSnubNosePPC.java
@@ -29,7 +29,7 @@ public class ISSnubNosePPC extends PPCWeapon {
         name = "Snub-Nose PPC";
         setInternalName("ISSNPPC");
         addLookupName("ISSnubNosedPPC");
-        sortingName = "PPC X";
+        sortingName = "PPC Snub";
         heat = 10;
         damage = DAMAGE_VARIABLE;
         minimumRange = 0;


### PR DESCRIPTION
This tweaks weapon sorting a bit. There is a tradeoff here betweek weapons being sorted alphabetically and grouping them together. With the filters and text search one can achieve more than we can by pure sorting, so I did not do everything the MML issue suggests. I do not to update unofficial weapons.

Fixes Megamek/megameklab#1308