### PR TITLE
Initialize EquipmentType for individual unit tests.

### DIFF
--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -22,7 +22,6 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
-import megamek.common.equipment.ArmorType;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
-import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 
 import java.math.BigInteger;
@@ -146,7 +144,6 @@ public class FireControlTest {
     @BeforeAll
     public static void beforeAll() {
         EquipmentType.initializeTypes();
-        ArmorType.initializeTypes();
     }
 
     @BeforeEach

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -22,6 +22,7 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
+import megamek.common.equipment.ArmorType;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
@@ -29,6 +30,8 @@ import megamek.common.weapons.StopSwarmAttack;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.server.SmokeCloud;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
@@ -139,6 +142,12 @@ public class FireControlTest {
     private Map<Mounted, Double> testToHitThreshold;
 
     private FireControl testFireControl;
+
+    @BeforeAll
+    public static void beforeAll() {
+        EquipmentType.initializeTypes();
+        ArmorType.initializeTypes();
+    }
 
     @BeforeEach
     public void beforeEach() {

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -22,6 +22,7 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
+import megamek.common.equipment.ArmorType;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,6 +48,12 @@ public class PrincessTest {
 
     private Princess mockPrincess;
     private BasicPathRanker mockPathRanker;
+
+    @BeforeAll
+    public static void beforeAll() {
+        EquipmentType.initializeTypes();
+        ArmorType.initializeTypes();
+    }
 
     @BeforeEach
     public void beforeEach() {

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -22,7 +22,6 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
-import megamek.common.equipment.ArmorType;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import org.junit.jupiter.api.BeforeAll;
@@ -52,7 +51,6 @@ public class PrincessTest {
     @BeforeAll
     public static void beforeAll() {
         EquipmentType.initializeTypes();
-        ArmorType.initializeTypes();
     }
 
     @BeforeEach

--- a/megamek/unittests/megamek/common/ComputeECMTest.java
+++ b/megamek/unittests/megamek/common/ComputeECMTest.java
@@ -20,6 +20,8 @@
 package megamek.common;
 
 import megamek.common.options.GameOptions;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -37,7 +39,11 @@ import static org.mockito.Mockito.when;
  * @since 11/3/13 8:48 AM
  */
 public class ComputeECMTest {
-    
+    @BeforeAll
+    public static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
     @Test
     public void testEntityGetECMInfo() {
         // Mock Player

--- a/megamek/unittests/megamek/common/EntityTest.java
+++ b/megamek/unittests/megamek/common/EntityTest.java
@@ -21,7 +21,6 @@ package megamek.common;
 
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.battlevalue.BVCalculator;
-import megamek.common.equipment.ArmorType;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -66,7 +65,6 @@ public class EntityTest {
     @BeforeAll
     public static void beforeAll() {
         EquipmentType.initializeTypes();
-        ArmorType.initializeTypes();
     }
 
     @Test

--- a/megamek/unittests/megamek/common/EntityTest.java
+++ b/megamek/unittests/megamek/common/EntityTest.java
@@ -21,6 +21,9 @@ package megamek.common;
 
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.battlevalue.BVCalculator;
+import megamek.common.equipment.ArmorType;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -58,6 +61,12 @@ public class EntityTest {
         when(testEntity.getWeaponList()).thenReturn(equipment);
         when(testEntity.getAmmo()).thenReturn(new ArrayList<>(0));
         return testEntity;
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        EquipmentType.initializeTypes();
+        ArmorType.initializeTypes();
     }
 
     @Test

--- a/megamek/unittests/megamek/common/PlanetaryConditionsTest.java
+++ b/megamek/unittests/megamek/common/PlanetaryConditionsTest.java
@@ -3,8 +3,6 @@ package megamek.common;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import megamek.common.equipment.ArmorType;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -19,7 +17,6 @@ public class PlanetaryConditionsTest {
     @BeforeAll
     public static void beforeAll() {
         EquipmentType.initializeTypes();
-        ArmorType.initializeTypes();
     }
 
     @Test

--- a/megamek/unittests/megamek/common/PlanetaryConditionsTest.java
+++ b/megamek/unittests/megamek/common/PlanetaryConditionsTest.java
@@ -1,6 +1,9 @@
 package megamek.common;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import megamek.common.equipment.ArmorType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -12,6 +15,12 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 public class PlanetaryConditionsTest {
+
+    @BeforeAll
+    public static void beforeAll() {
+        EquipmentType.initializeTypes();
+        ArmorType.initializeTypes();
+    }
 
     @Test
     public void testWhyDoomed() {


### PR DESCRIPTION
This PR ensures that specific unit test classes that mock BattleArmor.class can be run from an IDE as individual unit tests by initializing the static collections of ArmorType and EquipmentType as they may not have been initialized when running these test classes as jUnit tests in isolation.

FireControlTest.java
PrincessTest.java
EntityTest.java
PlanetaryConditionsTest.java

Without these changes, these tests depend upon some other test to run before them that initialize these static collections.