### PR TITLE
Aero movement envelope and acc/dec next optimizations.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -5030,6 +5030,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     && !(((IAero) ce).isSpheroid() || clientgui.getClient()
                     .getGame().getPlanetaryConditions().isVacuum())) {
                 addStepToMovePath(MoveStepType.ACC, true);
+                computeAeroMovementEnvelope(ce);
             }
             addStepToMovePath(MoveStepType.DOWN);
         } else if (actionCmd.equals(MoveCommand.MOVE_CLIMB_MODE.getCmd())) {
@@ -5098,8 +5099,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
             cmd.compile(clientgui.getClient().getGame(), ce, false);
             updateMove();
         } else if (actionCmd.equals(MoveCommand.MOVE_ACCN.getCmd())) {
+            removeIllegalSteps();
             addStepToMovePath(MoveStepType.ACCN);
         } else if (actionCmd.equals(MoveCommand.MOVE_DECN.getCmd())) {
+            removeIllegalSteps();
             addStepToMovePath(MoveStepType.DECN);
         } else if (actionCmd.equals(MoveCommand.MOVE_ACC.getCmd())) {
             addStepToMovePath(MoveStepType.ACC);


### PR DESCRIPTION
Fixes #5064 
Fixes #5065 

This PR refreshes the Aerospace movement envelope in the movement phase when the unit gains a free velocity by going down in elevations.

This PR also adds an optimization to automatically roll back illegal moves when doing an Accelerate Next or Decelerate Next to remove any illegal move steps before applying the acceleration similar to the EVADE optimization that was done previously.