### PR TITLE
correct issue with life support abbreviation in unit tooltip

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -484,7 +484,7 @@ public final class UnitToolTip {
                     case Mech.LOC_RT:
                     case Mech.LOC_LT:
                         col3 = sysCrits(entity, CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_ENGINE, loc, msg_abbr_engine).toString();
-                        col3 += sysCrits(entity, CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT, loc, msg_abbr_gyro).toString();
+                        col3 += sysCrits(entity, CriticalSlot.TYPE_SYSTEM, Mech.SYSTEM_LIFE_SUPPORT, loc, msg_abbr_lifesupport).toString();
                         break;
                     case Mech.LOC_RARM:
                     case Mech.LOC_LARM:


### PR DESCRIPTION
- correct issue with life support abbreviation in unit tooltip