### PR TITLE
Fix Long Tom Cannon not dealing damage to flying dropship

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7318,4 +7318,8 @@ public class Compute {
                     && !(isLandedSpheroid && noseWeaponAimedAtGroundTarget);
     }
 
+    public static boolean isFlakAttack(Entity attacker, Entity target) {
+        return (!attacker.isAirborne()) && (target.isAirborne() || target.isAirborneVTOLorWIGE());
+    }
+
 } // End public class Compute

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7319,7 +7319,8 @@ public class Compute {
     }
 
     public static boolean isFlakAttack(Entity attacker, Entity target) {
-        return (!attacker.isAirborne()) && (target.isAirborne() || target.isAirborneVTOLorWIGE());
+        boolean validLocation = !(attacker.isSpaceborne() || target.isSpaceborne());
+        return validLocation && (target.isAirborne() || target.isAirborneVTOLorWIGE());
     }
 
 } // End public class Compute

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -363,7 +363,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         boolean isFlakAttack = !game.getBoard().inSpace() && (te != null)
-                && (te.isAirborne() || te.isAirborneVTOLorWIGE())
+                && Compute.isFlakAttack(ae, te)
                 && (wtype instanceof CLBALBX
                     || ((atype != null)
                         && (
@@ -409,9 +409,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
         // hack, otherwise when actually resolves shot labeled impossible.
         boolean isArtilleryFLAK = isArtilleryDirect && (te != null)
-                && ((((te.getMovementMode() == EntityMovementMode.VTOL)
-                        || (te.getMovementMode() == EntityMovementMode.WIGE)) && te.isAirborneVTOLorWIGE())
-                        || (te.isAirborne()))
+                && Compute.isFlakAttack(ae, te)
                 && (atype != null) && (usesAmmo && (atype.countsAsFlak()));
 
         boolean isHaywireINarced = ae.isINarcedWith(INarcPod.HAYWIRE);

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -148,8 +148,9 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
         final Vector<Integer> spottersBefore = aaa.getSpotterIds();
         Coords targetPos = target.getPosition();
         final int playerId = aaa.getPlayerId();
-        boolean isFlak = (target instanceof VTOL) || (target.isAero());
-        boolean asfFlak = target.isAero();
+        boolean targetIsEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
+        boolean isFlak = targetIsEntity && Compute.isFlakAttack(ae, (Entity) target);
+        boolean asfFlak = isFlak && target.isAirborne();
         boolean mineClear = target.getTargetType() == Targetable.TYPE_MINEFIELD_CLEAR;
         Entity bestSpotter = null;
         if (ae == null) {

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -46,14 +46,15 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
         if (!cares(phase)) {
             return true;
         }
-
-        Coords targetPos = target.getPosition();
-        boolean isFlak = (target instanceof VTOL) || target.isAero();
-        boolean asfFlak = target.isAero();
         if (ae == null) {
             LogManager.getLogger().error("Artillery Entity is null!");
             return true;
         }
+
+        Coords targetPos = target.getPosition();
+        boolean targetIsEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
+        boolean isFlak = targetIsEntity && Compute.isFlakAttack(ae, (Entity) target);
+        boolean asfFlak = isFlak && target.isAirborne();
         Mounted ammoUsed = ae.getEquipment(waa.getAmmoId());
         final AmmoType ammoType = (ammoUsed == null) ? null : (AmmoType) ammoUsed.getType();
 

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -126,24 +126,33 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
             vPhaseReport.addElement(r);
         } else {
             targetPos = Compute.scatter(targetPos, (Math.abs(toHit.getMoS()) + 1) / 2);
-            if (game.getBoard().contains(targetPos)) {
-                // misses and scatters to another hex
-                if (!isFlak) {
-                    r = new Report(3195);
+            if (!game.getBoard().inSpace()) {
+                if (game.getBoard().contains(targetPos)) {
+                    // misses and scatters to another hex
+                    if (!isFlak) {
+                        r = new Report(3195);
+                    } else {
+                        r = new Report(3192);
+                    }
+                    r.subject = subjectId;
+                    r.add(targetPos.getBoardNum());
+                    vPhaseReport.addElement(r);
                 } else {
-                    r = new Report(3192);
+                    // misses and scatters off-board
+                    if (isFlak) {
+                        r = new Report(3193);
+                    } else {
+                        r = new Report(3200);
+                    }
+                    r.subject = subjectId;
+                    vPhaseReport.addElement(r);
+                    return !bMissed;
                 }
+            } else {
+                // No scattering in space
+                r = new Report(3196);
                 r.subject = subjectId;
                 r.add(targetPos.getBoardNum());
-                vPhaseReport.addElement(r);
-            } else {
-                // misses and scatters off-board
-                if (isFlak) {
-                    r = new Report(3193);
-                } else {
-                    r = new Report(3200);
-                }
-                r.subject = subjectId;
                 vPhaseReport.addElement(r);
                 return !bMissed;
             }

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -123,9 +123,8 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
 
         final int playerId = aaa.getPlayerId();
         boolean targetIsEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
-        boolean targetIsAirborneVTOL = targetIsEntity && target.isAirborneVTOLorWIGE();
-        boolean isFlak = targetIsAirborneVTOL || target.isAirborne();
-        boolean asfFlak = target.isAirborne();
+        boolean isFlak = targetIsEntity && Compute.isFlakAttack(ae, (Entity) target);
+        boolean asfFlak = isFlak && target.isAirborne();
         Entity bestSpotter = null;
         if (ae == null) {
             LogManager.getLogger().error("Artillery Entity is null!");


### PR DESCRIPTION
This fixes a number of issues caused by disparate checks for Flak attacks, and some incorrect handling of AE damage and scattering in the ArtilleryCannon handler:

1. Artillery Cannon attacks on _all_ aerospace were counted as Flak; this should only apply to Airborne Aerospace, VTOLs, and WiGEs on the Ground and Low Altitude maps (Artillery Flak attacks can also target the Ground row of the High Altitude map but this does not apply here).
2. Artillery Cannon attacks, being Flak attacks, could not damage grounded Aerospace targets because they would be at Altitude 0 and thus invalid to be damaged by AE Flak.
3. Aerospace-mounted Artillery Cannon attacks were being counted as Flak even on the Space map, which is not correct.
4. Artillery Cannon attacks in Space were allowed to scatter and damage units in other hexes due to not checking for inSpace(); this is incorrect.

Additionally, we had several disparate locations where the check for if an attack counted as Flak() was handled differently, leading to some of the above issues.  I consolidated all these checks to a Compute function; this should make updating handling of all Flak attacks somewhat smoother in the future.

There is an outstanding Forum question regarding whether AE weapons deal any AE damage to non-target units in the intended hex: https://bg.battletech.com/forums/index.php/topic,83963.0.html

Testing:
Tested with various Aerospace attackers and targets, plus ground-based Flak units where applicable, on Ground and Space maps.