### PR TITLE
Fix SV armor tech rating

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1305,6 +1305,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 ctl.addComponent(EquipmentType.getArmorTechAdvancement(armorType[loc],
                         TechConstants.isClan(armorTechLevel[loc])));
             }
+        } else if (isSupportVehicle() && hasBARArmor(firstArmorIndex())) {
+            ctl.addComponent(EquipmentType.getSVArmorTechAdvancement(getBARRating(firstArmorIndex())));
         } else {
             ctl.addComponent(EquipmentType.getArmorTechAdvancement(armorType[0],
                     TechConstants.isClan(armorTechLevel[0])));

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1316,18 +1316,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         }
         ctl.addComponent(EquipmentType.getStructureTechAdvancement(structureType,
                 TechConstants.isClan(structureTechLevel)));
-        /* TM, p. 122 gives general eras for each tech rating, but not specific dates.
-         * Besides that, there are many canon units with higher tech ratings than should
-         * be possible in their era, so we're just going to add a stub to get the tech rating right
-         * for cost purposes. */
-        if (isSupportVehicle()) {
-            TechAdvancement blank = new TechAdvancement(getConstructionTechAdvancement());
-            ctl.addComponent(blank.setTechRating(getEngineTechRating()));
-            ctl.addComponent(blank.setTechRating(getStructuralTechRating()));
-            if (!hasPatchworkArmor() && (getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD)) {
-                ctl.addComponent(blank.setTechRating(getArmorTechRating()));
-            }
-        }
     }
 
     public int getRecoveryTurn() {

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -73,7 +73,7 @@ public class FixedWingSupport extends ConvFighter {
      */
     @Override
     public boolean hasBARArmor(int loc) {
-        return true;
+        return getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD;
     }
 
     @Override

--- a/megamek/src/megamek/common/FixedWingSupport.java
+++ b/megamek/src/megamek/common/FixedWingSupport.java
@@ -63,7 +63,7 @@ public class FixedWingSupport extends ConvFighter {
      */
     @Override
     public int getBARRating(int loc) {
-        return barRating[loc];
+        return (barRating == null) ? 0 : barRating[loc];
     }
 
     /*

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -5380,14 +5380,7 @@ public abstract class Mech extends Entity {
      */
     @Override
     public int getBARRating(int loc) {
-        if (armorType[loc] == EquipmentType.T_ARMOR_COMMERCIAL) {
-            return 5;
-        }
-        if ((armorType[loc] == EquipmentType.T_ARMOR_INDUSTRIAL)
-                || (armorType[loc] == EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL)) {
-            return 10;
-        }
-        return 10;
+        return (armorType[loc] == EquipmentType.T_ARMOR_COMMERCIAL) ? 5 : 10;
     }
 
     /**

--- a/megamek/src/megamek/common/SupportTank.java
+++ b/megamek/src/megamek/common/SupportTank.java
@@ -53,7 +53,7 @@ public class SupportTank extends Tank {
 
     @Override
     public boolean hasBARArmor(int loc) {
-        return true;
+        return getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD;
     }
 
     @Override

--- a/megamek/src/megamek/common/SupportTank.java
+++ b/megamek/src/megamek/common/SupportTank.java
@@ -48,7 +48,7 @@ public class SupportTank extends Tank {
 
     @Override
     public int getBARRating(int loc) {
-        return barRating[loc];
+        return (barRating == null) ? 0 : barRating[loc];
     }
 
     @Override

--- a/megamek/src/megamek/common/SupportVTOL.java
+++ b/megamek/src/megamek/common/SupportVTOL.java
@@ -46,7 +46,7 @@ public class SupportVTOL extends VTOL {
 
     @Override
     public int getBARRating(int loc) {
-        return barRating[loc];
+        return (barRating == null) ? 0 : barRating[loc];
     }
 
     @Override

--- a/megamek/src/megamek/common/SupportVTOL.java
+++ b/megamek/src/megamek/common/SupportVTOL.java
@@ -51,7 +51,7 @@ public class SupportVTOL extends VTOL {
 
     @Override
     public boolean hasBARArmor(int loc) {
-        return true;
+        return getArmorType(firstArmorIndex()) == EquipmentType.T_ARMOR_STANDARD;
     }
 
     @Override


### PR DESCRIPTION
Added a missing check for SV BAR armor when compiling composite tech advancement data. Without the check it is adding standard Mech/CV armor, which has a higher tech rating (D) than some SV armors.

I also added a null check to getBARRating because the first pass at building the composite tech level happens in the Entity constructor, which is before the barRating field is initialized. It seems to be building the tech advancement three times, but streamlining that is a different issue entirely.

Fixes MegaMek/megameklab#1064