### PR TITLE
AS conversion: give VSTOL to STOL units and aerodyne DS/SC

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASAeroSpecialAbilityConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASAeroSpecialAbilityConverter.java
@@ -66,8 +66,8 @@ public class ASAeroSpecialAbilityConverter extends ASSpecialAbilityConverter {
             assign("Fighter Bombs", BOMB, element.getSize());
         }
 
-        if (aero.isVSTOL()) {
-            assign("VSTOL gear or capable", VSTOL);
+        if (aero.isVSTOL() || aero.isSTOL() || element.isType(AF)) {
+            assign("VSTOL or STOL gear or capable", VSTOL);
         }
         
         if (element.isType(AF)) {

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASLargeAeroSpecialAbilityConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASLargeAeroSpecialAbilityConverter.java
@@ -114,6 +114,11 @@ public class ASLargeAeroSpecialAbilityConverter extends ASSpecialAbilityConverte
             }
         }
 
+        Aero aero = (Aero) entity;
+        if (aero.isVSTOL() || aero.isSTOL() || (aero instanceof SmallCraft && aero.isAerodyne())) {
+            assign("VSTOL or STOL gear or capable", VSTOL);
+        }
+
         assign("Space capable", SPC);
     }
 }


### PR DESCRIPTION
Corrects AS conversion according to the ruling in https://bg.battletech.com/forums/index.php/topic,80685.150.html and ASC p.133

Fixes #4603 