### PR TITLE
Ice Fix:  Princess Movement Cryophobia

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -33,11 +33,11 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
     // this is a value used to indicate how much we value the unit being at its destination
     private final int ARRIVED_AT_DESTINATION_FACTOR = 250;
-    
+
     // this is a value used to indicate how much we dis-value the unit being destroyed as a result of
     // what it's doing
     private final int UNIT_DESTRUCTION_FACTOR = 1000;
-    
+
     protected final DecimalFormat LOG_DECIMAL =
             new DecimalFormat("0.00", DecimalFormatSymbols.getInstance());
     private final NumberFormat LOG_INT = NumberFormat.getIntegerInstance();
@@ -45,19 +45,19 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
     private PathEnumerator pathEnumerator;
 
-    // the best damage enemies could expect were I not here. Used to determine 
+    // the best damage enemies could expect were I not here. Used to determine
     // whether they will target me.
     private Map<Integer, Double> bestDamageByEnemies;
-    
+
     public BasicPathRanker(Princess owningPrincess) {
         super(owningPrincess);
-        
+
         bestDamageByEnemies = new TreeMap<>();
-        
+
         LogManager.getLogger().debug("Using " + getOwner().getBehaviorSettings().getDescription()
                         + " behavior");
     }
-    
+
     FireControl getFireControl(Entity entity) {
         return getOwner().getFireControl(entity);
     }
@@ -65,7 +65,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
     void setPathEnumerator(PathEnumerator pathEnumerator) {
         this.pathEnumerator = pathEnumerator;
     }
-    
+
     PathEnumerator getPathEnumerator() {
         return pathEnumerator;
     }
@@ -125,13 +125,13 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         EntityEvaluationResponse returnResponse =
                 new EntityEvaluationResponse();
 
-        //Airborne aeros on ground maps always move after other units, and would require an 
+        //Airborne aeros on ground maps always move after other units, and would require an
         // entirely different evaluation
         //TODO (low priority) implement a way to see if I can dodge aero units
         if (enemy.isAirborneAeroOnGroundMap()) {
             return returnResponse;
         }
-        
+
         Coords finalCoords = path.getFinalCoords();
         int myFacing = path.getFinalFacing();
         Coords behind = finalCoords.translated((myFacing + 3) % 6);
@@ -143,9 +143,9 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         }
         int range = closest.distance(finalCoords);
 
-        // I would prefer if the enemy must end its move in my line of fire 
-        // if so, I can guess that I may do some damage to it (cover 
-        // notwithstanding).  At the very least, I can force the enemy to 
+        // I would prefer if the enemy must end its move in my line of fire
+        // if so, I can guess that I may do some damage to it (cover
+        // notwithstanding).  At the very least, I can force the enemy to
         // take cover on its move.
         HexLine leftBounds;
         HexLine rightBounds;
@@ -181,9 +181,10 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                     Math.ceil(enemy.getWeight() / 5.0) *
                     damageDiscount);
         }
-        
+
         return returnResponse;
     }
+
 
     @Override
     protected List<TargetRoll> getPSRList(MovePath path) {
@@ -227,13 +228,13 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         if (!losEffects.canSee()) {
             return 0;
         }
-        
+
         Targetable actualTarget = path.getEntity();
-        
-        // if the target is infantry protected by a building, we have to fire at the building instead. 
+
+        // if the target is infantry protected by a building, we have to fire at the building instead.
         if (losEffects.infantryProtected()) {
             actualTarget = new BuildingTarget(targetState.getPosition(), game.getBoard(), false);
-            targetState = new EntityState(actualTarget);            
+            targetState = new EntityState(actualTarget);
         }
 
         int maxHeat = (enemy.getHeatCapacity() - enemy.heat) + (enemy.isAero() ? 0 : 5);
@@ -284,7 +285,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             return 0;
         }
 
