### PR TITLE
1021 Automatic Ctrl-Backspace on Evade for Aero

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -5090,6 +5090,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 ready();
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_EVADE_AERO.getCmd())) {
+            removeIllegalSteps();
             addStepToMovePath(MoveStepType.EVADE);
             setEvadeAeroEnabled(false);
         } else if (actionCmd.equals(MoveCommand.MOVE_ROLL.getCmd())) {

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -47,6 +47,7 @@ public class KeyBindingsOverlay extends AbstractBoardViewOverlay {
     private static final List<KeyCommandBind> BINDS_MOVE = Arrays.asList(
             KeyCommandBind.TOGGLE_MOVEMODE,
             KeyCommandBind.UNDO_LAST_STEP,
+            KeyCommandBind.UNDO_ILLEGAL_STEPS,
             KeyCommandBind.TOGGLE_CONVERSIONMODE,
             KeyCommandBind.DONE_NO_ACTION
     );


### PR DESCRIPTION
This is a full fix for #1021.  The previous functionality added the Ctrl-Backspace key to undo all illegal steps.  This fix automatically does the Ctrl-Backspace when the 'EVADE' button is presses so that the EVADE is applied to the last legal step.  This is the full intent of #1021.

Also added the keyboard short cut to the Movement Phase Keyboard Shortcut panel to provide awareness.

- Automatically undo aero overshoot when the Evade button is pressed.
- Add Ctrl-Backspace to Movement Phase keyboard shortcut panel.