### PR TITLE
Fix Searchlights auto-enabled during daytime

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1090,7 +1090,8 @@ public class GameManager implements IGameManager {
             // reset spotlights
             // If deployment phase, set Searchlight state based on startSearchLightsOn;
             if (phase.isDeployment()) {
-                boolean startSLOn = PreferenceManager.getClientPreferences().getStartSearchlightsOn();
+                boolean startSLOn = PreferenceManager.getClientPreferences().getStartSearchlightsOn()
+                        && game.getPlanetaryConditions().isIlluminationEffective();;
                 entity.setSearchlightState(startSLOn);
                 entity.setIlluminated(startSLOn);
             }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1091,7 +1091,7 @@ public class GameManager implements IGameManager {
             // If deployment phase, set Searchlight state based on startSearchLightsOn;
             if (phase.isDeployment()) {
                 boolean startSLOn = PreferenceManager.getClientPreferences().getStartSearchlightsOn()
-                        && game.getPlanetaryConditions().isIlluminationEffective();;
+                        && game.getPlanetaryConditions().isIlluminationEffective();
                 entity.setSearchlightState(startSLOn);
                 entity.setIlluminated(startSLOn);
             }


### PR DESCRIPTION
Currently the client setting to enable searchlights by default _should_ be skipping the pre-deployment Searchlight activation during daytime, but it is not.

This change disables starting with Searchlights on, even if the user has this option set, when doing so would not improve visibility.