### PR TITLE
Fix Laser-Guided Bombs missing the -2 bonus on tagged units

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3686,11 +3686,11 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 // +4 Modifier for strafing
                 } else if (isStrafing) {
                     toHit.addModifier(+4, Messages.getString("WeaponAttackAction.Strafing"));
-                    // Additional +2 if flying at Nape-of-Earth
+                    // Additional +2 if flying at Nap-of-Earth
                     if (ae.getAltitude() == 1) {
                         toHit.addModifier(+2, Messages.getString("WeaponAttackAction.StrafingNoe"));
                     }
-                    // Additional Nape-of-Earth restrictions for strafing
+                    // Additional Nap-of-Earth restrictions for strafing
                     if (ae.getAltitude() == 1) {
                         Coords prevCoords = ae.passedThroughPrevious(target.getPosition());
                         Hex prevHex = game.getBoard().getHex(prevCoords);

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -411,6 +411,11 @@ public class AreaEffectHelper {
                         toHit.addModifier(2, "cluster artillery hitting a Tank");
                     }
                 }
+
+                // According to TW, need to set attack to hit either front or back, 50/50
+                if (ammo instanceof BombType) {
+                    toHit.setSideTable((Compute.d6() <= 3) ? ToHitData.SIDE_FRONT : ToHitData.SIDE_REAR);
+                }
             }
         }
 

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -94,11 +94,18 @@ public class BombAttackHandler extends WeaponHandler {
             typeModifiedToHit.setSideTable(toHit.getSideTable());
 
             // currently, only type of bomb with type-specific to-hit mods
-            // Laser-Guided Bombs are getting errata'ed to auto-hit a tagged hex
+            // Laser-Guided Bombs are getting errata'ed to get bonus from either A) a tagged hex or B) a tagged target
             boolean laserGuided = false;
             if (type == BombType.B_LG) {
                 for (TagInfo ti : game.getTagInfo()) {
-                    if (target.getId() == ti.target.getId()) {
+                    if (ti.missed || game.getEntity(waa.getEntityId()).isEnemyOf(game.getEntity(ti.attackerId))) {
+                        // Not a usable friendly TAG
+                        continue;
+                    }
+                    if (target.getId() == ti.target.getId()
+                        || ((ti.targetType != Targetable.TYPE_HEX_TAG)
+                            && target.getPosition().equals(ti.target.getPosition()))
+                    ) {
                         typeModifiedToHit.addModifier(-2,
                                 "laser-guided bomb against tagged target");
                         laserGuided = true;

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -94,6 +94,7 @@ public class BombAttackHandler extends WeaponHandler {
             typeModifiedToHit.setSideTable(toHit.getSideTable());
 
             // currently, only type of bomb with type-specific to-hit mods
+            // Laser-Guided Bombs are getting errata'ed to auto-hit a tagged hex
             boolean laserGuided = false;
             if (type == BombType.B_LG) {
                 for (TagInfo ti : game.getTagInfo()) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -34511,13 +34511,16 @@ public class GameManager implements IGameManager {
         }
         Vector<Integer> alreadyHit = new Vector<>();
 
-        alreadyHit = artilleryDamageHex(centre, centre, damage, null,
+        // We need the actual ammo type in order to handle certain bomb issues correctly.
+        BombType ammo = BombType.createBombByType(type);
+
+        alreadyHit = artilleryDamageHex(centre, centre, damage, ammo,
                 subjectId, killer, null, false, 0, vPhaseReport, false,
                 alreadyHit, false);
         if (range > 0) {
             List<Coords> hexes = centre.allAtDistance(range);
             for (Coords c : hexes) {
-                alreadyHit = artilleryDamageHex(c, centre, damage, null,
+                alreadyHit = artilleryDamageHex(c, centre, damage, ammo,
                         subjectId, killer, null, false, 0, vPhaseReport, false,
                         alreadyHit, false);
             }


### PR DESCRIPTION
We identified that Laser-Guided Bombs do not currently get the -2 to-hit bonus against TAGged target _units_, which led to requesting clarification on the interaction in the forums [here](https://bg.battletech.com/forums/index.php/topic,83734.msg1986639.html#msg1986639).

This change adds the -2 to-hit bonus when LG bombing a hex containing a unit TAGged by a friendly unit.  LG Bombing a _hex_ TAGged by a friendly unit already works correctly.

This change also adds the 1-3/4-6 d6 roll to determine whether a bombed unit is hit in the front or back side (TW , which previously was not implemented.

Testing:

- Ran existing MM/MHQ unit tests.
- Tested with player-controlled units and Bot-controlled units.