### PR TITLE
Add clan CASE in postLoadInit for explosive secondary locations

### DIFF
--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -2730,7 +2730,8 @@ public abstract class Mech extends Entity {
         for (int i = 0; i < locations(); i++) {
             explosiveFound = false;
             for (Mounted m : getEquipment()) {
-                if (m.getType().isExplosive(m, true) && (m.getLocation() == i)) {
+                if (m.getType().isExplosive(m, true)
+                        && ((m.getLocation() == i) || (m.getSecondLocation() == i))) {
                     explosiveFound = true;
                 }
             }


### PR DESCRIPTION
Secondary locations for explosive stuff were not considered when adding clan CASE to units in postLoadInit

Fixes #5033