### PR TITLE
Fix 5028: Tow Button no longer working.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2996,7 +2996,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         final boolean canTow = ce.getHitchLocations().stream()
                 .flatMap(c -> game().getEntitiesVector(c).stream())
-                .anyMatch(ce::canTow);
+                .anyMatch(e -> ce.canTow(e.getId()));
         setTowEnabled(canTow);
     }
 


### PR DESCRIPTION
Fix #5028 Tow Button no longer working in 0.49.17.

Fixed the match expression as it was referring to the `Transporter::canTow(Entity)` interface default method which is hard-coded to return `false` and is not overridden by the `Entity` hierarchy.  