### PR TITLE
AS conversion: fix medium and long range damage with SSW

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASBattleArmorDamageConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASBattleArmorDamageConverter.java
@@ -157,7 +157,11 @@ public class ASBattleArmorDamageConverter extends ASDamageConverter {
             report.addLine("Troop Factor", formatForReport(mDamage) + " x " + formatForReport(troopFactor),
                     "= " + formatForReport(mDamage * troopFactor));
             mDamage *= troopFactor;
-            mDamage += assembleSquadSupportDamage(MEDIUM_RANGE);
+        }
+
+        mDamage += assembleSquadSupportDamage(MEDIUM_RANGE);
+
+        if (mDamage > 0) {
             finalMDamage = ASDamage.createDualRoundedUp(mDamage);
             report.addLine("Final M damage:",
                     formatForReport(mDamage) + ", dual rounded", "= " + finalMDamage.toStringWithZero());
@@ -175,7 +179,11 @@ public class ASBattleArmorDamageConverter extends ASDamageConverter {
             report.addLine("Troop Factor", formatForReport(lDamage) + " x " + formatForReport(troopFactor),
                     "= " + formatForReport(lDamage * troopFactor));
             lDamage *= troopFactor;
-            lDamage += assembleSquadSupportDamage(LONG_RANGE);
+        }
+
+        lDamage += assembleSquadSupportDamage(LONG_RANGE);
+
+        if (lDamage > 0) {
             finalLDamage = ASDamage.createDualRoundedUp(lDamage);
             report.addLine("Final L damage:",
                     formatForReport(lDamage) + ", dual rounded", "= " + finalLDamage.toStringWithZero());


### PR DESCRIPTION
The damage of SSW on BA was ignored when there was no other damage on M and L range. The Callisto Bearhunter now gets 1 M damage instead of 0.

New card:
![image](https://github.com/MegaMek/megamek/assets/17069663/1762b59f-3b0c-49a6-b922-ecd6600586fb)
