### PR TITLE
Fix 5104: no to-hit malus for units expending VTOL movement

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -264,8 +264,9 @@ public class FireControl {
                 }
             }
         } else {
+            // Now more inclusive VTOL/WiGE check, should cover VTOL CI/BA as well.
             toHitData.append(getTargetMovementModifier(targetState.getHexesMoved(), targetState.isJumping(),
-                                                       target instanceof VTOL, game));
+                                                       target.isAirborneVTOLorWIGE(), game));
         }
         if (shooterState.isProne()) {
             toHitData.addModifier(TH_ATT_PRONE);

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2561,7 +2561,7 @@ public class Compute {
                             || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT)
                         );
 
-        boolean isVTOL = (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
+        boolean validFlying = (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
                         || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
                         || (entity.getMovementMode() == EntityMovementMode.VTOL)
                         || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT);
@@ -2570,7 +2570,7 @@ public class Compute {
                 .getTargetMovementModifier(
                         entity.delta_distance,
                         jumped,
-                        isVTOL,
+                        validFlying,
                         game);
 
         if (entity.moved != EntityMovementType.MOVE_JUMP
@@ -2645,7 +2645,7 @@ public class Compute {
             }
         }
 
-        if (jumped) {
+        if (isVTOL || jumped) {
             if (isVTOL && (distance > 0)) {
                 toHit.addModifier(1, "target VTOL used MPs");
             } else {

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2645,12 +2645,10 @@ public class Compute {
             }
         }
 
-        if (isVTOL || jumped) {
-            if (isVTOL && (distance > 0)) {
-                toHit.addModifier(1, "target VTOL used MPs");
-            } else {
-                toHit.addModifier(1, "target jumped");
-            }
+        if (isVTOL && (distance > 0)) {
+            toHit.addModifier(1, "target VTOL used MPs");
+        } else if (jumped) {
+            toHit.addModifier(1, "target jumped");
         }
 
         return toHit;

--- a/megamek/unittests/megamek/common/TargetRollTest.java
+++ b/megamek/unittests/megamek/common/TargetRollTest.java
@@ -18,9 +18,19 @@
  */
 package megamek.common;
 
+import megamek.client.ui.swing.calculationReport.CalculationReport;
+import megamek.common.battlevalue.BVCalculator;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TargetRollTest {
     @Test
@@ -64,7 +74,7 @@ public class TargetRollTest {
         assertEquals("Automatic Success", roll.getValueAsString());
         assertEquals("great success", roll.getDesc());
     }
-    
+
     @Test
     public void checkFalseTest() {
         TargetRoll roll = new TargetRoll(TargetRoll.CHECK_FALSE, "check one, check one two");
@@ -105,5 +115,33 @@ public class TargetRollTest {
         assertEquals("1 (first) - 2 (second) + 3 (third) + 0 (fourth)", roll.getDesc());
         assertEquals(2, roll.getValue());
         assertEquals("2", roll.getValueAsString());
+    }
+
+    // Check to-hit roll mods for VTOL, WiGE, jumping Hovers, etc.
+    private Game setupGame() {
+        Game game = new Game();
+        GameOptions gOp = new GameOptions();
+        game.setOptions(gOp);
+        return game;
+    }
+
+    @Test
+    public void addOneForFlyingVTOL() {
+        int distance = 1;
+        boolean jumped = false;
+        boolean vtol = true;
+        Game game = setupGame();
+        ToHitData thd = Compute.getTargetMovementModifier(distance, jumped, vtol, game);
+        assertEquals(1, thd.getValue());
+    }
+
+    @Test
+    public void addOneForJumping() {
+        int distance = 1;
+        boolean jumped = true;
+        boolean vtol = false;
+        Game game = setupGame();
+        ToHitData thd = Compute.getTargetMovementModifier(distance, jumped, vtol, game);
+        assertEquals(1, thd.getValue());
     }
 }


### PR DESCRIPTION
Fixes a bug I introduced while making the Jumping +1 to-hit malus for WiGEs work.
The check I introduced was supposed to work for _either_ jumping units _or_ VTOL units, but in fact would only give the +1 for VTOL MPs expended if the unit _also_ jumped, which is not possible.

Testing:
- Tested every Jumping unit type, every VTOL sub-type, and a few weird combos like jumping WiGEs against most every AAA weapon or unit type.
- Added two unit tests that would have caught this error originally, to fully shut that barn door.

Close #5104 