### PR TITLE
QuirkEntry: remove maximum slot number check

### DIFF
--- a/megamek/src/megamek/common/QuirkEntry.java
+++ b/megamek/src/megamek/common/QuirkEntry.java
@@ -90,7 +90,7 @@ public class QuirkEntry {
             throw new IllegalArgumentException("No location for " + code + " : " + unitId);
         } else if (StringUtility.isNullOrBlank(weaponName)) {
             throw new IllegalArgumentException("No weapon for " + code + " : " + unitId);
-        } else if ((slot < 0) || (slot > 11)) {
+        } else if (slot < 0) {
             throw new IllegalArgumentException("Invalid slot index (" + slot + ") for " + code + " : " + unitId);
         }
 
@@ -115,7 +115,7 @@ public class QuirkEntry {
             throw new IllegalArgumentException("Invalid location!");
         } else if (StringUtility.isNullOrBlank(weaponName)) {
             throw new IllegalArgumentException("Invalid weapon name!");
-        } else if ((slot < 0) || (slot > 11)) {
+        } else if (slot < 0) {
             throw new IllegalArgumentException("Invalid slot index!");
         }
 


### PR DESCRIPTION
Weapon quirks are allowed on large craft and the slot numbers there can be higher than 11. The slot number test in the QuirkEntry constructor was obstructing this.

Fixes MegaMek/megameklab#1364

