### PR TITLE
Space station KF adapters

### DIFF
--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -43,6 +43,14 @@ public class SpaceStation extends Jumpship {
             .setAvailability(RATING_C, RATING_D, RATING_C, RATING_C)
             .setStaticTechLevel(SimpleTechLevel.ADVANCED);
 
+    private static final TechAdvancement TA_SPACE_STATION_KF_ADAPTER = new TechAdvancement(TECH_BASE_ALL)
+            .setISAdvancement(2350, 2375, DATE_NONE, 2850, 3048).setClanAdvancement(2350, 2375)
+            .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
+            // The adapter itself is tech rating C, but this is the base for a station with an adapter.
+            .setReintroductionFactions(F_FS).setTechRating(RATING_D)
+            .setAvailability(RATING_D, RATING_F, RATING_D, RATING_D)
+            .setStaticTechLevel(SimpleTechLevel.ADVANCED);
+
     private static final TechAdvancement TA_SPACE_STATION_MODULAR = new TechAdvancement(TECH_BASE_ALL)
             .setISAdvancement(2565, 2585, DATE_NONE, 2790, 3090).setClanAdvancement(2565, 2585)
             .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
@@ -52,13 +60,21 @@ public class SpaceStation extends Jumpship {
 
     @Override
     public TechAdvancement getConstructionTechAdvancement() {
-        return modularOrKFAdapter ? TA_SPACE_STATION_MODULAR : TA_SPACE_STATION;
+        if (isModular()) {
+            return TA_SPACE_STATION_MODULAR;
+        } else if (hasKFAdapter()) {
+            return TA_SPACE_STATION_KF_ADAPTER;
+        } else {
+            return TA_SPACE_STATION;
+        }
     }
-    
+
+    public static TechAdvancement getKFAdapterTA() { return TA_SPACE_STATION_KF_ADAPTER; }
+
     public static TechAdvancement getModularTA() {
         return TA_SPACE_STATION_MODULAR;
     }
-    
+
     /**
      * Designates whether this is a modular space station
      * @param modularOrKFAdapter Whether the space station can be transported by jumpship.
@@ -79,6 +95,10 @@ public class SpaceStation extends Jumpship {
         return modularOrKFAdapter && getWeight() > 100000;
     }
 
+    public boolean hasKFAdapter() {
+        return modularOrKFAdapter && getWeight() <= 100000;
+    }
+
     @Override
     public double getCost(CalculationReport calcReport, boolean ignoreAmmo) {
         return SpaceStationCostCalculator.calculateCost(this, calcReport, ignoreAmmo);
@@ -88,7 +108,7 @@ public class SpaceStation extends Jumpship {
     public double getPriceMultiplier() {
         if (isModular()) {
             return 50.0;
-        } else if (modularOrKFAdapter) {
+        } else if (hasKFAdapter()) {
             return 20.0;
         } else {
             return 5.0;

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -22,7 +22,10 @@ import megamek.common.options.OptionsConstants;
  */
 public class SpaceStation extends Jumpship {
     private static final long serialVersionUID = -3160156173650960985L;
-    
+
+    /** A station over this weight in may built as a modular station. */
+    public static final double MODULAR_MININUM_WEIGHT = 100000.0;
+
     // This only affects cost, but may have an effect in a large-scale strategic setting.
     private boolean modularOrKFAdapter = false;
     
@@ -92,11 +95,11 @@ public class SpaceStation extends Jumpship {
     }
 
     public boolean isModular() {
-        return modularOrKFAdapter && getWeight() > 100000;
+        return modularOrKFAdapter && getWeight() > MODULAR_MININUM_WEIGHT;
     }
 
     public boolean hasKFAdapter() {
-        return modularOrKFAdapter && getWeight() <= 100000;
+        return modularOrKFAdapter && getWeight() <= MODULAR_MININUM_WEIGHT;
     }
 
     @Override

--- a/megamek/src/megamek/common/SpaceStation.java
+++ b/megamek/src/megamek/common/SpaceStation.java
@@ -24,7 +24,7 @@ public class SpaceStation extends Jumpship {
     private static final long serialVersionUID = -3160156173650960985L;
     
     // This only affects cost, but may have an effect in a large-scale strategic setting.
-    private boolean modular = false;
+    private boolean modularOrKFAdapter = false;
     
     @Override
     public int getUnitType() {
@@ -52,7 +52,7 @@ public class SpaceStation extends Jumpship {
 
     @Override
     public TechAdvancement getConstructionTechAdvancement() {
-        return modular? TA_SPACE_STATION_MODULAR : TA_SPACE_STATION;
+        return modularOrKFAdapter ? TA_SPACE_STATION_MODULAR : TA_SPACE_STATION;
     }
     
     public static TechAdvancement getModularTA() {
@@ -61,17 +61,22 @@ public class SpaceStation extends Jumpship {
     
     /**
      * Designates whether this is a modular space station
-     * @param modular
+     * @param modularOrKFAdapter Whether the space station can be transported by jumpship.
      */
-    public void setModular(boolean modular) {
-        this.modular = modular;
+    public void setModularOrKFAdapter(boolean modularOrKFAdapter) {
+        this.modularOrKFAdapter = modularOrKFAdapter;
     }
     
     /**
-     * @return True if this space station has a modular construction, otherwise false.
+     * @return True if this space station has a modular construction (or has a KF adapter for stations less than 100kt,
+     *         otherwise false.
      */
+    public boolean isModularOrKFAdapter() {
+        return modularOrKFAdapter;
+    }
+
     public boolean isModular() {
-        return modular;
+        return modularOrKFAdapter && getWeight() > 100000;
     }
 
     @Override
@@ -81,7 +86,13 @@ public class SpaceStation extends Jumpship {
 
     @Override
     public double getPriceMultiplier() {
-        return modular ? 50.0 : 5.0;
+        if (isModular()) {
+            return 50.0;
+        } else if (modularOrKFAdapter) {
+            return 20.0;
+        } else {
+            return 5.0;
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -26,8 +26,6 @@ import megamek.common.options.PilotOptions;
 import megamek.common.util.BuildingBlock;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 
 public class BLKFile {
 
@@ -1106,7 +1104,7 @@ public class BLKFile {
                 blk.writeBlockData("jump_range", ws.getJumpRange());
             }
         } else if ((t instanceof SpaceStation)
-                && ((SpaceStation) t).isModular()) {
+                && ((SpaceStation) t).isModularOrKFAdapter()) {
             blk.writeBlockData("modular", 1);
         }
 

--- a/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
@@ -125,7 +125,7 @@ public class BLKSpaceStationFile extends BLKFile implements IMechLoader {
         }
 
         if (dataFile.exists("modular")) {
-            a.setModular(true);
+            a.setModularOrKFAdapter(true);
         }
 
         // Grav Decks - two approaches


### PR DESCRIPTION
See MegaMek/megameklab#1401 for rules references.

Only stations > 100kt can be modular, though stations <= 100kt can be equipped with a KF adapter that lets them be moved via jumpship. For simplicity in MML I've kept the single field and broadened it to include both situations, with the tonnage determining the precise meaning. There's no practical difference between the two other than cost and tech advancement.

Companion to MegaMek/megameklab#1368