### PR TITLE
Fix #4648: Update AT Classes for MekMortar and IS BA Tube Arty

### DIFF
--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -230,6 +230,7 @@ public class WeaponType extends EquipmentType {
     public static final int CLASS_TELE_MISSILE = 25;
     public static final int CLASS_GAUSS = 26;
     public static final int CLASS_THUNDERBOLT = 27;
+    public static final int CLASS_MORTAR = 28;
 
     public static final int WEAPON_DIRECT_FIRE = 0;
     public static final int WEAPON_CLUSTER_BALLISTIC = 1;
@@ -249,7 +250,7 @@ public class WeaponType extends EquipmentType {
     // Used for BA vs BA damage for BA Plasma Rifle
     public static final int WEAPON_PLASMA = 15;
 
-    public static String[] classNames = { "Unknown", "Laser", "Point Defense", "PPC", "Pulse Laser", "Artilery", "AMS",
+    public static String[] classNames = { "Unknown", "Laser", "Point Defense", "PPC", "Pulse Laser", "Artillery", "AMS",
             "AC", "LBX", "LRM", "SRM", "MRM", "ATM", "Rocket Launcher", "Capital Laser", "Capital PPC", "Capital AC",
             "Capital Gauss", "Capital Missile", "AR10", "Screen", "Sub Capital Cannon", "Capital Mass Driver", "AMS" };
 

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -250,7 +250,7 @@ public class WeaponType extends EquipmentType {
     // Used for BA vs BA damage for BA Plasma Rifle
     public static final int WEAPON_PLASMA = 15;
 
-    public static String[] classNames = { "Unknown", "Laser", "Point Defense", "PPC", "Pulse Laser", "Artillery", "AMS",
+    public static String[] classNames = { "Unknown", "Laser", "Point Defense", "PPC", "Pulse Laser", "Artillery", "Plasma",
             "AC", "LBX", "LRM", "SRM", "MRM", "ATM", "Rocket Launcher", "Capital Laser", "Capital PPC", "Capital AC",
             "Capital Gauss", "Capital Missile", "AR10", "Screen", "Sub Capital Cannon", "Capital Mass Driver", "AMS" };
 

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBATubeArtillery.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBATubeArtillery.java
@@ -43,7 +43,7 @@ public class ISBATubeArtillery extends ArtilleryWeapon {
         rulesRefs = "284, TO";
         flags = flags.or(F_BA_WEAPON).andNot(F_MECH_WEAPON).andNot(F_TANK_WEAPON).or(F_MEK_MORTAR).or(F_MISSILE);
         damage = DAMAGE_BY_CLUSTERTABLE;
-        atClass = CLASS_NONE;
+        atClass = CLASS_ARTILLERY;
         infDamageClass = WEAPON_CLUSTER_MISSILE;
         techAdvancement.setTechBase(TECH_BASE_IS)
                 .setIntroLevel(false)
@@ -55,12 +55,12 @@ public class ISBATubeArtillery extends ArtilleryWeapon {
                 .setPrototypeFactions(F_CS)
                 .setProductionFactions(F_CS);
     }
-    
+
     @Override
     public boolean hasIndirectFire() {
         return true;
     }
-    
+
     @Override
     public void adaptToGameOptions(GameOptions gOp) {
         super.adaptToGameOptions(gOp);

--- a/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
+++ b/megamek/src/megamek/common/weapons/mortars/MekMortarWeapon.java
@@ -47,7 +47,7 @@ public abstract class MekMortarWeapon extends AmmoWeapon {
         super();
         ammoType = AmmoType.T_MEK_MORTAR;
         damage = DAMAGE_BY_CLUSTERTABLE;
-        atClass = CLASS_NONE;
+        atClass = CLASS_MORTAR;
         flags = flags.or(F_MEK_MORTAR).or(F_MORTARTYPE_INDIRECT).or(F_MECH_WEAPON).or(F_MISSILE).or(F_TANK_WEAPON);
         infDamageClass = WEAPON_CLUSTER_MISSILE;
     }


### PR DESCRIPTION
It turns out that Mek Mortars (and, coincidentally, IS BA Tube Artillery) are filtered out of the MekHQ "Spend XP -> SPA" context menu because they have the AT Class "CLASS_NONE".  Because MekHQ uses a different code path to validate weapon validity for SPAs, these weapons are filtered out in MekHQ but work fine in MegaMek.

This patch by itself only fixes the issue for IS BA Tube Artillery; the matching MekHQ PR [here](https://github.com/MegaMek/mekhq/pull/3810) must also be applied to fix the issue for Mek Mortars as well.

We should probably look at:
1. removing all AT Class filtering, as it is apparently quite old and mostly unused,
2. importing the MegaMek SPA validity test, which is much more robust, into MekHQ.

but I have some other stuff to work on right now.

Tested with MegaMek and MekHQ; ran all tests on both packages.

Close #4648 