### PR TITLE
Fix CF warning sprite to work with isometric view.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1160,7 +1160,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         // draw structure warning in the deployment or movement phases
         // draw this before moving entities, so they show up under if overlapped.
-        if (shouldShowCFWarning())  {
+        if (!useIsometric() && shouldShowCFWarning())  {
             drawSprites(g, cfWarningSprites);
         }
 
@@ -2252,7 +2252,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
             // draw structure collapse warning sprites if in movement or deploy phase.
             // draw this before moving entities, so they show up under if overlapped.
-            if (shouldShowCFWarning()) {
+            if (!useIsometric() && shouldShowCFWarning()) {
                 drawSprites(boardGraph, cfWarningSprites);
             }
 
@@ -2334,6 +2334,9 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                             }
                             drawHexSpritesForHex(c, g, moveEnvSprites);
                             drawHexSpritesForHex(c, g, moveModEnvSprites);
+                            if (shouldShowCFWarning()) {
+                                drawHexSpritesForHex(c, g, cfWarningSprites);
+                            }
                             if ((en_Deployer != null)
                                     && board.isLegalDeployment(c, en_Deployer)) {
                                 drawHexBorder(g, getHexLocation(c), Color.YELLOW);
@@ -6188,6 +6191,11 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
         for (Sprite spr : fieldOfFireSprites) {
             spr.prepare();
         }
+
+        for (Sprite spr : cfWarningSprites) {
+            spr.prepare();
+        }
+
         clearHexImageCache();
         updateBoard();
         for (MovementEnvelopeSprite sprite: moveEnvSprites) {


### PR DESCRIPTION
This PR fixes the CF Warning rendering for isometric view.  Specifically when toggling back and forth between isometric and normal rendering.  The warning signs were not being updated to the correct elevation on toggle.

![image](https://github.com/MegaMek/megamek/assets/83041327/02ba5bab-445f-4bfa-8df0-c8050776d224)

should be:

![image](https://github.com/MegaMek/megamek/assets/83041327/49bf55a2-9016-4b72-9c88-a52789c24cbd)
