### PR TITLE
Enhance backspace key to rollback illegal moves if they exist.

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1903,8 +1903,8 @@ KeyBinds.cmdNames.replacePlayer=Replace Player
 KeyBinds.cmdDesc.replacePlayer=Replace a faction in a game with a human or bot player
 KeyBinds.cmdNames.sensorRange=Visual & Sensor Ranges
 KeyBinds.cmdDesc.sensorRange=Turns the Visual & Sensor Ranges rings on and off
-KeyBinds.cmdNames.undoIllegalSteps=Undo Illegal Steps
-KeyBinds.cmdDesc.undoIllegalSteps=Undo all illegal move steps in movement phase
+KeyBinds.cmdNames.undoSingleStep=Undo Single Step
+KeyBinds.cmdDesc.undoSingleStep=Undo single step in movement phase
 
 #Key Bindings Overlay
 KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -470,7 +470,7 @@
     </KeyBind>
 
     <KeyBind>
-         <command>undoIllegalSteps</command> <!-- Ctrl+BackSpace -->
+         <command>undoSingleStep</command> <!-- Ctrl+BackSpace -->
         <keyCode>8</keyCode>      
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -473,7 +473,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
                     @Override
                     public void performAction() {
-                        removeLastStep();
+                        // Remove all illegal steps, if none, then do normal backspace function.
+                        if (!removeIllegalSteps()) {
+                            removeLastStep();
+                        }
+
                         if (ce() instanceof Aero) {
                             computeAeroMovementEnvelope(ce());
                         } else {
@@ -483,7 +487,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 });
 
         // Register the action for UNDO_ILLEGAL_STEPS
-        controller.registerCommandAction(KeyCommandBind.UNDO_ILLEGAL_STEPS.cmd,
+        controller.registerCommandAction(KeyCommandBind.UNDO_SINGLE_STEP.cmd,
                 new CommandAction() {
                     @Override
                     public boolean shouldPerformAction() {
@@ -495,7 +499,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
                     @Override
                     public void performAction() {
-                        removeIllegalSteps();
+                        removeLastStep();
                         if (ce() instanceof Aero) {
                             computeAeroMovementEnvelope(ce());
                         } else {
@@ -1456,18 +1460,23 @@ public class MovementDisplay extends ActionPhaseDisplay {
     /**
      * Removes all the trailing illegal movement steps and the end of the current entities movement path.
      * (This is helpful for Aero movement, overshooting MP and wanting to evade etc.)
+     *
+     * @return - Returns true if the call removed any illegal steps otherwise returns false.
      */
-    private void removeIllegalSteps() {
+    private boolean removeIllegalSteps() {
         if (cmd == null) {
-            return;
+            return false;
         }
+
+        boolean removed = false;
 
         // Keep removing last step until it's a valid movement step.
-        while ((cmd.getLastStepMovementType() != null) && (cmd.getLastStepMovementType() == EntityMovementType.MOVE_ILLEGAL)) {
+        while (cmd.getLastStepMovementType() == EntityMovementType.MOVE_ILLEGAL) {
             removeLastStep();
+            removed = true;
         }
 
-        return;
+        return removed;
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/KeyBindingsOverlay.java
@@ -47,7 +47,6 @@ public class KeyBindingsOverlay extends AbstractBoardViewOverlay {
     private static final List<KeyCommandBind> BINDS_MOVE = Arrays.asList(
             KeyCommandBind.TOGGLE_MOVEMODE,
             KeyCommandBind.UNDO_LAST_STEP,
-            KeyCommandBind.UNDO_ILLEGAL_STEPS,
             KeyCommandBind.TOGGLE_CONVERSIONMODE,
             KeyCommandBind.DONE_NO_ACTION
     );

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -118,7 +118,7 @@ public enum KeyCommandBind {
     REPLACE_PLAYER(true, "replacePlayer", VK_R, CTRL_DOWN_MASK | SHIFT_DOWN_MASK),
     MOD_ENVELOPE(true, "viewModEnvelope", VK_W, CTRL_DOWN_MASK),
     SENSOR_RANGE(true, "sensorRange", VK_C),
-    UNDO_ILLEGAL_STEPS("undoIllegalSteps", VK_BACK_SPACE, CTRL_DOWN_MASK),
+    UNDO_SINGLE_STEP("undoSingleStep", VK_BACK_SPACE, CTRL_DOWN_MASK),
     FORCE_DISPLAY(true, "toggleForceDisplay", VK_F, CTRL_DOWN_MASK);
 
     /** The command associated with this binding. */


### PR DESCRIPTION
Fixes #5067 

This PR implements the Backspace key enhancements that automatically removes all illegal move steps in the movement phase if illegal moves exist.  If the last step is a legal move, it operates as the Backspace key normally would operate.

Ctrl-Backspace which was recently added to "Undo all illegal steps" has been changed to "Undo Single Step" which preserves the legacy backspace functionality if needed.  (i.e.  enables single backstep of illegal moves.)

Additionally, the Ctrl-Backspace shortcut was removed from the shortcut overlay panel to remove clutter as this will not be a commonly used, special case key binding.  (The Ctrl-Backspace shown in the View->Client Settings->Key Binds settings dialog and is configurable.)