### PR TITLE
Fix remaining armor test failures

### DIFF
--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -34,6 +34,9 @@ public class ArmorType extends MiscType {
     private static final List<ArmorType> allTypes = new ArrayList<>();
 
     public static ArmorType of(int type, boolean clan) {
+        if (armorTypeLookupClan.isEmpty() && armorTypeLookupIS.isEmpty()) {
+            initializeTypes();
+        }
         ArmorType armor = clan ? armorTypeLookupClan.get(type) : armorTypeLookupIS.get(type);
         // Some mixed tech unit files use the unit tech base instead of the armor tech base.
         if (armor == null) {
@@ -59,6 +62,7 @@ public class ArmorType extends MiscType {
     }
 
     public static void initializeTypes() {
+        addArmorType(createUnknownArmor());
         addArmorType(createStandardArmor());
         addArmorType(createISFerroFibrous());
         addArmorType(createClanFerroFibrous());

--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -62,7 +62,6 @@ public class ArmorType extends MiscType {
     }
 
     public static void initializeTypes() {
-        addArmorType(createUnknownArmor());
         addArmorType(createStandardArmor());
         addArmorType(createISFerroFibrous());
         addArmorType(createClanFerroFibrous());
@@ -253,29 +252,6 @@ public class ArmorType extends MiscType {
 
     public int getBAR() {
         return bar;
-    }
-
-    private static ArmorType createUnknownArmor() {
-        ArmorType armor = new ArmorType();
-        armor.name = "Unknown";
-        armor.setInternalName("Unknown Armor");
-        armor.addLookupName("IS Unknown");
-        armor.addLookupName("Clan Unknown");
-        armor.addLookupName("Unknown");
-
-        armor.flags = armor.flags.or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT)
-                .or(F_VTOL_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_PROTOMECH_EQUIPMENT);
-        armor.criticals = 0;
-
-        armor.techAdvancement = new TechAdvancement(TECH_BASE_ALL)
-                .setAdvancement(2460, 2470, 2470).setApproximate(true, false, false)
-                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_C, RATING_C, RATING_B)
-                .setStaticTechLevel(SimpleTechLevel.INTRO);
-
-        armor.armorType = T_ARMOR_UNKNOWN;
-        armor.weightPerPoint = 0.050; // when used as protomech armor
-
-        return armor;
     }
 
     private static ArmorType createStandardArmor() {

--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -251,6 +251,29 @@ public class ArmorType extends MiscType {
         return bar;
     }
 
+    private static ArmorType createUnknownArmor() {
+        ArmorType armor = new ArmorType();
+        armor.name = "Unknown";
+        armor.setInternalName("Unknown Armor");
+        armor.addLookupName("IS Unknown");
+        armor.addLookupName("Clan Unknown");
+        armor.addLookupName("Unknown");
+
+        armor.flags = armor.flags.or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT)
+                .or(F_VTOL_EQUIPMENT).or(F_FIGHTER_EQUIPMENT).or(F_PROTOMECH_EQUIPMENT);
+        armor.criticals = 0;
+
+        armor.techAdvancement = new TechAdvancement(TECH_BASE_ALL)
+                .setAdvancement(2460, 2470, 2470).setApproximate(true, false, false)
+                .setTechRating(RATING_D).setAvailability(RATING_C, RATING_C, RATING_C, RATING_B)
+                .setStaticTechLevel(SimpleTechLevel.INTRO);
+
+        armor.armorType = T_ARMOR_UNKNOWN;
+        armor.weightPerPoint = 0.050; // when used as protomech armor
+
+        return armor;
+    }
+
     private static ArmorType createStandardArmor() {
         ArmorType armor = new ArmorType();
 

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -25,6 +25,7 @@ import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.MovePath.Key;
+import megamek.common.equipment.ArmorType;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
@@ -61,6 +62,11 @@ public class BasicPathRankerTest {
 
     @BeforeEach
     public void beforeEach() {
+
+        // We now need to make sure all armor types are initialized or mockito will complain.
+        if (!ArmorType.getAllTypes().hasMoreElements()) {
+            ArmorType.initializeTypes();
+        }
         final BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
         when(mockBehavior.getFallShameValue()).thenReturn(BehaviorSettings.FALL_SHAME_VALUES[5]);
         when(mockBehavior.getBraveryValue()).thenReturn(BehaviorSettings.BRAVERY[5]);

--- a/megamek/unittests/megamek/common/loaders/TdbFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/TdbFileTest.java
@@ -23,7 +23,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import megamek.common.equipment.ArmorType;
 import megamek.common.BipedMech;
 import megamek.common.Engine;
 import megamek.common.Entity;
@@ -32,7 +31,6 @@ import megamek.common.Mounted;
 import megamek.common.QuadMech;
 import megamek.common.loaders.TdbFile.CriticalSlot;
 import megamek.common.loaders.TdbFile.Location;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/megamek/unittests/megamek/common/loaders/TdbFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/TdbFileTest.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import megamek.common.equipment.ArmorType;
 import megamek.common.BipedMech;
 import megamek.common.Engine;
 import megamek.common.Entity;
@@ -31,6 +32,7 @@ import megamek.common.Mounted;
 import megamek.common.QuadMech;
 import megamek.common.loaders.TdbFile.CriticalSlot;
 import megamek.common.loaders.TdbFile.Location;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,34 +41,34 @@ import static org.junit.jupiter.api.Assertions.*;
  * @author nderwin
  */
 public class TdbFileTest {
-    
+
     @Test
     public void testJenner() throws Exception {
         InputStream is = getClass().getResourceAsStream("JR7-D Jenner.xml");
         assertNotNull(is);
-        
+
         TdbFile testMe = TdbFile.getInstance(is);
-        
+
         assertEquals(6, testMe.mounted.items.size());
-        
+
         Entity result = testMe.getEntity();
 
         assertTrue(result instanceof BipedMech);
         BipedMech mek = (BipedMech) result;
-        
+
         assertEquals("Jenner", mek.getChassis());
         assertEquals("JR7-D", mek.getModel());
         assertEquals(35.0f, mek.getWeight(), 0.0f);
 
         assertEquals(Mech.COCKPIT_STANDARD, mek.getCockpitType());
         assertEquals(Mech.GYRO_STANDARD, mek.getGyroType());
-        
+
         assertTrue(mek.getEngine().engineValid);
         assertTrue(mek.getEngine().isFusion());
         assertEquals(Engine.NORMAL_ENGINE, mek.getEngine().getEngineType());
         assertEquals(7, mek.getWalkMP());
         assertEquals(11, mek.getRunMP());
-        
+
         assertEquals(10, mek.getActiveSinks());
 
         assertEquals(7, mek.getArmor(Mech.LOC_HEAD));
@@ -80,7 +82,7 @@ public class TdbFileTest {
         assertEquals(4, mek.getArmor(Mech.LOC_LARM));
         assertEquals(6, mek.getArmor(Mech.LOC_RLEG));
         assertEquals(6, mek.getArmor(Mech.LOC_LLEG));
-        
+
         assertFalse(mek.getFailedEquipment().hasNext());
 
         boolean foundSRM = false;
@@ -90,14 +92,14 @@ public class TdbFileTest {
         int jjCT = 0;
         int jjRT = 0;
         int jjLT = 0;
-        
+
         for (Mounted m : mek.getEquipment()) {
             switch (m.getLocation()) {
                 case Mech.LOC_CT:
                     if ("Jump Jet".equals(m.getName())) {
                         jjCT++;
                     }
-                    
+
                     if (!foundSRM && "SRM 4".equals(m.getName())) {
                         foundSRM = true;
                     } else if (foundSRM && "SRM 4".equals(m.getName())) {
@@ -112,7 +114,7 @@ public class TdbFileTest {
                     if ("Jump Jet".equals(m.getName())) {
                         jjRT++;
                     }
-                    
+
                     if (!foundAmmo && "SRM 4 Ammo".equals(m.getName())) {
                         foundAmmo = true;
                     } else if (foundAmmo && "SRM 4 Ammo".equals(m.getName())) {
@@ -151,7 +153,7 @@ public class TdbFileTest {
                     break;
             }
         }
-        
+
         assertTrue(foundSRM, "Found SRM-4");
         assertTrue(foundAmmo, "Found SRM-4 ammo");
         assertEquals(1, jjCT, "Found 1 Jump Jet in CT");
@@ -160,36 +162,36 @@ public class TdbFileTest {
         assertEquals(2, mlRARM, "Found 2 Medium Lasers in RARM");
         assertEquals(2, mlLARM, "Found 2 Medium Lasers in LARM");
     }
-    
+
     @Test
     public void testTarantula() throws Exception {
         InputStream is = getClass().getResourceAsStream("ZPH-1A Tarantula.xml");
         assertNotNull(is);
-        
+
         TdbFile testMe = TdbFile.getInstance(is);
-        
+
         assertEquals(4, testMe.mounted.items.size());
-        
+
         Entity result = testMe.getEntity();
 
         assertTrue(result instanceof QuadMech);
         QuadMech mek = (QuadMech) result;
-        
+
         assertEquals("Tarantula", mek.getChassis());
         assertEquals("ZPH-1A", mek.getModel());
         assertEquals(25.0f, mek.getWeight(), 0.0f);
 
         assertEquals(Mech.COCKPIT_STANDARD, mek.getCockpitType());
         assertEquals(Mech.GYRO_STANDARD, mek.getGyroType());
-        
+
         assertTrue(mek.getEngine().engineValid);
         assertTrue(mek.getEngine().isFusion());
         assertEquals(Engine.XL_ENGINE, mek.getEngine().getEngineType());
         assertEquals(8, mek.getWalkMP());
         assertEquals(12, mek.getRunMP());
-        
+
         assertEquals(10, mek.getActiveSinks());
-        
+
         assertEquals(6, mek.getArmor(Mech.LOC_HEAD));
         assertEquals(7, mek.getArmor(Mech.LOC_RT));
         assertEquals(10, mek.getArmor(Mech.LOC_CT));
@@ -201,7 +203,7 @@ public class TdbFileTest {
         assertEquals(7, mek.getArmor(Mech.LOC_LARM));
         assertEquals(7, mek.getArmor(Mech.LOC_RLEG));
         assertEquals(7, mek.getArmor(Mech.LOC_LLEG));
-        
+
         assertFalse(mek.getFailedEquipment().hasNext());
 
         boolean foundSSRM = false;
@@ -222,7 +224,7 @@ public class TdbFileTest {
                     } else if (foundSSRM && "Streak SRM 2".equals(m.getName())) {
                         fail("Only 1 SSRM-2 in CT");
                     }
-                    
+
                     if (!foundAmmo && "Streak SRM 2 Ammo".equals(m.getName())) {
                         foundAmmo = true;
                     } else if (foundAmmo && "Streak SRM 2 Ammo".equals(m.getName())) {
@@ -250,7 +252,7 @@ public class TdbFileTest {
                     if ("Double Heat Sink".equals(m.getName())) {
                         dblHS++;
                     }
-                    
+
                     if ("Medium Laser".equals(m.getName())) {
                         mlLT++;
                     }
@@ -263,7 +265,7 @@ public class TdbFileTest {
                     if ("Jump Jet".equals(m.getName())) {
                         jjFRL++;
                     }
-                    
+
                     assertFalse(m.getName().contains("Heat Sink"), "Found a Heat Sink in RARM");
                     assertNotEquals("Medium Laser", m.getName(), "Found a Medium Laser in RARM");
                     assertNotEquals("Streak SRM 2", m.getName(), "Found a SSRM-2 in RARM");
@@ -273,7 +275,7 @@ public class TdbFileTest {
                     if ("Jump Jet".equals(m.getName())) {
                         jjFLL++;
                     }
-                    
+
                     assertFalse(m.getName().contains("Heat Sink"), "Found a Heat Sink in LARM");
                     assertNotEquals("Medium Laser", m.getName(), "Found a Medium Laser in LARM");
                     assertNotEquals("Streak SRM 2", m.getName(), "Found a SSRM-2 in LARM");


### PR DESCRIPTION
This should allow the remaining failing unit tests to pass.

The issue is that the ArmorType types are not guaranteed to be initialized, because `ArmorType.initializeTypes()` is only called from `EquipmentType.initializeTypes()`, and _that_ is only called in a few specific paths that rely on actually starting up the game itself.

I've added a check in `ArmorType.of()` that should avoid _some_ infinite recursions as well.

These fixes will allow tests to pass but are pretty fragile.  It would be better to ensure that ArmorTypes are always initialized no matter what, but I'm not sure where would be best so I will leave that to others.