### PR TITLE
Fix Elemental III Date

### DIFF
--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd4).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd4).blk
@@ -29,7 +29,7 @@ Elemental III Battle Armor
 </year>
 
 <originalBuildYear>
-3081
+3091
 </originalBuildYear>
 
 <type>

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd4).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd4).blk
@@ -25,7 +25,7 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd5).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd5).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 </originalBuildYear>
 
 <type>
@@ -64,7 +64,7 @@ CLBAAPGaussRifle:RA
 BAAPMount:LA
 InfantryAssaultRifle:APM:LA
 BABattleClaw:LA
-Clan BA Stealth (Basic):LA
+Clan BA Stealth (Basic):Body
 Clan BA Stealth (Basic):LA
 Clan BA Stealth (Basic):RA
 CLAdvancedSRM2OS:Body

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd6).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [AP Gauss](Sqd6).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 </originalBuildYear>
 
 <type>
@@ -64,7 +64,7 @@ CLBAAPGaussRifle:RA
 BAAPMount:LA
 InfantryAssaultRifle:APM:LA
 BABattleClaw:LA
-Clan BA Stealth (Basic):LA
+Clan BA Stealth (Basic):Body
 Clan BA Stealth (Basic):LA
 Clan BA Stealth (Basic):RA
 CLAdvancedSRM2OS:Body

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd4).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd4).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 
 <type>
 Clan Level 2
@@ -62,7 +62,7 @@ Jump
 BAAPMount:LA
 InfantryAssaultRifle:APM:LA
 BABattleClaw:LA
-Clan BA Stealth (Basic):RA
+Clan BA Stealth (Basic):Body
 Clan BA Stealth (Basic):LA
 Clan BA Stealth (Basic):RA
 CLAdvancedSRM2OS:Body

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd5).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd5).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 
 <type>
 Clan Level 2
@@ -62,7 +62,7 @@ Jump
 BAAPMount:LA
 InfantryAssaultRifle:APM:LA
 BABattleClaw:LA
-Clan BA Stealth (Basic):RA
+Clan BA Stealth (Basic):Body
 Clan BA Stealth (Basic):LA
 Clan BA Stealth (Basic):RA
 CLAdvancedSRM2OS:Body

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd6).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [Flamer] (Sqd6).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 
 <type>
 Clan Level 2
@@ -62,7 +62,7 @@ Jump
 BAAPMount:LA
 InfantryAssaultRifle:APM:LA
 BABattleClaw:LA
-Clan BA Stealth (Basic):RA
+Clan BA Stealth (Basic):Body
 Clan BA Stealth (Basic):LA
 Clan BA Stealth (Basic):RA
 CLAdvancedSRM2OS:Body

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd4).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd4).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 </originalBuildYear>
 
 <type>

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd5).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd5).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 </originalBuildYear>
 
 <type>

--- a/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd6).blk
+++ b/megamek/data/mechfiles/battlearmor/Rec Guides ilClan/Vol 24/Elemental III BA [MicroPL] (Sqd6).blk
@@ -25,11 +25,11 @@ Elemental III Battle Armor
 </mul id:>
 
 <year>
-3081
+3091
 </year>
 
 <originalBuildYear>
-3081
+3091
 </originalBuildYear>
 
 <type>


### PR DESCRIPTION
Fixed persistent eras where all Elemental IIIs debuted 10 years too early, and most variants had crit assignment issues that caused them to be flagged as illegal.