### PR TITLE
CI Anti-Mek Gear

### DIFF
--- a/megamek/src/megamek/client/generator/skillGenerators/AbstractSkillGenerator.java
+++ b/megamek/src/megamek/client/generator/skillGenerators/AbstractSkillGenerator.java
@@ -144,7 +144,7 @@ public abstract class AbstractSkillGenerator implements Serializable {
         // based on whether the unit has anti-mek training, which gets set in the BLK file.
         // We therefore check if they are anti-mek trained before setting
         if (entity.isConventionalInfantry() && !((Infantry) entity).hasAntiMekGear()) {
-            skills[1] = Infantry.ANTI_MECH_SKILL_UNTRAINED;
+            skills[1] = Infantry.ANTI_MECH_SKILL_NO_GEAR;
         } else if (isForceClose()) {
             skills[1] = skills[0] + 1;
         }

--- a/megamek/src/megamek/client/generator/skillGenerators/AbstractSkillGenerator.java
+++ b/megamek/src/megamek/client/generator/skillGenerators/AbstractSkillGenerator.java
@@ -143,7 +143,7 @@ public abstract class AbstractSkillGenerator implements Serializable {
         // For conventional infantry, piloting doubles as anti-mek skill, and this is set
         // based on whether the unit has anti-mek training, which gets set in the BLK file.
         // We therefore check if they are anti-mek trained before setting
-        if (entity.isConventionalInfantry() && !((Infantry) entity).isAntiMekTrained()) {
+        if (entity.isConventionalInfantry() && !((Infantry) entity).hasAntiMekGear()) {
             skills[1] = Infantry.ANTI_MECH_SKILL_UNTRAINED;
         } else if (isForceClose()) {
             skills[1] = skills[0] + 1;

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -700,7 +700,15 @@ public class EquipmentType implements ITechnology {
         namesVector.addElement(s); // member variable
     }
 
-    public static EquipmentType get(String key) {
+    /**
+     * Returns an EquipmentType having the given internal name or lookup name (but not the "name" which
+     * is the display text unless it's equal to the internal name). Internal names may be taken from
+     * {@link EquipmentTypeLookup}. Returns null if there is none with that name.
+     *
+     * @param key The internal name or lookup name
+     * @return The EquipmentType with the given internal name or lookup name
+     */
+    public static @Nullable EquipmentType get(String key) {
         if (null == EquipmentType.lookupHash) {
             EquipmentType.initializeTypes();
         }

--- a/megamek/src/megamek/common/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/EquipmentTypeLookup.java
@@ -122,6 +122,7 @@ public class EquipmentTypeLookup {
     @EquipmentName public static final String DEMOLITION_CHARGE = "Demolition Charge";
     @EquipmentName public static final String INFANTRY_AMMO = "Infantry Ammo";
     @EquipmentName public static final String INFANTRY_INFERNO_AMMO = "Infantry Inferno Ammo";
+    @EquipmentName public static final String ANTI_MEK_GEAR = "AntiMekGear";
 
     @EquipmentName public static final String AC_BAY = "AC Bay";
     @EquipmentName public static final String AMS_BAY = "AMS Bay";

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -296,15 +296,6 @@ public class Infantry extends Entity {
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED);
     }
 
-    public static TechAdvancement getAntiMekTA() {
-        return new TechAdvancement(TECH_BASE_ALL)
-                .setAdvancement(2456, 2460, 2500).setApproximate(true, false, false)
-                .setPrototypeFactions(F_LC).setProductionFactions(F_LC)
-                .setTechRating(RATING_D)
-                .setAvailability(RATING_D, RATING_D, RATING_D, RATING_D)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD);
-    }
-
     @Override
     protected void addSystemTechAdvancement(CompositeTechLevel ctl) {
         super.addSystemTechAdvancement(ctl);
@@ -326,9 +317,6 @@ public class Infantry extends Entity {
         }
         if (hasSpecialization(TAG_TROOPS)) {
             ctl.addComponent(Infantry.getTAGTroopsTA());
-        }
-        if (isAntiMekTrained()) {
-            ctl.addComponent(Infantry.getAntiMekTA());
         }
     }
 
@@ -956,7 +944,7 @@ public class Infantry extends Entity {
         double priceMultiplier = 1.0;
 
         // Anti-Mek Trained Multiplier
-        if (isAntiMekTrained()) {
+        if (hasAntiMekGear()) {
             priceMultiplier *= 5.0;
         }
 
@@ -1219,17 +1207,13 @@ public class Infantry extends Entity {
     }
 
     /**
-     * Returns true if this unit has anti-mek training.  According to TM pg 155,
-     * any unit that has less than 8 anti-mek skill is assumed to have anti-mek
-     * training.  This implies that the unit carries the requisite equipment for
-     * properly performing anti-mek attacks (and the weight and cost that goes
-     * along with that).
-     * @return True when this infantry is Anti-Mek trained
+     * Returns true if this unit carries anti-mek gear. Only with this gear can it improve
+     * its anti-mek skill below 8.
+     *
+     * @return True when this infantry carries anti-mek gear
      */
-    public boolean isAntiMekTrained() {
-        // Anything below the antimech skill default is considered to be AM
-        // trained.  See TM pg 155
-        return getAntiMekSkill() < ANTI_MECH_SKILL_UNTRAINED;
+    public boolean hasAntiMekGear() {
+        return hasWorkingMisc(EquipmentTypeLookup.ANTI_MEK_GEAR);
     }
 
     public boolean isMechanized() {

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -132,9 +132,7 @@ public class Infantry extends Entity {
     public static final String SWARM_WEAPON_MEK = "SwarmWeaponMek";
     public static final String STOP_SWARM = "StopSwarm";
 
-    public static final int ANTI_MECH_SKILL_UNTRAINED = 8;
-    public static final int ANTI_MECH_SKILL_FOOT = 5;
-    public static final int ANTI_MECH_SKILL_JUMP = 6;
+    public static final int ANTI_MECH_SKILL_NO_GEAR = 8;
 
     @Override
     public String[] getLocationAbbrs() {
@@ -1155,44 +1153,10 @@ public class Infantry extends Entity {
      *
      * @param transportID The entity ID of the transporter
      */
-    public void setTransportID(int transportID) {
+    @Override
+    public void setTransportId(int transportID) {
         super.setTransportId(transportID);
         setDugIn(DUG_IN_NONE);
-    }
-
-    /**
-     * Convenience method for setting the anti-mek skill of the unit based on
-     * whether or not they have anti-mek training.  If the input is false, the
-     * anti-mek skill is set to the default untrained value, otherwise it's
-     * set to the default value based on motive type.
-     *
-     * @param amTraining True when the platoon is anti-mek trained
-     */
-    public void setAntiMekSkill(boolean amTraining) {
-        if (getCrew() == null) {
-            return;
-        }
-        if (amTraining) {
-            if ((getMovementMode().isMotorizedInfantry()) || getMovementMode().isJumpInfantry()) {
-                getCrew().setPiloting(ANTI_MECH_SKILL_JUMP, 0);
-            } else {
-                getCrew().setPiloting(ANTI_MECH_SKILL_FOOT, 0);
-            }
-        } else {
-            getCrew().setPiloting(ANTI_MECH_SKILL_UNTRAINED, 0);
-        }
-    }
-
-    /**
-     * Set the anti-mek skill for this unit.  Since Infantry don't have piloting
-     * the crew's piloting skill is treated as the anti-mek skill.  This is
-     * largely just a convenience method for setting the Crew's piloting skill.
-     * @param amSkill The new Anti-Mek skill
-     */
-    public void setAntiMekSkill(int amSkill) {
-        if (getCrew() != null) {
-            getCrew().setPiloting(amSkill, 0);
-        }
     }
 
     /**
@@ -1202,8 +1166,9 @@ public class Infantry extends Entity {
      * skill.
      * @return The Anti-Mek skill
      */
+    @SuppressWarnings("unused") // used in MHQ
     public int getAntiMekSkill() {
-        return (getCrew() == null) ? ANTI_MECH_SKILL_UNTRAINED : getCrew().getPiloting();
+        return (getCrew() == null) ? (hasAntiMekGear() ? 5 : ANTI_MECH_SKILL_NO_GEAR) : getCrew().getPiloting();
     }
 
     /**
@@ -1231,7 +1196,7 @@ public class Infantry extends Entity {
     }
 
     public EquipmentType getArmorKit() {
-        return getEquipment().stream()
+        return getMisc().stream()
                 .filter(m -> m.getType().hasFlag(MiscType.F_ARMOR_KIT))
                 .findFirst().map(Mounted::getType).orElse(null);
     }

--- a/megamek/src/megamek/common/MechFileParser.java
+++ b/megamek/src/megamek/common/MechFileParser.java
@@ -17,6 +17,7 @@ package megamek.common;
 import megamek.common.loaders.*;
 import megamek.common.util.BuildingBlock;
 import megamek.common.util.fileUtils.MegaMekFile;
+import megamek.common.verifier.TestInfantry;
 import megamek.common.weapons.ppc.*;
 import org.apache.logging.log4j.LogManager;
 
@@ -733,25 +734,8 @@ public class MechFileParser {
             }
         }
         // physical attacks for conventional infantry
-        else if ((ent instanceof Infantry) && ((Infantry) ent).canMakeAntiMekAttacks()) {
-            try {
-                InfantryMount mount = ((Infantry) ent).getMount();
-                if ((mount == null) || mount.getSize().canMakeSwarmAttacks) {
-                    ent.addEquipment(EquipmentType.get(Infantry.SWARM_MEK),
-                            Infantry.LOC_INFANTRY, false,
-                            BattleArmor.MOUNT_LOC_NONE, false);
-                    ent.addEquipment(EquipmentType.get(Infantry.STOP_SWARM),
-                            Infantry.LOC_INFANTRY, false,
-                            BattleArmor.MOUNT_LOC_NONE, false);
-                }
-                if ((mount == null) || mount.getSize().canMakeLegAttacks) {
-                    ent.addEquipment(EquipmentType.get(Infantry.LEG_ATTACK),
-                            Infantry.LOC_INFANTRY, false,
-                            BattleArmor.MOUNT_LOC_NONE, false);
-                }
-            } catch (LocationFullException ex) {
-                throw new EntityLoadingException(ex.getMessage());
-            }
+        else if (ent instanceof Infantry) {
+            TestInfantry.adaptAntiMekAttacks((Infantry) ent);
         }
 
         // Check if it's canon; if it is, mark it as such.

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -17,6 +17,7 @@ package megamek.common;
 import java.math.BigInteger;
 import java.text.NumberFormat;
 
+import megamek.common.miscGear.AntiMekGear;
 import megamek.common.weapons.ppc.CLERPPC;
 import megamek.common.weapons.ppc.ISERPPC;
 import megamek.common.weapons.ppc.ISHeavyPPC;
@@ -1834,6 +1835,7 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createClanLamellorFerroCarbideArmor());
 
         // Infantry Equipment Packs
+        EquipmentType.addType(new AntiMekGear());
         EquipmentType.addType(MiscType.createISAblativeStandardInfArmor());
         EquipmentType.addType(MiscType.createISAblativeConcealedInfArmor());
         EquipmentType.addType(MiscType.createISAblativeFlakStandardArmorInfArmor());

--- a/megamek/src/megamek/common/battlevalue/BVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BVCalculator.java
@@ -1177,7 +1177,7 @@ public abstract class BVCalculator {
     public static double bvMultiplier(Entity entity, List<String> pilotModifiers) {
         if (entity.getCrew() == null) {
             if (entity.isConventionalInfantry() && !((Infantry) entity).hasAntiMekGear()) {
-                return bvSkillMultiplier(4, 8);
+                return bvSkillMultiplier(4, Infantry.ANTI_MECH_SKILL_NO_GEAR);
             } else {
                 return bvSkillMultiplier(4, 5);
             }
@@ -1189,7 +1189,7 @@ public abstract class BVCalculator {
                 || (entity instanceof Protomech)) {
             piloting = 5;
         } else if (entity.isConventionalInfantry() && !((Infantry) entity).hasAntiMekGear()) {
-            piloting = 8;
+            piloting = Infantry.ANTI_MECH_SKILL_NO_GEAR;
         } else if (entity.getCrew() instanceof LAMPilot) {
             LAMPilot lamPilot = (LAMPilot) entity.getCrew();
             gunnery = (lamPilot.getGunneryMech() + lamPilot.getGunneryAero()) / 2;

--- a/megamek/src/megamek/common/battlevalue/BVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BVCalculator.java
@@ -1176,7 +1176,11 @@ public abstract class BVCalculator {
      */
     public static double bvMultiplier(Entity entity, List<String> pilotModifiers) {
         if (entity.getCrew() == null) {
-            return 1;
+            if (entity.isConventionalInfantry() && !((Infantry) entity).hasAntiMekGear()) {
+                return bvSkillMultiplier(4, 8);
+            } else {
+                return bvSkillMultiplier(4, 5);
+            }
         }
         int gunnery = entity.getCrew().getGunnery();
         int piloting = entity.getCrew().getPiloting();
@@ -1184,6 +1188,8 @@ public abstract class BVCalculator {
         if (((entity instanceof Infantry) && (!((Infantry) entity).canMakeAntiMekAttacks()))
                 || (entity instanceof Protomech)) {
             piloting = 5;
+        } else if (entity.isConventionalInfantry() && !((Infantry) entity).hasAntiMekGear()) {
+            piloting = 8;
         } else if (entity.getCrew() instanceof LAMPilot) {
             LAMPilot lamPilot = (LAMPilot) entity.getCrew();
             gunnery = (lamPilot.getGunneryMech() + lamPilot.getGunneryAero()) / 2;

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -889,9 +889,7 @@ public class BLKFile {
             }
         }
         for (int i = 0; i < numLocs; i++) {
-//            if (!(t.isConventionalInfantry() && (i == Infantry.LOC_INFANTRY))) {
-                blk.writeBlockData(t.getLocationName(i) + " Equipment", eq.get(i));
-//            }
+            blk.writeBlockData(t.getLocationName(i) + " Equipment", eq.get(i));
         }
         if (!t.hasPatchworkArmor() && t.hasBARArmor(1)) {
             blk.writeBlockData("barrating", t.getBARRating(1));
@@ -1004,14 +1002,6 @@ public class BLKFile {
                         .getInternalName());
             }
 
-//            if (infantry.canMakeAntiMekAttacks()) {
-//                blk.writeBlockData("antimek", (infantry.getAntiMekSkill() + ""));
-//            }
-
-//            EquipmentType et = infantry.getArmorKit();
-//            if (et != null) {
-//                blk.writeBlockData("armorKit", et.getInternalName());
-//            }
             if (infantry.getArmorDamageDivisor() != 1) {
                 blk.writeBlockData("armordivisor",
                         Double.toString(infantry.getArmorDamageDivisor()));

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -24,6 +24,7 @@ import megamek.common.options.IBasicOption;
 import megamek.common.options.IOption;
 import megamek.common.options.PilotOptions;
 import megamek.common.util.BuildingBlock;
+import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
@@ -830,7 +831,12 @@ public class BLKFile {
         for (Mounted m : t.getEquipment()) {
             // Ignore Mounteds that represent a WeaponGroup
             // BA anti-personnel weapons are written just after the mount
-            if (m.isWeaponGroup() || m.isAPMMounted()) {
+            if (m.isWeaponGroup() || m.isAPMMounted() || (m.getType() instanceof InfantryAttack)) {
+                continue;
+            }
+
+            // Infantry primary and secondary are written separately
+            if (t.isConventionalInfantry() && m.getType() instanceof InfantryWeapon) {
                 continue;
             }
 
@@ -883,9 +889,9 @@ public class BLKFile {
             }
         }
         for (int i = 0; i < numLocs; i++) {
-            if (!(t.isConventionalInfantry() && (i == Infantry.LOC_INFANTRY))) {
+//            if (!(t.isConventionalInfantry() && (i == Infantry.LOC_INFANTRY))) {
                 blk.writeBlockData(t.getLocationName(i) + " Equipment", eq.get(i));
-            }
+//            }
         }
         if (!t.hasPatchworkArmor() && t.hasBARArmor(1)) {
             blk.writeBlockData("barrating", t.getBARRating(1));
@@ -998,14 +1004,14 @@ public class BLKFile {
                         .getInternalName());
             }
 
-            if (infantry.canMakeAntiMekAttacks()) {
-                blk.writeBlockData("antimek", (infantry.getAntiMekSkill() + ""));
-            }
+//            if (infantry.canMakeAntiMekAttacks()) {
+//                blk.writeBlockData("antimek", (infantry.getAntiMekSkill() + ""));
+//            }
 
-            EquipmentType et = infantry.getArmorKit();
-            if (et != null) {
-                blk.writeBlockData("armorKit", et.getInternalName());
-            }
+//            EquipmentType et = infantry.getArmorKit();
+//            if (et != null) {
+//                blk.writeBlockData("armorKit", et.getInternalName());
+//            }
             if (infantry.getArmorDamageDivisor() != 1) {
                 blk.writeBlockData("armordivisor",
                         Double.toString(infantry.getArmorDamageDivisor()));

--- a/megamek/src/megamek/common/loaders/BLKInfantryFile.java
+++ b/megamek/src/megamek/common/loaders/BLKInfantryFile.java
@@ -140,7 +140,11 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
         }
 
         if (dataFile.exists("specialization")) {
-            infantry.setSpecializations(Integer.parseInt(dataFile.getDataAsString("specialization")[0]));
+            try {
+                infantry.setSpecializations(Integer.parseInt(dataFile.getDataAsString("specialization")[0]));
+            } catch (NumberFormatException ex) {
+                throw new EntityLoadingException("Could not read specialization");
+            }
         }
         
         if (dataFile.exists("encumberingarmor")) {
@@ -164,7 +168,11 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
         }
 
         if (dataFile.exists("armordivisor")) {
-            infantry.setArmorDamageDivisor(Double.parseDouble(dataFile.getDataAsString("armordivisor")[0]));
+            try {
+                infantry.setArmorDamageDivisor(Double.parseDouble(dataFile.getDataAsString("armordivisor")[0]));
+            } catch (NumberFormatException ex) {
+                throw new EntityLoadingException("Could not read armor divisor");
+            }
         }
 
         loadEquipment(infantry, "Field Guns", Infantry.LOC_FIELD_GUNS);

--- a/megamek/src/megamek/common/loaders/BLKInfantryFile.java
+++ b/megamek/src/megamek/common/loaders/BLKInfantryFile.java
@@ -32,31 +32,31 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
     @Override
     public Entity getEntity() throws EntityLoadingException {
 
-        Infantry t = new Infantry();
-        setBasicEntityData(t);
+        Infantry infantry = new Infantry();
+        setBasicEntityData(infantry);
 
         if (!dataFile.exists("squad_size")) {
             throw new EntityLoadingException("Could not find squad size.");
         }
-        t.setSquadSize(dataFile.getDataAsInt("squad_size")[0]);
+        infantry.setSquadSize(dataFile.getDataAsInt("squad_size")[0]);
         if (!dataFile.exists("squadn")) {
             throw new EntityLoadingException("Could not find number of squads.");
         }
-        t.setSquadCount(dataFile.getDataAsInt("squadn")[0]);
+        infantry.setSquadCount(dataFile.getDataAsInt("squadn")[0]);
 
-        t.autoSetInternal();
+        infantry.autoSetInternal();
 
         if (dataFile.exists("InfantryArmor")) {
-            t.setArmorDamageDivisor(dataFile.getDataAsInt("InfantryArmor")[0]);
+            infantry.setArmorDamageDivisor(dataFile.getDataAsInt("InfantryArmor")[0]);
         }
 
         if (!dataFile.exists("motion_type")) {
             throw new EntityLoadingException("Could not find movement block.");
         }
         String sMotion = dataFile.getDataAsString("motion_type")[0];
-        t.setMicrolite(sMotion.equalsIgnoreCase("microlite"));
+        infantry.setMicrolite(sMotion.equalsIgnoreCase("microlite"));
         if (sMotion.startsWith("Beast:")) {
-            t.setMount(InfantryMount.parse(sMotion));
+            infantry.setMount(InfantryMount.parse(sMotion));
         } else {
             EntityMovementMode nMotion = EntityMovementMode.parseFromString(sMotion);
             if (nMotion.isNone()) {
@@ -64,15 +64,15 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
             }
             if (nMotion == EntityMovementMode.INF_UMU
                     && sMotion.toLowerCase().contains("motorized")) {
-                t.setMotorizedScuba();
+                infantry.setMotorizedScuba();
             } else {
-                t.setMovementMode(nMotion);
+                infantry.setMovementMode(nMotion);
             }
         }
 
         // get primary and secondary weapons
         if (dataFile.exists("secondn")) {
-            t.setSecondaryWeaponsPerSquad(dataFile.getDataAsInt("secondn")[0]);
+            infantry.setSecondaryWeaponsPerSquad(dataFile.getDataAsInt("secondn")[0]);
         }
 
         if (!dataFile.exists("Primary")) {
@@ -83,7 +83,7 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
         if (!(ptype instanceof InfantryWeapon)) {
             throw new EntityLoadingException("primary weapon is not an infantry weapon");
         }
-        t.setPrimaryWeapon((InfantryWeapon) ptype);
+        infantry.setPrimaryWeapon((InfantryWeapon) ptype);
 
         EquipmentType stype = null;
         if (dataFile.exists("Secondary")) {
@@ -92,131 +92,115 @@ public class BLKInfantryFile extends BLKFile implements IMechLoader {
             if (!(stype instanceof InfantryWeapon)) {
                 throw new EntityLoadingException("secondary weapon " + secondName + " is not an infantry weapon");
             }
-            t.setSecondaryWeapon((InfantryWeapon) stype);
+            infantry.setSecondaryWeapon((InfantryWeapon) stype);
         }
 
-        // if there is more than one secondary weapon per squad, then add that
-        // to the unit
+        // if there is more than one secondary weapon per squad, then add that to the unit
         // otherwise add the primary weapon
         Mounted m;
         try {
-            if ((t.getSecondaryWeaponsPerSquad() > 1)) {
-                m = new InfantryWeaponMounted(t, stype, (InfantryWeapon) ptype);
+            if ((infantry.getSecondaryWeaponsPerSquad() > 1)) {
+                m = new InfantryWeaponMounted(infantry, stype, (InfantryWeapon) ptype);
             } else if (stype != null) {
-                m = new InfantryWeaponMounted(t, ptype, (InfantryWeapon) stype);
+                m = new InfantryWeaponMounted(infantry, ptype, (InfantryWeapon) stype);
             } else {
-                m = new Mounted(t, ptype);
+                m = new Mounted(infantry, ptype);
             }
         } catch (ClassCastException ex) {
             throw new EntityLoadingException(ex.getMessage());
         }
         try {
-            t.addEquipment(m, Infantry.LOC_INFANTRY, false);
+            infantry.addEquipment(m, Infantry.LOC_INFANTRY, false);
         } catch (LocationFullException ex) {
             throw new EntityLoadingException(ex.getMessage());
         }
-        //TAG infantry have separate attacks for primary and secondary weapons.
+
+        // TAG infantry have separate attacks for primary and secondary weapons.
         if (null != stype && stype.hasFlag(WeaponType.F_TAG)) {
-            t.setSpecializations(t.getSpecializations() | Infantry.TAG_TROOPS);
+            infantry.setSpecializations(infantry.getSpecializations() | Infantry.TAG_TROOPS);
             try {
-                t.addEquipment(ptype, Infantry.LOC_INFANTRY);
+                infantry.addEquipment(ptype, Infantry.LOC_INFANTRY);
             } catch (LocationFullException ex) {
                 throw new EntityLoadingException(ex.getMessage());
             }
         }
-        
+
+        // backward compatibility: armor kits should now be saved and loaded as part of LOC_INFANTRY equipment
         if (dataFile.exists("armorKit")) {
             String kitName = dataFile.getDataAsString("armorKit")[0];
             EquipmentType kit = EquipmentType.get(kitName);
             if ((null == kit) || !(kit.hasFlag(MiscType.F_ARMOR_KIT))) {
                 throw new EntityLoadingException(kitName + " is not an infantry armor kit");
             }
-            t.setArmorKit(kit);
+            infantry.setArmorKit(kit);
         }
 
         if (dataFile.exists("dest")) {
-            t.setDEST(true);
+            infantry.setDEST(true);
         }
 
         if (dataFile.exists("specialization")) {
-            t.setSpecializations(Integer.parseInt(dataFile.getDataAsString("specialization")[0]));
+            infantry.setSpecializations(Integer.parseInt(dataFile.getDataAsString("specialization")[0]));
         }
         
         if (dataFile.exists("encumberingarmor")) {
-            t.setArmorEncumbering(true);
+            infantry.setArmorEncumbering(true);
         }
 
         if (dataFile.exists("spacesuit")) {
-            t.setSpaceSuit(true);
+            infantry.setSpaceSuit(true);
         }
 
         if (dataFile.exists("sneakcamo")) {
-            t.setSneakCamo(true);
+            infantry.setSneakCamo(true);
         }
 
         if (dataFile.exists("sneakir")) {
-            t.setSneakIR(true);
+            infantry.setSneakIR(true);
         }
 
         if (dataFile.exists("sneakecm")) {
-            t.setSneakECM(true);
+            infantry.setSneakECM(true);
         }
 
         if (dataFile.exists("armordivisor")) {
-            t.setArmorDamageDivisor(Double.parseDouble(dataFile.getDataAsString("armordivisor")[0]));
+            infantry.setArmorDamageDivisor(Double.parseDouble(dataFile.getDataAsString("armordivisor")[0]));
         }
-        // get field guns
-        loadEquipment(t, "Field Guns", Infantry.LOC_FIELD_GUNS);
 
+        loadEquipment(infantry, "Field Guns", Infantry.LOC_FIELD_GUNS);
+        loadEquipment(infantry, "Troopers", Infantry.LOC_INFANTRY);
+
+        // Update some internals if there's an armor kit
+        infantry.getMisc().stream()
+                .filter(misc -> misc.getType().hasFlag(MiscType.F_ARMOR_KIT))
+                .findFirst()
+                .ifPresent(mounted -> infantry.setArmorKit(mounted.getType()));
+
+        // backward compatibility: if an antimek better than 8 entry exists, assume anti-mek gear
         if (dataFile.exists("antimek")) {
-            int startIndex = dataFile.findStartIndex("antimek");
-            int endIndex = dataFile.findEndIndex("antimek");
-            int[] amSkill;
-            // If startIndex is the same as end, then tag is blank, use defaults
-            if (startIndex == endIndex) {
-                amSkill = new int[0];
-            } else {
-                String[] amSkillString = dataFile.getDataAsString("antimek");
-                if (amSkillString[0].equalsIgnoreCase("false")) {
-                    amSkill = new int[1];
-                    amSkill[0] = Infantry.ANTI_MECH_SKILL_UNTRAINED;
-                } else if (amSkillString[0].equalsIgnoreCase("true")) {
-                    amSkill = null;
-                } else {
-                    amSkill = dataFile.getDataAsInt("antimek");
+            int[] amSkill = dataFile.getDataAsInt("antimek");
+            if (amSkill[0] != 8) {
+                try {
+                    infantry.addEquipment(EquipmentType.get(EquipmentTypeLookup.ANTI_MEK_GEAR), Infantry.LOC_INFANTRY);
+                } catch (LocationFullException ex) {
+                    throw new EntityLoadingException(ex.getMessage());
                 }
             }
-            // If we just have the tag without values, take defaults
-            if ((amSkill == null) || (amSkill.length < 1)) {
-                // TM lists AM skill defaults on pg 40
-                if ((t.getMovementMode() == EntityMovementMode.INF_MOTORIZED) 
-                        || (t.getMovementMode() == EntityMovementMode.INF_JUMP)) {
-                    t.setAntiMekSkill(Infantry.ANTI_MECH_SKILL_JUMP);
-                } else {
-                    t.setAntiMekSkill(Infantry.ANTI_MECH_SKILL_FOOT);
-                }
-            } else {
-                t.setAntiMekSkill(amSkill[0]);
-            }
-        } else {
-            t.setAntiMekSkill(Infantry.ANTI_MECH_SKILL_UNTRAINED);
         }
         
-        /* Some units (mostly Manei Domini) have cybernetics/prosthetics as part of the official
-         * unit description.
-         */
+        // Some units (mostly Manei Domini) have cybernetics/prosthetics as part of the official unit description.
         if (dataFile.exists("augmentation")) {
             String[] augmentations = dataFile.getDataAsString("augmentation");
             for (String aug : augmentations) {
                 try {
-                    t.getCrew().getOptions().getOption(aug).setValue(true);
+                    infantry.getCrew().getOptions().getOption(aug).setValue(true);
                 } catch (NullPointerException ex) {
                     throw new EntityLoadingException("Could not locate pilot option " + aug);
                 }
             }
         }
-        t.recalculateTechAdvancement();
-        loadQuirks(t);
-        return t;
+        infantry.recalculateTechAdvancement();
+        loadQuirks(infantry);
+        return infantry;
     }
 }

--- a/megamek/src/megamek/common/miscGear/AntiMekGear.java
+++ b/megamek/src/megamek/common/miscGear/AntiMekGear.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMekLab.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
 package megamek.common.miscGear;
 
 import megamek.common.EquipmentTypeLookup;

--- a/megamek/src/megamek/common/miscGear/AntiMekGear.java
+++ b/megamek/src/megamek/common/miscGear/AntiMekGear.java
@@ -1,0 +1,22 @@
+package megamek.common.miscGear;
+
+import megamek.common.EquipmentTypeLookup;
+import megamek.common.MiscType;
+import megamek.common.SimpleTechLevel;
+
+public class AntiMekGear extends MiscType {
+
+    public AntiMekGear() {
+        name = "Anti-Mek Gear";
+        setInternalName(EquipmentTypeLookup.ANTI_MEK_GEAR);
+        tonnage = 0.015;
+        flags = flags.or(F_INF_EQUIPMENT);
+        cost = COST_VARIABLE;
+        rulesRefs = "155, TM";
+        techAdvancement.setTechBase(TECH_BASE_ALL).setAdvancement(2456, 2460, 2500)
+                .setStaticTechLevel(SimpleTechLevel.STANDARD)
+                .setApproximate(true, false, false).setTechBase(RATING_D)
+                .setPrototypeFactions(F_LC).setProductionFactions(F_LC)
+                .setAvailability(RATING_D, RATING_D, RATING_D, RATING_D);
+    }
+}

--- a/megamek/src/megamek/common/util/BuildingBlock.java
+++ b/megamek/src/megamek/common/util/BuildingBlock.java
@@ -380,11 +380,7 @@ public class BuildingBlock {
      */
     public boolean createNewBlock() {
         rawData.clear();
-
         writeBlockComment("Saved from version " + SuiteConstants.VERSION + " on " + LocalDate.now());
-
-        this.writeBlockData("BlockVersion", "" + BuildingBlock.version);
-
         return true;
     }
 

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -143,6 +143,12 @@ public class TestInfantry extends TestEntity {
             return true;
         }
 
+        // We currently have many unit introduction dates that are too early for their gear or anti-mek attacks
+        // enable this when dates have been straightened
+//        if (showIncorrectIntroYear() && hasIncorrectIntroYear(buff)) {
+//            correct = false;
+//        }
+
         int max = maxSecondaryWeapons(inf);
         if (inf.getSecondaryWeaponsPerSquad() > max) {
             buff.append("Number of secondary weapons exceeds maximum of " + max).append("\n\n");
@@ -165,7 +171,7 @@ public class TestInfantry extends TestEntity {
             }
             secondaryCrew = Math.max(secondaryCrew, 1);
             if (secondaryCrew * inf.getSecondaryWeaponsPerSquad() > inf.getSquadSize()) {
-                buff.append("Secondary weapon crew requirement exceeds squad size.").append("\n\n");
+                buff.append("Secondary weapon crew requirement exceeds squad size.\n\n");
                 correct = false;
             }
         }
@@ -180,6 +186,11 @@ public class TestInfantry extends TestEntity {
                 inf.hasSpecialization(Infantry.COMBAT_ENGINEERS | Infantry.MOUNTAIN_TROOPS), inf.getMount());
         if (inf.getShootingStrength() > max) {
             buff.append("Maximum platoon size is " + max + "\n\n");
+            correct = false;
+        }
+
+        if (inf.isMechanized() && inf.countEquipment(EquipmentTypeLookup.ANTI_MEK_GEAR) > 0) {
+            buff.append("Mechanized infantry may not have anti-mek gear!\n");
             correct = false;
         }
 
@@ -410,31 +421,31 @@ public class TestInfantry extends TestEntity {
                 default:
                     mult = 0.085;
             }
-            report.addLine("Weight multiplier: ", infantry.getMovementModeAsString(), formatForReport(mult));
+            report.addLine("Base Weight: ", infantry.getMovementModeAsString(), formatForReport(mult) + " t");
 
             if (infantry.hasSpecialization(Infantry.COMBAT_ENGINEERS)) {
                 mult += 0.1;
-                report.addLine("", "Combat Engineers", "+ 0.1");
+                report.addLine("", "Combat Engineers", "+ 0.1 t");
 
             }
 
             if (infantry.hasSpecialization(Infantry.PARATROOPS)) {
                 mult += 0.05;
-                report.addLine("", "Paratroopers", "+ 0.05");
+                report.addLine("", "Paratroopers", "+ 0.05 t");
             }
 
             if (infantry.hasSpecialization(Infantry.PARAMEDICS)) {
                 mult += 0.05;
-                report.addLine("", "Paramedics", "+ 0.05");
+                report.addLine("", "Paramedics", "+ 0.05 t");
             }
 
-            if (infantry.isAntiMekTrained()) {
+            if (infantry.hasAntiMekGear()) {
                 mult += .015;
-                report.addLine("", "Anti-Mek Training", "+ 0.015");
+                report.addLine("", "Anti-Mek Gear", "+ 0.015 t");
             }
 
             weight = activeTroopers * mult;
-            report.addLine("Trooper Weight:", activeTroopers + " x " + formatForReport(mult),
+            report.addLine("Trooper Weight:", activeTroopers + " x " + formatForReport(mult) + " t",
                     formatForReport(weight) + " t");
 
             weight += infantry.activeFieldWeapons().stream().mapToDouble(Mounted::getTonnage).sum();
@@ -454,5 +465,44 @@ public class TestInfantry extends TestEntity {
         report.addLine("Final Weight:", "round up to nearest half ton",
                 formatForReport(roundedWeight) + " t");
         return weight;
+    }
+
+    public static void adaptAntiMekAttacks(Infantry infantry) {
+        try {
+            removeAntiMekAttacks(infantry);
+            if (infantry.canMakeAntiMekAttacks()) {
+                InfantryMount mount = infantry.getMount();
+                if ((mount == null) || mount.getSize().canMakeSwarmAttacks) {
+                    infantry.addEquipment(EquipmentType.get(Infantry.SWARM_MEK), Infantry.LOC_INFANTRY);
+                    infantry.addEquipment(EquipmentType.get(Infantry.STOP_SWARM), Infantry.LOC_INFANTRY);
+                }
+                if ((mount == null) || mount.getSize().canMakeLegAttacks) {
+                    infantry.addEquipment(EquipmentType.get(Infantry.LEG_ATTACK), Infantry.LOC_INFANTRY);
+                }
+            }
+        } catch (LocationFullException ignored) {
+            // not on Infantry
+        }
+    }
+
+
+    // The following methods are a condensed version of MML's UnitUtil.removeMounted
+    // and can be replaced if the latter is ever moved into MM
+    public static void removeAntiMekAttacks(Infantry unit) {
+        removeAntiMekAttack(unit, EquipmentType.get(Infantry.SWARM_MEK));
+        removeAntiMekAttack(unit, EquipmentType.get(Infantry.STOP_SWARM));
+        removeAntiMekAttack(unit, EquipmentType.get(Infantry.LEG_ATTACK));
+        unit.recalculateTechAdvancement();
+    }
+
+    public static void removeAntiMekAttack(Infantry unit, EquipmentType et) {
+        for (int pos = unit.getEquipment().size() - 1; pos >= 0; pos--) {
+            Mounted mount = unit.getEquipment().get(pos);
+            if (mount.getType().equals(et)) {
+                unit.getEquipment().remove(mount);
+                unit.getWeaponList().remove(mount);
+                unit.getTotalWeaponList().remove(mount);
+            }
+        }
     }
 }

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -194,6 +194,11 @@ public class TestInfantry extends TestEntity {
             correct = false;
         }
 
+        if (inf.countWorkingMisc(MiscType.F_ARMOR_KIT) > 1) {
+            buff.append("Infantry may not have more than one armor kit!\n");
+            correct = false;
+        }
+
         return correct;
     }
     


### PR DESCRIPTION
This is the MM side of adding anti-mek gear for conv. infantry, replacing the approach of only storing anti-mek in the skill value.
- adds anti-mek gear as a MiscType (as its own class because why not)
- isAntiMekTrained() is renamed to hasAntiMekGear() which pops up in a few classes
- removes the TechAdvancement for AM gear from Infantry since it's now part of its gear, also removes a few unused methods (checked MHQ)
- adding or removing anti-mek attacks has been moved to TestInfantry; this is used in MML and in the MechFileParser upon loading; we might want to update this further to look at the game's year as these attacks aren't always available
- updates the BV calculator to (hopefully correctly) assign 5 or 8 or other anti-mek depending on gear and crew
- updates the BLKFile load and save for conv inf; I changed it to write the LOC_INFANTRY location where armor kits and anti-mek gear and prim or sec weapon are stored; this used to be blocked in favor of writing the info individually; it seems to work rather easily like this, but I had to explicitly block this location from writing the infantry prim or sec weapon as these still need to be written individually. Also, I removed the block version; it will no longer be written. It was ignored during load anyway.
- and, finally, updates TestInfantry to catch anti-mek gear on mechanized as invalid; I wanted to add general equipment checks but this makes many infantry units invalid as their intro dates are too early, so I commented that out for now, but it should be added at some point. Also tweaked the weight calculation report a bit.
-
Fixes #5063 
Also happens to ... Fixes MegaMek/megameklab#1333 as BA wrongly wrote InfantryAttacks into the blk file which it shouldn't