### PR TITLE
Update ADA Missile to-hit mods to match RAW (as we understand them)

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4889,7 +4889,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // Air-Defense Arrow missiles use a simplified to-hit calculation because they:
             // A) are Flak; B) are not Artillery, C) use three ranges (same low-alt hex, 1 hex, 2 hexes)
             // as S/M/L
-            // Per TO:AR 6th printing, p153, ADA Missils should use TW Flak rules rather than TO Artillery Flak rules.
+            // Per TO:AR 6th printing, p153, ADA Missiles should use TW Flak rules rather than TO Artillery Flak rules.
             // Per TW pg 114, all other mods _should_ be included.
 
             // Special range calc

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4925,7 +4925,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 }
 
                 // Ground-to-air attacks against a target flying at NOE
-                if (Compute.isGroundToAir(ae, target) && te.isNOE()) {
+                if (te.isNOE()) {
                     if (te.passedWithin(ae.getPosition(), 1)) {
                         toHit.addModifier(+1, Messages.getString("WeaponAttackAction.TeNoe"));
                     } else {
@@ -4933,8 +4933,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     }
                 }
 
-                // Vs Aero, hits from below
-                if ((ae.getAltitude() - target.getAltitude()) > 2) {
+                // evading bonuses
+                if (te.isEvading()) {
+                    toHit.addModifier(te.getEvasionBonus(), Messages.getString("WeaponAttackAction.TeEvading"));
+                }
+
+                // Vs Aero, hits from below; attacker _should_ always be below target.
+                if ((te.getAltitude() - ae.getAltitude()) > 2) {
                     toHit.setHitTable(ToHitData.HIT_BELOW);
                 }
             }


### PR DESCRIPTION
A recent conversation showed that I probably had not properly implemented all of the relevant To-Hit mods for Air-Defense Arrow IV Missiles in MegaMek:

```
As far as I can tell, a unit firing an ADA at a fighter over their own map would have the following calculations:

Gunnery +
Attacker Movement +
Angle of Attack(side if you're not on the flight path, nose if you are) +
Flak (-2) +
NOE (+3) (if applicable) +
Any relevant attacker crits +
Evasion (+3) (if applicable)
```
Plus the special ADA Missile range bands, and possibly Stealth Armor.
Looking at the Aerospace Attack Modifiers Table (TW. pg 237) we are likely also missing "Target is at Zero Velocity" and "Target is Conducting Air-To-Ground Attack This Turn".

Due to some confusion between the Flak Artillery rules and the Total Warfare Flak rules, the _current_ implementation does not include:
- AoA Nose/Side/Aft (+1/+2/+0)
- Nap-of-the-Earth overhead/distant (+1/+3)
- Evasion for ASF/Small Craft/Large Craft (+3/+2/+1)
- Target Aerospace unit currently attacking a ground target (-3)
- Stealth Armor, variable for range (+0/+1/+2)
- Target at Zero Velocity (-2)
- Target conducting A2G attack this turn (-3)

The VTOL to-hit calculations are likely also missing some mods, namely TMM.
The "Below" table logic also needed to be reversed.

Another user previously posted a forum question asking for clarification of the exact mods that apply to ADA Missile attacks, [here](https://bg.battletech.com/forums/index.php/topic,82937.0.html), but after discussing the topic with more players I'm going to go ahead with this PR on the assumption that most - if not all - points are correct.

I will likely submit another, more compact, patch after determining how best to place the ADA range calculations in the normal to-hit code path as opposed to handling it all as a special case.

Testing:
- Verified with ADA Missile units against a variety of targets.
- Ran all MegaMek unit tests.