### PR TITLE
Data fix for Cicada CDA-4A.mtf

### DIFF
--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 28/Cicada CDA-4A.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 28/Cicada CDA-4A.mtf
@@ -36,7 +36,7 @@ RTR armor:5
 RTC armor:6
 
 Weapons:3
-Medium VSP Laser, Right Torso
+Medium VSP Laser, Left Torso
 Medium VSP Laser, Right Torso
 Medium Re-engineered Laser, Center Torso
 
@@ -72,12 +72,12 @@ Left Torso:
 Fusion Engine
 Fusion Engine
 Fusion Engine
+ISMediumVSPLaser
+ISMediumVSPLaser
 IS Ferro-Fibrous
 IS Ferro-Fibrous
 IS Ferro-Fibrous
 IS Ferro-Fibrous
--Empty-
--Empty-
 -Empty-
 -Empty-
 -Empty-
@@ -88,12 +88,12 @@ Fusion Engine
 Fusion Engine
 ISMediumVSPLaser
 ISMediumVSPLaser
-ISMediumVSPLaser
-ISMediumVSPLaser
 Supercharger
 IS Ferro-Fibrous
 IS Ferro-Fibrous
 IS Ferro-Fibrous
+-Empty-
+-Empty-
 -Empty-
 
 Center Torso:


### PR DESCRIPTION
Medium VSP lasers should be in each side torso, not both in the right torso.

Rec. guide vol. 28, CDA-4A, pg.28: 

![Screenshot 2024-01-03 at 11 17 58 AM](https://github.com/MegaMek/megamek/assets/17239616/377e75f9-aee1-4cc7-b994-822dd68878f8)
