### PR TITLE
Mek Clan Chassis Name - Code Changes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -890,7 +890,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
             if (col == COL_MODEL) {
                 return ms.getModel();
             } else if (col == COL_CHASSIS) {
-                return ms.getChassis();
+                return ms.getFullChassis();
             } else if (col == COL_WEIGHT) {
                 if ((gameOptions != null) && ms.getUnitType().equals("BattleArmor")) {
                     if (gameOptions.booleanOption(OptionsConstants.ADVANCED_TACOPS_BA_WEIGHT)) {

--- a/megamek/src/megamek/client/ui/swing/tileset/MechTileset.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/MechTileset.java
@@ -196,8 +196,8 @@ public class MechTileset {
         }
 
         // second, check for chassis matches
-        if (chassis.containsKey(entity.getChassis().toUpperCase() + mode + addendum)) {
-            return chassis.get(entity.getChassis().toUpperCase() + mode + addendum);
+        if (chassis.containsKey(entity.getFullChassis().toUpperCase() + mode + addendum)) {
+            return chassis.get(entity.getFullChassis().toUpperCase() + mode + addendum);
         }
 
         // last, the generic model

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -222,7 +222,7 @@ public final class UnitToolTip {
             String ownerName = (owner != null) ? owner.getName() : ReportMessages.getString("BoardView1.Tooltip.unknownOwner");
             String msg_clanbrackets = Messages.getString("BoardView1.Tooltip.ClanBrackets");
             String clanStr = entity.isClan() && !entity.isMixedTech() ? " " + msg_clanbrackets + " " : "";
-            result = entity.getChassis() + clanStr;
+            result = entity.getFullChassis() + clanStr;
             result += " (" + (int) entity.getWeight() + "t)";
             result += "&nbsp;&nbsp;" + entity.getEntityTypeName(entity.getEntityType());
             result += "<BR>" + ownerName;

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -14,10 +14,8 @@
  */
 package megamek.client.ui.swing.util;
 
-import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.alphaStrike.ASCardDisplayable;
-import megamek.common.alphaStrike.ASUnitType;
 import megamek.common.annotations.Nullable;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.fileUtils.MegaMekFile;
@@ -46,7 +44,7 @@ public class FluffImageHelper {
     public static final String DIR_NAME_SPACESTATION = "Space Station";
     public static final String DIR_NAME_VEHICLE = "Vehicle";
     public static final String DIR_NAME_WARSHIP = "WarShip";
-    public static final String[] EXTENSIONS_FLUFF_IMAGE_FORMATS = { ".png", ".jpg", ".gif", ".PNG", ".JPG", ".GIF" };
+    public static final String[] EXTENSIONS_FLUFF_IMAGE_FORMATS = { ".PNG", ".png", ".JPG", ".JPEG", ".jpg", ".jpeg", ".GIF", ".gif" };
 
     /**
      * Get the fluff image for the specified unit, if available.
@@ -236,7 +234,7 @@ public class FluffImageHelper {
         }
     }
 
-    private static String getImagePath(final Entity unit) {
+    public static String getImagePath(final Entity unit) {
         if (unit instanceof Warship) {
             return DIR_NAME_WARSHIP;
         } else if (unit instanceof SpaceStation) {

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -103,14 +103,14 @@ public class FluffImageHelper {
         String userDir = PreferenceManager.getClientPreferences().getUserDir();
         if (!userDir.isBlank()) {
             var userDirPath = new File(userDir + "/" + Configuration.fluffImagesDir(), getImagePath(element));
-            Image image = loadFluffImageHeuristic(userDirPath, element.getModel(), element.getChassis());
+            Image image = loadFluffImageHeuristic(userDirPath, element.getModel(), element.getFullChassis());
             if (image != null) {
                 return image;
             }
         }
 
         var path = new MegaMekFile(Configuration.fluffImagesDir(), getImagePath(element));
-        return loadFluffImageHeuristic(path.getFile(), element.getModel(), element.getChassis());
+        return loadFluffImageHeuristic(path.getFile(), element.getModel(), element.getFullChassis());
     }
 
     private static @Nullable Image loadFluffImageHeuristic(File path, String model, String chassis) {

--- a/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/FluffImageHelper.java
@@ -14,6 +14,7 @@
  */
 package megamek.client.ui.swing.util;
 
+import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.alphaStrike.ASCardDisplayable;
 import megamek.common.alphaStrike.ASUnitType;
@@ -85,7 +86,7 @@ public class FluffImageHelper {
         String userDir = PreferenceManager.getClientPreferences().getUserDir();
         if (!userDir.isBlank()) {
             var userDirPath = new File(userDir + "/" + Configuration.fluffImagesDir(), getImagePath(entity));
-            Image image = loadFluffImageHeuristic(userDirPath, entity.getModel(), entity.getChassis());
+            Image image = loadFluffImageHeuristic(userDirPath, entity.getModel(), entity.getFullChassis());
             if (image != null) {
                 return image;
             }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -31,7 +31,6 @@ import megamek.common.icons.Camouflage;
 import megamek.common.options.*;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.weapons.*;
-import megamek.common.weapons.battlearmor.ISBAPopUpMineLauncher;
 import megamek.common.weapons.bayweapons.AR10BayWeapon;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.bayweapons.CapitalMissileBayWeapon;
@@ -144,9 +143,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     protected String model;
 
     /**
-     * The additional name can be, e.g., the Clan name for Clan Meks (Timber Wolf).
+     * The special chassis name for Clan Meks such as Timber Wolf for the Mad Cat. This is appended to the
+     * base chassis name to form the full chassis name such as Mad Cat (Timber Wolf) in
+     * {@link #getShortNameRaw()} and {@link #getFullChassis()}.
      */
-    protected String additionalName = "";
+    protected String clanChassisName = "";
 
     /**
      * If this is a unit from an official source, the MUL ID links it to its corresponding
@@ -1035,7 +1036,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return The full chassis name plus the additional name, if any, e.g. Mad Cat (Timber Wolf)
      */
     public String getFullChassis() {
-        return chassis + (StringUtility.isNullOrBlank(additionalName) ? "" : " (" + additionalName + ")");
+        return chassis + (StringUtility.isNullOrBlank(clanChassisName) ? "" : " (" + clanChassisName + ")");
     }
 
     /**
@@ -1047,14 +1048,14 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         this.chassis = chassis;
     }
 
-    /** Sets the {@link #additionalName} for this unit (e.g. IS name for Clan Meks or infantry designation). */
-    public void setAdditionalName(String name) {
-        additionalName = name;
+    /** Sets the {@link #clanChassisName} for this unit, e.g. "Timber Wolf". */
+    public void setClanChassisName(String name) {
+        clanChassisName = Objects.requireNonNullElse(name, "");
     }
 
-    /** @return The {@link #additionalName} for this unit (e.g. IS name for Clan Meks or infantry designation). */
-    public String getAdditionalName() {
-        return additionalName;
+    /** @return The {@link #clanChassisName} for this unit, e.g. "Timber Wolf", or "" if there is none. */
+    public String getClanChassisName() {
+        return clanChassisName;
     }
 
     /**
@@ -2586,7 +2587,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     public String getShortNameRaw() {
         String unitName = chassis;
-        unitName += StringUtility.isNullOrBlank(additionalName) ? "" : " (" + additionalName + ")";
+        unitName += StringUtility.isNullOrBlank(clanChassisName) ? "" : " (" + clanChassisName + ")";
         unitName += StringUtility.isNullOrBlank(model) ? "" : " " + model;
         return unitName;
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -145,7 +145,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * The special chassis name for Clan Meks such as Timber Wolf for the Mad Cat. This is appended to the
      * base chassis name to form the full chassis name such as Mad Cat (Timber Wolf) in
-     * {@link #getShortNameRaw()} and {@link #getFullChassis()}.
+     * {@link #getShortNameRaw()} and {@link #getFullChassis()}. This is only saved in mtf files (as of 2024).
      */
     protected String clanChassisName = "";
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -144,6 +144,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     protected String model;
 
     /**
+     * The additional name can be, e.g., the Clan name for Clan Meks (Timber Wolf).
+     */
+    protected String additionalName = "";
+
+    /**
      * If this is a unit from an official source, the MUL ID links it to its corresponding
      * entry in the online Master Unit List.
      */
@@ -1020,10 +1025,17 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
-     * Returns the chassis name for this entity.
+     * @return The pure chassis name without any additions, e.g. "Mad Cat"
      */
     public String getChassis() {
         return chassis;
+    }
+
+    /**
+     * @return The full chassis name plus the additional name, if any, e.g. Mad Cat (Timber Wolf)
+     */
+    public String getFullChassis() {
+        return chassis + (StringUtility.isNullOrBlank(additionalName) ? "" : " (" + additionalName + ")");
     }
 
     /**
@@ -1033,6 +1045,16 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public void setChassis(String chassis) {
         this.chassis = chassis;
+    }
+
+    /** Sets the {@link #additionalName} for this unit (e.g. IS name for Clan Meks or infantry designation). */
+    public void setAdditionalName(String name) {
+        additionalName = name;
+    }
+
+    /** @return The {@link #additionalName} for this unit (e.g. IS name for Clan Meks or infantry designation). */
+    public String getAdditionalName() {
+        return additionalName;
     }
 
     /**
@@ -2563,7 +2585,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public String getShortNameRaw() {
-        return StringUtility.isNullOrBlank(model) ? chassis : chassis + ' ' + model;
+        String unitName = chassis;
+        unitName += StringUtility.isNullOrBlank(additionalName) ? "" : " (" + additionalName + ")";
+        unitName += StringUtility.isNullOrBlank(model) ? "" : " " + model;
+        return unitName;
     }
 
     /**

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -693,7 +693,7 @@ public class EntityListFile {
 
             // Start writing this entity to the file.
             output.write(indentStr(indentLvl) + "<" + MULParser.ELE_ENTITY + " " + MULParser.ATTR_CHASSIS + "=\"");
-            output.write(entity.getChassis().replaceAll("\"", "&quot;"));
+            output.write(entity.getFullChassis().replaceAll("\"", "&quot;"));
             output.write("\" " + MULParser.ATTR_MODEL + "=\"");
             output.write(entity.getModel().replaceAll("\"", "&quot;"));
             output.write("\" " + MULParser.ATTR_TYPE + "=\"");

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -693,7 +693,7 @@ public class EntityListFile {
 
             // Start writing this entity to the file.
             output.write(indentStr(indentLvl) + "<" + MULParser.ELE_ENTITY + " " + MULParser.ATTR_CHASSIS + "=\"");
-            output.write(entity.getFullChassis().replaceAll("\"", "&quot;"));
+            output.write(entity.getChassis().replaceAll("\"", "&quot;"));
             output.write("\" " + MULParser.ATTR_MODEL + "=\"");
             output.write(entity.getModel().replaceAll("\"", "&quot;"));
             output.write("\" " + MULParser.ATTR_TYPE + "=\"");

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4181,10 +4181,12 @@ public abstract class Mech extends Entity {
         boolean standard = (getCockpitType() == Mech.COCKPIT_STANDARD)
                 && (getGyroType() == Mech.GYRO_STANDARD);
         sb.append(MtfFile.CHASSIS).append(chassis).append(newLine);
-        sb.append(MtfFile.CLAN_CHASSIS_NAME).append(clanChassisName).append(newLine);
+        if (!clanChassisName.isBlank()) {
+            sb.append(MtfFile.CLAN_CHASSIS_NAME).append(clanChassisName).append(newLine);
+        }
         sb.append(MtfFile.MODEL).append(model).append(newLine);
         if (hasMulId()) {
-            sb.append(MtfFile.MUL_ID).append(mulId);
+            sb.append(MtfFile.MUL_ID).append(mulId).append(newLine);
         }
         sb.append(newLine);
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4181,6 +4181,7 @@ public abstract class Mech extends Entity {
         boolean standard = (getCockpitType() == Mech.COCKPIT_STANDARD)
                 && (getGyroType() == Mech.GYRO_STANDARD);
         sb.append(MtfFile.CHASSIS).append(chassis).append(newLine);
+        sb.append(MtfFile.CLAN_CHASSIS_NAME).append(clanChassisName).append(newLine);
         sb.append(MtfFile.MODEL).append(model).append(newLine);
         if (hasMulId()) {
             sb.append(MtfFile.MUL_ID).append(mulId);

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -14,7 +14,6 @@
  */
 package megamek.common;
 
-import megamek.codeUtilities.StringUtility;
 import megamek.common.alphaStrike.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.*;
@@ -186,7 +185,7 @@ public class MechSummary implements Serializable, ASCardDisplayable {
         return chassis;
     }
 
-    public void setAdditionalName(String name) {
+    public void setClanChassisName(String name) {
         additionalName = name;
     }
 

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -31,7 +31,7 @@ public class MechSummary implements Serializable, ASCardDisplayable {
 
     private String name;
     private String chassis;
-    private String additionalName;
+    private String clanChassisName;
     private String model;
     private int mulId;
     private String unitType;
@@ -186,11 +186,11 @@ public class MechSummary implements Serializable, ASCardDisplayable {
     }
 
     public void setClanChassisName(String name) {
-        additionalName = name;
+        clanChassisName = name;
     }
 
-    public String getAdditionalName() {
-        return additionalName;
+    public String getClanChassisName() {
+        return clanChassisName;
     }
 
     @Override

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -186,6 +186,7 @@ public class MechSummary implements Serializable, ASCardDisplayable {
         return chassis;
     }
 
+    @Override
     public String getFullChassis() {
         return chassis + (StringUtility.isNullOrBlank(clanChassisName) ? "" : " (" + clanChassisName + ")");
     }

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -14,6 +14,7 @@
  */
 package megamek.common;
 
+import megamek.codeUtilities.StringUtility;
 import megamek.common.alphaStrike.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.*;
@@ -31,6 +32,7 @@ public class MechSummary implements Serializable, ASCardDisplayable {
 
     private String name;
     private String chassis;
+    private String additionalName;
     private String model;
     private int mulId;
     private String unitType;
@@ -182,6 +184,14 @@ public class MechSummary implements Serializable, ASCardDisplayable {
     @Override
     public String getChassis() {
         return chassis;
+    }
+
+    public void setAdditionalName(String name) {
+        additionalName = name;
+    }
+
+    public String getAdditionalName() {
+        return additionalName;
     }
 
     @Override

--- a/megamek/src/megamek/common/MechSummary.java
+++ b/megamek/src/megamek/common/MechSummary.java
@@ -14,6 +14,7 @@
  */
 package megamek.common;
 
+import megamek.codeUtilities.StringUtility;
 import megamek.common.alphaStrike.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.options.*;
@@ -183,6 +184,10 @@ public class MechSummary implements Serializable, ASCardDisplayable {
     @Override
     public String getChassis() {
         return chassis;
+    }
+
+    public String getFullChassis() {
+        return chassis + (StringUtility.isNullOrBlank(clanChassisName) ? "" : " (" + clanChassisName + ")");
     }
 
     public void setClanChassisName(String name) {

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -389,7 +389,7 @@ public class MechSummaryCache {
         MechSummary ms = new MechSummary();
         ms.setName(e.getShortNameRaw());
         ms.setChassis(e.getFullChassis());
-        ms.setAdditionalName(e.getAdditionalName());
+        ms.setClanChassisName(e.getClanChassisName());
         ms.setModel(e.getModel());
         ms.setMulId(e.getMulId());
         ms.setUnitType(UnitType.getTypeName(e.getUnitType()));

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -388,7 +388,7 @@ public class MechSummaryCache {
     private MechSummary getSummary(Entity e, File f, String entry) {
         MechSummary ms = new MechSummary();
         ms.setName(e.getShortNameRaw());
-        ms.setChassis(e.getFullChassis());
+        ms.setChassis(e.getChassis());
         ms.setClanChassisName(e.getClanChassisName());
         ms.setModel(e.getModel());
         ms.setMulId(e.getMulId());

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -388,7 +388,8 @@ public class MechSummaryCache {
     private MechSummary getSummary(Entity e, File f, String entry) {
         MechSummary ms = new MechSummary();
         ms.setName(e.getShortNameRaw());
-        ms.setChassis(e.getChassis());
+        ms.setChassis(e.getFullChassis());
+        ms.setAdditionalName(e.getAdditionalName());
         ms.setModel(e.getModel());
         ms.setMulId(e.getMulId());
         ms.setUnitType(UnitType.getTypeName(e.getUnitType()));

--- a/megamek/src/megamek/common/alphaStrike/ASCardDisplayable.java
+++ b/megamek/src/megamek/common/alphaStrike/ASCardDisplayable.java
@@ -49,6 +49,8 @@ public interface ASCardDisplayable extends BattleForceSUAFormatter, BTObject, Co
     /** @return The AS element's chassis, such as "Atlas". */
     String getChassis();
 
+    String getFullChassis();
+
     /** @return This AS element's MUL ID if it has one, -1 otherwise. */
     int getMulId();
 

--- a/megamek/src/megamek/common/alphaStrike/ASStatsExporter.java
+++ b/megamek/src/megamek/common/alphaStrike/ASStatsExporter.java
@@ -60,7 +60,7 @@ public class ASStatsExporter {
     private void prepareData() {
         model = new HashMap<>();
         if (element != null) {
-            model.put("chassis", element.getChassis());
+            model.put("chassis", element.getFullChassis());
             model.put("model", element.getModel());
             model.put("PV", element.getPointValue());
             model.put("TP", element.getASUnitType().toString());

--- a/megamek/src/megamek/common/alphaStrike/AlphaStrikeElement.java
+++ b/megamek/src/megamek/common/alphaStrike/AlphaStrikeElement.java
@@ -130,6 +130,11 @@ public class AlphaStrikeElement implements Serializable, ASCardDisplayable, ASSp
     }
 
     @Override
+    public String getFullChassis() {
+        return getChassis();
+    }
+
+    @Override
     public String getModel() {
         return model;
     }

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCard.java
@@ -276,7 +276,7 @@ public class ASCard {
         }
         new StringDrawer(model).at(36, 44).font(modelFont).centerY()
                 .maxWidth(750).scaleX(1.3f).draw(g);
-        new StringDrawer(element.getChassis().toUpperCase(Locale.ROOT)).at(36, 89)
+        new StringDrawer(element.getFullChassis().toUpperCase(Locale.ROOT)).at(36, 89)
                 .font(chassisFont).centerY().maxWidth(770).scaleX(0.8f).draw(g);
 
         // Add BA Squad Size

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASConverter.java
@@ -20,6 +20,7 @@ package megamek.common.alphaStrike.conversion;
 
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.client.ui.swing.calculationReport.DummyCalculationReport;
+import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.alphaStrike.ASArcs;
 import megamek.common.alphaStrike.ASUnitType;
@@ -101,7 +102,7 @@ public final class ASConverter {
         element.setName(entity.getShortName());
         element.setQuirks(entity.getQuirks());
         element.setModel(entity.getModel());
-        element.setChassis(entity.getChassis());
+        element.setChassis(entity.getFullChassis());
         element.setMulId(entity.getMulId());
         element.setRole(entity.getRole());
 

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -96,7 +96,7 @@ public class MtfFile implements IMechLoader {
     public static final String MTF_VERSION = "version:";
     public static final String GENERATOR = "generator:";
     public static final String CHASSIS = "chassis:";
-    public static final String CLAN_CHASSIS_NAME = "additionalname:";
+    public static final String CLAN_CHASSIS_NAME = "clanname:";
     public static final String MODEL = "model:";
     public static final String COCKPIT = "cockpit:";
     public static final String GYRO = "gyro:";

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -40,7 +40,7 @@ public class MtfFile implements IMechLoader {
 
     private String chassis;
     private String model;
-    private String additionalName = "";
+    private String clanChassisName = "";
     private int mulId = -1;
 
     private String chassisConfig;
@@ -96,7 +96,7 @@ public class MtfFile implements IMechLoader {
     public static final String MTF_VERSION = "version:";
     public static final String GENERATOR = "generator:";
     public static final String CHASSIS = "chassis:";
-    public static final String ADDITIONAL_NAME = "additionalname:";
+    public static final String CLAN_CHASSIS_NAME = "additionalname:";
     public static final String MODEL = "model:";
     public static final String COCKPIT = "cockpit:";
     public static final String GYRO = "gyro:";
@@ -223,7 +223,7 @@ public class MtfFile implements IMechLoader {
             }
             mech.setFullHeadEject(fullHead);
             mech.setChassis(chassis.trim());
-            mech.setAdditionalName(additionalName);
+            mech.setClanChassisName(clanChassisName);
             mech.setModel(model.trim());
             mech.setMulId(mulId);
             mech.setYear(Integer.parseInt(techYear.substring(4).trim()));
@@ -1178,8 +1178,8 @@ public class MtfFile implements IMechLoader {
             return true;
         }
 
-        if (lineLower.startsWith(ADDITIONAL_NAME)) {
-            additionalName = line.substring(ADDITIONAL_NAME.length());
+        if (lineLower.startsWith(CLAN_CHASSIS_NAME)) {
+            clanChassisName = line.substring(CLAN_CHASSIS_NAME.length());
             return true;
         }
 

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -40,6 +40,7 @@ public class MtfFile implements IMechLoader {
 
     private String chassis;
     private String model;
+    private String additionalName = "";
     private int mulId = -1;
 
     private String chassisConfig;
@@ -95,6 +96,7 @@ public class MtfFile implements IMechLoader {
     public static final String MTF_VERSION = "version:";
     public static final String GENERATOR = "generator:";
     public static final String CHASSIS = "chassis:";
+    public static final String ADDITIONAL_NAME = "additionalname:";
     public static final String MODEL = "model:";
     public static final String COCKPIT = "cockpit:";
     public static final String GYRO = "gyro:";
@@ -221,6 +223,7 @@ public class MtfFile implements IMechLoader {
             }
             mech.setFullHeadEject(fullHead);
             mech.setChassis(chassis.trim());
+            mech.setAdditionalName(additionalName);
             mech.setModel(model.trim());
             mech.setMulId(mulId);
             mech.setYear(Integer.parseInt(techYear.substring(4).trim()));
@@ -1172,6 +1175,11 @@ public class MtfFile implements IMechLoader {
 
         if (lineLower.startsWith(OVERVIEW)) {
             overview = line.substring(OVERVIEW.length());
+            return true;
+        }
+
+        if (lineLower.startsWith(ADDITIONAL_NAME)) {
+            additionalName = line.substring(ADDITIONAL_NAME.length());
             return true;
         }
 


### PR DESCRIPTION
This adds a specialized field to Entity to separate the chassis name of Clan meks into their Clan and IS names (if they have a Clan name). This means that the Mad Cat (Timber Wolf) can now have chassis=Mad Cat and clanname=Timber Wolf and the two can be combined in the code in whatever way. As this affects only Meks, only mtf files store it.

The other code changes are adaptations that make MM behave as it did before, so the change is not visible. 
Updates to the affected units are in #5106 
There are accompanying updates for MML and MHQ