### PR TITLE
Princess non-combat PSR reduction.

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
+++ b/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
@@ -49,16 +49,16 @@ public class BehaviorSettings implements Serializable {
             30};
     static final int[] FALL_SHAME_VALUES = {
             10,
-            20,
             40,
-            60,
             80,
             100,
-            120,
-            140,
             160,
-            180,
-            200};
+            500,
+            500,
+            500,
+            500,
+            500,
+            500};
     protected static final double[] BRAVERY = {
             0.1,
             0.3,

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -430,7 +430,7 @@ public class BasicPathRankerTest {
 
         RankedPath expected = new RankedPath(baseRank, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0)
-                + " * " + LOG_DECIMAL.format(100) + "] + braveryMod ["
+                + " * " + LOG_DECIMAL.format(500) + "] + braveryMod ["
                 + LOG_DECIMAL.format(-6.25) + " = " + LOG_PERCENT.format(1) + " * (("
                 + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5) + ") - "
                 + LOG_DECIMAL.format(40) + "] - aggressionMod ["
@@ -448,9 +448,9 @@ public class BasicPathRankerTest {
         doReturn(0.5)
                .when(testRanker)
                .getMovePathSuccessProbability(any(MovePath.class), any(StringBuilder.class));
-        expected = new RankedPath(-98.125, mockPath, "Calculation: {fall mod ["
-                + LOG_DECIMAL.format(50) + " = " + LOG_DECIMAL.format(0.5) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod ["
+        expected = new RankedPath(-298.125, mockPath, "Calculation: {fall mod ["
+                + LOG_DECIMAL.format(250) + " = " + LOG_DECIMAL.format(0.5) + " * "
+                + LOG_DECIMAL.format(500) + "] + braveryMod ["
                 + LOG_DECIMAL.format(-3.12) + " = " + LOG_PERCENT.format(0.5)
                 + " * ((" + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5)
                 + ") - " + LOG_DECIMAL.format(40) + "] - aggressionMod ["
@@ -469,9 +469,9 @@ public class BasicPathRankerTest {
         doReturn(0.75)
                .when(testRanker)
                .getMovePathSuccessProbability(any(MovePath.class), any(StringBuilder.class));
-        expected = new RankedPath(-74.6875, mockPath, "Calculation: {fall mod ["
-                + LOG_DECIMAL.format(25) + " = " + LOG_DECIMAL.format(0.25) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod ["
+        expected = new RankedPath(-174.6875, mockPath, "Calculation: {fall mod ["
+                + LOG_DECIMAL.format(125) + " = " + LOG_DECIMAL.format(0.25) + " * "
+                + LOG_DECIMAL.format(500) + "] + braveryMod ["
                 + LOG_DECIMAL.format(-4.69) + " = " + LOG_PERCENT.format(0.75)
                 + " * ((" + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5)
                 + ") - " + LOG_DECIMAL.format(40) + "] - aggressionMod ["
@@ -501,7 +501,7 @@ public class BasicPathRankerTest {
                .evaluateMovedEnemy(eq(mockEnemyMech1), any(MovePath.class), any(Game.class));
         expected = new RankedPath(-51.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod ["
+                + LOG_DECIMAL.format(500) + "] + braveryMod ["
                 + LOG_DECIMAL.format(-6.25) + " = " + LOG_PERCENT.format(1) + " * (("
                 + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5) + ") - "
                 + LOG_DECIMAL.format(40) + "] - aggressionMod ["
@@ -525,7 +525,7 @@ public class BasicPathRankerTest {
                .evaluateMovedEnemy(eq(mockEnemyMech1), any(MovePath.class), any(Game.class));
         expected = new RankedPath(-61.0, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-16)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-16)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(16)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -558,7 +558,7 @@ public class BasicPathRankerTest {
                .evaluateMovedEnemy(eq(mockEnemyMech1), any(MovePath.class), any(Game.class));
         expected = new RankedPath(-61.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-16.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-16.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(50)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -582,7 +582,7 @@ public class BasicPathRankerTest {
                .evaluateMovedEnemy(eq(mockEnemyMech1), any(MovePath.class), any(Game.class));
         expected = new RankedPath(-41.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(3.75)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(3.75)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(30)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -611,7 +611,7 @@ public class BasicPathRankerTest {
                .distanceToClosestEnemy(any(Entity.class), any(Coords.class), any(Game.class));
         expected = new RankedPath(-26.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + " + "braveryMod ["
+                + LOG_DECIMAL.format(500) + "] + " + "braveryMod ["
                 + LOG_DECIMAL.format(-6.25) + " = " + LOG_PERCENT.format(1) + " * (("
                 + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5) + ") - "
                 + LOG_DECIMAL.format(40) + "] - " +"aggressionMod [" + LOG_DECIMAL.format(5)
@@ -631,7 +631,7 @@ public class BasicPathRankerTest {
                .distanceToClosestEnemy(any(Entity.class), any(Coords.class), any(Game.class));
         expected = new RankedPath(-76.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(55) + " = "
@@ -654,7 +654,7 @@ public class BasicPathRankerTest {
         friendsCoords = new Coords(0, 10);
         expected = new RankedPath(-46.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -672,7 +672,7 @@ public class BasicPathRankerTest {
         friendsCoords = new Coords(20, 10);
         expected = new RankedPath(-56.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -689,7 +689,7 @@ public class BasicPathRankerTest {
         }
         expected = new RankedPath(-36.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL .format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -707,7 +707,7 @@ public class BasicPathRankerTest {
         when(mockMover.isCrippled()).thenReturn(true);
         expected = new RankedPath(baseFleeingRank, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -724,7 +724,7 @@ public class BasicPathRankerTest {
                .distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class));
         expected = new RankedPath(-51.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -744,7 +744,7 @@ public class BasicPathRankerTest {
                .distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class));
         expected = new RankedPath(-51.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - "+ LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = " + LOG_DECIMAL.format(12)
@@ -768,7 +768,7 @@ public class BasicPathRankerTest {
         when(mockPath.getFinalFacing()).thenReturn(1);
         expected = new RankedPath(baseRank, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -786,7 +786,7 @@ public class BasicPathRankerTest {
         when(mockPath.getFinalFacing()).thenReturn(4);
         expected = new RankedPath(-101.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -804,7 +804,7 @@ public class BasicPathRankerTest {
         when(mockPath.getFinalFacing()).thenReturn(3);
         expected = new RankedPath(-151.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "
@@ -827,7 +827,7 @@ public class BasicPathRankerTest {
                .findClosestEnemy(eq(mockMover), nullable(Coords.class), any(Game.class));
         expected = new RankedPath(-51.25, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(0) + " = " + LOG_DECIMAL.format(0) + " * "
-                + LOG_DECIMAL.format(100) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
+                + LOG_DECIMAL.format(500) + "] + braveryMod [" + LOG_DECIMAL.format(-6.25)
                 + " = " + LOG_PERCENT.format(1) + " * ((" + LOG_DECIMAL.format(22.5)
                 + " * " + LOG_DECIMAL.format(1.5) + ") - " + LOG_DECIMAL.format(40)
                 + "] - aggressionMod [" + LOG_DECIMAL.format(30) + " = "


### PR DESCRIPTION
Summary: This PR changes the maximum fall shame values and prevents Princess from taking most unnecessary non-combat PSR rolls, and does not hurt her combat performance at all.  Resulting in drastically fewer "she killed half of her force before I ever saw her" issues with the same (or better) combat performance (becase she has more living units).  

The "Fall Shame" scale maximum has been increased from 200 to 500 and 500 has been made default.  The old default of 100 has been moved down to spot 4, but I dont think there is really any reason to ever use it, honestly.  

I have tested it extensively.  Its impossible to test every possible combination, but I have tested extremes that I think will cover most cases.  I tested Mechs, Vehicles, VTOL, ASF and infantry.  Its been tested via terrain hazards, pavement, gravity (high and low) and the most extreme weather and light conditions, including combinations thereof.  There has been no performance reduction in any condition that I could find.  Detailed testing info posted below, for anyone that cares to look at it.

Caveat 1:  She will still take non-combat PSRs in Swamp, Quicksand, Ice (with no water under it), Mud, and a few other terrains because she does not currently "see" them as hazards.  I hope to fix those issues in a future PR.

Caveat 2:  She will still take in-combat PSRs and sometimes wreck herself, but is a much smaller issue because if there is a time to risk a PSR its in combat.

This fixes #4878.  I will add another issue later for the separate Swamp/Mud/Quicksand, and other hazards.

Detailed Testing, and its TLDR:
![image](https://github.com/MegaMek/megamek/assets/23645569/cba1ecd3-d26e-43cc-ab5b-97d7490edbf6)

![image](https://github.com/MegaMek/megamek/assets/23645569/5f63b81e-2e77-496f-ab64-b81f6fc7b001)

