### PR TITLE
CF Warning clean up sprites when turn ends.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -274,6 +274,7 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
         clientgui.getBoardView().cursor(null);
         clientgui.getBoardView().markDeploymentHexesFor(null);
         clientgui.setSelectedEntityNum(Entity.NONE);
+        clientgui.getBoardView().clearCFWarningData();
         disableButtons();
     }
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1231,6 +1231,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         clientgui.getBoardView().clearMovementData();
         clientgui.getBoardView().clearFieldOfFire();
         clientgui.getBoardView().clearSensorsRanges();
+        clientgui.getBoardView().clearCFWarningData();
     }
 
     /**


### PR DESCRIPTION
I noticed when watching Joker's stream that when a players turn ends, the construction factor warning signs hang around while the remote players taking their turns.  The PR is a polish that cleans up sprites at the end of the current players turn and makes it look a little cleaner.