-        // If I am an infantry unit that cannot both move and fire, and I am 
+        // If I am an infantry unit that cannot both move and fire, and I am
         // moving, I can't do damage.
         boolean isZeroMpInfantry = me instanceof Infantry && (me.getWalkMP() == 0);
         if (isZeroMpInfantry && path.getMpUsed() > 0) {
@@ -328,7 +329,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         EntityEvaluationResponse returnResponse = new EntityEvaluationResponse();
 
         int distance = enemy.getPosition().distance(path.getFinalCoords());
-        
+
         // How much damage can they do to me?
         double theirDamagePotential = calculateDamagePotential(enemy,
                 new EntityState(enemy), path, new EntityState(path), distance, game);
@@ -341,7 +342,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
         // How much damage can I do to them?
         returnResponse.setMyEstimatedDamage(calculateMyDamagePotential(path, enemy, distance, game));
-       
+
         // How much physical damage can I do to them?
         if (distance <= 1) {
             returnResponse.setMyEstimatedPhysicalDamage(calculateMyKickDamagePotential(path, enemy, game));
@@ -350,7 +351,8 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         return returnResponse;
     }
 
-    // The further I am from a target, the lower this path ranks (weighted by 
+
+    // The further I am from a target, the lower this path ranks (weighted by
     // Hyper Aggression.
     protected double calculateAggressionMod(Entity movingUnit, MovePath path, Game game,
                                             StringBuilder formula) {
@@ -367,7 +369,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         return aggressionMod;
     }
 
-    // The further I am from my teammates, the lower this path ranks (weighted 
+    // The further I am from my teammates, the lower this path ranks (weighted
     // by Herd Mentality).
     protected double calculateHerdingMod(Coords friendsCoords, MovePath path, StringBuilder formula) {
         if (friendsCoords == null) {
@@ -425,8 +427,8 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                                                 MovePath path,
                                                 Game game,
                                                 StringBuilder formula) {
-        BehaviorType behaviorType = getOwner().getUnitBehaviorTracker().getBehaviorType(movingUnit, getOwner()); 
-        
+        BehaviorType behaviorType = getOwner().getUnitBehaviorTracker().getBehaviorType(movingUnit, getOwner());
+
         if (behaviorType == BehaviorType.ForcedWithdrawal ||
                 behaviorType == BehaviorType.MoveToDestination) {
             int newDistanceToHome = distanceToHomeEdge(path.getFinalCoords(),
@@ -434,17 +436,17 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                                                        game);
             double selfPreservation = getOwner().getBehaviorSettings()
                                                 .getSelfPreservationValue();
-            
+
             double selfPreservationMod = 0;
-            
+
             // normally, we favor being closer to the edge we're trying to get to
             if (newDistanceToHome > 0) {
                 selfPreservationMod = newDistanceToHome * selfPreservation;
-            // if this path gets us to the edge, we value it considerably more than we do paths that don't get us there    
+            // if this path gets us to the edge, we value it considerably more than we do paths that don't get us there
             } else {
                 selfPreservationMod = -ARRIVED_AT_DESTINATION_FACTOR;
             }
-            
+
             formula.append(" - selfPreservationMod [")
                    .append(LOG_DECIMAL.format(selfPreservationMod))
                    .append(" = ").append(LOG_DECIMAL.format(newDistanceToHome))
@@ -454,16 +456,17 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         }
         return 0.0;
     }
-    
+
     /**
      * Tells me whether this path will result in me flying to a location
      * from which there is absolutely no way to remain on the board the following turn.
-     * 
+     *
      * Not applicable for ground units, so the default behavior is to return 0.
      */
     protected double calculateOffBoardMod(MovePath path) {
         return 0.0;
     }
+
 
     /**
      * A path ranking
@@ -481,13 +484,13 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         double successProbability = getMovePathSuccessProbability(pathCopy, formula);
         double utility = -calculateFallMod(successProbability, formula);
 
-        // look at all of my enemies          
+        // look at all of my enemies
         FiringPhysicalDamage damageEstimate = new FiringPhysicalDamage();
-        
+
         double expectedDamageTaken = checkPathForHazards(pathCopy, movingUnit, game);
-        
+
         expectedDamageTaken += MinefieldUtil.checkPathForMinefieldHazards(pathCopy);
-        
+
         boolean extremeRange = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE);
         boolean losRange = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE);
         for (Entity enemy : enemies) {
@@ -517,7 +520,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 // For units that have not moved this round
                 eval = evaluateUnmovedEnemy(enemy, path, extremeRange, losRange);
             }
-            
+
             // if we're not ignoring the enemy, we consider damage that we may do to them;
             // however, just because we're ignoring them doesn't mean they won't shoot at us.
             if (!getOwner().getBehaviorSettings().getIgnoredUnitTargets().contains(enemy.getId())) {
@@ -528,7 +531,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                     damageEstimate.physicalDamage = eval.getMyEstimatedPhysicalDamage();
                 }
             }
-            
+
             expectedDamageTaken += eval.getEstimatedEnemyDamage();
         }
 
@@ -536,14 +539,14 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         if (!path.getEntity().isAirborne() && !path.getEntity().isAirborneVTOLorWIGE()) {
             double friendlyArtilleryDamage = 0;
             Map<Coords, Double> artyDamage = getOwner().getPathRankerState().getIncomingFriendlyArtilleryDamage();
-            
+
             if (!artyDamage.containsKey(path.getFinalCoords())) {
                 friendlyArtilleryDamage = ArtilleryTargetingControl.evaluateIncomingArtilleryDamage(path.getFinalCoords(), getOwner());
                 artyDamage.put(path.getFinalCoords(), friendlyArtilleryDamage);
             } else {
                 friendlyArtilleryDamage = artyDamage.get(path.getFinalCoords());
             }
-            
+
             expectedDamageTaken += friendlyArtilleryDamage;
         }
 
@@ -556,12 +559,12 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             damageEstimate.physicalDamage = 0;
         }
 
-        // I can kick a different target than I shoot, so add physical to 
+        // I can kick a different target than I shoot, so add physical to
         // total damage after I've looked at all enemies
         double maximumDamageDone = damageEstimate.firingDamage + damageEstimate.physicalDamage;
 
-        // My bravery modifier is based on my chance of getting to the 
-        // firing position (successProbability), how much damage I can do 
+        // My bravery modifier is based on my chance of getting to the
+        // firing position (successProbability), how much damage I can do
         // (weighted by bravery), less the damage I might take.
         double braveryValue = getOwner().getBehaviorSettings().getBraveryValue();
         double braveryMod = successProbability * ((maximumDamageDone * braveryValue) - expectedDamageTaken);
@@ -577,11 +580,11 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         // the only critters not subject to aggression and herding mods are
         // airborne aeros on ground maps, as they move incredibly fast
         if (!path.getEntity().isAirborneAeroOnGroundMap()) {
-            // The further I am from a target, the lower this path ranks 
+            // The further I am from a target, the lower this path ranks
             // (weighted by Aggression slider).
             utility -= calculateAggressionMod(movingUnit, pathCopy, game, formula);
 
-            // The further I am from my teammates, the lower this path 
+            // The further I am from my teammates, the lower this path
             // ranks (weighted by Herd Mentality).
             utility -= calculateHerdingMod(friendsCoords, pathCopy, formula);
         }
@@ -592,10 +595,10 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             return new RankedPath(facingMod, pathCopy, formula.toString());
         }
         utility -= facingMod;
-        
+
         // If I need to flee the board, I want to get closer to my home edge.
         utility -= calculateSelfPreservationMod(movingUnit, pathCopy, game, formula);
-        
+
         // if we're an aircraft, we want to de-value paths that will force us off the board
         // on the subsequent turn.
         utility -= utility * calculateOffBoardMod(pathCopy);
@@ -604,7 +607,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         rankedPath.setExpectedDamage(maximumDamageDone);
         return rankedPath;
     }
-    
+
     /**
      * Worker function that determines if a given enemy entity should be evaluated as if it has moved.
      */
@@ -613,7 +616,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         // somewhat pointless to try to predict their movement.
         return !enemy.isSelectableThisTurn() || enemy.isImmobile() || enemy.isAirborneAeroOnGroundMap();
     }
-    
+
     /**
      * Calculate who all other units would shoot at if I weren't around
      */
@@ -645,15 +648,15 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
     protected void calcDamageToStrategicTargets(MovePath path, Game game,
             FireControlState fireControlState, FiringPhysicalDamage damageStructure) {
-                
+
         for (int i = 0; i < fireControlState.getAdditionalTargets().size(); i++) {
             Targetable target = fireControlState.getAdditionalTargets().get(i);
-            
+
             if (target.isOffBoard() || (target.getPosition() == null)
                     || !game.getBoard().contains(target.getPosition())) {
                 continue; // Skip targets not actually on the board.
             }
-            
+
             FiringPlanCalculationParameters guess =
                     new FiringPlanCalculationParameters.Builder()
                             .buildGuess(path.getEntity(),
@@ -663,12 +666,12 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                                         Entity.DOES_NOT_TRACK_HEAT,
                                         null);
             FiringPlan myFiringPlan = getFireControl(path.getEntity()).determineBestFiringPlan(guess);
-            
+
             double myDamagePotential = myFiringPlan.getUtility();
             if (myDamagePotential > damageStructure.firingDamage) {
                 damageStructure.firingDamage = myDamagePotential;
             }
-            
+
             if (path.getEntity() instanceof Mech) {
                 PhysicalInfo myKick = new PhysicalInfo(
                         path.getEntity(), new EntityState(path), target,
@@ -684,7 +687,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             }
         }
     }
-    
+
     /**
      * Gives the distance to the closest enemy unit, or -1 if none exist.
      * The reason being that the closest enemy unit may be 0 away.
@@ -720,6 +723,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         }
         return minimum;
     }
+
 
     double checkPathForHazards(MovePath path, Entity movingUnit, Game game) {
         StringBuilder logMsg = new StringBuilder("Checking Path (")
@@ -829,13 +833,13 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                     break;
             }
         }
-        
+
         logMsg.append("\n\tTotal Hazard = ")
               .append(LOG_DECIMAL.format(hazardValue));
 
         return hazardValue;
     }
-    
+
     // Building collapse and basements are handled in PathRanker.validatePaths.
     private double calcBuildingHazard(MoveStep step, Entity movingUnit, boolean jumpLanding,
                                       Board board, StringBuilder logMsg) {
@@ -869,11 +873,11 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
               .append(LOG_DECIMAL.format(hazard)).append(").");
         return hazard;
     }
-    
+
     private double calcBridgeHazard(Entity movingUnit, Hex hex, MoveStep step, boolean jumpLanding,
                                     Board board, StringBuilder logMsg) {
         logMsg.append("\n\tCalculating bridge hazard:  ");
-        
+
         // if we are going to BWONGGG into a bridge from below, then it's treated as a building.
         // Otherwise, bridge collapse checks have already been handled in validatePaths
         int bridgeElevation = hex.terrainLevel(Terrains.BRIDGE_ELEV);
@@ -881,7 +885,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 (bridgeElevation <= (step.getElevation() + movingUnit.getHeight()))) {
             return calcBuildingHazard(step, movingUnit, jumpLanding, board, logMsg);
         }
-        
+
         return 0;
     }
 
@@ -896,7 +900,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
             return 0;
         }
 
-        // If there is no water under the ice, don't worry about breaking 
+        // If there is no water under the ice, don't worry about breaking
         // through.
         if (hex.depth() < 1) {
             logMsg.append("No water under ice (0).");
@@ -912,7 +916,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                         breakthroughMod;
         logMsg.append("\n\t\tHazard value (")
               .append(LOG_DECIMAL.format(hazard)).append(").");
-        return hazard;
+        return UNIT_DESTRUCTION_FACTOR;
     }
 
     private double calcWaterHazard(Entity movingUnit, Hex hex, MoveStep step, MovePath movePath,
@@ -950,7 +954,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 return 0;
             }
         }
-        
+
         // Most other units are automatically destroyed.
         if (!(movingUnit instanceof Mech || movingUnit instanceof Protomech ||
               movingUnit instanceof BattleArmor)) {
@@ -1008,7 +1012,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
                 continue;
             }
 
-            // Mechs or Protomechs having a head or torso breach is deadly.  
+            // Mechs or Protomechs having a head or torso breach is deadly.
             // For other units, any breach is deadly.
             //noinspection ConstantConditions
             if (Mech.LOC_HEAD == loc ||
@@ -1158,7 +1162,7 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
 
         return hazardValue;
     }
-    
+
     /**
      * Simple data structure that holds a separate firing and physical damage number.
      *


### PR DESCRIPTION
Ice Fix: This PR changes one line of code to give Princess some Cryophobia in her movement planning.  Currently, On a map with approximately 50/50 Ice/Land, she would jump and walk mechs onto the ice every turn, and lose many to Ice before she ever got to  and during combat.  With this change she jumped mechs into the ice Zero times in 10 games.  And she will still walk on the ice when forced because she is landlocked.  Otherwise she will take a land path around.  

So in summary, it strongly discourages her from using ice as a path, but does not prevent it when necessary.

I simply changed a calculated hazard value (which has never been enough) to UNIT_DESTRUCTION_FACTOR and that solved it.  

I tested it over 10 bot v bot games and could see no drawbacks.  A sample savegame is attached below.

[ICET1.sav.gz](https://github.com/MegaMek/megamek/files/13890784/ICET1.sav.gz)

I attach a screen below that show a patch over ice that Locusts would still take when they deployed landlocked.  So it doesnt prevent use of ice entirely.

![Screenshot 2024-01-10 101852](https://github.com/MegaMek/megamek/assets/23645569/3644b975-aec4-4a05-9197-c24d9a33469c)


