### PR TITLE
Infantry Weight Breakdown 

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/WeightDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/WeightDisplayDialog.java
@@ -1,0 +1,91 @@
+package megamek.client.ui.dialogs;
+
+import megamek.client.ui.baseComponents.AbstractDialog;
+import megamek.client.ui.swing.calculationReport.FlexibleCalculationReport;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.Entity;
+import megamek.common.Infantry;
+import megamek.common.verifier.TestEntity;
+import megamek.common.verifier.TestInfantry;
+
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import javax.swing.text.DefaultCaret;
+import java.awt.*;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.util.Objects;
+
+public class WeightDisplayDialog extends AbstractDialog {
+
+    private final Entity entity;
+
+    public WeightDisplayDialog(final JFrame frame, final Entity entity) {
+        this(frame, false, entity);
+    }
+
+    public WeightDisplayDialog(final JFrame frame, final boolean modal, final Entity entity) {
+        super(frame, modal, "BVDisplayDialog", "BVDisplayDialog.title");
+        this.entity = Objects.requireNonNull(entity);
+        initialize();
+    }
+
+    @Override
+    protected void finalizeInitialization() throws Exception {
+        super.finalizeInitialization();
+        setTitle(getTitle() + " (" + entity.getShortName() + ")");
+        adaptToGUIScale();
+        pack();
+        Dimension screenSize = UIUtil.getScaledScreenSize(this);
+        setSize(new Dimension(getSize().width, Math.min(getHeight(), (int) (screenSize.getHeight() * 0.8))));
+    }
+
+    public Entity getEntity() {
+        return entity;
+    }
+
+    @Override
+    protected Container createCenterPane() {
+        var scrollPane = new JScrollPane(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
+                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
+        String textReport;
+        if (entity.isConventionalInfantry()) {
+            FlexibleCalculationReport weightReport = new FlexibleCalculationReport();
+            TestInfantry.getWeightExact((Infantry) entity, weightReport);
+            scrollPane.setViewportView(weightReport.toJComponent());
+            textReport = weightReport.getTextReport().toString();
+        } else {
+            TestEntity testEntity = TestEntity.getEntityVerifier(entity);
+            textReport = testEntity.printEntity().toString();
+            JTextPane textPane = new JTextPane();
+            textPane.setText(textReport);
+            textPane.setEditable(false);
+            textPane.setCaret(new DefaultCaret());
+            scrollPane.setViewportView(textPane);
+        }
+
+        JButton exportText = new JButton("Copy as Text");
+        exportText.addActionListener(evt -> copyToClipboard(textReport));
+
+        scrollPane.getVerticalScrollBar().setUnitIncrement(16);
+        scrollPane.setBorder(new EmptyBorder(10, 0, 0, 0));
+
+        Box centerPanel = Box.createVerticalBox();
+        centerPanel.setBorder(new EmptyBorder(25, 15, 25, 15));
+        JPanel buttonPanel = new UIUtil.FixedYPanel(new FlowLayout(FlowLayout.LEFT));
+
+        buttonPanel.add(exportText);
+        centerPanel.add(buttonPanel);
+        centerPanel.add(scrollPane);
+        return centerPanel;
+    }
+
+    private void copyToClipboard(String reportString) {
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(new StringSelection(reportString), null);
+    }
+
+    private void adaptToGUIScale() {
+        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
+    }
+}

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -26,6 +26,7 @@ import megamek.common.cost.InfantryCostCalculator;
 import megamek.common.enums.AimingMode;
 import megamek.common.enums.GamePhase;
 import megamek.common.options.OptionsConstants;
+import megamek.common.verifier.TestInfantry;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import org.apache.logging.log4j.LogManager;
 
@@ -1693,64 +1694,7 @@ public class Infantry extends Entity {
 
     @Override
     public double getWeight() {
-        if (mount != null) {
-            if (mount.getSize().troopsPerCreature > 1) {
-                return (mount.getWeight() + 0.2 * getSquadSize()) * getSquadCount();
-            } else {
-                return (mount.getWeight() + 0.2) * activeTroopers;
-            }
-        }
-        double mult;
-        switch (getMovementMode()) {
-            case INF_MOTORIZED:
-                mult = 0.195;
-                break;
-            case HOVER:
-            case TRACKED:
-            case WHEELED:
-                mult = 1.0;
-                break;
-            case VTOL:
-                mult = hasMicrolite() ? 1.4 : 1.9;
-                break;
-            case INF_JUMP:
-                mult = 0.165;
-                break;
-            case INF_UMU:
-                if (getActiveUMUCount() > 1) {
-                    mult = 0.295; // motorized + 0.1 for motorized scuba
-                } else {
-                    mult = 0.135; // foot + 0.05 for scuba
-                }
-                break;
-            case SUBMARINE:
-                mult = 0.9;
-                break;
-            case INF_LEG:
-            default:
-                mult = 0.085;
-        }
-
-        if (hasSpecialization(COMBAT_ENGINEERS)) {
-            mult += 0.1;
-        }
-
-        if (hasSpecialization(PARATROOPS)) {
-            mult += 0.05;
-        }
-
-        if (hasSpecialization(PARAMEDICS)) {
-            mult += 0.05;
-        }
-
-        if (isAntiMekTrained()) {
-            mult +=.015;
-        }
-
-        double ton = activeTroopers * mult;
-        ton += activeFieldWeapons().stream().mapToDouble(Mounted::getTonnage).sum();
-        ton += getAmmo().stream().mapToDouble(Mounted::getTonnage).sum();
-        return RoundWeight.nearestHalfTon(ton);
+        return TestInfantry.getWeight(this);
     }
 
     public String getArmorDesc() {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -19,6 +19,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.enums.MPBoosters;
 import megamek.common.util.StringUtil;
 
+import java.io.File;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.function.Predicate;
@@ -82,6 +83,37 @@ public abstract class TestEntity implements TestEntityOption {
     public abstract String getName();
 
     public String fileString = null; // where the unit came from
+
+    /**
+     * @param unit The entity the supplied entity
+     * @return a TestEntity instance for the supplied Entity.
+     */
+    public static TestEntity getEntityVerifier(Entity unit) {
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+                "data/mechfiles/UnitVerifierOptions.xml")); // TODO : Remove inline file path
+        TestEntity testEntity = null;
+
+        if (unit.hasETypeFlag(Entity.ETYPE_MECH)) {
+            testEntity = new TestMech((Mech) unit, entityVerifier.mechOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_PROTOMECH)) {
+            testEntity = new TestProtomech((Protomech) unit, entityVerifier.protomechOption, null);
+        } else if (unit.isSupportVehicle()) {
+            testEntity = new TestSupportVehicle(unit, entityVerifier.tankOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_TANK)) {
+            testEntity = new TestTank((Tank) unit, entityVerifier.tankOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
+            testEntity = new TestSmallCraft((SmallCraft) unit, entityVerifier.aeroOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            testEntity = new TestAdvancedAerospace((Jumpship) unit, entityVerifier.aeroOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_AERO)) {
+            testEntity = new TestAero((Aero) unit, entityVerifier.aeroOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_BATTLEARMOR)) {
+            testEntity = new TestBattleArmor((BattleArmor) unit, entityVerifier.baOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
+            testEntity = new TestInfantry((Infantry)unit, entityVerifier.infOption, null);
+        }
+        return testEntity;
+    }
 
     public TestEntity(TestEntityOption options, Engine engine, Armor[] armor,
             Structure structure) {


### PR DESCRIPTION
This PR:
- moves infantry weight calculation to TestInfantry 
- adds a report for weight calculation and updates TestInfantry to show the weight calculation when asked
- adds a specialized weight display dialog
- adds the getEntityVerifier() static method from MML's UnitUtil to TestEntity. It can later be removed in MML