### PR TITLE
Fixes #5088 Missing holes in Aero Move envelope.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -975,7 +975,12 @@ public class ClientGUI extends JPanel implements BoardViewListener,
             case VIEW_MOVE_ENV:
                 if (curPanel instanceof MovementDisplay) {
                     GUIP.setMoveEnvelope(!GUIP.getMoveEnvelope());
-                    ((MovementDisplay) curPanel).computeMovementEnvelope(getUnitDisplay().getCurrentEntity());
+                    Entity entity = getUnitDisplay().getCurrentEntity();
+                    if (!(entity instanceof Aero)) {
+                        ((MovementDisplay) curPanel).computeMovementEnvelope(entity);
+                    } else {
+                        ((MovementDisplay) curPanel).computeAeroMovementEnvelope(entity);
+                    }
                 }
                 break;
             case VIEW_MOVE_MOD_ENV:

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -976,7 +976,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
                 if (curPanel instanceof MovementDisplay) {
                     GUIP.setMoveEnvelope(!GUIP.getMoveEnvelope());
                     Entity entity = getUnitDisplay().getCurrentEntity();
-                    if (!(entity instanceof Aero)) {
+                    if (!entity.isAero()) {
                         ((MovementDisplay) curPanel).computeMovementEnvelope(entity);
                     } else {
                         ((MovementDisplay) curPanel).computeAeroMovementEnvelope(entity);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4548,7 +4548,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
             mp.addStep(MoveStepType.START_JUMP);
         }
 
-        ShortestPathFinder pf = ShortestPathFinder.newInstanceOfOneToAll(maxMP, stepType, en.getGame());
+        // Create a path finder to find possible moves; if aerodyne, use a custom Aero path finder.
+        ShortestPathFinder pf = null;
+        if (!en.isAerodyne()) {
+            pf = ShortestPathFinder.newInstanceOfOneToAll(maxMP, stepType, en.getGame());
+        } else {
+            pf = ShortestPathFinder.newInstanceOfOneToAllAero(maxMP, stepType, en.getGame());
+        }
+
         pf.run(mp);
         mvEnvData = pf.getAllComputedPaths();
         Map<Coords, Integer> mvEnvMP = new HashMap<>((int) ((mvEnvData.size() * 1.25) + 1));
@@ -4569,7 +4576,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return - This method will do nothing if the Entity passed in is null or
      *           is not an Aero based unity.
      */
-    private void computeAeroMovementEnvelope(Entity entity) {
+    public void computeAeroMovementEnvelope(Entity entity) {
         if ((entity == null) || !(entity instanceof Aero) || (cmd == null)) {
             return;
         }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -478,7 +478,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                             removeLastStep();
                         }
 
-                        if (ce() instanceof Aero) {
+                        if (ce() != null && ce().isAero()) {
                             computeAeroMovementEnvelope(ce());
                         } else {
                             computeMovementEnvelope(ce());
@@ -500,7 +500,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     @Override
                     public void performAction() {
                         removeLastStep();
-                        if (ce() instanceof Aero) {
+                        if (ce() != null && ce().isAero()) {
                             computeAeroMovementEnvelope(ce());
                         } else {
                             computeMovementEnvelope(ce());
@@ -4577,7 +4577,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      *           is not an Aero based unity.
      */
     public void computeAeroMovementEnvelope(Entity entity) {
-        if ((entity == null) || !(entity instanceof Aero) || (cmd == null)) {
+        if ((entity == null) || !(entity.isAero()) || (cmd == null)) {
             return;
         }
 

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -259,6 +259,24 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
     }
 
     /**
+     * See {@link newInstanceOfOneToAll} - this returns a customized ShortestPathFinder to support Aerodyne units.
+     * @param maxMP maximum MP that entity can use
+     * @param stepType
+     * @param game The current {@link Game}
+     * @return - Customized ShortestPathFinder specifically for Aerodyne unit move envelope.
+     */
+    public static ShortestPathFinder newInstanceOfOneToAllAero(final int maxMP, final MoveStepType stepType, final Game game) {
+        final ShortestPathFinder spf =
+                new ShortestPathFinder(
+                        new ShortestPathFinder.AeroMovePathRelaxer(),
+                        new ShortestPathFinder.MovePathLengthComparator(),
+                        stepType, game);
+        spf.addFilter(new MovePathLengthFilter(maxMP));
+        spf.addFilter(new MovePathLegalityFilter(game));
+        return spf;
+    }
+
+    /**
      * Constructs a greedy algorithms. It considers only the moves end closer to
      * destination. Ignores legality of the move. Stops after reaching
      * destination.


### PR DESCRIPTION
Fixes #5088 

This PR improves the aerospace movement envelope.  Using a path length comparator instead of a movement point comparator, the strange holes and missing edges are filled in more symmetrically.  

The move envelope for Aero here is not 100% accurate as some of the inside radius hexes are not accounted for, but it has a uniform envelope without holes or missing wedges and good performance past 8 velocity.

This PR also adds a fix for showing the current velocity move envelope when toggling "View Possible Moves" instead of reverting back to the initial move velocity when toggling.

This image shows the improved Aero move envelope without the edge gaps and wedges, but shows that there are still some inside radius hexes that are not represented.
![image](https://github.com/MegaMek/megamek/assets/83041327/8c11a68b-cd90-457f-974d-e371ecaf0a98)

This image shows the same envelope before this fix:
![image](https://github.com/MegaMek/megamek/assets/83041327/f3cfc546-3012-4f27-9ee9-8da089ec7ad4)
 