### PR TITLE
Naive fix for #5088 - Aerospace Move Envelope Inaccuracy

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -975,7 +975,12 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             case VIEW_MOVE_ENV:
                 if (curPanel instanceof MovementDisplay) {
                     GUIP.setMoveEnvelope(!GUIP.getMoveEnvelope());
-                    ((MovementDisplay) curPanel).computeMovementEnvelope(getUnitDisplay().getCurrentEntity());
+                    Entity entity = getUnitDisplay().getCurrentEntity();
+                    if (!(entity instanceof Aero)) {
+                        ((MovementDisplay) curPanel).computeMovementEnvelope(entity);
+                    } else {
+                        ((MovementDisplay) curPanel).computeAeroMovementEnvelope(entity);
+                    }
                 }
                 break;
             case VIEW_MOVE_MOD_ENV:

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4548,7 +4548,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
             mp.addStep(MoveStepType.START_JUMP);
         }
 
-        ShortestPathFinder pf = ShortestPathFinder.newInstanceOfOneToAll(maxMP, stepType, en.getGame());
+        // Create a path finder to find possible moves; if aerodyne, use a custom Aero path finder.
+        ShortestPathFinder pf = null;
+        if (!en.isAerodyne()) {
+            pf = ShortestPathFinder.newInstanceOfOneToAll(maxMP, stepType, en.getGame());
+        } else {
+            pf = ShortestPathFinder.newInstanceOfOneToAllAero(maxMP, stepType, en.getGame());
+        }
+
         pf.run(mp);
         mvEnvData = pf.getAllComputedPaths();
         Map<Coords, Integer> mvEnvMP = new HashMap<>((int) ((mvEnvData.size() * 1.25) + 1));
@@ -4569,7 +4576,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return - This method will do nothing if the Entity passed in is null or
      *           is not an Aero based unity.
      */
-    private void computeAeroMovementEnvelope(Entity entity) {
+    public void computeAeroMovementEnvelope(Entity entity) {
         if ((entity == null) || !(entity instanceof Aero) || (cmd == null)) {
             return;
         }

--- a/megamek/src/megamek/common/pathfinder/MovePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/MovePathFinder.java
@@ -210,6 +210,20 @@ public class MovePathFinder<C> extends AbstractPathFinder<CoordsWithFacing, C, M
     }
 
     /**
+     * A MovePath comparator that compares the number of steps in the path.
+     *
+     * Order paths with fewer total steps first.
+     */
+    public static class MovePathStepsComparator implements Comparator<MovePath> {
+        @Override
+        public int compare(final MovePath first, final MovePath second) {
+            final int firstLength = first.getStepVector().size();
+            final int secondLength = second.getStepVector().size();
+            return firstLength - secondLength;
+        }
+    }
+
+    /**
      * A MovePath comparator that compares number of steps. Generally used for
      * spheroids, which don't have the same velocity expenditure restrictions as
      * Aerodynes, however they can't compare based on MP like ground units.

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -121,6 +121,12 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
                 }
             }
 
+            // If the movepath entity is an aerospace / conventional fighter type, don't 
+            // relax the edge.  See megamek issue #5088
+            if (v.getEntity().isAerospace()) {
+                return e;
+            }
+
             return comparator.compare(e, v) < 0 ? e : null;
         }
     }

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -121,12 +121,6 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
                 }
             }
 
-            // If the movepath entity is an aerospace / conventional fighter type, don't 
-            // relax the edge.  See megamek issue #5088
-            if (v.getEntity().isAerospace()) {
-                return e;
-            }
-
             return comparator.compare(e, v) < 0 ? e : null;
         }
     }
@@ -258,6 +252,24 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
                 new ShortestPathFinder(
                         new ShortestPathFinder.MovePathRelaxer(),
                         new ShortestPathFinder.MovePathMPCostComparator(),
+                        stepType, game);
+        spf.addFilter(new MovePathLengthFilter(maxMP));
+        spf.addFilter(new MovePathLegalityFilter(game));
+        return spf;
+    }
+
+    /**
+     * See {@link newInstanceOfOneToAll} - this returns a customized ShortestPathFinder to support Aerodyne units.
+     * @param maxMP maximum MP that entity can use
+     * @param stepType
+     * @param game The current {@link Game}
+     * @return - Customized ShortestPathFinder specifically for Aerodyne unit move envelope.
+     */
+    public static ShortestPathFinder newInstanceOfOneToAllAero(final int maxMP, final MoveStepType stepType, final Game game) {
+        final ShortestPathFinder spf =
+                new ShortestPathFinder(
+                        new ShortestPathFinder.AeroMovePathRelaxer(),
+                        new ShortestPathFinder.MovePathStepsComparator(),
                         stepType, game);
         spf.addFilter(new MovePathLengthFilter(maxMP));
         spf.addFilter(new MovePathLegalityFilter(game));


### PR DESCRIPTION
Naive fix for #5088.  Poor performance.

This code-tweak provides a hack for fixing the inaccurate Aero or CF movement envelope showing the possible moves, but does so at a cost that is prohibitive past velocity = 2.  

Posting as a draft for visibility and discussion.