### PR TITLE
Fix 4952: Princess does not select alt ammo

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -728,7 +728,7 @@
 5560=<data> takes over as <data> of <data> (<data>).
 5600=<newline>Bomb Bay Explosions<newline>-------------------
 5601=<data> (<data>) took ground fire damage while dropping internal bay bombs.
-5602=<data> (<data>) must roll under <data>+ to avoid bomb bay explosion, rolls <data>.
+5602=<data> (<data>) Checking for bomb bay explosion on <data>+, rolls <data>.
 5603=\ <font color='C00000'><data> (<data>) takes <data> damage when <data> remaining bombs explode!</font>
 5604=\ <font color='008000'><data> (<data>) avoids bomb bay explosion; <data> internal bombs remaining.</font>
 5605=\ <font color='C00000'><data> (<data>) suffers a critical Cargo hit; <msg:5606,5607></font>

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -55,6 +55,19 @@
 1241=Blue Shield Field Dampener <font color='C00000'>fails</font>!
 1242=no effect
 
+# 1500s - ammo handling related
+1500=<data> (<data>) switched their <data> ammo to <data>
+1501= due to <font color='C00000'>out of ammo!</font>
+1502= due to better to-hit chance.
+1503= due to better damage potential.
+1504= due to special effects.
+1505= due to expectation of TAG support.
+1506= due to having no better option.
+1507= randomly.
+1508= from attached ammo carrier.
+1509= to maximise critical chances.
+1510= to maximise heat on target.
+1511= to maximise range.
 
 2000=<newline><B>Movement Phase</B><newline>-------------------
 2005=<newline><data> (<data>) flees the battlefield.

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -56,7 +56,7 @@
 1242=no effect
 
 # 1500s - ammo handling related
-1500=<data> (<data>) switched their <data> ammo to <data>
+1500=<data> (<data>) selected <data> <data>
 1501= due to <font color='C00000'>out of ammo!</font>
 1502= due to better to-hit chance.
 1503= due to better damage potential.

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -546,8 +546,8 @@ public class Client implements IClientCommandHandler {
     /**
      * Send mode-change data to the server
      */
-    public void sendAmmoChange(int nEntity, int nWeapon, int nAmmo) {
-        send(new Packet(PacketCommand.ENTITY_AMMOCHANGE, nEntity, nWeapon, nAmmo));
+    public void sendAmmoChange(int nEntity, int nWeapon, int nAmmo, int reason) {
+        send(new Packet(PacketCommand.ENTITY_AMMOCHANGE, nEntity, nWeapon, nAmmo, reason));
     }
 
     /**

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -548,6 +548,7 @@ public abstract class BotClient extends Client {
                 sendArtyAutoHitHexes(autoHitHexes);
             } else if (game.getPhase().isTargeting() || game.getPhase().isOffboard()) {
                 // Princess implements arty targeting
+                // TODO: TAG should be handled separately.
                 calculateTargetingOffBoardTurn();
             } else if (game.getPhase().isPremovement() || game.getPhase().isPrefiring()) {
                 calculatePrephaseTurn();

--- a/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
+++ b/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
@@ -4,10 +4,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import megamek.common.IAero;
-import megamek.common.MovePath;
-import megamek.common.UnitType;
+import megamek.common.*;
 import megamek.common.MovePath.MoveStepType;
+import megamek.common.annotations.Nullable;
 
 /**
  * Helper class that contains functionality relating mostly to aero unit paths.
@@ -15,32 +14,32 @@ import megamek.common.MovePath.MoveStepType;
  */
 public class AeroPathUtil {
     public static List<List<MoveStepType>> TURNS;
-    
+
     static {
         // put together a pre-defined array of turns. Indexes correspond to the directional values found in Coords.java
         TURNS = new ArrayList<>();
         TURNS.add(new ArrayList<>()); // "no turns"
-        
+
         TURNS.add(new ArrayList<>());
         TURNS.get(1).add(MoveStepType.TURN_RIGHT);
-        
+
         TURNS.add(new ArrayList<>());
         TURNS.get(2).add(MoveStepType.TURN_RIGHT);
         TURNS.get(2).add(MoveStepType.TURN_RIGHT);
-        
+
         TURNS.add(new ArrayList<>());
         TURNS.get(3).add(MoveStepType.TURN_RIGHT);
         TURNS.get(3).add(MoveStepType.TURN_RIGHT);
         TURNS.get(3).add(MoveStepType.TURN_RIGHT);
-        
+
         TURNS.add(new ArrayList<>());
         TURNS.get(4).add(MoveStepType.TURN_LEFT);
         TURNS.get(4).add(MoveStepType.TURN_LEFT);
-        
+
         TURNS.add(new ArrayList<>());
         TURNS.get(5).add(MoveStepType.TURN_LEFT);
     }
-    
+
     /**
      * Determines if the aircraft undertaking the given path will stall at the end of the turn.
      * Only relevant for aerodyne units
@@ -63,13 +62,13 @@ public class AeroPathUtil {
         if ((movePath.getFinalVelocity() == 0) && isAirborne && !isSpheroid) {
             return true;
         }
-        
-        if (isSpheroid && (movePath.getFinalNDown() == 0) 
+
+        if (isSpheroid && (movePath.getFinalNDown() == 0)
                 && (movePath.getMpUsed() == 0)
                 && !movePath.contains(MoveStepType.VLAND)) {
             return true;
         }
-        
+
         return false;
     }
 
@@ -110,14 +109,14 @@ public class AeroPathUtil {
      */
     public static Collection<MovePath> generateValidAccelerations(MovePath startingPath, int lowerBound, int upperBound) {
         Collection<MovePath> paths = new ArrayList<>();
-        
+
         // sanity check: if we've already done something else with the path, there's no acceleration to be done
         if (startingPath.length() > 0) {
             return paths;
         }
-        
+
         int currentVelocity = startingPath.getFinalVelocity();
-        
+
         // we go from the lower bound to the current velocity and generate paths with the required number of DECs to get to
         // the desired velocity
         for (int desiredVelocity = lowerBound; desiredVelocity < currentVelocity; desiredVelocity++) {
@@ -125,16 +124,16 @@ public class AeroPathUtil {
             for (int deltaVelocity = 0; deltaVelocity < currentVelocity - desiredVelocity; deltaVelocity++) {
                 path.addStep(MoveStepType.DEC);
             }
-            
+
             paths.add(path);
         }
-        
+
         // If the unaltered starting path is within acceptable velocity bounds, it's also a valid "acceleration".
         if (startingPath.getFinalVelocity() <= upperBound &&
            startingPath.getFinalVelocity() >= lowerBound) {
             paths.add(startingPath.clone());
         }
-        
+
         // we go from the current velocity to the upper bound and generate paths with the required number of DECs to get to
         // the desired velocity
         for (int desiredVelocity = currentVelocity; desiredVelocity < upperBound; desiredVelocity++) {
@@ -142,13 +141,13 @@ public class AeroPathUtil {
             for (int deltaVelocity = 0; deltaVelocity < upperBound - desiredVelocity; deltaVelocity++) {
                 path.addStep(MoveStepType.ACC);
             }
-            
+
             paths.add(path);
         }
-        
+
         return paths;
     }
-    
+
     /**
      * Helper function to calculate the maximum thrust we should use for a particular aircraft
      * We limit ourselves to the lowest of "safe thrust" and "structural integrity", as anything further is unsafe, meaning it requires a PSR.
@@ -159,7 +158,7 @@ public class AeroPathUtil {
         int maxThrust = Math.min(aero.getCurrentThrust(), aero.getSI());    // we should only thrust up to our SI
         return maxThrust;
     }
-    
+
     /**
      * Given a move path, generate all possible increases and decreases in elevation.
      * @param path The move path to process.
@@ -167,75 +166,100 @@ public class AeroPathUtil {
      */
     public static List<MovePath> generateValidAltitudeChanges(MovePath path) {
         List<MovePath> paths = new ArrayList<>();
-        
+
         // clone path add UP
         // if path uses more MP than entity has available or altitude higher than 10, stop
         for (int altChange = 0; ; altChange++) {
             int altChangeCost = altChange * 2;
-            
+
             // if we are going to attempt to change altitude but won't actually be able to, break out.
             if ((path.getFinalAltitude() + altChange > 10) ||
                     path.getMpUsed() + altChangeCost > path.getEntity().getRunMP()) {
                 break;
             }
-            
+
             MovePath childPath = path.clone();
-            
+
             for (int numSteps = 0; numSteps < altChange; numSteps++) {
                 childPath.addStep(MoveStepType.UP);
             }
-            
+
             if ((childPath.getFinalAltitude() > 10) ||
                     childPath.getMpUsed() > path.getEntity().getRunMP()) {
                 break;
             }
-            
+
             paths.add(childPath);
         }
-        
+
         // clone path add DOWN
         // if the path is already at minimum altitude, skip this
         // if path uses more MP than entity has available or altitude lower than 1, stop
         if (path.getFinalAltitude() > 1) {
             for (int altChange = 1; ; altChange++) {
                 MovePath childPath = path.clone();
-                
+
                 for (int numSteps = 0; numSteps < altChange; numSteps++) {
                     childPath.addStep(MoveStepType.DOWN);
                 }
-                
-                // going down doesn't use MP, but if we drop down more than 2 altitude it causes a massive 
+
+                // going down doesn't use MP, but if we drop down more than 2 altitude it causes a massive
                 // difficulty PSR, which is just not worth it.
                 if ((childPath.getFinalAltitude() < 1) ||
                         childPath.length() > 2) {
                     break;
                 }
-                
+
                 paths.add(childPath);
             }
         }
-        
+
         return paths;
     }
 
     /**
      * Given a move path, generates all possible rotations from it,
-     * without any regard to legality. Mostly because it's intended for spheroid 
+     * without any regard to legality. Mostly because it's intended for spheroid
      * dropships in atmosphere, which can rotate as much as they want.
      */
     public static List<MovePath> generateValidRotations(MovePath path) {
         List<MovePath> childPaths = new ArrayList<>();
-        
+
         for (int x = 1; x < TURNS.size(); x++) {
             MovePath childPath = path.clone();
-            
+
             for (MoveStepType turn : TURNS.get(x)) {
                 childPath.addStep(turn);
             }
-            
+
             childPaths.add(childPath);
         }
-        
+
         return childPaths;
+    }
+
+    public static List<MovePath> generateValidRotation(MovePath path, @Nullable Coords poi) {
+        List<MovePath> childPaths = new ArrayList<>();
+        if (null != poi) {
+            MovePath childPath = path.clone();
+            Coords curCoords = childPath.getFinalCoords();
+
+            int dir = curCoords.direction(poi);
+
+            // Only turn if not facing correct direction
+            if (dir > 0) {
+                for (MoveStepType turn : TURNS.get(dir)) {
+                    childPath.addStep(turn);
+                }
+                childPaths.add(childPath);
+            }
+        }
+
+        return childPaths;
+
+    }
+
+    public static Coords getSpheroidPOI(Game game, Entity mover) {
+        return game.getBoard().getCenter();
     }
 }

--- a/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
+++ b/megamek/src/megamek/client/bot/princess/AeroPathUtil.java
@@ -241,12 +241,17 @@ public class AeroPathUtil {
     }
 
     public static int getSpheroidDir(Game game, Entity mover) {
-        final StringBuilder msg = new StringBuilder("Deciding where to point ")
-                .append(mover.getDisplayName()).append("...");
+        boolean debug = LogManager.getLogger().isDebugEnabled();
+        final StringBuilder msg = (debug)
+                ? new StringBuilder("Deciding where to point ")
+                .append(mover.getDisplayName()).append("...")
+                : null;
 
         // Face the center of the board
         int dir = mover.getPosition().direction(game.getBoard().getCenter());
-        msg.append("\nMap center is to the ").append(ClientCommand.getDirection(dir));
+        if (debug) {
+            msg.append("\nMap center is to the ").append(ClientCommand.getDirection(dir));
+        }
 
         int enemyDir = dir;
 
@@ -261,15 +266,19 @@ public class AeroPathUtil {
             // Calc center of allies _of the enemy_
             centroid = PathRanker.calcAllyCenter(enemies.get(0).getId(), enemies, game);
             enemyDir = mover.getPosition().direction(centroid);
-            msg.append("\nEnemies are over in ").append(ClientCommand.getDirection(enemyDir));
+
+            if (debug) {
+                msg.append("\nEnemies are over in ").append(ClientCommand.getDirection(enemyDir));
+            }
         }
 
         // Then determine if we need to protect part of the ship
         if (mover.getDamageLevel() == Entity.DMG_NONE) {
             dir = enemyDir;
-            msg.append("\nBeing hale and hearty, we will aim toward the ")
-                    .append(ClientCommand.getDirection(dir));
-
+            if (debug) {
+                msg.append("\nBeing hale and hearty, we will aim toward the ")
+                        .append(ClientCommand.getDirection(dir));
+            }
         } else {
             int leastArmor = 9999999;
             int leastLoc = Dropship.LOC_NONE;
@@ -297,13 +306,17 @@ public class AeroPathUtil {
                         // Default is nose to enemy.  If this should be different, suggest using NOSE case.
                         dir = enemyDir;
                 }
-                msg.append("\nWe've taken a lot of damage to our ").append(mover.getLocationAbbr(leastLoc));
-                msg.append("\nTurning to the ").append(ClientCommand.getDirection(dir))
-                        .append(" to protect ourselves!");
+                if (debug) {
+                    msg.append("\nWe've taken a lot of damage to our ").append(mover.getLocationAbbr(leastLoc));
+                    msg.append("\nTurning to the ").append(ClientCommand.getDirection(dir))
+                            .append(" to protect ourselves!");
+                }
             }
         }
 
-        LogManager.getLogger().debug(msg.toString());
+        if (debug) {
+            LogManager.getLogger().debug(msg.toString());
+        }
         return dir;
     }
 }

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -297,6 +297,7 @@ public class ArtilleryTargetingControl {
 
         // if we haven't built a target list yet, do so now.
         // potential target list is the same regardless of the entity doing the shooting
+        // TODO: allow for counter-battery fire on spotted off-board shooters.
         if (targetSet == null) {
             buildTargetList(shooter, game, owner);
             // If we decided not to shoot this phase, no reason to continue calculating.

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -379,15 +379,19 @@ public class ArtilleryTargetingControl {
                     // for each enemy unit, evaluate damage value of firing at its hex.
                     // keep track of top target hexes with the same value and fire at them
                     boolean isADA = ((AmmoType) ammo.getType()).getMunitionType().contains(AmmoType.Munitions.M_ADA);
+                    boolean isSmoke = ((AmmoType) ammo.getType()).getMunitionType().contains(AmmoType.Munitions.M_SMOKE);
                     for (Targetable target : targetSet) {
                         WeaponFireInfo wfi;
                         double damageValue = 0.0;
                         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
                             damageValue = damage;
                         } else {
-                            if (!isADA) {
+                            if (!(isADA || isSmoke)) {
                                 damageValue = calculateDamageValue(damage, (HexTarget) target, shooter, game, owner);
-                            } else {
+                            } else if (isSmoke) {
+                                damageValue = 0;
+                            }
+                            else {
                                 // No ADA attacks except at Entities.
                                 continue;
                             }

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -402,6 +402,12 @@ public class ArtilleryTargetingControl {
                             damageValue *= wfi.getProbabilityToHit();
 
                             if (damageValue > maxDamage) {
+                                if (((AmmoType) (wfi.getAmmo().getType())).getMunitionType()
+                                        .contains(AmmoType.Munitions.M_HOMING)){
+                                    wfi.getAmmo().setSwitchedReason(1505);
+                                } else {
+                                    wfi.getAmmo().setSwitchedReason(1503);
+                                }
                                 if (isADA) {
                                     topValuedADAInfos.clear();
                                     maxDamage = damage;  // Actual expected damage will be higher
@@ -427,10 +433,15 @@ public class ArtilleryTargetingControl {
                 // then set the fire info's attack action to the created attack action
                 // add the fire info to the firing plan
                 if (!topValuedFireInfos.isEmpty()) {
-                    WeaponFireInfo actualFireInfo = topValuedFireInfos.get(Compute.randomInt(topValuedFireInfos.size()));
-                    if (actualFireInfo.getAmmo() != actualFireInfo.getWeapon().getLinked()) {
-                        // Announce why we switched
-                        actualFireInfo.getAmmo().setSwitchedReason(1507);
+                    WeaponFireInfo actualFireInfo;
+                    if (topValuedFireInfos.size() == 1) {
+                        actualFireInfo = topValuedFireInfos.get(0);
+                    } else {
+                        actualFireInfo = topValuedFireInfos.get(Compute.randomInt(topValuedFireInfos.size()));
+                        if (actualFireInfo.getAmmo() != actualFireInfo.getWeapon().getLinked()) {
+                            // Announce why we switched
+                            actualFireInfo.getAmmo().setSwitchedReason(1507);
+                        }
                     }
                     ArtilleryAttackAction aaa = (ArtilleryAttackAction) actualFireInfo.buildWeaponAttackAction();
                     HelperAmmo ammo = findAmmo(shooter, actualFireInfo.getWeapon(), actualFireInfo.getAmmo());
@@ -447,7 +458,7 @@ public class ArtilleryTargetingControl {
                                 shooter.getId(),
                                 shooter.getEquipmentNum(actualFireInfo.getWeapon()),
                                 ammo.equipmentNum,
-                                1508);
+                                actualFireInfo.getAmmo().getSwitchedReason());
                     }
                 }
             } else if (currentWeapon.getType().hasFlag(WeaponType.F_TAG)) {

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -502,8 +502,8 @@ public class ArtilleryTargetingControl {
                 Mounted weapon = aaa.getEntity(operator.getGame()).getEquipment(aaa.getWeaponId());
                 if (null == weapon) {
                     // The weaponId couldn't get us a weapon; probably a bomb Arrow IV dropped on a prior turn.
-                    // Arrow IV is in the 20 damage range.
-                    damage = 20;
+                    BombType btype = BombType.createBombByType(BombType.getBombTypeFromName("Arrow IV Missile"));
+                    damage = btype.getRackSize();
                 } else {
                     if (weapon.getType() instanceof BombType) {
                         damage = (weapon.getExplosionDamage());

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -317,7 +317,7 @@ public class ArtilleryTargetingControl {
                     }
 
                     WeaponFireInfo wfi = new WeaponFireInfo(shooter, hexTarget,
-                            currentWeapon, game, false, owner);
+                            currentWeapon, null, game, false, owner);
 
                     // factor the chance to hit when picking a target - if we've got a spotted hex or an auto-hit hex
                     // we should prefer to hit that over something that may scatter to who knows where
@@ -383,7 +383,7 @@ public class ArtilleryTargetingControl {
 
         // pretty simple logic here: take the best shot that you have
         for (Targetable target : FireControl.getAllTargetableEnemyEntities(owner.getLocalPlayer(), game, owner.getFireControlState())) {
-            WeaponFireInfo wfi = new WeaponFireInfo(shooter, target, weapon, game, false, owner);
+            WeaponFireInfo wfi = new WeaponFireInfo(shooter, target, weapon, null, game, false, owner);
             if (wfi.getProbabilityToHit() > hitOdds) {
                 hitOdds = wfi.getProbabilityToHit();
                 retval = wfi;

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -500,12 +500,17 @@ public class ArtilleryTargetingControl {
                 // damage for artillery weapons is, for some reason, derived from the weapon type's rack size
                 int damage = 0;
                 Mounted weapon = aaa.getEntity(operator.getGame()).getEquipment(aaa.getWeaponId());
-                if (weapon.getType() instanceof BombType){
-                    damage = (weapon.getExplosionDamage());
+                if (null == weapon) {
+                    // The weaponId couldn't get us a weapon; probably a bomb Arrow IV dropped on a prior turn.
+                    // Arrow IV is in the 20 damage range.
+                    damage = 20;
                 } else {
-                    damage = ((WeaponType) weapon.getType()).getRackSize();
+                    if (weapon.getType() instanceof BombType) {
+                        damage = (weapon.getExplosionDamage());
+                    } else {
+                        damage = ((WeaponType) weapon.getType()).getRackSize();
+                    }
                 }
-
 
                 // distance from given coordinates reduces damage
                 Coords attackDestination = aaa.getTarget(operator.getGame()).getPosition();

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -625,19 +625,23 @@ public class BasicPathRanker extends PathRanker implements IPathRanker {
         for (Entity e : enemies) {
             double max_damage = 0;
             for (Entity f : friends) {
-                FiringPlanCalculationParameters guess =
-                        new FiringPlanCalculationParameters.Builder()
-                                .buildGuess(e,
+                if (f == unit){
+                    // Docstring says ignore self, so ignore self.
+                    max_damage = 0;
+                } else {
+                    FiringPlanCalculationParameters guess =
+                            new FiringPlanCalculationParameters.Builder()
+                                    .buildGuess(e,
                                             null,
                                             f,
                                             null,
                                             (e.getHeatCapacity() - e.getHeat()) + 5,
                                             null);
-                double damage = getFireControl(f).determineBestFiringPlan(guess).getExpectedDamage();
-                if (damage > max_damage) {
-                    max_damage = damage;
+                    double damage = getFireControl(f).determineBestFiringPlan(guess).getExpectedDamage();
+                    if (damage > max_damage) {
+                        max_damage = damage;
+                    }
                 }
-
             }
             bestDamageByEnemies.put(e.getId(), max_damage);
         }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -885,7 +885,7 @@ public class FireControl {
                     final StringBuilder msg = new StringBuilder("Estimating to-hit for Homing artillery fire by ")
                             .append(shooter.getDisplayName());
 
-                    if (Compute.isTargetTagged(target, game)) {
+                    if (Compute.isTargetTagged(target, game) || (target instanceof Entity && ((Entity) target).getTaggedBy() != -1)) {
                         // If it's been tagged recently, assume we can get that support again!
                         msg.append("\nAssuming the last guy who TAGged this target will do so again!");
                         toHit.addModifier(TH_HOMING_TARGET_TAGGED);

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1637,7 +1637,7 @@ public class FireControl {
                             game,
                             true);
 
-                    // Choose best expected damage shot if possible, not best to-hit
+                    // Choose first option, then best expected damage shot if possible, then the best to-hit
                     if (null == bestShoot
                             || shoot.getExpectedDamage() > bestShoot.getExpectedDamage()
                             || (shoot.getExpectedDamage() == bestShoot.getExpectedDamage()
@@ -1651,12 +1651,14 @@ public class FireControl {
                         } else {
                             switchedReason = 1502;
                         }
-                        if (shoot.getAmmo() != null) {
+
+                        bestShoot = shoot;
+
+                        if (shoot.getAmmo() != null && bestShoot != null) {
                             bestShoot.getAmmo().setSwitchedReason(
                                     (bestShoot.getAmmo() == weapon.getLinked()) ? 0 : switchedReason
                             );
                         }
-                        bestShoot = shoot;
                     }
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1590,7 +1590,7 @@ public class FireControl {
                 }
             }
 
-            if (0 < bestShoot.getProbabilityToHit()) {
+            if (bestShoot != null && 0 < bestShoot.getProbabilityToHit()) {
                 myPlan.add(bestShoot);
             }
         }
@@ -1703,7 +1703,7 @@ public class FireControl {
             }
 
             // for now, just fire weapons that will do damage until we get to heat capacity
-            if (0 < bestShoot.getProbabilityToHit() &&
+            if (bestShoot != null && 0 < bestShoot.getProbabilityToHit() &&
                     myPlan.getHeat() + bestShoot.getHeat() + shooter.getHeat() <= shooter.getHeatCapacity() &&
                     0 < bestShoot.getExpectedDamage()) {
                 myPlan.add(bestShoot);
@@ -1867,14 +1867,15 @@ public class FireControl {
             }
 
             // Choose the best shot
-            if (null != bestShoot && (bestShoot.getProbabilityToHit() > toHitThreshold)) {
-                myPlan.add(bestShoot);
-                continue;
+            if (null != bestShoot) {
+                if (bestShoot.getProbabilityToHit() > toHitThreshold) {
+                    myPlan.add(bestShoot);
+                    continue;
+                }
+                LogManager.getLogger().debug("\nTo Hit Chance (" + DECF.format(bestShoot.getProbabilityToHit())
+                        + ") for " + weapon.getName() +
+                        " is less than threshold (" + DECF.format(toHitThreshold) + ")");
             }
-
-            LogManager.getLogger().debug("\nTo Hit Chance (" + DECF.format(bestShoot.getProbabilityToHit())
-                    + ") for " + weapon.getName() +
-                    " is less than threshold (" + DECF.format(toHitThreshold) + ")");
         }
 
         // Rank how useful this plan is.

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1581,7 +1581,10 @@ public class FireControl {
                             ammo,
                             game,
                             true);
-                    if (null == bestShoot || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
+                    // Choose best expected damage shot, not best to-hit
+                    if (null == bestShoot ||
+                            (shoot.getExpectedDamage() > bestShoot.getExpectedDamage())
+                    ){
                         bestShoot = shoot;
                     }
                 }
@@ -1690,7 +1693,10 @@ public class FireControl {
                             true,
                             true);
 
-                    if (null == bestShoot || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
+                    // Choose best expected damage shot, not best to-hit
+                    if (null == bestShoot ||
+                            (shoot.getExpectedDamage() > bestShoot.getExpectedDamage())
+                    ){
                         bestShoot = shoot;
                     }
                 }
@@ -1817,8 +1823,12 @@ public class FireControl {
             return myPlan;
         }
 
-        // cycle through my weapons
+        // cycle through my weapons; should probably filter out already-fired / IDF arty
         for (final Mounted weapon : shooter.getWeaponList()) {
+            if (!weapon.canFire()) {
+                continue;
+            }
+
             // respect restriction on manual AMS firing.
             if (!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) &&
                     weapon.getType().hasFlag(WeaponType.F_AMS)) {
@@ -1847,7 +1857,10 @@ public class FireControl {
                             shoot.setUpdatedFiringMode(updatedMissileMode);
                         }
                     }
-                    if (null == bestShoot || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
+                    // Choose best expected damage shot, not best to-hit
+                    if (null == bestShoot ||
+                        (shoot.getExpectedDamage() > bestShoot.getExpectedDamage())
+                    ){
                         bestShoot = shoot;
                     }
                 }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2266,11 +2266,18 @@ public class FireControl {
             return false;
         }
 
-        for (Mounted weapon : shooter.getWeaponList()) {
-            if (weapon.hasModeType(Weapon.MODE_MISSILE_INDIRECT) || weapon.hasModeType(Weapon.MODE_INDIRECT_HEAT)) {
-                fireControlState.getEntityIDFStates().put(shooter.getId(), true);
-                return true;
+        try {
+            // Beware concurrent modification
+            for (Mounted weapon : shooter.getWeaponList()) {
+                if (weapon.hasModeType(Weapon.MODE_MISSILE_INDIRECT) || weapon.hasModeType(Weapon.MODE_INDIRECT_HEAT)) {
+                    fireControlState.getEntityIDFStates().put(shooter.getId(), true);
+                    return true;
+                }
             }
+        }
+        catch (ConcurrentModificationException e) {
+            // Needs more investigation, but for now just say IDF mode can't change right now.
+            LogManager.getLogger().error(e.getMessage(), e);
         }
 
         fireControlState.getEntityIDFStates().put(shooter.getId(), false);

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1614,6 +1614,18 @@ public class FireControl {
             return myPlan;
         }
 
+        if (shooter.isAirborne() && shooter.isLargeCraft() && game.getBoard().onGround()) {
+            // This process takes a long time for no reason; the likelihood of being able to strike
+            // or hit an enemy Aero is next to nil.
+            boolean debug = LogManager.getLogger().isDebugEnabled();
+            if (debug) {
+                LogManager.getLogger().debug(
+                        "Skip guessing firing plan for airborne dropship " + shooter.getShortName()
+                );
+            }
+            return null;
+        }
+
         // cycle through my weapons
         for (final Mounted weapon : shooter.getWeaponList()) {
             // respect restriction on manual AMS firing.

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1199,8 +1199,15 @@ public class FireControl {
                         ret.append(shootingCheck);
                     }
                 } else {
+                    // For certain weapon types, look over all their loaded ammos
                     ArrayList<Mounted> ammos;
-                    ammos = shooter.getAmmo(weapon);
+                    if (wtype.getAmmoType() == AmmoType.T_ATM || wtype.getAmmoType() == AmmoType.T_MML) {
+                        ammos = shooter.getAmmo(weapon);
+                    } else {
+                        // Otherwise assume the current loaded ammo is suitable representative
+                        ammos = new ArrayList<Mounted>();
+                        ammos.add(weapon.getLinked());
+                    }
 
                     for (Mounted ammo: ammos) {
                         shootingCheck = checkGuess(shooter, enemy, weapon, ammo, game);
@@ -1623,8 +1630,15 @@ public class FireControl {
             if (AmmoType.T_NA == wtype.getAmmoType()) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
+                // For certain weapon types, look over all their loaded ammos
                 ArrayList<Mounted> ammos;
-                ammos = shooter.getAmmo(weapon);
+                if (wtype.getAmmoType() == AmmoType.T_ATM || wtype.getAmmoType() == AmmoType.T_MML) {
+                    ammos = shooter.getAmmo(weapon);
+                } else {
+                    // Otherwise assume the current loaded ammo is suitable representative
+                    ammos = new ArrayList<Mounted>();
+                    ammos.add(weapon.getLinked());
+                }
 
                 WeaponFireInfo shoot;
                 for (Mounted ammo: ammos) {
@@ -1753,8 +1767,15 @@ public class FireControl {
             if (AmmoType.T_NA == wtype.getAmmoType()) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
+                // For certain weapon types, look over all their loaded ammos
                 ArrayList<Mounted> ammos;
-                ammos = shooter.getAmmo(weapon);
+                if (wtype.getAmmoType() == AmmoType.T_ATM || wtype.getAmmoType() == AmmoType.T_MML) {
+                    ammos = shooter.getAmmo(weapon);
+                } else {
+                    // Otherwise assume the current loaded ammo is suitable representative
+                    ammos = new ArrayList<Mounted>();
+                    ammos.add(weapon.getLinked());
+                }
 
                 WeaponFireInfo shoot;
                 for (Mounted ammo: ammos) {
@@ -1885,6 +1906,7 @@ public class FireControl {
                                  final Map<Mounted, Double> ammoConservation,
                                  final Game game) {
         final NumberFormat DECF = new DecimalFormat("0.000");
+        boolean debug = LogManager.getLogger().isDebugEnabled();
 
         final FiringPlan myPlan = new FiringPlan(target);
 
@@ -1920,6 +1942,7 @@ public class FireControl {
             if (AmmoType.T_NA == wtype.getAmmoType()) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
+                // Check _all_ ammunition for _all_ weapons here.
                 ArrayList<Mounted> ammos;
                 ammos = shooter.getAmmo(weapon);
 
@@ -1949,19 +1972,20 @@ public class FireControl {
             if (null != bestShoot) {
                 if ((bestShoot.getAmmo() != null) && ((AmmoType) bestShoot.getAmmo().getType()).getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
                     // Avoid weird interaction where Dead-Fire gets chosen despite out-of-range mod.
-                    if (bestShoot.getToHit().getValue() == TargetRoll.AUTOMATIC_FAIL) {
+                    if (bestShoot.getToHit().getValue() == TargetRoll.AUTOMATIC_FAIL && debug) {
                         LogManager.getLogger().debug("\nDead-fire selected despite impossible to-hit chance!  Skipping...");
                         continue;
                     }
-
                 }
                 if (bestShoot.getProbabilityToHit() > toHitThreshold) {
                     myPlan.add(bestShoot);
                     continue;
                 }
-                LogManager.getLogger().debug("\nTo Hit Chance (" + DECF.format(bestShoot.getProbabilityToHit())
-                        + ") for " + weapon.getName() +
-                        " is less than threshold (" + DECF.format(toHitThreshold) + ")");
+                if (debug) {
+                    LogManager.getLogger().debug("\nTo Hit Chance (" + DECF.format(bestShoot.getProbabilityToHit())
+                            + ") for " + weapon.getName() +
+                            " is less than threshold (" + DECF.format(toHitThreshold) + ")");
+                }
             }
         }
 
@@ -2583,8 +2607,17 @@ public class FireControl {
             } else {
                 // Iterate over all valid ammo for this weapon
                 int bracket;
+
+                // For certain weapon types, look over all their loaded ammos
                 ArrayList<Mounted> ammos;
-                ammos = shooter.getAmmo(weapon);
+                if (weaponType.getAmmoType() == AmmoType.T_ATM || weaponType.getAmmoType() == AmmoType.T_MML) {
+                    ammos = shooter.getAmmo(weapon);
+                } else {
+                    // Otherwise assume the current loaded ammo is suitable representative
+                    ammos = new ArrayList<Mounted>();
+                    ammos.add(weapon.getLinked());
+                }
+
                 for (Mounted ammo: ammos) {
                     bracket = RangeType.rangeBracket(range,
                             weaponType.getRanges(weapon, ammo),

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1924,10 +1924,10 @@ public class FireControl {
 
             // Choose the best shot
             if (null != bestShoot) {
-                if (((AmmoType) bestShoot.getAmmo().getType()).getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
+                if ((bestShoot.getAmmo() != null) && ((AmmoType) bestShoot.getAmmo().getType()).getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
                     // Avoid weird interaction where Dead-Fire gets chosen despite out-of-range mod.
                     if (bestShoot.getToHit().getValue() == TargetRoll.AUTOMATIC_FAIL) {
-                        LogManager.getLogger().debug("\nDead-fire selected despite impossible to-hit chance!");
+                        LogManager.getLogger().debug("\nDead-fire selected despite impossible to-hit chance!  Skipping...");
                         continue;
                     }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -693,7 +693,7 @@ public class FireControl {
             }
         }
 
-        final boolean bayWeapon = (!weapon.getBayWeapons().isEmpty());
+        final boolean bayWeapon = (!(weapon.getBayWeapons() == null || weapon.getBayWeapons().isEmpty()));
         // Check if torso twists affect weapon
         int shooterFacing = shooterState.getFacing();
         if (shooter.isSecondaryArcWeapon(shooter.getEquipmentNum(weapon))) {

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -251,10 +251,12 @@ public class InfantryFireControl extends FireControl {
             if (weaponIsAppropriate(weapon, firingPlanType)) {
                 WeaponFireInfo bestShoot = null;
 
-                // Compare all ammo for this weapon
                 final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, shooterState, target, targetState, weapon,
                         null, game, true);
-                if (bestShoot == null || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
+                // Choose best expected damage shot, not best to-hit
+                if (null == bestShoot ||
+                        (shoot.getExpectedDamage() > bestShoot.getExpectedDamage())
+                ){
                     bestShoot = shoot;
                 }
 

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -249,11 +249,20 @@ public class InfantryFireControl extends FireControl {
         // cycle through my field guns
         for (final Mounted weapon : shooter.getWeaponList()) {
             if (weaponIsAppropriate(weapon, firingPlanType)) {
-                final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, shooterState, target, targetState, weapon,
-                        game, true);
+                WeaponFireInfo bestShoot = null;
 
-                if (0 < shoot.getProbabilityToHit()) {
-                    myPlan.add(shoot);
+                // Compare all ammo for this weapon
+                for (final Mounted ammo: shooter.getAmmo(weapon)) {
+                    final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, shooterState, target, targetState, weapon,
+                            ammo, game, true);
+                    if (bestShoot == null || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
+                        bestShoot = shoot;
+                    }
+                }
+
+                // If best shot can hit, use it.
+                if (0 < bestShoot.getProbabilityToHit()) {
+                    myPlan.add(bestShoot);
                 }
             }
         }

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -252,12 +252,10 @@ public class InfantryFireControl extends FireControl {
                 WeaponFireInfo bestShoot = null;
 
                 // Compare all ammo for this weapon
-                for (final Mounted ammo: shooter.getAmmo(weapon)) {
-                    final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, shooterState, target, targetState, weapon,
-                            ammo, game, true);
-                    if (bestShoot == null || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
-                        bestShoot = shoot;
-                    }
+                final WeaponFireInfo shoot = buildWeaponFireInfo(shooter, shooterState, target, targetState, weapon,
+                        null, game, true);
+                if (bestShoot == null || shoot.getProbabilityToHit() > bestShoot.getProbabilityToHit()) {
+                    bestShoot = shoot;
                 }
 
                 // If best shot can hit, use it.

--- a/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/InfantryFireControl.java
@@ -261,7 +261,7 @@ public class InfantryFireControl extends FireControl {
                 }
 
                 // If best shot can hit, use it.
-                if (0 < bestShoot.getProbabilityToHit()) {
+                if (bestShoot != null && 0 < bestShoot.getProbabilityToHit()) {
                     myPlan.add(bestShoot);
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -118,7 +118,12 @@ public class MultiTargetFireControl extends FireControl {
             }
 
             ArrayList<Mounted> ammos;
-            ammos = shooter.getAmmo(weapon);
+            if (weapon.getBayWeapons().isEmpty()) {
+                ammos = shooter.getAmmo(weapon);
+            } else {
+                ammos = new ArrayList<>();
+                ammos.add(null);
+            }
 
             for (Mounted ammo: ammos) {
                 WeaponFireInfo shot = buildWeaponFireInfo(shooter, target, weapon, ammo, owner.getGame(), false);

--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -118,18 +118,7 @@ public class MultiTargetFireControl extends FireControl {
             }
 
             ArrayList<Mounted> ammos;
-            if (shooter.isLargeCraft()) {
-                // Bay ammo is handled differently
-                ammos = new ArrayList<Mounted>();
-                for (final Mounted a : shooter.getAmmo()) {
-                    if (AmmoType.isAmmoValid(a, (WeaponType) weapon.getType())
-                            && AmmoType.canSwitchToAmmo(weapon, (AmmoType) a.getType())) {
-                        ammos.add(a);
-                    }
-                }
-            } else {
-                ammos = shooter.getAmmo(weapon);
-            }
+            ammos = shooter.getAmmo(weapon);
 
             for (Mounted ammo: ammos) {
                 WeaponFireInfo shot = buildWeaponFireInfo(shooter, target, weapon, ammo, owner.getGame(), false);

--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -19,10 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import megamek.common.Entity;
-import megamek.common.Game;
-import megamek.common.Mounted;
-import megamek.common.Targetable;
+import megamek.common.*;
 import megamek.common.options.OptionsConstants;
 import org.apache.logging.log4j.LogManager;
 
@@ -120,7 +117,21 @@ public class MultiTargetFireControl extends FireControl {
                 continue;
             }
 
-            for (Mounted ammo: shooter.getAmmo(weapon)) {
+            ArrayList<Mounted> ammos;
+            if (shooter.isLargeCraft()) {
+                // Bay ammo is handled differently
+                ammos = new ArrayList<Mounted>();
+                for (final Mounted a : shooter.getAmmo()) {
+                    if (AmmoType.isAmmoValid(a, (WeaponType) weapon.getType())
+                            && AmmoType.canSwitchToAmmo(weapon, (AmmoType) a.getType())) {
+                        ammos.add(a);
+                    }
+                }
+            } else {
+                ammos = shooter.getAmmo(weapon);
+            }
+
+            for (Mounted ammo: ammos) {
                 WeaponFireInfo shot = buildWeaponFireInfo(shooter, target, weapon, ammo, owner.getGame(), false);
 
                 // this is a better shot if it has a chance of doing damage and the damage is better than the previous best shot

--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -46,91 +46,94 @@ public class MultiTargetFireControl extends FireControl {
     public FiringPlan getBestFiringPlan(final Entity shooter,
             final IHonorUtil honorUtil,
             final Game game,
-            final Map<Mounted, Double> ammoConservation) { 
+            final Map<Mounted, Double> ammoConservation) {
         FiringPlan bestPlan = new FiringPlan();
-        
+
         // optimal firing patterns for units such as dropships, Thunderbolts with multi-trac
         // units with 'multi-tasker' quirk, multi-gunner vehicles, etc.
         // are different (and easier to calculate) than optimal firing patterns for other units
         // because there is no secondary target penalty.
-        // 
+        //
         // So, the basic algorithm is as follows:
-        // For each weapon, calculate the easiest shot. 
+        // For each weapon, calculate the easiest shot.
         // Then, solve the backpack problem.
-        
+
         List<Mounted> weaponList;
-        
+
         if (shooter.usesWeaponBays()) {
             weaponList = shooter.getWeaponBayList();
         } else {
             weaponList = shooter.getWeaponList();
         }
-        
+
         int originalFacing = shooter.getSecondaryFacing();
-        
+
         // check all valid secondary facings (turret rotations/torso twists) and arm/flip combination
         // to see if there's a better firing plan
         List<Integer> facingChanges = getValidFacingChanges(shooter);
         facingChanges.add(0); // "no facing change"
-        
+
         for (int currentTwist : facingChanges) {
             shooter.setSecondaryFacing(correctFacing(originalFacing + currentTwist), false);
-            
+
             FiringPlan currentPlan = calculateFiringPlan(shooter, weaponList);
             currentPlan.setTwist(currentTwist);
-            
+
             if (currentPlan.getUtility() > bestPlan.getUtility()) {
                 bestPlan = currentPlan;
             }
-            
+
             // check the plan where the shooter flips its arms
             if (shooter.canFlipArms()) {
                 shooter.setArmsFlipped(true);
-                
+
                 currentPlan = calculateFiringPlan(shooter, weaponList);
                 currentPlan.setFlipArms(true);
-                
+
                 if (currentPlan.getUtility() > bestPlan.getUtility()) {
                     bestPlan = currentPlan;
                 }
-                
+
                 // put it back as we found it
                 shooter.setArmsFlipped(false);
             }
         }
-        
+
         // put it back as we found it
-        shooter.setSecondaryFacing(originalFacing, false);        
-        
+        shooter.setSecondaryFacing(originalFacing, false);
+
         return bestPlan;
     }
-    
+
     /**
-     * Get me the best shot that this particular weapon can take. 
+     * Get me the best shot that this particular weapon can take.
      * @param weapon Weapon to fire.
      * @return The weapon fire info with the most expected damage. Null if no such thing.
      */
-    WeaponFireInfo getBestShot(Mounted weapon) {
+    WeaponFireInfo getBestShot(Entity shooter, Mounted weapon) {
         WeaponFireInfo bestShot = null;
-        
-        for (Targetable target : getTargetableEnemyEntities(weapon.getEntity(), owner.getGame(), owner.getFireControlState())) {
+
+        for (Targetable target : getTargetableEnemyEntities(shooter, owner.getGame(), owner.getFireControlState())) {
             final int ownerID = (target instanceof Entity) ? ((Entity) target).getOwnerId() : -1;
             if (owner.getHonorUtil().isEnemyBroken(target.getId(), ownerID, owner.getBehaviorSettings().isForcedWithdrawal())) {
                 LogManager.getLogger().info(target.getDisplayName() + " is broken - ignoring");
                 continue;
             }
-            
-            WeaponFireInfo shot = buildWeaponFireInfo(weapon.getEntity(), target, weapon, owner.getGame(), false);
-            // this is a better shot if it has a chance of doing damage and the damage is better than the previous best shot
-            if ((shot.getExpectedDamage() > 0) &&
-                    ((bestShot == null) || (shot.getExpectedDamage() > bestShot.getExpectedDamage()))) {
-                bestShot = shot;
+
+            for (Mounted ammo: shooter.getAmmo(weapon)) {
+                WeaponFireInfo shot = buildWeaponFireInfo(shooter, target, weapon, ammo, owner.getGame(), false);
+
+                // this is a better shot if it has a chance of doing damage and the damage is better than the previous best shot
+                if ((shot.getExpectedDamage() > 0) &&
+                        ((bestShot == null) || (shot.getExpectedDamage() > bestShot.getExpectedDamage()))) {
+                    bestShot = shot;
+                }
             }
         }
-        
+
         return bestShot;
     }
-    
+
     /**
      * calculates the 'utility' of a firing plan. This particular function
      * ignores any characteristics of the firing plan that depend on having a single target.
@@ -154,7 +157,7 @@ public class MultiTargetFireControl extends FireControl {
 
         double modifier = 1;
         // eliminated calls to calcCommandUtility, calcStrategicBuildingTargetUtility, calcPriorityUnitTargetUtility
-        
+
         double expectedDamage = firingPlan.getExpectedDamage();
         double utility = 0;
         utility += DAMAGE_UTILITY * expectedDamage;
@@ -170,31 +173,31 @@ public class MultiTargetFireControl extends FireControl {
 
     FiringPlan calculateFiringPlan(Entity shooter, List<Mounted> weaponList) {
         FiringPlan retVal = new FiringPlan();
-        
+
         List<WeaponFireInfo> shotList = new ArrayList<>();
         for (Mounted weapon : weaponList) {
-            WeaponFireInfo shot = getBestShot(weapon);
+            WeaponFireInfo shot = getBestShot(shooter, weapon);
             if (shot != null) {
                 shotList.add(shot);
             }
         }
-        
+
         boolean shooterIsLarge =
                 shooter.hasETypeFlag(Entity.ETYPE_DROPSHIP) ||
                 shooter.hasETypeFlag(Entity.ETYPE_JUMPSHIP) ||
                 shooter.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT);
-        
+
         // the logic is significantly different when heat is generated by firing arc, rather than by individual weapon/bay
         if (!owner.getGame().getOptions().booleanOption(OptionsConstants.ADVAERORULES_HEAT_BY_BAY) && shooterIsLarge) {
             retVal = calculatePerArcFiringPlan(shooter, shotList);
         } else {
             retVal = calculateIndividualWeaponFiringPlan(shooter, shotList, shooterIsLarge);
         }
-        
+
         calculateUtility(retVal, calcHeatTolerance(shooter, shooter.isAero()), true);
         return retVal;
     }
-    
+
     /**
      * Worker function that calculates a firing plan for a shooter under the "heat per weapon arc" rules
      * (which are the default), given a list of optimal shots for each weapon.
@@ -204,15 +207,15 @@ public class MultiTargetFireControl extends FireControl {
      */
     FiringPlan calculatePerArcFiringPlan(Entity shooter, List<WeaponFireInfo> shotList) {
         FiringPlan retVal = new FiringPlan();
-        
+
         // Arc # < 0 indicates that same arc, but rear firing
         // organize weapon fire infos: arc #, list of weapon fire info
         Map<Integer, List<WeaponFireInfo>> arcShots = new HashMap<>();
-        // heat values by arc: arc #, arc heat. 
+        // heat values by arc: arc #, arc heat.
         Map<Integer, Integer> arcHeat = new HashMap<>();
         // damage values by arc: arc #, arc damage
         Map<Integer, Double> arcDamage = new HashMap<>();
-        
+
         // assemble the data we'll need to solve the backpack problem
         for (WeaponFireInfo shot : shotList) {
             int arc = shooter.getWeaponArc(shooter.getEquipmentNum(shot.getWeapon()));
@@ -220,45 +223,45 @@ public class MultiTargetFireControl extends FireControl {
             if (shot.getWeapon().isRearMounted()) {
                 arc = -arc;
             }
-            
+
             if (!arcShots.containsKey(arc)) {
                 arcShots.put(arc, new ArrayList<>());
                 arcHeat.put(arc, shooter.getHeatInArc(shot.getWeapon().getLocation(), shot.getWeapon().isRearMounted()));
                 arcDamage.put(arc, 0.0);
             }
-            
+
             arcShots.get(arc).add(shot);
             arcDamage.put(arc, arcDamage.get(arc) + shot.getExpectedDamage());
         }
-        
+
         // initialize the backpack
         Map<Integer, Map<Integer, List<Integer>>> arcBackpack = new HashMap<>();
         for (int x = 0; x < arcShots.keySet().size(); x++) {
             arcBackpack.put(x, new HashMap<>());
-            
+
             for (int y = 0; y < shooter.getHeatCapacity(); y++) {
                 arcBackpack.get(x).put(y, new ArrayList<>());
             }
         }
-        
+
         double[][] damageBackpack = new double[arcShots.keySet().size()][shooter.getHeatCapacity()];
         Integer[] arcHeatKeyArray = new Integer[arcHeat.keySet().size()];
-        System.arraycopy(arcHeat.keySet().toArray(), 0, arcHeatKeyArray, 0, arcHeat.keySet().size());       
-        
+        System.arraycopy(arcHeat.keySet().toArray(), 0, arcHeatKeyArray, 0, arcHeat.keySet().size());
+
         // now, we essentially solve the backpack problem, where the arcs are the items:
         // arc expected damage is the "value", and arc heat is the "weight", while the backpack capacity is the unit's heat capacity.
         // while we're at it, we assemble the list of arcs fired for each cell
         for (int arcIndex = 0; arcIndex < arcHeatKeyArray.length; arcIndex++) {
             for (int heatIndex = 0; heatIndex < shooter.getHeatCapacity(); heatIndex++) {
                 int previousArc = arcIndex > 0 ? arcHeatKeyArray[arcIndex - 1] : 0;
-                
+
                 if (arcIndex == 0 || heatIndex == 0) {
                     damageBackpack[arcIndex][heatIndex] = 0;
                 } else if (arcHeat.get(previousArc) <= heatIndex) {
                     int previousHeatIndex = heatIndex - arcHeat.get(previousArc);
                     double currentArcDamage = arcDamage.get(previousArc) + damageBackpack[arcIndex - 1][previousHeatIndex];
                     double accumulatedPreviousArcDamage = damageBackpack[arcIndex - 1][heatIndex];
-                    
+
                     if (currentArcDamage > accumulatedPreviousArcDamage) {
                         // we can add this arc to the list and it'll improve the damage done
                         // so let's do it
@@ -273,7 +276,7 @@ public class MultiTargetFireControl extends FireControl {
                         damageBackpack[arcIndex][heatIndex] = accumulatedPreviousArcDamage;
                         arcBackpack.get(arcIndex).put(heatIndex, arcBackpack.get(arcIndex - 1).get(heatIndex));
                     }
-                    
+
                 } else {
                     // in this case, we're simply carrying the value from the left to the right
                     damageBackpack[arcIndex][heatIndex] = damageBackpack[arcIndex - 1][heatIndex];
@@ -281,7 +284,7 @@ public class MultiTargetFireControl extends FireControl {
                 }
             }
         }
-        
+
         // now, we look at the bottom right cell, which contains our optimal firing solution
         // unless there is no firing solution at all, in which case we skip this part
         if (!arcBackpack.isEmpty()) {
@@ -289,10 +292,10 @@ public class MultiTargetFireControl extends FireControl {
                 retVal.addAll(arcShots.get(arc));
             }
         }
-        
+
         return retVal;
     }
-    
+
     /**
      * Worker function that calculates a firing plan for a shooter under the "individual weapon heat" rules,
      * given a list of optimal shots for each weapon.
@@ -309,42 +312,42 @@ public class MultiTargetFireControl extends FireControl {
         int heatCapacityModifier = -shooter.getHeat();
         heatCapacityModifier += shooter.isAero() ? 0 : 4;
         heatCapacityModifier += shooter.hasQuirk(OptionsConstants.QUIRK_POS_COMBAT_COMPUTER) ? 4 : 0;
-        
+
         // if firing every gun won't bring heat above the shooter's heat capacity (this includes non-heat-tracking units)
         // then we just return every shot to save ourselves a backpack problem
         int alphaStrikeHeat = 0;
         for (WeaponFireInfo shot : shotList) {
             alphaStrikeHeat += shot.getHeat();
         }
-        
+
         if (alphaStrikeHeat < shooter.getHeatCapacity() - shooter.getHeat() + heatCapacityModifier) {
             for (WeaponFireInfo shot : shotList) {
                 retVal.add(shot);
             }
-            
+
             return retVal;
         }
-        
+
         // if we are a "large" craft that can't overheat, we simply cannot fire more weapons than heat capacity
         // if we are an aerospace fighter or ground-based unit that tracks heat, we totally can overheat and the "heat capacity"
         int actualHeatCapacity = shooter.getHeatCapacity();
-        
+
         if (!shooterIsLarge) {
             actualHeatCapacity += heatCapacityModifier;
         }
-        
+
         // initialize the backpack
         Map<Integer, Map<Integer, List<Integer>>> shotBackpack = new HashMap<>();
         for (int x = 0; x <= shotList.size(); x++) {
             shotBackpack.put(x, new HashMap<>());
-            
+
             for (int y = 0; y < actualHeatCapacity; y++) {
                 shotBackpack.get(x).put(y, new ArrayList<>());
             }
         }
-        
-        double[][] damageBackpack = new double[shotList.size() + 1][actualHeatCapacity];     
-        
+
+        double[][] damageBackpack = new double[shotList.size() + 1][actualHeatCapacity];
+
         // like the above method, we solve the backpack problem here:
         // WeaponFireInfo are the items
         // expected damage is the "value", heat is the "weight", backpack capacity is the unit's heat capacity
@@ -355,10 +358,10 @@ public class MultiTargetFireControl extends FireControl {
                     damageBackpack[shotIndex][heatIndex] = 0;
                 } else if (shotList.get(shotIndex - 1).getHeat() <= heatIndex) {
                     int previousHeatIndex = heatIndex - shotList.get(shotIndex - 1).getHeat();
-                    double currentShotDamage = shotList.get(shotIndex - 1).getExpectedDamage() + 
+                    double currentShotDamage = shotList.get(shotIndex - 1).getExpectedDamage() +
                             damageBackpack[shotIndex - 1][previousHeatIndex];
                     double accumulatedPreviousShotDamage = damageBackpack[shotIndex - 1][heatIndex];
-                    
+
                     if (currentShotDamage > accumulatedPreviousShotDamage) {
                         // we can add this shot to the list and it'll improve the damage done
                         // so let's do it
@@ -373,7 +376,7 @@ public class MultiTargetFireControl extends FireControl {
                         damageBackpack[shotIndex][heatIndex] = accumulatedPreviousShotDamage;
                         shotBackpack.get(shotIndex).put(heatIndex, shotBackpack.get(shotIndex - 1).get(heatIndex));
                     }
-                    
+
                 } else {
                     // in this case, we're simply carrying the value from the left to the right
                     damageBackpack[shotIndex][heatIndex] = damageBackpack[shotIndex - 1][heatIndex];
@@ -381,12 +384,12 @@ public class MultiTargetFireControl extends FireControl {
                 }
             }
         }
-        
+
         // now, we look at the bottom right cell, which contains our optimal firing solution
         for (int shotIndex : shotBackpack.get(shotBackpack.size() - 1).get(actualHeatCapacity - 1)) {
             retVal.add(shotList.get(shotIndex));
         }
-        
+
         return retVal;
     }
 }

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -218,8 +218,8 @@ public class PathEnumerator {
                 paths.addAll(apf.getAllComputedPathsUncategorized());
             // this handles the case of the mover acting like a spheroid aerospace unit in an atmosphere
             } else if (Compute.useSpheroidAtmosphere(game, mover)) {
-                Coords poi = AeroPathUtil.getSpheroidPOI(game, mover);
-                SpheroidPathFinder spf = SpheroidPathFinder.getInstance(game, poi);
+                int dir = AeroPathUtil.getSpheroidDir(game, mover);
+                SpheroidPathFinder spf = SpheroidPathFinder.getInstance(game, dir);
                 spf.run(new MovePath(game, mover));
                 paths.addAll(spf.getAllComputedPathsUncategorized());
             // this handles the case of the mover being an infantry unit of some kind, that's not airborne.

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * This class contains logic that calculates and stores 
+ * This class contains logic that calculates and stores
  * a) possible paths that units in play can take, and
  * b) their possible locations
  */
@@ -122,10 +122,10 @@ public class PathEnumerator {
     public synchronized void recalculateMovesFor(final Entity mover) {
         int retryCount = 0;
         boolean success = false;
-        
+
         while ((retryCount < BotClient.BOT_TURN_RETRY_COUNT) && !success) {
             success = recalculateMovesForWorker(mover);
-            
+
             if (!success) {
                 // if we fail, take a nap for 500-1500 milliseconds, then try again
                 // as it may be due to some kind of thread-related issue
@@ -140,7 +140,7 @@ public class PathEnumerator {
             }
         }
     }
-    
+
     /**
      * calculates all moves for a given unit, keeping the shortest (or longest, depending) path to each facing/pair
      */
@@ -155,7 +155,7 @@ public class PathEnumerator {
             // Clear out any already calculated paths.
             getUnitPaths().remove(mover.getId());
             getLongRangePaths().remove(mover.getId());
-            
+
             // if the entity does not exist in the game for any reason, let's cut out safely
             // otherwise, we'll run into problems calculating paths
             if (getGame().getEntity(mover.getId()) == null) {
@@ -168,7 +168,7 @@ public class PathEnumerator {
 
             // Start constructing the new list of paths.
             List<MovePath> paths = new ArrayList<>();
-            
+
             // Aero movement on atmospheric ground maps
             // currently only applies to a) conventional aircraft, b) aerotech units, c) lams in air mode
             if (mover.isAirborneAeroOnGroundMap() && !((IAero) mover).isSpheroid()) {
@@ -176,7 +176,7 @@ public class PathEnumerator {
                 MovePath startPath = new MovePath(getGame(), mover);
                 apf.run(startPath);
                 paths.addAll(apf.getAllComputedPathsUncategorized());
-                
+
                 // Remove illegal paths.
                 Filter<MovePath> filter = new Filter<>() {
                     @Override
@@ -184,21 +184,21 @@ public class PathEnumerator {
                         return isLegalAeroMove(movePath);
                     }
                 };
-                
+
                 LogManager.getLogger().debug("Unfiltered paths: " + paths.size());
                 paths = new ArrayList<>(filter.doFilter(paths));
                 LogManager.getLogger().debug("Filtered out illegal paths: " + paths.size());
                 AeroGroundOffBoardFilter offBoardFilter = new AeroGroundOffBoardFilter();
                 paths = new ArrayList<>(offBoardFilter.doFilter(paths));
-                
+
                 MovePath offBoardPath = offBoardFilter.getShortestPath();
                 if (offBoardPath != null) {
                     paths.add(offBoardFilter.getShortestPath());
                 }
 
                 LogManager.getLogger().debug("Filtered out offboard paths: " + paths.size());
-                
-                // This is code useful for debugging, but puts out a lot of log entries, which slows things down. 
+
+                // This is code useful for debugging, but puts out a lot of log entries, which slows things down.
                 // disabled
                 // logAllPaths(paths);
             // this handles the case of the mover being an aerospace unit and "advances space flight" rules being on
@@ -218,7 +218,8 @@ public class PathEnumerator {
                 paths.addAll(apf.getAllComputedPathsUncategorized());
             // this handles the case of the mover acting like a spheroid aerospace unit in an atmosphere
             } else if (Compute.useSpheroidAtmosphere(game, mover)) {
-                SpheroidPathFinder spf = SpheroidPathFinder.getInstance(game);
+                Coords poi = AeroPathUtil.getSpheroidPOI(game, mover);
+                SpheroidPathFinder spf = SpheroidPathFinder.getInstance(game, poi);
                 spf.run(new MovePath(game, mover));
                 paths.addAll(spf.getAllComputedPathsUncategorized());
             // this handles the case of the mover being an infantry unit of some kind, that's not airborne.
@@ -226,7 +227,7 @@ public class PathEnumerator {
                 InfantryPathFinder ipf = InfantryPathFinder.getInstance(getGame());
                 ipf.run(new MovePath(game, mover));
                 paths.addAll(ipf.getAllComputedPathsUncategorized());
-                
+
                 // generate long-range paths appropriate to the bot's current state
                 updateLongRangePaths(mover);
             // this handles situations where a unit is high up in the air, but is not an aircraft
@@ -249,11 +250,11 @@ public class PathEnumerator {
                 lpf.run(new MovePath(getGame(), mover));
                 paths.addAll(lpf.getLongestComputedPaths());
 
-                // add all moves that involve the entity remaining prone 
+                // add all moves that involve the entity remaining prone
                 PronePathFinder ppf = new PronePathFinder();
                 ppf.run(new MovePath(getGame(), mover));
                 paths.addAll(ppf.getPronePaths());
-                
+
                 // add jumping moves
                 if (mover.getJumpMP() > 0) {
                     ShortestPathFinder spf = ShortestPathFinder.newInstanceOfOneToAll(mover.getJumpMP(),
@@ -268,7 +269,7 @@ public class PathEnumerator {
                 /* for (MovePath path : paths) {
                         getOwner().getLogger().debug(path.toString());
                 }*/
-                
+
                 // Try climbing over obstacles and onto bridges
                 adjustPathsForBridges(paths);
 
@@ -282,7 +283,7 @@ public class PathEnumerator {
                     }
                 };
                 paths = new ArrayList<>(filter.doFilter(paths));
-                
+
                 // generate long-range paths appropriate to the bot's current state
                 updateLongRangePaths(mover);
             }
@@ -303,7 +304,7 @@ public class PathEnumerator {
             return false;
         }
     }
-    
+
     /**
      * Worker function that updates the long-range path collection for a particular entity
      */
@@ -312,13 +313,13 @@ public class PathEnumerator {
         // or if it's not one of mine
         // or if I've already moved it
         if ((mover.getWalkMP() == 0) ||
-                ((getOwner().getLocalPlayer() != null) && (mover.getOwnerId() != getOwner().getLocalPlayer().getId())) || 
+                ((getOwner().getLocalPlayer() != null) && (mover.getOwnerId() != getOwner().getLocalPlayer().getId())) ||
                 !mover.isSelectableThisTurn()) {
             return;
         }
-        
+
         DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
-        
+
         // where are we going?
         Set<Coords> destinations = new HashSet<>();
         // if we're going to an edge or can't see anyone, generate long-range paths to the opposite edge
@@ -333,36 +334,36 @@ public class PathEnumerator {
                 break;
             default:
                 for (Targetable target : FireControl.getAllTargetableEnemyEntities(getOwner().getLocalPlayer(), getGame(), getOwner().getFireControlState())) {
-                    // don't consider crippled units as valid long-range pathfinding targets 
+                    // don't consider crippled units as valid long-range pathfinding targets
                     if ((target.getTargetType() == Targetable.TYPE_ENTITY) && ((Entity) target).isCrippled()) {
                         continue;
                     }
-                    
+
                     destinations.add(target.getPosition());
                     // we can easily shoot at an entity from right next to it as well
                     destinations.addAll(target.getPosition().allAdjacent());
                 }
                 break;
         }
-        
+
         if (!getLongRangePaths().containsKey(mover.getId())) {
             getLongRangePaths().put(mover.getId(), new ArrayList<>());
         }
-        
+
         // calculate a ground-bound long range path
         BulldozerMovePath bmp = dpf.findPathToCoords(mover, destinations, owner.getClusterTracker());
-        
+
         if (bmp != null) {
             getLongRangePaths().get(mover.getId()).add(bmp);
         }
-        
+
         // calculate a jumping long range path
-        BulldozerMovePath jmp = dpf.findPathToCoords(mover, destinations, true, owner.getClusterTracker()); 
+        BulldozerMovePath jmp = dpf.findPathToCoords(mover, destinations, true, owner.getClusterTracker());
         if (jmp != null) {
             getLongRangePaths().get(mover.getId()).add(jmp);
         }
     }
-    
+
     private void adjustPathsForBridges(List<MovePath> paths) {
         if (!worryAboutBridges()) {
             return;
@@ -451,7 +452,7 @@ public class PathEnumerator {
         }
         return true;
     }
-    
+
     private void LogAeroMoveLegalityEvaluation(String whyNot, MovePath path) {
         LogManager.getLogger().debug(path.length() + ":" + path + ":" + whyNot);
     }
@@ -459,7 +460,7 @@ public class PathEnumerator {
     protected Map<Integer, List<BulldozerMovePath>> getLongRangePaths() {
         return longRangePaths;
     }
-    
+
     protected Map<Integer, List<MovePath>> getUnitPaths() {
         return unitPaths;
     }

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -136,6 +136,8 @@ public class PathEnumerator {
                     Thread.sleep(Compute.randomInt(1000) + 500);
                 } catch (InterruptedException e) {
                     LogManager.getLogger().error("", e);
+                } catch (Exception e) {
+                    LogManager.getLogger().error("Unexpected (non-interrupt) exception!", e);
                 }
             }
         }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -464,7 +464,7 @@ public abstract class PathRanker implements IPathRanker {
         return false;
     }
 
-    protected @Nullable Coords calcAllyCenter(int myId, @Nullable List<Entity> friends, Game game) {
+    public static @Nullable Coords calcAllyCenter(int myId, @Nullable List<Entity> friends, Game game) {
         if ((friends == null) || friends.isEmpty()) {
             return null;
         }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -117,7 +117,7 @@ public abstract class PathRanker implements IPathRanker {
                         game, maxRange, fallTolerance, enemies, friends);
             }
         } catch (Exception ignored) {
-            LogManager.getLogger().error(ignored.toString());
+            LogManager.getLogger().error(ignored.getMessage(), ignored);
             return returnPaths;
         }
 

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -467,6 +467,9 @@ public abstract class PathRanker implements IPathRanker {
     public static @Nullable Coords calcAllyCenter(int myId, @Nullable List<Entity> friends, Game game) {
         if ((friends == null) || friends.isEmpty()) {
             return null;
+        } else if (friends.size() == 1) {
+            // Nobody here but me...
+            return friends.get(0).getPosition();
         }
 
         int xTotal = 0;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1705,7 +1705,7 @@ public class Princess extends BotClient {
             ArtilleryAttackAction a = attacks.nextElement();
             if (a.getTurnsTilHit() == 0 && a.getAmmoMunitionType().contains(AmmoType.Munitions.M_HOMING) && (!a.getEntity(game).isEnemyOf(entityToFire))) {
                 // Must be a shot that should land within 8 hexes of the target hex
-                if (a.getCoords().distance(location) <= 8) {
+                if (a.getCoords().distance(location) <= Compute.HOMING_RADIUS) {
                     friendlyGuidedWeapons.add(a.getEntity(game).getEquipment(a.getWeaponId()));
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1216,7 +1216,7 @@ public class Princess extends BotClient {
                 } else if (entity.isCrippled()) {
                     msg += " is crippled and withdrawing.";
                 }
-                LogManager.getLogger().debug(msg);
+                LogManager.getLogger().debug(msg.toString());
                 sendChat(msg, Level.ERROR);
 
                 // If this entity is falling back, able to flee the board, on

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -726,7 +726,7 @@ public class Princess extends BotClient {
     }
 
     private Map<Mounted, Double> calcAmmoConservation(final Entity shooter) {
-        final double aggroFactor = (10 - getBehaviorSettings().getHyperAggressionIndex()) * 2;
+        final double aggroFactor = getBehaviorSettings().getHyperAggressionIndex();
         final StringBuilder msg = new StringBuilder("\nCalculating ammo conservation for ")
                 .append(shooter.getDisplayName());
         msg.append("\nAggression Factor = ").append(aggroFactor);
@@ -767,8 +767,13 @@ public class Princess extends BotClient {
                     ammoCount += ammoCounts.get(ammoType);
                 }
                 msg.append(" has ").append(ammoCount).append(" shots left");
+                // Desired behavior:
+                // At min aggro (0 of 10), require ~50% chance to hit with > 3 shots left
+                // At normal aggro (5 of 10), require at least 10% to-hit chance with > 3 shots left
+                // At max aggro (10 of 10) require just over 0% chance to hit until at 1 round left.
                 final double toHitThreshold =
-                        Math.max(0.0, 1 - (ammoCount / aggroFactor));
+                        Math.max(0.0,
+                                (0.8/((aggroFactor) + 2) + 1.0 / ((ammoCount*ammoCount)+1)));
                 msg.append("; To Hit Threshold = ").append(new DecimalFormat("0.000").format(toHitThreshold));
                 ammoConservation.put(weapon, toHitThreshold);
             }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -688,7 +688,7 @@ public class Princess extends BotClient {
 
             sendAttackData(shooter.getId(), miscPlan);
         } catch (Exception ignored) {
-
+            LogManager.getLogger().error(ignored.getMessage(), ignored);
         }
     }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1285,6 +1285,9 @@ public class Princess extends BotClient {
             LogManager.getLogger().info("Best Path: " + bestpath.getPath() + "  Rank: " + bestpath.getRank());
 
             return performPathPostProcessing(bestpath);
+        } catch (Exception e) {
+            LogManager.getLogger().error("MP is now null!", e);
+            return null;
         } finally {
             precognition.unPause();
         }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -548,11 +548,18 @@ public class Princess extends BotClient {
 
     @Override
     protected void calculateFiringTurn() {
+        final Entity shooter;
         try {
             // get the first entity that can act this turn make sure weapons
             // are loaded
-            final Entity shooter = getEntityToFire(fireControlState);
+            shooter = getEntityToFire(fireControlState);
+        } catch (Exception e) {
+            // If we fail to get the shooter, literally nothing can be done.
+            LogManager.getLogger().error(e.getMessage(), e);
+            return;
+        }
 
+        try {
             // Forego firing if
             // a) hidden,
             // b) under "peaceful" forced withdrawal,
@@ -687,8 +694,11 @@ public class Princess extends BotClient {
             }
 
             sendAttackData(shooter.getId(), miscPlan);
-        } catch (Exception ignored) {
-            LogManager.getLogger().error(ignored.getMessage(), ignored);
+        } catch (Exception e) {
+            LogManager.getLogger().error(e.getMessage(), e);
+            // Don't lock up, just skip this entity.
+            Vector<EntityAction> fallback = new Vector<>();
+            sendAttackData(shooter.getId(), fallback);
         }
     }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1216,7 +1216,7 @@ public class Princess extends BotClient {
                 } else if (entity.isCrippled()) {
                     msg += " is crippled and withdrawing.";
                 }
-                LogManager.getLogger().debug(msg.toString());
+                LogManager.getLogger().debug(msg);
                 sendChat(msg, Level.ERROR);
 
                 // If this entity is falling back, able to flee the board, on

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -487,14 +487,15 @@ public class WeaponFireInfo {
             }
         }
 
-        // Get a list of incoming or potentially incoming guidable weapons from the relevant Princess and compute damage.
-        // If target is already tagged, make it undesirable as a target.
-        int incomingAttacksDamage = (Compute.isTargetTagged(target, game))
-                ? Compute.computeTotalDamage(owner.computeGuidedWeapons(shooter, target.getPosition()))
-                : 0;
+        int incomingAttacksDamage =  owner.computeTeamTagUtility(
+                target,
+                Compute.computeTotalDamage(owner.computeGuidedWeapons(shooter, target.getPosition()))
+        );
         int utility = incomingAttacksDamage - myWeaponsDamage;
-        msg.append("\n\tUtility: ").append(utility).append(" damage (Max, estimated)");
-        LogManager.getLogger().debug(msg.toString());
+        if (debug) {
+            msg.append("\n\tUtility: ").append(utility).append(" damage (Max, estimated)");
+            LogManager.getLogger().debug(msg.toString());
+        }
 
         return Math.max(utility, 0);
     }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -555,6 +555,9 @@ public class WeaponFireInfo {
             setAction(buildBombAttackAction(bombPayloads));
         }
 
+        // Set ammoId here so we can tell toHitCalc which ammo to use for calculations; later overwritten.
+        getWeaponAttackAction().setAmmoId(shooter.getEquipmentNum(this.getAmmo()));
+
         if (!guess) {
             setToHit(calcRealToHit(getWeaponAttackAction()));
         } else if (null != shooterPath) {

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -690,6 +690,9 @@ public class WeaponFireInfo {
 
         setKillProbability(0);
         if (!(getTarget() instanceof Mech)) {
+            if (debugging) {
+                LogManager.getLogger().debug(msg.toString());
+            }
             return;
         }
 

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -469,21 +469,29 @@ public class WeaponFireInfo {
      * @return
      */
     double computeExpectedTAGDamage(boolean exclusiveWithOtherWeapons){
-        final StringBuilder msg = new StringBuilder("Assessing the expected max damage from ")
+        boolean debug = LogManager.getLogger().isDebugEnabled();
+        final StringBuilder msg = (debug) ?
+                new StringBuilder("Assessing the expected max damage from ")
                 .append(shooter.getDisplayName())
-                .append(" using their TAG this turn");
+                .append(" using their TAG this turn")
+                : null;
 
         int myWeaponsDamage = 0;
         if (exclusiveWithOtherWeapons) {
             // We need to know what we're giving up if we fire this TAG...
             myWeaponsDamage = Compute.computeTotalDamage(shooter.getTotalWeaponList());
-            msg.append("\nThe unit will be giving up ")
-                    .append(myWeaponsDamage)
-                    .append(" damage from other weapons");
+            if (debug) {
+                msg.append("\nThe unit will be giving up ")
+                        .append(myWeaponsDamage)
+                        .append(" damage from other weapons");
+            }
         }
 
         // Get a list of incoming or potentially incoming guidable weapons from the relevant Princess and compute damage.
-        int incomingAttacksDamage = Compute.computeTotalDamage(owner.computeGuidedWeapons(shooter, target.getPosition()));
+        // If target is already tagged, make it undesirable as a target.
+        int incomingAttacksDamage = (Compute.isTargetTagged(target, game))
+                ? Compute.computeTotalDamage(owner.computeGuidedWeapons(shooter, target.getPosition()))
+                : 0;
         int utility = incomingAttacksDamage - myWeaponsDamage;
         msg.append("\n\tUtility: ").append(utility).append(" damage (Max, estimated)");
         LogManager.getLogger().debug(msg.toString());

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -570,7 +570,7 @@ public class WeaponFireInfo {
                     final boolean assumeUnderFlightPath,
                     final boolean guess,
                     final HashMap<String, int[]> bombPayloads) {
-        boolean debugging = false;
+        boolean debugging = LogManager.getLogger().isDebugEnabled();
 
         final StringBuilder msg =
                 debugging ?
@@ -743,6 +743,8 @@ public class WeaponFireInfo {
             setProbabilityToHit(0);
             return null;
         }
+        // Set the ammoId for calcs.
+        getAction().setAmmoId(shooter.getEquipmentNum(this.getAmmo()));
         setProbabilityToHit(Compute.oddsAbove(getAction().toHit(getGame()).getValue(),
                                               getShooterState().hasNaturalAptGun()) / 100.0);
         return getAction();

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -43,6 +43,7 @@ public class WeaponFireInfo {
     private Entity shooter;
     private Targetable target;
     private Mounted weapon;
+    private Mounted preferredAmmo;
     private double probabilityToHit;
     private int heat;
     private double maxDamage;
@@ -70,16 +71,18 @@ public class WeaponFireInfo {
      * @param shooter The {@link megamek.common.Entity} doing the attacking.
      * @param target  The {@link megamek.common.Targetable} of the attack.
      * @param weapon  The {@link megamek.common.Mounted} weapon used for the attack.
+     * @param ammo    The {@link megamek.common.Mounted} ammo to use for the attack; may be null.
      * @param game    The current {@link Game}
      * @param guess   Set TRUE to estimate the chance to hit rather than doing the full calculation.
      */
     WeaponFireInfo(final Entity shooter,
                    final Targetable target,
                    final Mounted weapon,
+                   final Mounted ammo,
                    final Game game,
                    final boolean guess,
                    final Princess owner) {
-        this(shooter, null, null, target, null, weapon, game, false, guess, owner, null);
+        this(shooter, null, null, target, null, weapon, ammo, game, false, guess, owner, null);
     }
 
     /**
@@ -98,10 +101,11 @@ public class WeaponFireInfo {
                    final Targetable target,
                    final EntityState targetState,
                    final Mounted weapon,
+                   final Mounted ammo,
                    final Game game,
                    final boolean guess,
                    final Princess owner) {
-        this(shooter, shooterState, null, target, targetState, weapon, game, false, guess, owner, null);
+        this(shooter, shooterState, null, target, targetState, weapon, ammo, game, false, guess, owner, null);
     }
 
     /**
@@ -123,12 +127,13 @@ public class WeaponFireInfo {
                    final Targetable target,
                    final EntityState targetState,
                    final Mounted weapon,
+                   final Mounted ammo,
                    final Game game,
                    final boolean assumeUnderFlightPath,
                    final boolean guess,
                    final Princess owner,
                    final HashMap<String, int[]> bombPayloads) {
-        this(shooter, null, shooterPath, target, targetState, weapon, game, assumeUnderFlightPath, guess, owner, bombPayloads);
+        this(shooter, null, shooterPath, target, targetState, weapon, ammo, game, assumeUnderFlightPath, guess, owner, bombPayloads);
     }
 
     /**
@@ -154,6 +159,7 @@ public class WeaponFireInfo {
                            final Targetable target,
                            final EntityState targetState,
                            final Mounted weapon,
+                           final Mounted ammo,
                            final Game game,
                            final boolean assumeUnderFlightPath,
                            final boolean guess,
@@ -166,6 +172,7 @@ public class WeaponFireInfo {
         setTarget(target);
         setTargetState(targetState);
         setWeapon(weapon);
+        setAmmo(ammo);
         setGame(game);
         initDamage(shooterPath, assumeUnderFlightPath, guess, bombPayloads);
     }
@@ -263,14 +270,15 @@ public class WeaponFireInfo {
     ToHitData calcToHit() {
         return owner.getFireControl(getShooter()).guessToHitModifierForWeapon(getShooter(), getShooterState(), getTarget(),
                                                                   getTargetState(),
-                                                                  getWeapon(), getGame());
+                                                                  getWeapon(), getAmmo(), getGame());
     }
 
     private ToHitData calcToHit(final MovePath shooterPath,
                                 final boolean assumeUnderFlightPath) {
         return owner.getFireControl(getShooter()).guessAirToGroundStrikeToHitModifier(getShooter(), null, getTarget(),
                                                                           getTargetState(),
-                                                                          shooterPath, getWeapon(), getGame(),
+                                                                          shooterPath, getWeapon(),
+                                                                          getAmmo(), getGame(),
                                                                           assumeUnderFlightPath);
     }
 
@@ -313,6 +321,10 @@ public class WeaponFireInfo {
         this.weapon = weapon;
     }
 
+    protected void setAmmo(final Mounted ammo) {
+        this.preferredAmmo = ammo;
+    }
+
     protected void setHeat(final int heat) {
         this.heat = heat;
     }
@@ -323,6 +335,10 @@ public class WeaponFireInfo {
 
     public Mounted getWeapon() {
         return weapon;
+    }
+
+    public Mounted getAmmo() {
+        return preferredAmmo;
     }
 
     public double getExpectedDamage() {

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -385,6 +385,9 @@ public class WeaponFireInfo {
                 int maxRange = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)
                         ? weaponType.getExtremeRange() : weaponType.getLongRange();
                 int targetDistance = getShooter().getPosition().distance(getTarget().getPosition());
+                if (shooter.isAirborne() && target.isAirborne()) {
+                    targetDistance /= 16;
+                }
 
                 // if the particular weapon is within range or we're an aircraft strafing a ground unit
                 // then we can count it. Otherwise, it's not going to contribute to damage, and we want

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -715,12 +715,13 @@ public class WeaponFireInfo {
     }
 
     String getDebugDescription() {
+        String ammoClause = (getAmmo() == null) ? "" : ", Ammo: " + ((AmmoType) getAmmo().getType()).getSubMunitionName();
         return getWeapon().getName() + " P. Hit: " + LOG_PER.format(getProbabilityToHit())
                 + ", Max Dam: " + LOG_DEC.format(getMaxDamage())
                 + ", Exp. Dam: " + LOG_DEC.format(getExpectedDamageOnHit())
                 + ", Num Crits: " + LOG_DEC.format(getExpectedCriticals())
                 + ", Kill Prob: " + LOG_PER.format(getKillProbability())
-                + ", Ammo: " + ((AmmoType) getAmmo().getType()).getSubMunitionName();
+                + ammoClause;
 
     }
 

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -465,7 +465,7 @@ public class WeaponFireInfo {
 
     /**
      * Generalized computation of hitting with TAG given current guidable muniitions in play
-     * @param skipOtherWeapons true if Aero, false otherwise.
+     * @param exclusiveWithOtherWeapons true if Aero, false otherwise.
      * @return
      */
     double computeExpectedTAGDamage(boolean exclusiveWithOtherWeapons){

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -719,7 +719,8 @@ public class WeaponFireInfo {
                 + ", Max Dam: " + LOG_DEC.format(getMaxDamage())
                 + ", Exp. Dam: " + LOG_DEC.format(getExpectedDamageOnHit())
                 + ", Num Crits: " + LOG_DEC.format(getExpectedCriticals())
-                + ", Kill Prob: " + LOG_PER.format(getKillProbability());
+                + ", Kill Prob: " + LOG_PER.format(getKillProbability())
+                + ", Ammo: " + ((AmmoType) getAmmo().getType()).getSubMunitionName();
 
     }
 

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -390,10 +390,18 @@ public class WeaponFireInfo {
                 // then we can count it. Otherwise, it's not going to contribute to damage, and we want
                 // to avoid grossly overestimating damage.
                 if (targetDistance <= maxRange || shooter.isAirborne() && !target.isAirborne()) {
-                    bayDamage += weaponType.getDamage();
+                    switch (weaponType.getDamage()) {
+                        case WeaponType.DAMAGE_BY_CLUSTERTABLE:
+                        case WeaponType.DAMAGE_ARTILLERY:
+                        case WeaponType.DAMAGE_SPECIAL:
+                        case WeaponType.DAMAGE_VARIABLE:
+                            bayDamage += weaponType.getRackSize();
+                            break;
+                        default:
+                            bayDamage += weaponType.getDamage();
+                        }
+                    }
                 }
-            }
-
             return bayDamage;
         }
 
@@ -609,7 +617,11 @@ public class WeaponFireInfo {
         // If we can't hit, set everything zero and return...
         if (12 < getToHit().getValue()) {
             if (debugging) {
-                LogManager.getLogger().debug(msg.append("\n\tImpossible toHit: ").append(getToHit().getValue()).toString());
+                LogManager.getLogger().debug(
+                        msg.append("\n\tImpossible toHit: ").append(getToHit().getValue())
+                            .append(" (").append(getToHit().getCumulativePlainDesc()).append(")")
+                                .append((guess) ? " [guess]" : " [real]")
+                );
             }
             setProbabilityToHit(0);
             setMaxDamage(0);
@@ -656,7 +668,7 @@ public class WeaponFireInfo {
         // If expected damage from Aero tagging is zero, return out - save attacks for later.
         if (weapon.getType().hasFlag(WeaponType.F_TAG) && shooter.isAero() && getExpectedDamageOnHit() <= 0) {
             if (debugging) {
-                LogManager.getLogger().debug(msg.append("\n\tAerospace TAG attack not advised at this juncture"));
+                LogManager.getLogger().debug(msg.append("\n\tAerospace TAG attack not advised at this juncture").toString());
             }
             setProbabilityToHit(0);
             setMaxDamage(0);

--- a/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
@@ -859,20 +859,20 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
                 if (aiming) {
                     toHit = WeaponAttackAction.toHit(game, cen, target,
                             weaponId, ash.getAimingAt(), ash.getAimingMode(),
-                            false, false, null, null, false, true);
+                            false, false, null, null, false, true, -1);
                     clientgui.getUnitDisplay().wPan.setTarget(target, Messages.getFormattedString("MechDisplay.AimingAt", ash.getAimingLocation()));
 
                 } else {
                     toHit = WeaponAttackAction.toHit(game, cen, target, weaponId, Entity.LOC_NONE,
                             AimingMode.NONE, false, false,
-                            null, null, false, true);
+                            null, null, false, true, -1);
                     clientgui.getUnitDisplay().wPan.setTarget(target, null);
                 }
                 ash.setPartialCover(toHit.getCover());
             } else {
                 toHit = WeaponAttackAction.toHit(game, cen, target, weaponId, Entity.LOC_NONE,
                         AimingMode.NONE, false, false, null,
-                        null, false, true);
+                        null, false, true, -1);
                 clientgui.getUnitDisplay().wPan.setTarget(target, null);
             }
             int effectiveDistance = Compute.effectiveDistance(game, ce(), target);

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -6382,7 +6382,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         // check if extreme range is used
         int maxrange = 4;
-        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)) {
+        if (!game.getBoard().onGround() || game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)) {
             maxrange = 5;
         }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/EntityActionLog.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/EntityActionLog.java
@@ -198,6 +198,8 @@ public class EntityActionLog implements Collection<EntityAction> {
         final String buffer = toHit.getValueAsString() + ((!table.isEmpty()) ? ' ' + table : "");
         final Entity entity = game.getEntity(attack.getEntityId());
         final String weaponName = (entity.getEquipment(attack.getWeaponId()).getType()).getName();
+        final Mounted ammo = entity.getEquipment(attack.getAmmoId());
+        final String ammoName = (ammo == null) ? "" : " [" + ((AmmoType) ammo.getType()).getShortName() + "] ";
 
         //add to an existing entry if possible
         boolean found = false;
@@ -212,7 +214,7 @@ public class EntityActionLog implements Collection<EntityAction> {
         }
 
         if (!found) {
-            descriptions.add( weaponName + Messages.getString("BoardView1.needs") + buffer);
+            descriptions.add( weaponName + ammoName + Messages.getString("BoardView1.needs") + buffer);
         }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2771,7 +2771,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                         clientgui.getClient().sendAmmoChange(
                                 entity.getId(),
                                 entity.getEquipmentNum(bWeap),
-                                entity.getEquipmentNum(mAmmo));
+                                entity.getEquipmentNum(mAmmo),
+                                0);
                     }
                 }
             } else {
@@ -2779,7 +2780,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 // Alert the server of the update.
                 clientgui.getClient().sendAmmoChange(entity.getId(),
                         entity.getEquipmentNum(mWeap),
-                        entity.getEquipmentNum(mAmmo));
+                        entity.getEquipmentNum(mAmmo),
+                        0);
             }
 
             // Refresh for hot load change

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -13930,6 +13930,7 @@ public class AmmoType extends EquipmentType {
             }
 
             munition.shortName = munition.shortName.replace("(Clan) ", "");
+            munition.subMunitionName = munition.shortName;
 
             // Assign our munition type.
             munition.munitionType = type;
@@ -14303,7 +14304,7 @@ public class AmmoType extends EquipmentType {
     }
 
     public String getSubMunitionName() {
-        return subMunitionName;
+        return subMunitionName.isBlank() ? getShortName() : subMunitionName;
     }
 
     /**

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -13832,7 +13832,13 @@ public class AmmoType extends EquipmentType {
                     index = base.internalName.lastIndexOf("Ammo");
                     nameBuf.insert(index, name);
                     munition.setInternalName(nameBuf.toString());
-                    munition.shortName = munition.name.replace("Prototype ", "p");
+
+                    // ADA full name is embarrassingly long.
+                    if (base.name.contains("ADA")) {
+                        munition.shortName = "ADA Missile";
+                    } else {
+                        munition.shortName = munition.name.replace("Prototype ", "p");
+                    }
 
                     munition.addBeforeString(base, "Ammo", name + " ");
                     munition.addToEnd(base, " - " + name);

--- a/megamek/src/megamek/common/ArtilleryTracker.java
+++ b/megamek/src/megamek/common/ArtilleryTracker.java
@@ -15,6 +15,8 @@
  */
 package megamek.common;
 
+import megamek.common.weapons.Weapon;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -65,6 +67,19 @@ public class ArtilleryTracker implements Serializable {
      */
     public int getSize() {
         return weapons.size();
+    }
+
+    public boolean weaponInList(Mounted mounted) {
+        return (weapons.containsKey(mounted));
+    }
+
+    public boolean ammoTypeInList(int ammoType) {
+        for (Mounted mounted: weapons.keySet()) {
+            if (((WeaponType) mounted.getType()).getAmmoType() == ammoType ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1858,6 +1858,73 @@ public class Compute {
         return findC3Spotter(game, attacker, target);
     }
 
+    public static Entity findTAGSpotter(Game game, Entity attacker, Targetable target, boolean stopAtFirst) {
+        Entity spotter = null;
+
+        ArrayList<Entity> spotters = new ArrayList<>();
+        ToHitData bestMods = new ToHitData(TargetRoll.IMPOSSIBLE, "");
+
+        // Compute friendly spotters
+        for (Entity friend : game.getEntitiesVector()) {
+
+            if (attacker.equals(friend)
+                    || !friend.isDeployed()
+                    || friend.isOffBoard()
+                    || (friend.getTransportId() != Entity.NONE)) {
+                continue; // useless to us...
+            }
+
+            Mounted tag = null;
+            int range = 0;
+            for (Mounted m : friend.getWeaponList()) {
+                WeaponType wtype = ((WeaponType) m.getType());
+                if (wtype.hasFlag(WeaponType.F_TAG)) {
+                    tag = m;
+                    range = wtype.getMaxRange(m);
+                    break;
+                }
+            }
+            if (tag == null) {
+                continue;
+            }
+
+            // what are this guy's mods to the attack?
+            LosEffects los = LosEffects.calculateLOS(game, friend, target, false);
+            ToHitData mods = los.losModifiers(game);
+            los.setTargetCover(LosEffects.COVER_NONE);
+            mods.append(Compute.getAttackerMovementModifier(game,
+                    friend.getId()));
+
+            // If the target isn't spotted, can't target
+            if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
+                    && !Compute.inVisualRange(game, los, friend, target)
+                    && !Compute.inSensorRange(game, los, friend, target, null)) {
+                mods.addModifier(TargetRoll.IMPOSSIBLE,
+                        "outside of visual and sensor range");
+            }
+
+            int buddyRange = Compute.effectiveDistance(game, friend, target,
+                    false);
+
+            if (buddyRange > friend.getWalkMP() + range) {
+                // Probably can't get close enough this turn.
+                continue;
+            }
+
+            // is this guy a better spotter?
+            if ((spotter == null && mods.getValue() < TargetRoll.AUTOMATIC_FAIL)
+                    || (mods.getValue() < bestMods.getValue())) {
+                spotter = friend;
+                bestMods = mods;
+                if (stopAtFirst) {
+                    break;
+                }
+            }
+        }
+
+        return spotter;
+    }
+
     /**
      * find a c3, c3i, NC3, or nova spotter that is closer to the target than the
      * attacker.

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1900,11 +1900,12 @@ public class Compute {
                 continue;
             }
 
-            int buddyRange = Compute.effectiveDistance(game, friend, target,
-                    false);
+            int buddyRange =  Compute.effectiveDistance(game, friend, target, false);
+            // Friend has to be as close as their max running speed * flight time, + TAG range, + 8
+            int taggingRange = (1 + Compute.turnsTilHit(game, attacker, target)) * friend.getRunMP() + range + 8;
 
             // Need a target hex within 8 of the main target, and within shooting distance of the spotter.
-            if (buddyRange > friend.getRunMP() + range + 8) {
+            if (buddyRange > taggingRange) {
                 // Probably can't get close enough this turn.
                 LogManager.getLogger().debug("Found a TAG spotter but too far from target");
                 continue;
@@ -7384,6 +7385,24 @@ public class Compute {
     public static boolean isFlakAttack(Entity attacker, Entity target) {
         boolean validLocation = !(attacker.isSpaceborne() || target.isSpaceborne());
         return validLocation && (target.isAirborne() || target.isAirborneVTOLorWIGE());
+    }
+
+    public static int turnsTilHit(Game game, Entity ae, Targetable te) {
+        return turnsTilHit(game, ae, te, WeaponAttackAction.DEFAULT_VELOCITY);
+    }
+
+    /**
+     * Get turns for an indirect or off-board round to hit with its current velocity
+     * @param game
+     * @param ae Attacker
+     * @param target Target hex/entity
+     * @param velocity speed of round, default 50 according to WeaponAttackAction
+     * @return
+     */
+    public static int turnsTilHit(Game game, Entity ae, Targetable te, int velocity) {
+        int distance = Compute.effectiveDistance(game, ae, te);
+        distance = (int) Math.floor((double) distance / game.getPlanetaryConditions().getGravity());
+        return distance / velocity;
     }
 
 } // End public class Compute

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7497,7 +7497,7 @@ public class Compute {
                     .append(" ), direction ").append(direction)
                     .append(", lead range ").append(leadAmount);
 
-            LogManager.getLogger().debug(msg);
+            LogManager.getLogger().debug(msg.toString());
         }
         return newPoint;
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -33,6 +33,7 @@ import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.mgs.MGWeapon;
 import megamek.server.Server;
 import megamek.server.SmokeCloud;
+import org.apache.commons.logging.Log;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.*;
@@ -7460,9 +7461,9 @@ public class Compute {
 
             // Try to keep the current position within the homing radius, unless they're real fast...
             if (homing) {
-                leadAmount = (mp > 8) ? mp : HOMING_RADIUS;
+                leadAmount = (mp * (turnsTilHit + 1)) + HOMING_RADIUS;
             } else {
-                leadAmount = mp;
+                leadAmount = mp * (turnsTilHit + 1);
             }
 
             // Guess at the target's movement direction
@@ -7475,7 +7476,7 @@ public class Compute {
             }
         }
 
-        return calculateArtilleryLead(target.getPosition(), direction, turnsTilHit * leadAmount);
+        return calculateArtilleryLead(target.getPosition(), direction, leadAmount);
     }
 
     /**
@@ -7486,6 +7487,15 @@ public class Compute {
      */
     public static Coords calculateArtilleryLead(Coords targetPoint, int direction, int leadAmount) {
         Coords newPoint = targetPoint.translated(direction, leadAmount);
+        if (LogManager.getLogger().isDebugEnabled()) {
+            StringBuilder msg = new StringBuilder("Computed coordinates ( ")
+                    .append(newPoint.toString())
+                    .append(" ) for target point ( ").append(targetPoint.toString())
+                    .append(" ), direction ").append(direction)
+                    .append(", lead range ").append(leadAmount);
+
+            LogManager.getLogger().debug(msg);
+        }
         return newPoint;
     }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1887,11 +1887,12 @@ public class Compute {
         // Compute friendly spotters
         for (Entity friend : game.getPlayerEntities(attacker.getOwner(), true)) {
 
-            if (!friend.isDeployed()
+            if (friend == null
+                    || !friend.isDeployed()
                     || friend.isOffBoard()
                     || (friend.getTransportId() != Entity.NONE)
                     || friend.isAero() // Much higher bar for TAGging
-                    || friend == null) {
+            ) {
                 continue; // useless to us...
             }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7445,8 +7445,8 @@ public class Compute {
      * @param game
      * @param ae
      * @param target
-     * @param atype to determine if we need the homing lead or some other value.
-     * @return Coordinates to target to hit this target while on the move.
+     * @param homing to determine if we need the homing lead or some other value.
+     * @return Coordinates to aim at to hit this target while it's on the move (we think).
      */
     public static Coords calculateArtilleryLead(Game game, Entity ae, Targetable target, boolean homing) {
         int leadAmount = 0;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1309,7 +1309,7 @@ public class Compute {
                 }
             }
         }
-        int maxRange = wtype.getMaxRange(weapon);
+        int maxRange = wtype.getMaxRange(weapon, ammo);
 
         // if aero and greater than max range then swith to range_out
         if ((ae.isAirborne() || (ae.usesWeaponBays() && game.getBoard()

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1097,11 +1097,10 @@ public class Compute {
      *
      * @return the modifiers
      */
-    public static ToHitData getRangeMods(Game game, Entity ae, int weaponId,
+    public static ToHitData getRangeMods(Game game, Entity ae, Mounted weapon, Mounted ammo,
                                          Targetable target) {
-        Mounted weapon = ae.getEquipment(weaponId);
         WeaponType wtype = (WeaponType) weapon.getType();
-        int[] weaponRanges = wtype.getRanges(weapon);
+        int[] weaponRanges = wtype.getRanges(weapon, ammo);
         boolean isAttackerInfantry = (ae instanceof Infantry);
         boolean isAttackerBA = (ae instanceof BattleArmor);
         boolean isWeaponInfantry = (wtype instanceof InfantryWeapon) && !wtype.hasFlag(WeaponType.F_TAG);

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7457,11 +7457,15 @@ public class Compute {
         // Hexes can't move...
         if (target instanceof Entity) {
             Entity te = (Entity) target;
-            int mp = te.getPosition().distance(te.getPriorPosition()); // Assume last move presages the next
+            int mp = te.getPriorPosition().distance(te.getPosition()); // Assume last move presages the next
+            if (mp == 0 && game.getRoundCount() == 0) {
+                // Assume a mobile enemy will move somewhat after deploying
+                mp = te.getWalkMP();
+            }
 
             // Try to keep the current position within the homing radius, unless they're real fast...
             if (homing) {
-                leadAmount = (mp * (turnsTilHit + 1)) + HOMING_RADIUS;
+                leadAmount = (mp * (turnsTilHit)) + HOMING_RADIUS;
             } else {
                 leadAmount = mp * (turnsTilHit + 1);
             }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1858,7 +1858,19 @@ public class Compute {
         return findC3Spotter(game, attacker, target);
     }
 
+    /**
+     * Function that attempts to find one TAG spotter, or the best TAG spotter,
+     * @param game
+     * @param attacker should be an artillery unit
+     * @param target (if null, do not return a spotter!)
+     * @param stopAtFirst if we only want to know that there is one, not which is best
+     * @return The Spotter.
+     */
     public static Entity findTAGSpotter(Game game, Entity attacker, Targetable target, boolean stopAtFirst) {
+        if (target == null) {
+            return null;
+        }
+
         Entity spotter = null;
 
         ArrayList<Entity> spotters = new ArrayList<>();
@@ -1869,7 +1881,8 @@ public class Compute {
 
             if (!friend.isDeployed()
                     || friend.isOffBoard()
-                    || (friend.getTransportId() != Entity.NONE)) {
+                    || (friend.getTransportId() != Entity.NONE)
+                    || friend == null) {
                 continue; // useless to us...
             }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1880,8 +1880,6 @@ public class Compute {
                 : null;
 
         Entity spotter = null;
-
-        ArrayList<Entity> spotters = new ArrayList<>();
         int distance = -1;
 
         // Compute friendly spotters

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4201,6 +4201,13 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         return ammoList;
     }
 
+    public ArrayList<Mounted> getAmmo(Mounted weapon) {
+        return (ArrayList<Mounted>) ammoList.stream()
+                .filter(
+                    ammo -> AmmoType.isAmmoValid(ammo, (WeaponType) weapon.getType())
+                )
+                .collect(Collectors.toList());
+    }
     public ArrayList<Mounted> getMisc() {
         return miscList;
     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4201,12 +4201,25 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         return ammoList;
     }
 
+    /**
+     * @param weapon we want to find available ammo for
+     * @return an ArrayList containing _one_ Mounted ammo for each viable type
+     */
     public ArrayList<Mounted> getAmmo(Mounted weapon) {
-        return (ArrayList<Mounted>) ammoList.stream()
-                .filter(
-                    ammo -> AmmoType.isAmmoValid(ammo, (WeaponType) weapon.getType())
-                )
-                .collect(Collectors.toList());
+        WeaponType wtype = (WeaponType) weapon.getType();
+        Set<EquipmentType> etypes = new HashSet<EquipmentType>();
+        ArrayList<Mounted> ammos = new ArrayList<Mounted>();
+
+        // Only add one valid ammo to the list to reduce repeat calculations
+        for (Mounted ammo: ammoList) {
+            if (AmmoType.isAmmoValid(ammo, wtype)) {
+                if (etypes.add(ammo.getType())) {
+                    ammos.add(ammo);
+                }
+            }
+        }
+        // One entry per ammo type that is currently usable by this weapon.
+        return ammos;
     }
     public ArrayList<Mounted> getMisc() {
         return miscList;

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -551,6 +551,7 @@ public class EquipmentType implements ITechnology {
             return false;
         }
 
+        // Beware concurrent modification
         for (EquipmentMode mode : modes) {
             if (mode.getName().equals(modeType)) {
                 return true;

--- a/megamek/src/megamek/common/HexTarget.java
+++ b/megamek/src/megamek/common/HexTarget.java
@@ -21,13 +21,14 @@ public class HexTarget implements Targetable {
     private Coords m_coords;
     private boolean m_bIgnite;
     private int m_type;
+    private HexTarget originalTarget = null;
 
     public HexTarget(Coords c, int nType) {
         m_coords = c;
         m_type = nType;
         m_bIgnite = (nType == Targetable.TYPE_HEX_IGNITE);
     }
-    
+
     /**
      * Creates a new HexTarget given a set of coordinates and a type defined in Targetable.
      * the board parameter is ignored.
@@ -191,9 +192,20 @@ public class HexTarget implements Targetable {
     public int getAltitude() {
         return 0;
     }
-    
+
     @Override
     public boolean isEnemyOf(Entity other) {
         return true;
     }
+
+    // For artillery leading
+    public void setOriginalTarget(HexTarget target) {
+        this.originalTarget = target;
+    }
+
+    // For artillery leading
+    public HexTarget getOriginalTarget() {
+        return this.originalTarget;
+    }
+
 }

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -142,6 +142,9 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
     protected int baseDamageCapacity = 0;
     protected int damageTaken = 0;
 
+    // New stuff for ammo switching
+    protected int switchedReason = 0;
+
     /**
      * BattleArmor use the standard locations to track troopers. On BA, this field keeps track of where
      * a piece of equipment is mounted.
@@ -2149,6 +2152,14 @@ public class Mounted implements Serializable, RoundUpdated, PhaseUpdated {
         } else {
             return -1;
         }
+    }
+
+    public int getSwitchedReason() {
+        return switchedReason;
+    }
+
+    public void setSwitchedReason(int reason) {
+        switchedReason = reason;
     }
 
     @Override

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -608,9 +608,13 @@ public class WeaponType extends EquipmentType {
     }
 
     public int getMaxRange(Mounted weapon) {
+        return getMaxRange(weapon, weapon.getLinked());
+    }
+
+    public int getMaxRange(Mounted weapon, Mounted ammo) {
         if (null != weapon) {
             if (getAmmoType() == AmmoType.T_ATM) {
-                AmmoType ammoType = (AmmoType) weapon.getLinked().getType();
+                AmmoType ammoType = (AmmoType) ammo.getType();
                 if ((ammoType.getAmmoType() == AmmoType.T_ATM)
                         && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
                     return RANGE_EXT;
@@ -620,7 +624,7 @@ public class WeaponType extends EquipmentType {
                 }
             }
             if (getAmmoType() == AmmoType.T_MML) {
-                AmmoType ammoType = (AmmoType) weapon.getLinked().getType();
+                AmmoType ammoType = (AmmoType) ammo.getType();
                 if (ammoType.hasFlag(AmmoType.F_MML_LRM) || (getAmmoType() == AmmoType.T_LRM_TORPEDO)) {
                     return RANGE_LONG;
                 } else {

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -134,7 +134,7 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
     public int getPlayerId() {
         return playerId;
     }
-    
+
     public void setSpotterIds(Vector<Integer> spotterIds) {
         this.spotterIds = spotterIds;
     }
@@ -146,7 +146,7 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
     public Coords getCoords() {
         return this.firingCoords;
     }
-    
+
     // For use with AMS and artillery to-hit tables
     public void setOldTargetCoords(Coords coords) {
         this.oldTargetCoords = coords;
@@ -155,31 +155,29 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
     public Coords getOldTargetCoords() {
         return this.oldTargetCoords;
     }
-    
+
     /*
      * Updates the turnsTilHit value of this aaa
      * Needed after aaa setup by bearings-only missiles, which have a variable velocity
      */
     @Override
     public void updateTurnsTilHit(Game game) {
-        int distance = Compute.effectiveDistance(game, getEntity(game), getTarget(game));
         // adjust distance for gravity
-        distance = (int) Math.floor((double) distance / game.getPlanetaryConditions().getGravity());
-        this.turnsTilHit = distance / launchVelocity;
+        this.turnsTilHit = Compute.turnsTilHit(game, getEntity(game), getTarget(game), launchVelocity);
     }
-    
+
     public int getTurnsTilHit() {
         return this.turnsTilHit;
     }
-    
+
     public void setTurnsTilHit(int turnsTilHit) {
         this.turnsTilHit = turnsTilHit;
     }
-    
+
     public void decrementTurnsTilHit() {
         decrementTurnsTilHit(1);
     }
-    
+
     public void decrementTurnsTilHit(int numTurns) {
         this.turnsTilHit-=numTurns;
     }

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -110,20 +110,7 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
             // See TO p181. Cruise missile flight time is (1 + (Mapsheets / 5, round down)
             turnsTilHit = 1 + (distance / Board.DEFAULT_BOARD_HEIGHT / 5);
         } else {
-            // See indirect flight times table, TO p181
-            if (distance <= Board.DEFAULT_BOARD_HEIGHT) {
-                turnsTilHit = 0;
-            } else if (distance <= (8 * Board.DEFAULT_BOARD_HEIGHT)) {
-                turnsTilHit = 1;
-            } else if (distance <= (15 * Board.DEFAULT_BOARD_HEIGHT)) {
-                turnsTilHit = 2;
-            } else if (distance <= (21 * Board.DEFAULT_BOARD_HEIGHT)) {
-                turnsTilHit =3;
-            } else if (distance <= (26 * Board.DEFAULT_BOARD_HEIGHT)) {
-                turnsTilHit = 4;
-            } else {
-                turnsTilHit = 5;
-            }
+            turnsTilHit = Compute.turnsTilHit(distance);
         }
     }
 
@@ -163,7 +150,7 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
     @Override
     public void updateTurnsTilHit(Game game) {
         // adjust distance for gravity
-        this.turnsTilHit = Compute.turnsTilHit(game, getEntity(game), getTarget(game), launchVelocity);
+        this.turnsTilHit = Compute.turnsTilBOMHit(game, getEntity(game), getTarget(game), launchVelocity);
     }
 
     public int getTurnsTilHit() {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5075,12 +5075,24 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         processDefenderSPAs(toHit, ae, te, weapon, game);
 
         //Homing warheads just need a flat 4 to seek out a successful TAG, but Princess needs help
+        //judging what a good homing target is.
         if (isHoming) {
             srt.setSpecialResolution(true);
             String msg = Messages.getString("WeaponAttackAction.HomingArty");
             // Check if any spotters can help us out...
             if (Compute.findTAGSpotter(game, ae, target, true) != null) {
-                return new ToHitData(4, msg);
+                // Likelihood of hitting goes up as speed goes down...
+                ToHitData thd = new ToHitData(4, msg);
+                if (null != te) {
+                    thd.append(
+                            Compute.getTargetMovementModifier(
+                                    te.getRunMP(),
+                                    false,
+                                    false,
+                                    game)
+                    );
+                }
+                return thd;
             } else {
                 return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
             }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5079,7 +5079,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             srt.setSpecialResolution(true);
             String msg = Messages.getString("WeaponAttackAction.HomingArty");
             // Check if any spotters can help us out...
-            if (Compute.findTAGSpotter(game, ae, te, false) != null) {
+            if (Compute.findTAGSpotter(game, ae, target, true) != null) {
                 return new ToHitData(4, msg);
             } else {
                 return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5073,10 +5073,16 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         processAttackerSPAs(toHit, ae, te, weapon, game);
         processDefenderSPAs(toHit, ae, te, weapon, game);
 
-        //Homing warheads just need a flat 4 to seek out a successful TAG
+        //Homing warheads just need a flat 4 to seek out a successful TAG, but Princess needs help
         if (isHoming) {
             srt.setSpecialResolution(true);
-            return new ToHitData(4, Messages.getString("WeaponAttackAction.HomingArty"));
+            String msg = Messages.getString("WeaponAttackAction.HomingArty");
+            // Check if any spotters can help us out...
+            if (Compute.findTAGSpotter(game, ae, te, false) != null) {
+                return new ToHitData(4, msg);
+            } else {
+                return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
+            }
         }
 
         //Don't bother adding up modifiers if the target hex has been hit before

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -43,6 +43,7 @@ import java.util.*;
  * Represents intention to fire a weapon at the target.
  */
 public class WeaponAttackAction extends AbstractAttackAction implements Serializable {
+    public static int DEFAULT_VELOCITY = 50;
     private static final long serialVersionUID = -9096603813317359351L;
 
     public static final int STRATOPS_SENSOR_SHADOW_WEIGHT_DIFF = 100000;
@@ -56,7 +57,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
     private int otherAttackInfo = -1;
     private boolean nemesisConfused;
     private boolean swarmingMissiles;
-    protected int launchVelocity = 50;
+    protected int launchVelocity = DEFAULT_VELOCITY;
     /**
      * Keeps track of the ID of the current primary target for a swarm missile
      * attack.

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3221,7 +3221,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     toHit.addModifier(1, atype.getSubMunitionName()
                             + Messages.getString("WeaponAttackAction.AmmoMod"));
                 } else {
-                    // +1 bonus for each -1MP the target would get due to heat
+                    // -1 bonus for each -1MP the target would get due to heat
                     toHit.addModifier(-te.getHeatMPReduction(),
                             atype.getSubMunitionName()
                                     + Messages.getString("WeaponAttackAction.AmmoMod"));

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -775,7 +775,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
         // Collect the modifiers for terrain and line-of-sight. This includes any related to-hit table changes
         toHit = compileTerrainAndLosToHitMods(game, ae, target, ttype, aElev, tElev, targEl, distance, los, toHit,
-                    losMods, toSubtract, eistatus, wtype, weapon, weaponId, atype, munition, isAttackerInfantry,
+                    losMods, toSubtract, eistatus, wtype, weapon, weaponId, atype, ammo, munition, isAttackerInfantry,
                     inSameBuilding, isIndirect, isPointblankShot, underWater);
 
         // If this is a swarm LRM secondary attack, remove old target movement and terrain mods, then
@@ -787,7 +787,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         }
 
         // Collect the modifiers specific to the weapon the attacker is using
-        toHit = compileWeaponToHitMods(game, ae, spotter, target, ttype, toHit, wtype, weapon, atype, munition,
+        toHit = compileWeaponToHitMods(game, ae, spotter, target, ttype, toHit, wtype, weapon, atype, ammo, munition,
                     isFlakAttack, isIndirect, narcSpotter);
 
         // Collect the modifiers specific to the ammo the attacker is using
@@ -882,7 +882,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
         // Collect the modifiers for terrain and line-of-sight. This includes any related to-hit table changes
         toHit = compileTerrainAndLosToHitMods(game, ae, target, ttype, aElev, tElev, targEl, distance, los, toHit,
-                    losMods, toSubtract, eistatus, null, null, weaponId, null, EnumSet.of(AmmoType.Munitions.M_STANDARD), isAttackerInfantry,
+                    losMods, toSubtract, eistatus, null, null, weaponId, null, null, EnumSet.of(AmmoType.Munitions.M_STANDARD), isAttackerInfantry,
                     inSameBuilding, false, false, false);
 
         // okay!
@@ -2542,7 +2542,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     && (weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80) || weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60)
                             || weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40))
                     && target.isAero() && te!= null && !te.isLargeCraft()
-                    && (RangeType.rangeBracket(ae.getPosition().distance(target.getPosition()), wtype.getRanges(weapon),
+                    && (RangeType.rangeBracket(ae.getPosition().distance(target.getPosition()), wtype.getRanges(weapon, ammo),
                             true, false) == RangeType.RANGE_SHORT)) {
                 return Messages.getString("WeaponAttackAction.TooCloseForSCBracket");
             }
@@ -2947,7 +2947,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
      * @param narcSpotter  flag that indicates whether this spotting entity is using NARC equipment
      */
     private static ToHitData compileWeaponToHitMods(Game game, Entity ae, Entity spotter, Targetable target,
-                int ttype, ToHitData toHit, WeaponType wtype, Mounted weapon, AmmoType atype, EnumSet<AmmoType.Munitions> munition,
+                int ttype, ToHitData toHit, WeaponType wtype, Mounted weapon, AmmoType atype, Mounted ammo, EnumSet<AmmoType.Munitions> munition,
                 boolean isFlakAttack, boolean isIndirect, boolean narcSpotter) {
         if (ae == null || wtype == null || weapon == null) {
             // Can't calculate weapon mods without a valid weapon and an attacker to fire it
@@ -3038,7 +3038,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             int modifier = wtype.getToHitModifier();
             if (wtype instanceof VariableSpeedPulseLaserWeapon) {
                 int nRange = ae.getPosition().distance(target.getPosition());
-                int[] nRanges = wtype.getRanges(weapon);
+                int[] nRanges = wtype.getRanges(weapon, ammo);
 
                 if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
                     modifier += RangeType.RANGE_SHORT;
@@ -4347,7 +4347,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
      */
     private static ToHitData compileTerrainAndLosToHitMods(Game game, Entity ae, Targetable target, int ttype, int aElev, int tElev,
                 int targEl, int distance, LosEffects los, ToHitData toHit, ToHitData losMods, int toSubtract, int eistatus,
-                WeaponType wtype, Mounted weapon, int weaponId, AmmoType atype, EnumSet<AmmoType.Munitions> munition, boolean isAttackerInfantry,
+                WeaponType wtype, Mounted weapon, int weaponId, AmmoType atype, Mounted ammo, EnumSet<AmmoType.Munitions> munition, boolean isAttackerInfantry,
                 boolean inSameBuilding, boolean isIndirect, boolean isPointBlankShot, boolean underWater) {
         if (ae == null || target == null) {
             // Can't handle these attacks without a valid attacker and target
@@ -4381,7 +4381,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                         || wtype.hasFlag(WeaponType.F_DIVE_BOMB)
                         || (atype != null && atype.getMunitionType().contains(AmmoType.Munitions.M_ADA))))
                 && weaponId > WeaponType.WEAPON_NA)) {
-            toHit.append(Compute.getRangeMods(game, ae, weaponId, target));
+            toHit.append(Compute.getRangeMods(game, ae, weapon, ammo, target));
         }
 
         // add in LOS mods that we've been keeping

--- a/megamek/src/megamek/common/pathfinder/SpheroidPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/SpheroidPathFinder.java
@@ -114,13 +114,7 @@ public class SpheroidPathFinder {
             // Allow the entity to rotate any direction if it hovers.
             validRotations.addAll(AeroPathUtil.generateValidRotations(hoverPath));
 
-
-            // Set the correct facing for each end location
-            // for (MovePath path : spheroidPaths) {
-            //     validRotations.addAll(AeroPathUtil.generateValidRotation(path, poi));
-            //}
-
-            //spheroidPaths.addAll(validRotations);
+            spheroidPaths.addAll(validRotations);
 
             visitedCoords.clear();
 
@@ -177,11 +171,6 @@ public class SpheroidPathFinder {
         // we've moved further than 8 hexes on a ground map
         if (visitedCoords.contains(startingPath.getFinalCoords()) ||
                 (startingPath.getMpUsed() > startingPath.getEntity().getRunMP())) {
-            // End this path with turns to face our desired final direction
-            int diff = (6 + (direction - startingPath.getFinalFacing())) % 6;
-            for (MoveStepType stepType : AeroPathUtil.TURNS.get(diff)) {
-                startingPath.addStep(stepType);
-            }
             return retval;
         }
 
@@ -200,8 +189,17 @@ public class SpheroidPathFinder {
                 childPath.addStep(stepType);
             }
 
-            // finally, move forward
-            childPath.addStep(MoveStepType.FORWARDS);
+            // If we're right at the end of our possible movement, face our desired heading
+            if (childPath.getMpUsed() == startingPath.getEntity().getRunMP() - 1) {
+                // End this path with turns to face our desired final direction
+                int diff = (6 + (direction - startingPath.getFinalFacing())) % 6;
+                for (MoveStepType stepType : AeroPathUtil.TURNS.get(diff)) {
+                    startingPath.addStep(stepType);
+                }
+            } else {
+                // Allow continued movement forward
+                childPath.addStep(MoveStepType.FORWARDS);
+            }
 
             // having generated the child, we add it and (recursively) any of its children to the list of children to be returned
             // of course, if it winds up not being legal anyway for some other reason, then we discard it and move on

--- a/megamek/src/megamek/common/pathfinder/SpheroidPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/SpheroidPathFinder.java
@@ -53,8 +53,8 @@ public class SpheroidPathFinder {
     }
 
     /**
-     * We want to be able to set a point that the entity should turn to face
-     * @param target
+     * We want to be able to set the direction the entity should turn to face
+     * @param direction
      */
     public void setDirection(int direction) {
         this.direction = direction;

--- a/megamek/src/megamek/common/weapons/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/ATMHandler.java
@@ -135,19 +135,10 @@ public class ATMHandler extends MissileWeaponHandler {
         if (atype.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE)) {
             if (range == WeaponType.RANGE_SHORT) {
                 av = wtype.getRoundShortAV();
-                av = av + (av / 2);
+                av = av + (int) Math.ceil(av / 2.0);
             }
         } else if (atype.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE)) {
-            if (range == WeaponType.RANGE_SHORT) {
-                av = wtype.getRoundShortAV();
-            } else if (range == WeaponType.RANGE_MED) {
-                av = wtype.getRoundMedAV();
-            } else if (range == WeaponType.RANGE_LONG) {
-                av = wtype.getRoundLongAV();
-            } else if (range == WeaponType.RANGE_EXT) {
-                av = wtype.getRoundLongAV();
-            }
-            av = av / 2;
+            av = (int) Math.ceil(wtype.getRoundMedAV() / 2.0);
         } else {
             if (range == WeaponType.RANGE_SHORT) {
                 av = wtype.getRoundShortAV();

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -433,7 +433,7 @@ public class AreaEffectHelper {
         // Entity/ammo specific damage modifiers
         if (ammo != null) {
             if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
-                if (hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
+                if (hex != null && hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
                     hits *= 2;
                 }
             }

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -105,7 +105,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(wtype.getName());
+                r.add(wtype.getName() + " (" + atype.getShortName() + ")");
                 r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
@@ -69,7 +69,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(wtype.getName());
+                r.add(wtype.getName() + " (" + atype.getShortName() + ")");
                 r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
@@ -87,11 +87,11 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
             aaa.decrementTurnsTilHit();
             return true;
         }
-        
+
         convertHomingShotToEntityTarget();
         Entity entityTarget = (aaa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) aaa
                 .getTarget(game) : null;
-                
+
         final boolean targetInBuilding = Compute.isInBuilding(game,
                 entityTarget);
         final boolean bldgDamagedOnMiss = targetInBuilding
@@ -100,7 +100,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
 
         // Which building takes the damage?
         Building bldg = game.getBoard().getBuildingAt(target.getPosition());
-        
+
         //Determine what ammo we're firing for reporting and (later) damage
         Mounted ammoUsed = ae.getEquipment(aaa.getAmmoId());
         final AmmoType atype = (AmmoType) ammoUsed.getType();
@@ -187,32 +187,32 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
 
         //Set up the damage
         nDamPerHit = atype.getRackSize();
-        
+
         // copperhead gets 10 damage less than standard
         if (atype != null && atype.getAmmoType() != AmmoType.T_ARROW_IV) {
             nDamPerHit -= 10;
         }
-        
+
         nDamPerHit = applyGlancingBlowModifier(nDamPerHit, false);
 
         // Do we need some sort of special resolution (minefields, artillery,
         if (specialResolution(vPhaseReport, entityTarget)) {
             return false;
         }
-        
+
         //this has to be called here or it triggers before the TAG shot and we have no entityTarget
         //mounting AMS
-        if (atype != null 
+        if (atype != null
                 && atype.getAmmoType() == AmmoType.T_ARROW_IV) {
             gameManager.assignAMS();
         }
         while (nweaponsHit > 0) {
             int hits = 1;
-            int nCluster = 1;        
+            int nCluster = 1;
             if ((entityTarget != null) && (entityTarget.getTaggedBy() != -1)) {
                 //Do point defenses shoot down this homing missile? (Copperheads don't count)
                 hits = handleAMS(vPhaseReport, ammoUsed);
-                
+
                 if (bMissed && !missReported) {
                     reportMiss(vPhaseReport);
 
@@ -223,7 +223,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
                         return false;
                     }
                 }
-                
+
                 if (aaa.getCoords() != null && hits > 0) {
                     toHit.setSideTable(entityTarget.sideTable(aaa.getCoords()));
                 }
@@ -331,7 +331,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
     }
 
     /**
-     * Find the tagged entity for this attack 
+     * Find the tagged entity for this attack
      * Uses a CFR to let the player choose from eligible TAGs
      */
     public void convertHomingShotToEntityTarget() {
@@ -388,7 +388,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
                 allowed.add(ti);
             }
         }
-        
+
         if (allowed.isEmpty()) {
             aaa.setTargetId(newTarget.getId());
             aaa.setTargetType(newTarget.getTargetType());
@@ -430,7 +430,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
             Vector<Report> vPhaseReport) {
         return true;
     }
-    
+
     /**
      * This is a unified method that handles single AMS and AMS Bay counterfire against Arrow IV homing missiles
      * Artillery bays resolve each weapon individually and don't use Aero AV, so we can safely do this
@@ -439,7 +439,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
      * @return 1 hit if this missile survives any AMS fire, 0 if it is destroyed
      */
     protected int handleAMS(Vector<Report> vPhaseReport, Mounted ammoUsed) {
-        
+
         int hits = 1;
         if (((AmmoType) ammoUsed.getType()).getAmmoType() == AmmoType.T_ARROW_IV
                 || ((AmmoType) ammoUsed.getType()).getAmmoType() == BombType.B_HOMING) {
@@ -448,7 +448,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
             gameManager.assignAMS();
             calcCounterAV();
             // Report AMS/Pointdefense failure due to Overheating.
-            if (pdOverheated 
+            if (pdOverheated
                     && (!(amsBayEngaged
                             || amsBayEngagedCap
                             || amsBayEngagedMissile
@@ -507,7 +507,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
                     vPhaseReport.add(r);
                     nDamPerHit = 0;
                     hits = 0;
-                                           
+
                 } else {
                     r = new Report(3241);
                     r.add("missile");
@@ -520,15 +520,15 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
         }
         return hits;
     }
-    
+
     /**
      * Checks to see if the basic conditions needed for point defenses to work are in place
      * Artillery weapons need to change this slightly compared to other types of missiles
      */
     @Override
     protected boolean checkPDConditions() {
-        if ((target == null) 
-                || target.getTargetType() != Targetable.TYPE_ENTITY 
+        if ((target == null)
+                || target.getTargetType() != Targetable.TYPE_ENTITY
                 || !advancedPD
                 || !advancedAMS
                 || waa.getCounterEquipment() == null) {
@@ -536,7 +536,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
         }
         return true;
     }
-    
+
     /**
      * Sets the appropriate AMS Bay reporting flag depending on what type of missile this is
      */
@@ -544,7 +544,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
     protected void setAMSBayReportingFlag() {
         amsBayEngagedCap = true;
     }
-    
+
     /**
      * Sets the appropriate PD Bay reporting flag depending on what type of missile this is
      */
@@ -552,13 +552,13 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
     protected void setPDBayReportingFlag() {
         pdBayEngagedCap = true;
     }
-    
+
     @Override
     protected int calcCapMissileAMSMod() {
         CapMissileAMSMod = (int) Math.ceil(CounterAV / 10.0);
         return CapMissileAMSMod;
     }
-    
+
     @Override
     protected int getCapMissileAMSMod() {
         return CapMissileAMSMod;

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
@@ -384,7 +384,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
         for (TagInfo ti : v) {
             newTarget = ti.target;
             // homing target area is 8 hexes
-            if (tc.distance(newTarget.getPosition()) <= 8) {
+            if (tc.distance(newTarget.getPosition()) <= Compute.HOMING_RADIUS) {
                 allowed.add(ti);
             }
         }

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -140,9 +140,6 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             ammoCarrier = aaa.getEntity(game, aaa.getAmmoCarrier());
         }
 
-        Mounted ammoUsed = ammoCarrier.getEquipment(aaa.getAmmoId());
-        final AmmoType atype = (ammoUsed != null) ? (AmmoType) ammoUsed.getType() : null;
-
         // Are there any valid spotters?
         if ((null != spottersBefore) && !isFlak) {
             // fetch possible spotters now

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -69,7 +69,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(wtype.getName());
+                r.add(wtype.getName() + " (" + atype.getShortName() + ")");
                 r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -234,7 +234,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         r.newlines = 0;
         r.subject = subjectId;
         if (wtype != null) {
-            r.add(wtype.getName());
+            r.add(wtype.getName() + " (" + atype.getShortName() + ")");
         } else {
             r.add("Error: From Nowhere");
         }

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -25,6 +25,7 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.enums.GamePhase;
 import megamek.common.options.OptionsConstants;
 import megamek.server.GameManager;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -307,6 +308,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
      * Uses a CFR to let the player choose from eligible TAG
      */
     public void convertHomingShotToEntityTarget() {
+        boolean debug = LogManager.getLogger().isDebugEnabled();
         ArtilleryAttackAction aaa = (ArtilleryAttackAction) waa;
 
         final Coords tc = target.getPosition();
@@ -348,6 +350,11 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             newTarget = ti.target;
             if (!ti.missed && (newTarget != null)) {
                 v.add(ti);
+                if (debug) {
+                    LogManager.getLogger().debug(new StringBuilder("Found valid TAG on target ")
+                            .append(ti).append("; Range to original target is ")
+                            .append(tc.distance(ti.target.getPosition())));
+                }
             }
         }
 
@@ -368,7 +375,6 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             if (tc.distance(newTarget.getPosition()) <= Compute.HOMING_RADIUS) {
                 allowed.add(ti);
             }
-
         }
         if (allowed.isEmpty()) {
             aaa.setTargetId(newTarget.getId());

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -69,7 +69,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(wtype.getName());
+                r.add(wtype.getName() + " (" + atype.getShortName() + ")");
                 r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);
@@ -87,7 +87,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             aaa.decrementTurnsTilHit();
             return true;
         }
-        
+
         convertHomingShotToEntityTarget();
         Entity entityTarget = (aaa.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) aaa
                 .getTarget(game) : null;
@@ -179,7 +179,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             bMissed = true;
         }
         nDamPerHit = wtype.getRackSize();
-        
+
         AmmoType ammoType = (AmmoType) ammo.getType();
 
         // copperhead gets 10 damage less than standard
@@ -191,7 +191,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         if (specialResolution(vPhaseReport, entityTarget)) {
             return false;
         }
-        
+
         //Any AMS/Point Defense fire against homing rounds?
         int hits = handleAMS(vPhaseReport);
 
@@ -205,14 +205,14 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
                 return false;
             }
         }
-        int nCluster = 1;       
+        int nCluster = 1;
         if ((entityTarget != null) && (entityTarget.getTaggedBy() != -1)) {
             if (aaa.getCoords() != null && hits > 0) {
                 toHit.setSideTable(entityTarget.sideTable(aaa.getCoords()));
             }
-           
+
         }
-        
+
         // The building shields all units from a certain amount of damage.
         // The amount is based upon the building's CF at the phase's start.
         int bldgAbsorbs = 0;
@@ -245,9 +245,9 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             vPhaseReport.addElement(r);
             return false;
         }
-        
+
         boolean targetingHex = false;
-        
+
         if (!bMissed && (entityTarget != null)) {
             handleEntityDamage(entityTarget, vPhaseReport, bldg, hits, nCluster, bldgAbsorbs);
             gameManager.creditKill(entityTarget, ae);
@@ -267,34 +267,34 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
 
         Coords coords = target.getPosition();
         int ratedDamage = 5; // splash damage is 5 from all launchers
-        
+
         //If AMS shoots down a missile, it shouldn't deal any splash damage
         if (hits == 0) {
             ratedDamage = 0;
         }
-        
+
         // homing artillery splash damage is area effect.
         // do damage to woods, 2 * normal damage (TW page 112)
         // on the other hand, if the hex *is* the target, do full damage
         int hexDamage = targetingHex ? wtype.getRackSize() : ratedDamage * 2;
-        
+
         bldg = null;
         bldg = game.getBoard().getBuildingAt(coords);
         bldgAbsorbs = (bldg != null) ? bldg.getAbsorbtion(coords) : 0;
         bldgAbsorbs = Math.min(bldgAbsorbs, ratedDamage);
         handleClearDamage(vPhaseReport, bldg, hexDamage, false);
         ratedDamage -= bldgAbsorbs;
-        
+
         if (ratedDamage > 0) {
             Hex hex = game.getBoard().getHex(coords);
-            
+
             for (Entity entity : game.getEntitiesVector(coords)) {
                 if (!bMissed && (entity == entityTarget)) {
                         continue; // don't splash the original target unless it's a miss
                 }
-                
-                AreaEffectHelper.artilleryDamageEntity(entity, ratedDamage, bldg, bldgAbsorbs, 
-                        targetInBuilding, bldgDamagedOnMiss, missReported, ratedDamage, coords, ammoType, 
+
+                AreaEffectHelper.artilleryDamageEntity(entity, ratedDamage, bldg, bldgAbsorbs,
+                        targetInBuilding, bldgDamagedOnMiss, missReported, ratedDamage, coords, ammoType,
                         coords, targetingHex, entityTarget, hex, hexDamage, vPhaseReport, gameManager);
             }
         }
@@ -303,7 +303,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
     }
 
     /**
-     * Find the tagged entity for this attack 
+     * Find the tagged entity for this attack
      * Uses a CFR to let the player choose from eligible TAG
      */
     public void convertHomingShotToEntityTarget() {
@@ -315,14 +315,14 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         Vector<TagInfo> v = game.getTagInfo();
         Vector<TagInfo> allowed = new Vector<>();
         Entity attacker = game.getEntityFromAllSources(getAttackerId());
-        
+
         // get only TagInfo on the same side
-        for (TagInfo ti : v) { 
+        for (TagInfo ti : v) {
             Entity tagger = game.getEntityFromAllSources(ti.attackerId);
             if (attacker.getOwner().isEnemyOf(tagger.getOwner())) {
                 continue;
             }
-            
+
             switch (ti.targetType) {
                 case Targetable.TYPE_BLDG_TAG:
                 case Targetable.TYPE_HEX_TAG:
@@ -411,7 +411,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             Vector<Report> vPhaseReport) {
         return true;
     }
-    
+
     /**
      * Checks to see if the basic conditions needed for point defenses to work are in place
      * Artillery weapons need to change this slightly
@@ -424,7 +424,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         }
         return true;
     }
-        
+
     /**
      * Sets the appropriate AMS Bay reporting flag depending on what type of missile this is
      */
@@ -432,7 +432,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
     protected void setAMSBayReportingFlag() {
         amsBayEngagedCap = true;
     }
-    
+
     /**
      * Sets the appropriate PD Bay reporting flag depending on what type of missile this is
      */
@@ -440,20 +440,20 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
     protected void setPDBayReportingFlag() {
         pdBayEngagedCap = true;
     }
-    
+
     @Override
     protected int calcCapMissileAMSMod() {
         CapMissileAMSMod = (int) Math.ceil(CounterAV / 10.0);
         return CapMissileAMSMod;
     }
-    
+
     @Override
     protected int getCapMissileAMSMod() {
         return CapMissileAMSMod;
     }
-    
+
     protected int handleAMS(Vector<Report> vPhaseReport) {
-        
+
         int hits = 1;
         if (((AmmoType) ammo.getType()).getAmmoType() == AmmoType.T_ARROW_IV
                 || ((AmmoType) ammo.getType()).getAmmoType() == BombType.B_HOMING) {
@@ -462,7 +462,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             gameManager.assignAMS();
             calcCounterAV();
             // Report AMS/Pointdefense failure due to Overheating.
-            if (pdOverheated 
+            if (pdOverheated
                     && (!(amsBayEngaged
                             || amsBayEngagedCap
                             || amsBayEngagedMissile

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -105,7 +105,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         r.indent();
         r.newlines = 0;
         r.subject = subjectId;
-        r.add(wtype.getName());
+        r.add(wtype.getName() + " (" + atype.getShortName() + ")");
         if (entityTarget != null) {
             r.addDesc(entityTarget);
         } else {

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -365,7 +365,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         for (TagInfo ti : v) {
             newTarget = ti.target;
             // homing target area is 8 hexes
-            if (tc.distance(newTarget.getPosition()) <= 8) {
+            if (tc.distance(newTarget.getPosition()) <= Compute.HOMING_RADIUS) {
                 allowed.add(ti);
             }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -352,7 +352,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
                 v.add(ti);
                 if (debug) {
                     LogManager.getLogger().debug(new StringBuilder("Found valid TAG on target ")
-                            .append(ti).append("; Range to original target is ")
+                            .append(ti.target.getDisplayName()).append("; Range to original target is ")
                             .append(tc.distance(ti.target.getPosition())));
                 }
             }

--- a/megamek/src/megamek/common/weapons/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/CLIATMHandler.java
@@ -434,7 +434,7 @@ public class CLIATMHandler extends ATMHandler {
             r.indent();
             r.newlines = 0;
             r.subject = subjectId;
-            r.add(wtype.getName());
+            r.add(wtype.getName() + " (" + atype.getShortName() + ")");
             if (entityTarget != null) {
                 r.addDesc(entityTarget);
             } else {

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -54,7 +54,7 @@ public class LRMSwarmHandler extends LRMHandler {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see megamek.common.weapons.AttackHandler#handle(int, java.util.Vector)
      */
     @Override
@@ -83,7 +83,7 @@ public class LRMSwarmHandler extends LRMHandler {
         r.indent();
         r.newlines = 0;
         r.subject = subjectId;
-        r.add(wtype.getName());
+        r.add(wtype.getName() + " (" + atype.getShortName() + ")");
         if (entityTarget != null) {
             r.addDesc(entityTarget);
             // record which launcher targeted the target
@@ -192,7 +192,7 @@ public class LRMSwarmHandler extends LRMHandler {
                 && (toHit.getThruBldg() == null)) {
             bldgAbsorbs = bldg.getAbsorbtion(target.getPosition());
         }
-        
+
         // Attacking infantry in buildings from same building
         if (targetInBuilding && (bldg != null)
                 && (toHit.getThruBldg() != null)
@@ -336,7 +336,7 @@ public class LRMSwarmHandler extends LRMHandler {
                     wtype.getInfantryDamageClass(),
                     ((Infantry) target).isMechanized(),
                     toHit.getThruBldg() != null, ae.getId(), calcDmgPerHitReport);
-            
+
             toReturn = applyGlancingBlowModifier(toReturn, true);
             return (int) toReturn;
         }
@@ -345,7 +345,7 @@ public class LRMSwarmHandler extends LRMHandler {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.WeaponHandler#handleSpecialMiss(megamek.common
      * .Entity, boolean, megamek.common.Building, java.util.Vector)
@@ -418,7 +418,7 @@ public class LRMSwarmHandler extends LRMHandler {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see megamek.common.weapons.WeaponHandler#calcHits(java.util.Vector)
      */
     @Override
@@ -446,8 +446,8 @@ public class LRMSwarmHandler extends LRMHandler {
             }
         }
         nMissilesModifier += amsMod;
-        
-        
+
+
 
         int swarmMissilesLeft = waa.getSwarmMissiles();
         // swarm or swarm-I shots may just hit with the remaining missiles

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -625,7 +625,8 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         if (entityTarget != null) {
             if (wtype.getAmmoType() != AmmoType.T_NA) {
                 AmmoType atype = (AmmoType) ammo.getType();
-                if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)) {
+                if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)
+                        || atype.getAmmoType() == AmmoType.T_MML) {
                     r.messageId = 3116;
                     r.add(atype.getSubMunitionName());
                 }

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -626,7 +626,9 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
             if (wtype.getAmmoType() != AmmoType.T_NA) {
                 AmmoType atype = (AmmoType) ammo.getType();
                 if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)
-                        || atype.getAmmoType() == AmmoType.T_MML) {
+                        || atype.getAmmoType() == AmmoType.T_MML
+                        || atype.getAmmoType() == AmmoType.T_ATM
+                ) {
                     r.messageId = 3116;
                     r.add(atype.getSubMunitionName());
                 }

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -75,7 +75,7 @@ public class SRMInfernoHandler extends SRMHandler {
         r.indent();
         r.newlines = 0;
         r.subject = subjectId;
-        r.add(wtype.getName());
+        r.add(wtype.getName() + " (" + atype.getShortName() + ")");
         if (entityTarget != null) {
             r.addDesc(entityTarget);
         } else {
@@ -174,7 +174,7 @@ public class SRMInfernoHandler extends SRMHandler {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.MissileWeaponHandler#calcHits(java.util.Vector)
      */
@@ -206,7 +206,7 @@ public class SRMInfernoHandler extends SRMHandler {
 
         // add AMS mods
         nMissilesModifier += getAMSHitsMod(vPhaseReport);
-        
+
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
             Entity entityTarget = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target
                     : null;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -56,6 +56,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
     protected boolean bLowProfileGlancing = false;
     protected boolean nukeS2S = false;
     protected WeaponType wtype;
+    protected AmmoType atype;
     protected String typeName;
     protected Mounted weapon;
     protected Entity ae;
@@ -801,7 +802,6 @@ public class WeaponHandler implements AttackHandler, Serializable {
                 if ((wtype.getAmmoType() != AmmoType.T_NA)
                         && (weapon.getLinked() != null)
                         && (weapon.getLinked().getType() instanceof AmmoType)) {
-                    AmmoType atype = (AmmoType) weapon.getLinked().getType();
                     if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)
                         || atype.getAmmoType() == AmmoType.T_MML
                         || atype.getAmmoType() == AmmoType.T_AC_LBX) {
@@ -1753,6 +1753,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         ae = game.getEntity(waa.getEntityId());
         weapon = ae.getEquipment(waa.getWeaponId());
         wtype = (WeaponType) weapon.getType();
+        atype = (weapon.getLinked() != null) ? (AmmoType) weapon.getLinked().getType() : null;
         typeName = wtype.getInternalName();
         target = game.getTarget(waa.getTargetType(), waa.getTargetId());
         gameManager = m;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -804,7 +804,9 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         && (weapon.getLinked().getType() instanceof AmmoType)) {
                     if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)
                         || atype.getAmmoType() == AmmoType.T_MML
-                        || atype.getAmmoType() == AmmoType.T_AC_LBX) {
+                        || atype.getAmmoType() == AmmoType.T_AC_LBX
+                        || atype.getAmmoType() == AmmoType.T_ATM
+                    ) {
                         r.messageId = 3116;
                         r.add(atype.getSubMunitionName());
                     }

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -802,7 +802,9 @@ public class WeaponHandler implements AttackHandler, Serializable {
                         && (weapon.getLinked() != null)
                         && (weapon.getLinked().getType() instanceof AmmoType)) {
                     AmmoType atype = (AmmoType) weapon.getLinked().getType();
-                    if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)) {
+                    if (!atype.getMunitionType().contains(AmmoType.Munitions.M_STANDARD)
+                        || atype.getAmmoType() == AmmoType.T_MML
+                        || atype.getAmmoType() == AmmoType.T_AC_LBX) {
                         r.messageId = 3116;
                         r.add(atype.getSubMunitionName());
                     }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -10190,13 +10190,15 @@ public class GameManager implements IGameManager {
                                         int subjectId, Vector<Report> vPhaseReport) {
         Hex h = game.getBoard().getHex(coords);
         Report r;
-        // Unless there is a fire in the hex already, start one.
-        if (h.terrainLevel(Terrains.FIRE) < Terrains.FIRE_LVL_INFERNO_IV) {
-            ignite(coords, Terrains.FIRE_LVL_INFERNO_IV, vPhaseReport);
-        }
-        // possibly melt ice and snow
-        if (h.containsTerrain(Terrains.ICE) || h.containsTerrain(Terrains.SNOW)) {
-            vPhaseReport.addAll(meltIceAndSnow(coords, subjectId));
+        if (null != h) {
+            // Unless there is a fire in the hex already, start one.
+            if (h.terrainLevel(Terrains.FIRE) < Terrains.FIRE_LVL_INFERNO_IV) {
+                ignite(coords, Terrains.FIRE_LVL_INFERNO_IV, vPhaseReport);
+            }
+            // possibly melt ice and snow
+            if (h.containsTerrain(Terrains.ICE) || h.containsTerrain(Terrains.SNOW)) {
+                vPhaseReport.addAll(meltIceAndSnow(coords, subjectId));
+            }
         }
         for (Entity entity : game.getEntitiesVector(coords)) {
             // TacOps, p. 356 - treat as if hit by 5 inferno missiles
@@ -10222,13 +10224,15 @@ public class GameManager implements IGameManager {
                 continue;
             }
             h = game.getBoard().getHex(tempcoords);
-            // Unless there is a fire in the hex already, start one.
-            if (h.terrainLevel(Terrains.FIRE) < Terrains.FIRE_LVL_INFERNO_IV) {
-                ignite(tempcoords, Terrains.FIRE_LVL_INFERNO_IV, vPhaseReport);
-            }
-            // possibly melt ice and snow
-            if (h.containsTerrain(Terrains.ICE) || h.containsTerrain(Terrains.SNOW)) {
-                vPhaseReport.addAll(meltIceAndSnow(tempcoords, subjectId));
+            if (null != h) {
+                // Unless there is a fire in the hex already, start one.
+                if (h.terrainLevel(Terrains.FIRE) < Terrains.FIRE_LVL_INFERNO_IV) {
+                    ignite(tempcoords, Terrains.FIRE_LVL_INFERNO_IV, vPhaseReport);
+                }
+                // possibly melt ice and snow
+                if (h.containsTerrain(Terrains.ICE) || h.containsTerrain(Terrains.SNOW)) {
+                    vPhaseReport.addAll(meltIceAndSnow(tempcoords, subjectId));
+                }
             }
             for (Entity entity : game.getEntitiesVector(tempcoords)) {
                 r = new Report(6695);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -30110,6 +30110,7 @@ public class GameManager implements IGameManager {
         int entityId = c.getIntValue(0);
         int weaponId = c.getIntValue(1);
         int ammoId = c.getIntValue(2);
+        int reason = c.getIntValue(3);
         Entity e = game.getEntity(entityId);
 
         // Did we receive a request for a valid Entity?
@@ -30158,6 +30159,19 @@ public class GameManager implements IGameManager {
 
         // Load the weapon.
         e.loadWeapon(mWeap, mAmmo);
+
+        // Report the change, if reason is provided
+        if (reason != 0) {
+            Report r = new Report(1500);
+            r.subject = entityId;
+            r.addDesc(e);
+            r.add(mWeap.getShortName());
+            r.add(mAmmo.getShortName());
+            addReport(r);
+            r = new Report(reason);
+            r.indent(4);
+            addReport(r);
+        }
     }
 
     /**

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -30160,16 +30160,13 @@ public class GameManager implements IGameManager {
         // Load the weapon.
         e.loadWeapon(mWeap, mAmmo);
 
-        // Report the change, if reason is provided
-        if (reason != 0) {
+        // Report the change, if reason is provided and it's not already being used.
+        if (reason != 0 && mWeap.getLinked() != mAmmo) {
             Report r = new Report(1500);
             r.subject = entityId;
             r.addDesc(e);
-            r.add(mWeap.getShortName());
             r.add(mAmmo.getShortName());
-            addReport(r);
-            r = new Report(reason);
-            r.indent(4);
+            r.add(ReportMessages.getString(String.valueOf(reason)));
             addReport(r);
         }
     }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -10125,24 +10125,26 @@ public class GameManager implements IGameManager {
         vPhaseReport.add(r);
         createSmoke(coords, SmokeCloud.SMOKE_HEAVY, 3);
         Hex hex = game.getBoard().getHex(coords);
-        hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_HEAVY));
-        sendChangedHex(coords);
-        for (int dir = 0; dir <= 5; dir++) {
-            Coords tempcoords = coords.translated(dir);
-            if (!game.getBoard().contains(tempcoords)) {
-                continue;
-            }
-            if (coords.equals(tempcoords)) {
-                continue;
-            }
-            r = new Report(5185, Report.PUBLIC);
-            r.indent(2);
-            r.add(tempcoords.getBoardNum());
-            vPhaseReport.add(r);
-            createSmoke(tempcoords, SmokeCloud.SMOKE_HEAVY, 3);
-            hex = game.getBoard().getHex(tempcoords);
+        if (hex != null) {
             hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_HEAVY));
-            sendChangedHex(tempcoords);
+            sendChangedHex(coords);
+            for (int dir = 0; dir <= 5; dir++) {
+                Coords tempcoords = coords.translated(dir);
+                if (!game.getBoard().contains(tempcoords)) {
+                    continue;
+                }
+                if (coords.equals(tempcoords)) {
+                    continue;
+                }
+                r = new Report(5185, Report.PUBLIC);
+                r.indent(2);
+                r.add(tempcoords.getBoardNum());
+                vPhaseReport.add(r);
+                createSmoke(tempcoords, SmokeCloud.SMOKE_HEAVY, 3);
+                hex = game.getBoard().getHex(tempcoords);
+                hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_HEAVY));
+                sendChangedHex(tempcoords);
+            }
         }
     }
 
@@ -10158,24 +10160,26 @@ public class GameManager implements IGameManager {
         vPhaseReport.add(r);
         createSmoke(coords, SmokeCloud.SMOKE_LI_HEAVY, 2);
         Hex hex = game.getBoard().getHex(coords);
-        hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_LI_HEAVY));
-        sendChangedHex(coords);
-        for (int dir = 0; dir <= 5; dir++) {
-            Coords tempcoords = coords.translated(dir);
-            if (!game.getBoard().contains(tempcoords)) {
-                continue;
-            }
-            if (coords.equals(tempcoords)) {
-                continue;
-            }
-            r = new Report(5186, Report.PUBLIC);
-            r.indent(2);
-            r.add(tempcoords.getBoardNum());
-            vPhaseReport.add(r);
-            createSmoke(tempcoords, SmokeCloud.SMOKE_LI_HEAVY, 2);
-            hex = game.getBoard().getHex(tempcoords);
+        if (null != hex) {
             hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_LI_HEAVY));
-            sendChangedHex(tempcoords);
+            sendChangedHex(coords);
+            for (int dir = 0; dir <= 5; dir++) {
+                Coords tempcoords = coords.translated(dir);
+                if (!game.getBoard().contains(tempcoords)) {
+                    continue;
+                }
+                if (coords.equals(tempcoords)) {
+                    continue;
+                }
+                r = new Report(5186, Report.PUBLIC);
+                r.indent(2);
+                r.add(tempcoords.getBoardNum());
+                vPhaseReport.add(r);
+                createSmoke(tempcoords, SmokeCloud.SMOKE_LI_HEAVY, 2);
+                hex = game.getBoard().getHex(tempcoords);
+                hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_LI_HEAVY));
+                sendChangedHex(tempcoords);
+            }
         }
     }
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -30127,6 +30127,7 @@ public class GameManager implements IGameManager {
         // Make sure that the entity has the given equipment.
         Mounted mWeap = e.getEquipment(weaponId);
         Mounted mAmmo = e.getEquipment(ammoId);
+        Mounted oldAmmo = mWeap.getLinked();
         if (null == mAmmo) {
             LogManager.getLogger().error("Entity " + e.getDisplayName() + " does not have ammo #" + ammoId);
             return;
@@ -30161,13 +30162,16 @@ public class GameManager implements IGameManager {
         e.loadWeapon(mWeap, mAmmo);
 
         // Report the change, if reason is provided and it's not already being used.
-        if (reason != 0 && mWeap.getLinked() != mAmmo) {
+        if (reason != 0 && oldAmmo != mAmmo) {
             Report r = new Report(1500);
             r.subject = entityId;
             r.addDesc(e);
             r.add(mAmmo.getShortName());
             r.add(ReportMessages.getString(String.valueOf(reason)));
             addReport(r);
+            if (LogManager.getLogger().isDebugEnabled()) {
+
+            }
         }
     }
 

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -30127,7 +30127,7 @@ public class GameManager implements IGameManager {
         // Make sure that the entity has the given equipment.
         Mounted mWeap = e.getEquipment(weaponId);
         Mounted mAmmo = e.getEquipment(ammoId);
-        Mounted oldAmmo = mWeap.getLinked();
+        Mounted oldAmmo = (mWeap == null) ? null : mWeap.getLinked();
         if (null == mAmmo) {
             LogManager.getLogger().error("Entity " + e.getDisplayName() + " does not have ammo #" + ammoId);
             return;

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -978,10 +978,11 @@ public class BasicPathRankerTest {
         assertNull(actual);
         actual = testRanker.calcAllyCenter(myId, null, mockGame);
         assertNull(actual);
+        // I'm my own best friend
         final List<Entity> solo = new ArrayList<>(1);
         solo.add(mockFriend1);
         actual = testRanker.calcAllyCenter(myId, solo, mockGame);
-        assertNull(actual);
+        assertEquals(actual.equals(mockFriend1.getPosition()), true);
     }
 
     private void assertCoordsEqual(final Coords expected, final Coords actual) {

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -66,6 +66,9 @@ public class FireControlTest {
     @SuppressWarnings("FieldCanBeLocal")
     private AmmoType mockAmmoTypeAc5Flechette;
     private Mounted mockAmmoAc5Flechette;
+    private WeaponFireInfo mockAC5StdFireInfo;
+    private WeaponFireInfo mockAC5IncendiaryFireInfo;
+    private WeaponFireInfo mockAC5FlakFireInfo;
 
     // LB10X
     private Mounted mockWeaponLB10X;
@@ -267,6 +270,45 @@ public class FireControlTest {
         doReturn(true).when(mockAmmoTypeAc5Flechette).equalsAmmoTypeOnly(eq(mockAmmoTypeAC5Incendiary));
         doReturn(true).when(mockAmmoTypeAc5Flechette).equalsAmmoTypeOnly(eq(mockAmmoTypeAc5Flechette));
 
+        // AC5 WeaponFireInfo mocks
+        mockAC5StdFireInfo = mock(WeaponFireInfo.class);
+        mockAC5IncendiaryFireInfo = mock(WeaponFireInfo.class);
+        mockAC5FlakFireInfo = mock(WeaponFireInfo.class);
+        when(mockAC5StdFireInfo.getProbabilityToHit()).thenReturn(0.5833);
+        when(mockAC5StdFireInfo.getExpectedDamage()).thenReturn(0.5833 * 5);
+        when(mockAC5IncendiaryFireInfo.getProbabilityToHit()).thenReturn(0.5833);
+        when(mockAC5IncendiaryFireInfo.getExpectedDamage()).thenReturn(0.5833 * 5);
+        when(mockAC5FlakFireInfo.getProbabilityToHit()).thenReturn(0.8333);
+        when(mockAC5FlakFireInfo.getExpectedDamage()).thenReturn(0.8333 * 3);
+        // Std AC5
+        doReturn(mockAC5StdFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5), any(Mounted.class),
+                any(Game.class), anyBoolean());
+        doReturn(mockAC5StdFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5), any(Mounted.class),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockAC5StdFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponAC5), any(Mounted.class), any(Game.class), anyBoolean());
+        // Incendiary AC5
+        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5), any(Mounted.class),
+                any(Game.class), anyBoolean());
+        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5), any(Mounted.class),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponAC5), any(Mounted.class), any(Game.class), anyBoolean());
+        // Flak AC5
+        doReturn(mockAC5FlakFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5), any(Mounted.class),
+                any(Game.class), anyBoolean());
+        doReturn(mockAC5FlakFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5), any(Mounted.class),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockAC5FlakFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponAC5), any(Mounted.class), any(Game.class), anyBoolean());
+
+
         // LB10X
         mockLB10X = mock(WeaponType.class);
         mockAmmoTypeLB10XSlug = mock(AmmoType.class);
@@ -292,7 +334,7 @@ public class FireControlTest {
 
         mockLB10XSlugFireInfo = mock(WeaponFireInfo.class);
         mockLB10XClusterFireInfo = mock(WeaponFireInfo.class);
-        // TN 8, average cluster
+        // TN 8, average slug
         when(mockLB10XSlugFireInfo.getProbabilityToHit()).thenReturn(0.4166);
         when(mockLB10XSlugFireInfo.getExpectedDamage()).thenReturn(0.58*6);
         // TN 5 (as flak), average cluster
@@ -2451,6 +2493,22 @@ public class FireControlTest {
         // Should get the plan back with a Cluster shot
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockLB10XClusterFireInfo);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
+                testToHitThreshold, mockGame);
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    @Test
+    public void testChooseACAmmoForEngagingFlyer() {
+        ArrayList<Mounted> wepList = new ArrayList<Mounted>(Arrays.asList(mockWeaponAC5));
+        ArrayList<Mounted> ammoList = new ArrayList<Mounted>(Arrays.asList(
+                mockAmmoAC5Std, mockAmmoAc5Incendiary, mockAmmoAC5Flak
+        ));
+        prepForFullFiringPlan(wepList, ammoList);
+
+        // Should get the plan back with a Cluster shot
+        FiringPlan expected = new FiringPlan(mockTarget);
+        expected.add(mockAC5FlakFireInfo);
         final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
                 testToHitThreshold, mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -920,28 +920,6 @@ public class FireControlTest {
         when(mockWeaponMML5.getType()).thenReturn(mockMML5);
 
 
-        // Todo: delete
-        // Test ATMs
-        /**
-        when(mockTarget.getPosition()).thenReturn(new Coords(10, 30));
-        when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5Er);
-        assertEquals(mockAmmoAtm5Er, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
-        when(mockTarget.getPosition()).thenReturn(new Coords(10, 22));
-        assertEquals(mockAmmoAtm5Er, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
-        when(mockTarget.getPosition()).thenReturn(new Coords(10, 18));
-        when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5St);
-        assertEquals(mockAmmoAtm5St, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
-        when(mockTarget.getPosition()).thenReturn(new Coords(10, 16));
-        when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5He);
-        assertEquals(mockAmmoAtm5He, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
-        when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));
-        when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5St);
-        assertEquals(mockAmmoAtm5St, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
-        when(mockTarget.getPosition()).thenReturn(new Coords(10, 13));
-        when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5He);
-        assertEquals(mockAmmoAtm5He, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
-         */
-
         // Test shooting an AC5 at a building.
         mockTarget = mock(BuildingTarget.class);
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -399,13 +399,13 @@ public class FireControlTest {
         mockPPCFireInfo = mock(WeaponFireInfo.class);
         when(mockPPCFireInfo.getProbabilityToHit()).thenReturn(0.5);
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockPPC),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockPPC), any(Mounted.class),
                 any(Game.class), anyBoolean());
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockPPC),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockPPC), any(Mounted.class),
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockPPC), any(Game.class), anyBoolean());
+                any(Targetable.class), eq(mockPPC), any(Mounted.class), any(Game.class), anyBoolean());
 
         mockML = mock(Mounted.class);
         shooterWeapons.add(mockML);
@@ -413,13 +413,13 @@ public class FireControlTest {
         mockMLFireInfo = mock(WeaponFireInfo.class);
         when(mockMLFireInfo.getProbabilityToHit()).thenReturn(0.0);
         doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockML),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockML), any(Mounted.class),
                 any(Game.class), anyBoolean());
         doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockML),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockML), any(Mounted.class),
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockML), any(Game.class), anyBoolean());
+                any(Targetable.class), eq(mockML), any(Mounted.class), any(Game.class), anyBoolean());
 
         mockLRM5 = mock(Mounted.class);
         when(mockLRM5.getType()).thenReturn(mockWeaponType);
@@ -427,13 +427,20 @@ public class FireControlTest {
         mockLRMFireInfo = mock(WeaponFireInfo.class);
         when(mockLRMFireInfo.getProbabilityToHit()).thenReturn(0.6);
         doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5), any(Mounted.class),
                 any(Game.class), anyBoolean());
         doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5), any(Mounted.class),
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockLRM5), any(Game.class), anyBoolean());
+                any(Targetable.class), eq(mockLRM5), any(Mounted.class), any(Game.class), anyBoolean());
+
+
+        // Mock the getAmmo(Mounted) call return value
+        ArrayList<Mounted> mockAmmoList = new ArrayList<Mounted>();
+        mockAmmoList.add(mockAmmoLRM5);
+        mockAmmoList.add(mockAmmoSRM5);
+        when(mockShooter.getAmmo(any(Mounted.class))).thenReturn(mockAmmoList);
 
         testToHitThreshold = new HashMap<>();
         for (final Mounted weapon : mockShooter.getWeaponList()) {
@@ -1505,7 +1512,7 @@ public class FireControlTest {
         final WeaponType mockWeaponType = mock(WeaponType.class);
         when(mockWeapon.getType()).thenReturn(mockWeaponType);
         when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.T_AC);
-        when(mockWeaponType.getRanges(eq(mockWeapon))).thenReturn(new int[] { 3, 6, 12, 18, 24 });
+        when(mockWeaponType.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[] { 3, 6, 12, 18, 24 });
         when(mockWeaponType.getMinimumRange()).thenReturn(3);
         when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(true);
 
@@ -1517,7 +1524,7 @@ public class FireControlTest {
         ToHitData expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
 
         // Test weapon quirks.
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_POS_ACCURATE))).thenReturn(true);
@@ -1525,14 +1532,14 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_ACCURATE_WEAP);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_POS_ACCURATE))).thenReturn(false);
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_INACCURATE_WEAP);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE))).thenReturn(false);
 
         // Test long range shooter quirks.
@@ -1542,28 +1549,28 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_IMP_TARG_LONG);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_IMP_TARG_L))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARG_SHORT_AT_LONG);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARG_LONG_AT_LONG);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_L))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_POOR_TARG_LONG);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_L))).thenReturn(false);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
@@ -1573,14 +1580,14 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_IMP_TARG_MEDIUM);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_IMP_TARG_M))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_M))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_POOR_TARG_MEDIUM);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_M))).thenReturn(false);
 
         // Test short range shooter quirks.
@@ -1590,28 +1597,28 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_IMP_TARG_SHORT);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_IMP_TARG_S))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARG_SHORT_AT_SHORT);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARG_LONG_AT_SHORT);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_S))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_POOR_TARG_SHORT);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_S))).thenReturn(false);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
@@ -1621,12 +1628,12 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_TARGETTING_COMP);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(false);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(false);
         when(mockShooter.hasTargComp()).thenReturn(false);
 
@@ -1639,7 +1646,7 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(1, FireControl.TH_AMMO_MOD);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockAmmoType.getToHitModifier()).thenReturn(0);
 
         // Test target size mods.
@@ -1648,13 +1655,13 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_RNG_LARGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockLargeTank, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockLargeTank, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(((Mech) mockTarget).getCockpitType()).thenReturn(Mech.COCKPIT_SUPERHEAVY);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_RNG_LARGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(((Mech) mockTarget).getCockpitType()).thenReturn(Mech.COCKPIT_STANDARD);
 
         // Test weapon mods.
@@ -1663,7 +1670,7 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(-2, FireControl.TH_WEAPON_MOD);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockWeaponType.getToHitModifier()).thenReturn(0);
 
         // Test heat mods.
@@ -1672,7 +1679,7 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(1, FireControl.TH_HEAT);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.getHeatFiringModifier()).thenReturn(0);
 
         // Test fighter's at altitude
@@ -1687,30 +1694,30 @@ public class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockFighter, mockFighterState, mockWeapon, mockGame));
+                mockShooterState, mockFighter, mockFighterState, mockWeapon, mockAmmo, mockGame));
         when(mockFighter.getId()).thenReturn(1); // Target aero is also firing on shooter.
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockFighter, mockFighterState, mockWeapon, mockGame));
+                mockShooterState, mockFighter, mockFighterState, mockWeapon, mockAmmo, mockGame));
 
         // Test changing the range.
         when(mockTargetState.getPosition()).thenReturn(new Coords(5, 0));
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockTargetState.getPosition()).thenReturn(new Coords(1, 0));
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(3, FireControl.TH_MINIMUM_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockGameOptions.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)).thenReturn(true);
         when(mockTargetState.getPosition()).thenReturn(new Coords(20, 0));
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_EXTREME_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         // todo Test infantry range mods.
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
         when(mockGameOptions.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)).thenReturn(false);
@@ -1724,7 +1731,7 @@ public class FireControlTest {
                 eq(Mech.LOC_HEAD))).thenReturn(2);
         expected.addModifier(2, FireControl.TH_SENSORS);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         final Tank mockTank = mock(Tank.class); // Tank sensor damage is a little different.
         when(mockTank.getCrew()).thenReturn(mockCrew);
         expected = new ToHitData(mockTank.getCrew().getGunnery(), FireControl.TH_GUNNERY);
@@ -1732,23 +1739,23 @@ public class FireControlTest {
         when(mockTank.getSensorHits()).thenReturn(1);
         expected.addModifier(1, FireControl.TH_SENSORS);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockTank,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.getBadCriticals(eq(CriticalSlot.TYPE_SYSTEM), eq(Mech.SYSTEM_SENSORS),
                 eq(Mech.LOC_HEAD))).thenReturn(0);
 
         // Test stopping swarm attacks.
         final WeaponType mockSwarmStop = mock(StopSwarmAttack.class);
-        when(mockSwarmStop.getRanges(eq(mockWeapon))).thenReturn(new int[]{0, 0, 0, 0, 0});
+        when(mockSwarmStop.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[]{0, 0, 0, 0, 0});
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 0));
         when(mockWeapon.getType()).thenReturn(mockSwarmStop);
         when(mockShooter.getSwarmTargetId()).thenReturn(Entity.NONE); // Invalid attack.
         expected = new ToHitData(FireControl.TH_STOP_SWARM_INVALID);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooter.getSwarmTargetId()).thenReturn(10); // Valid attack.
         expected = new ToHitData(FireControl.TH_SWARM_STOPPED);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockWeapon.getType()).thenReturn(mockWeaponType);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
@@ -1756,7 +1763,7 @@ public class FireControlTest {
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 0));
         expected = new ToHitData(FireControl.TH_INF_ZERO_RNG);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         // TODO : Infantry on Infantry violence.
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
@@ -1764,7 +1771,7 @@ public class FireControlTest {
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 100));
         expected = new ToHitData(FireControl.TH_OUT_OF_RANGE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
         // Test the target being out of arc.
@@ -1772,7 +1779,7 @@ public class FireControlTest {
                 any(Coords.class), anyInt());
         expected = new ToHitData(FireControl.TH_WEAPON_NO_ARC);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
 
         // Test a prone mech w/ no arms.
         when(mockShooterState.isProne()).thenReturn(true);
@@ -1780,35 +1787,35 @@ public class FireControlTest {
         when(mockShooter.isLocationBad(Mech.LOC_LARM)).thenReturn(true);
         expected = new ToHitData(FireControl.TH_WEAP_PRONE_ARMLESS);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         // Propping self up on firing arm.
         when(mockShooter.isLocationBad(Mech.LOC_LARM)).thenReturn(false);
         expected = new ToHitData(FireControl.TH_WEAP_ARM_PROP);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         // Trying to fire a leg weapon.
         when(mockWeapon.getLocation()).thenReturn(Mech.LOC_LLEG);
         expected = new ToHitData(FireControl.TH_WEAP_PRONE_LEG);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
         when(mockShooterState.isProne()).thenReturn(false);
 
         // Test a weapon that is out of ammo.
         when(mockAmmo.getUsableShotsLeft()).thenReturn(0);
         expected = new ToHitData(FireControl.TH_WEAP_NO_AMMO);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockWeapon.getLinked(), mockGame));
         when(mockAmmo.getUsableShotsLeft()).thenReturn(10);
         when(mockWeapon.getLinked()).thenReturn(null);
         expected = new ToHitData(FireControl.TH_WEAP_NO_AMMO);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockWeapon.getLinked(), mockGame));
 
         // Test a weapon that cannot fire.
         when(mockWeapon.canFire()).thenReturn(false);
         expected = new ToHitData(FireControl.TH_WEAP_CANNOT_FIRE);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockGame));
+                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockWeapon.getLinked(), mockGame));
     }
 
     @Test
@@ -1843,37 +1850,37 @@ public class FireControlTest {
         expected.addModifier(FireControl.TH_AIR_STRIKE);
         assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
                 mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, mockGame, true));
+                mockWeapon, null, mockGame, true));
         assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
                 mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, mockGame, false));
+                mockWeapon, null, mockGame, false));
 
         // Test the target not being under our flight path.
         expected = new ToHitData(FireControl.TH_AIR_STRIKE_PATH);
         assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
                 mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathBad,
-                mockWeapon, mockGame, false));
+                mockWeapon, null, mockGame, false));
 
         // Test a weapon that is out of ammo.
         when(mockAmmo.getUsableShotsLeft()).thenReturn(0);
         expected = new ToHitData(FireControl.TH_WEAP_NO_AMMO);
         assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
                 mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, mockGame, true));
+                mockWeapon, null, mockGame, true));
 
         // Test a weapon who's ammo has been destroyed.
         when(mockWeapon.getLinked()).thenReturn(null);
         expected = new ToHitData(FireControl.TH_WEAP_NO_AMMO);
         assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
                 mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, mockGame, true));
+                mockWeapon, null, mockGame, true));
 
         // Test a weapon unable to fire.
         when(mockWeapon.canFire()).thenReturn(false);
         expected = new ToHitData(FireControl.TH_WEAP_CANNOT_FIRE);
         assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
                 mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, mockGame, true));
+                mockWeapon, null, mockGame, true));
     }
 
     @Test
@@ -2456,7 +2463,7 @@ public class FireControlTest {
     }
 
     /**
-     * Test to make sure that Princess will choose a FiringPlan that shots at
+     * Test to make sure that Princess will choose a FiringPlan that shoots at
      * a MechWarrior, instead of choosing to do nothing.
      */
     @Test

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -2273,6 +2273,8 @@ public class FireControlTest {
         when(mockTarget.isOffBoard()).thenReturn(false);
         when(mockBoard.contains(eq(mockShooterCoords))).thenReturn(true);
         when(mockBoard.contains(eq(mockTargetCoords))).thenReturn(true);
+        when(mockPPC.canFire()).thenReturn(true);
+        when(mockLRM5.canFire()).thenReturn(true);
         doNothing().when(testFireControl).calculateUtility(any(FiringPlan.class), anyInt(), anyBoolean());
 
         // Test the normal case.

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -920,7 +920,9 @@ public class FireControlTest {
         when(mockWeaponMML5.getType()).thenReturn(mockMML5);
 
 
+        // Todo: delete
         // Test ATMs
+        /**
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 30));
         when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5Er);
         assertEquals(mockAmmoAtm5Er, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
@@ -938,6 +940,7 @@ public class FireControlTest {
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 13));
         when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5He);
         assertEquals(mockAmmoAtm5He, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockAtm5Weapon));
+         */
 
         // Test shooting an AC5 at a building.
         mockTarget = mock(BuildingTarget.class);

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -136,6 +136,10 @@ public class FireControlTest {
     private WeaponFireInfo mockPPCFireInfo;
     private WeaponFireInfo mockMLFireInfo;
     private WeaponFireInfo mockLRMFireInfo;
+    private WeaponFireInfo mockMMLLRM5FireInfo;
+    private WeaponFireInfo mockMMLSRM5FireInfo;
+    private WeaponFireInfo mockLB10XSlugFireInfo;
+    private WeaponFireInfo mockLB10XClusterFireInfo;
 
     private Map<Mounted, Double> testToHitThreshold;
 
@@ -283,6 +287,36 @@ public class FireControlTest {
         doReturn(true).when(mockAmmoTypeLB10XSlug).equalsAmmoTypeOnly(eq(mockAmmoTypeLB10XCluster));
         doReturn(true).when(mockAmmoTypeLB10XCluster).equalsAmmoTypeOnly(eq(mockAmmoTypeLB10XSlug));
         doReturn(true).when(mockAmmoTypeLB10XCluster).equalsAmmoTypeOnly(eq(mockAmmoTypeLB10XCluster));
+
+        mockLB10XSlugFireInfo = mock(WeaponFireInfo.class);
+        mockLB10XClusterFireInfo = mock(WeaponFireInfo.class);
+        // TN 8, average cluster
+        when(mockLB10XSlugFireInfo.getProbabilityToHit()).thenReturn(0.4166);
+        when(mockLB10XSlugFireInfo.getExpectedDamage()).thenReturn(0.58*6);
+        // TN 5 (as flak), average cluster
+        when(mockLB10XClusterFireInfo.getProbabilityToHit()).thenReturn(0.8333);
+        when(mockLB10XClusterFireInfo.getExpectedDamage()).thenReturn(0.8333*6);
+
+        // Firing Slug ammo
+        doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug),
+                any(Game.class), anyBoolean());
+        doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug), any(Game.class), anyBoolean());
+
+        // Firing Cluster ammo
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XCluster),
+                any(Game.class), anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XCluster),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XCluster), any(Game.class), anyBoolean());
+
 
         // MML
         mockMML5 = mock(MMLWeapon.class);
@@ -434,6 +468,35 @@ public class FireControlTest {
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
                 any(Targetable.class), eq(mockLRM5), any(Mounted.class), any(Game.class), anyBoolean());
+
+        when(mockWeaponMML5.getType()).thenReturn(mockWeaponType);
+        shooterWeapons.add(mockWeaponMML5);
+        mockMMLLRM5FireInfo = mock(WeaponFireInfo.class);
+        mockMMLSRM5FireInfo = mock(WeaponFireInfo.class);
+        when(mockMMLLRM5FireInfo.getProbabilityToHit()).thenReturn(0.6);
+        when(mockMMLLRM5FireInfo.getExpectedDamage()).thenReturn(0.6*5);
+        when(mockMMLSRM5FireInfo.getProbabilityToHit()).thenReturn(0.0);
+        when(mockMMLSRM5FireInfo.getExpectedDamage()).thenReturn(0.0*10);
+
+        // Firing LRM5 ammo
+        doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5), eq(mockAmmoLRM5),
+                any(Game.class), anyBoolean());
+        doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5), eq(mockAmmoLRM5),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponMML5), eq(mockAmmoLRM5), any(Game.class), anyBoolean());
+
+        // Firing SRM5 ammo
+        doReturn(mockMMLSRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5), eq(mockAmmoSRM5),
+                any(Game.class), anyBoolean());
+        doReturn(mockMMLSRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5), eq(mockAmmoSRM5),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockMMLSRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponMML5), eq(mockAmmoSRM5), any(Game.class), anyBoolean());
 
 
         // Mock the getAmmo(Mounted) call return value
@@ -2265,17 +2328,36 @@ public class FireControlTest {
                 mockTargetState, mockFlightPath, mockGame, true));
     }
 
-    @Test
-    public void testGetFullFiringPlan() {
+    private void prepForFullFiringPlan(ArrayList<Mounted> wepList, ArrayList<Mounted> ammoList) {
         when(mockShooter.getPosition()).thenReturn(mockShooterCoords);
         when(mockShooter.isOffBoard()).thenReturn(false);
         when(mockTarget.getPosition()).thenReturn(mockTargetCoords);
         when(mockTarget.isOffBoard()).thenReturn(false);
         when(mockBoard.contains(eq(mockShooterCoords))).thenReturn(true);
         when(mockBoard.contains(eq(mockTargetCoords))).thenReturn(true);
-        when(mockPPC.canFire()).thenReturn(true);
-        when(mockLRM5.canFire()).thenReturn(true);
+
+        // Set up weapons and ammo
+        shooterWeapons.clear();
+        testToHitThreshold.clear();
+        for (Mounted weapon: wepList) {
+            when(weapon.canFire()).thenReturn(true);
+            shooterWeapons.add(weapon);
+            testToHitThreshold.put(weapon, 0.0);
+        }
+        ArrayList<Mounted> mockAmmoList = new ArrayList<Mounted>();
+        for (Mounted ammo: ammoList) {
+            mockAmmoList.add(ammo);
+        }
+        when(mockShooter.getAmmo(any(Mounted.class))).thenReturn(mockAmmoList);
+
         doNothing().when(testFireControl).calculateUtility(any(FiringPlan.class), anyInt(), anyBoolean());
+    }
+
+    @Test
+    public void testGetFullFiringPlan() {
+        ArrayList<Mounted> wepList = new ArrayList<Mounted>(Arrays.asList(mockPPC, mockLRM5));
+        ArrayList<Mounted> ammoList = new ArrayList<Mounted>(Arrays.asList(mockAmmoLRM5, mockAmmoSRM5));
+        prepForFullFiringPlan(wepList, ammoList);
 
         // Test the normal case.
         FiringPlan expected = new FiringPlan(mockTarget);
@@ -2306,6 +2388,53 @@ public class FireControlTest {
         assertEquals(expected, testFireControl.getFullFiringPlan(mockShooter, mockTarget,
                 testToHitThreshold, mockGame));
         testToHitThreshold.put(mockLRM5, 0.0);
+    }
+
+    @Test
+    public void testChooseAppropriateMMLAmmoForLongRange() {
+        ArrayList<Mounted> wepList = new ArrayList<Mounted>(Arrays.asList(mockWeaponMML5));
+        ArrayList<Mounted> ammoList = new ArrayList<Mounted>(Arrays.asList(mockAmmoSRM5, mockAmmoLRM5));
+        prepForFullFiringPlan(wepList, ammoList);
+
+        // Simulating longer-range engagement
+        // Should get the plan back with an LRM5 shot
+        FiringPlan expected = new FiringPlan(mockTarget);
+        expected.add(mockMMLLRM5FireInfo);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
+                testToHitThreshold, mockGame);
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    @Test
+    public void testChooseAppropriateMMLAmmoForShortRange() {
+        ArrayList<Mounted> wepList = new ArrayList<Mounted>(Arrays.asList(mockWeaponMML5));
+        ArrayList<Mounted> ammoList = new ArrayList<Mounted>(Arrays.asList(mockAmmoLRM5, mockAmmoSRM5));
+        prepForFullFiringPlan(wepList, ammoList);
+
+        // Simulating closer-range engagement
+        when(mockMMLSRM5FireInfo.getProbabilityToHit()).thenReturn(0.6);
+        when(mockMMLSRM5FireInfo.getExpectedDamage()).thenReturn(0.6*10);
+
+        // Should get the plan back with an SRM5 shot
+        FiringPlan expected = new FiringPlan(mockTarget);
+        expected.add(mockMMLSRM5FireInfo);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
+                testToHitThreshold, mockGame);
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
+    }
+
+    @Test
+    public void testChooseLBXAmmoForEngagingFlyer() {
+        ArrayList<Mounted> wepList = new ArrayList<Mounted>(Arrays.asList(mockWeaponLB10X));
+        ArrayList<Mounted> ammoList = new ArrayList<Mounted>(Arrays.asList(mockAmmoLB10XSlug, mockAmmoLB10XCluster));
+        prepForFullFiringPlan(wepList, ammoList);
+
+        // Should get the plan back with a Cluster shot
+        FiringPlan expected = new FiringPlan(mockTarget);
+        expected.add(mockLB10XClusterFireInfo);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
+                testToHitThreshold, mockGame);
+        assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 
     @Test

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -469,38 +469,45 @@ public class FireControlTest {
 
         // Weapon that will skip check for indirect fire mode
         WeaponType mockWeaponType = mock(WeaponType.class);
-        when(mockWeaponType.hasFlag(any())).thenReturn(false);
-        when(mockWeaponType.hasModeType(anyString())).thenReturn(false);
+        when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.T_LRM);
+        WeaponType mockEnergyWeaponType = mock(WeaponType.class);
+        when(mockEnergyWeaponType.getAmmoType()).thenReturn(AmmoType.T_NA);
+        when(mockEnergyWeaponType.hasFlag(any())).thenReturn(false);
+        when(mockEnergyWeaponType.hasModeType(anyString())).thenReturn(false);
         mockPPC = mock(Mounted.class);
-        when(mockPPC.getType()).thenReturn(mockWeaponType);
+        when(mockPPC.getType()).thenReturn(mockEnergyWeaponType);
         shooterWeapons.add(mockPPC);
         mockPPCFireInfo = mock(WeaponFireInfo.class);
         when(mockPPCFireInfo.getProbabilityToHit()).thenReturn(0.5);
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockPPC), any(Mounted.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockPPC), isNull(),
                 any(Game.class), anyBoolean());
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockPPC), any(Mounted.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockPPC), isNull(),
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockPPC), any(Mounted.class), any(Game.class), anyBoolean());
+                any(Targetable.class), eq(mockPPC), isNull(), any(Game.class), anyBoolean());
+        doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockPPC), isNull(), any(Game.class), anyBoolean());
+        // buildWeaponFireInfo(shooter, target, weapon, null, game, false);
 
         mockML = mock(Mounted.class);
         shooterWeapons.add(mockML);
-        when(mockML.getType()).thenReturn(mockWeaponType);
+        when(mockML.getType()).thenReturn(mockEnergyWeaponType);
         mockMLFireInfo = mock(WeaponFireInfo.class);
         when(mockMLFireInfo.getProbabilityToHit()).thenReturn(0.0);
         doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockML), any(Mounted.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockML), isNull(),
                 any(Game.class), anyBoolean());
         doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockML), any(Mounted.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockML), isNull(),
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockML), any(Mounted.class), any(Game.class), anyBoolean());
+                any(Targetable.class), eq(mockML), isNull(), any(Game.class), anyBoolean());
 
         mockLRM5 = mock(Mounted.class);
         when(mockLRM5.getType()).thenReturn(mockWeaponType);
+        when(mockLRM5.getLinked()).thenReturn(mockAmmoLRM5);
         shooterWeapons.add(mockLRM5);
         mockLRMFireInfo = mock(WeaponFireInfo.class);
         when(mockLRMFireInfo.getProbabilityToHit()).thenReturn(0.6);

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -136,6 +136,7 @@ public class FireControlTest {
     private WeaponFireInfo mockPPCFireInfo;
     private WeaponFireInfo mockMLFireInfo;
     private WeaponFireInfo mockLRMFireInfo;
+    private WeaponFireInfo mockMMLFireInfo;
     private WeaponFireInfo mockMMLLRM5FireInfo;
     private WeaponFireInfo mockMMLSRM5FireInfo;
     private WeaponFireInfo mockLB10XSlugFireInfo;
@@ -152,6 +153,7 @@ public class FireControlTest {
 
     @BeforeEach
     public void beforeEach() {
+        EquipmentType.initializeTypes();
         mockPrincess = mock(Princess.class);
 
         final BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
@@ -297,6 +299,16 @@ public class FireControlTest {
         when(mockLB10XClusterFireInfo.getProbabilityToHit()).thenReturn(0.8333);
         when(mockLB10XClusterFireInfo.getExpectedDamage()).thenReturn(0.8333*6);
 
+        // Firing Cluster ammo
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), any(Mounted.class),
+                any(Game.class), anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), any(Mounted.class),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponLB10X), any(Mounted.class), any(Game.class), anyBoolean());
+
         // Firing Slug ammo
         doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
                 any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug),
@@ -306,16 +318,6 @@ public class FireControlTest {
                 any(Game.class), anyBoolean(), anyBoolean());
         doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
                 any(Targetable.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug), any(Game.class), anyBoolean());
-
-        // Firing Cluster ammo
-        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XCluster),
-                any(Game.class), anyBoolean());
-        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XCluster),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XCluster), any(Game.class), anyBoolean());
 
 
         // MML
@@ -470,13 +472,24 @@ public class FireControlTest {
                 any(Targetable.class), eq(mockLRM5), any(Mounted.class), any(Game.class), anyBoolean());
 
         when(mockWeaponMML5.getType()).thenReturn(mockWeaponType);
-        shooterWeapons.add(mockWeaponMML5);
+        mockMMLFireInfo = mock(WeaponFireInfo.class);
         mockMMLLRM5FireInfo = mock(WeaponFireInfo.class);
         mockMMLSRM5FireInfo = mock(WeaponFireInfo.class);
+        when(mockMMLFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockMMLLRM5FireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockMMLLRM5FireInfo.getExpectedDamage()).thenReturn(0.6*5);
         when(mockMMLSRM5FireInfo.getProbabilityToHit()).thenReturn(0.0);
         when(mockMMLSRM5FireInfo.getExpectedDamage()).thenReturn(0.0*10);
+
+        // General
+        doReturn(mockMMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5), any(Mounted.class),
+                any(Game.class), anyBoolean());
+        doReturn(mockMMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5), any(Mounted.class),
+                any(Game.class), anyBoolean(), anyBoolean());
+        doReturn(mockMMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
+                any(Targetable.class), eq(mockWeaponMML5), any(Mounted.class), any(Game.class), anyBoolean());
 
         // Firing LRM5 ammo
         doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
@@ -860,6 +873,11 @@ public class FireControlTest {
         when(mockShooter.getAmmo()).thenReturn(testAmmoList);
         when(mockShooter.getPosition()).thenReturn(new Coords(10, 10));
 
+        // This needs to be reset now, for some reason
+        when(mockMML5.getAmmoType()).thenReturn(AmmoType.T_MML);
+        when(mockWeaponMML5.getType()).thenReturn(mockMML5);
+
+
         // Test ATMs
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 30));
         when(mockAtm5Weapon.getLinked()).thenReturn(mockAmmoAtm5Er);
@@ -922,6 +940,7 @@ public class FireControlTest {
         // Test a hot target.
         when(((Entity) mockTarget).getDamageLevel()).thenReturn(Entity.DMG_LIGHT);
         when(((Entity) mockTarget).getHeat()).thenReturn(12);
+
         when(mockWeaponMML5.getLinked()).thenReturn(mockAmmoInferno5);
         assertEquals(mockAmmoInferno5, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponMML5));
         when(((Entity) mockTarget).getArmorType(anyInt())).thenReturn(EquipmentType.T_ARMOR_HEAT_DISSIPATING);
@@ -2348,7 +2367,7 @@ public class FireControlTest {
         for (Mounted ammo: ammoList) {
             mockAmmoList.add(ammo);
         }
-        when(mockShooter.getAmmo(any(Mounted.class))).thenReturn(mockAmmoList);
+        when(mockShooter.getAmmo()).thenReturn(mockAmmoList);
 
         doNothing().when(testFireControl).calculateUtility(any(FiringPlan.class), anyInt(), anyBoolean());
     }

--- a/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
@@ -159,10 +159,7 @@ public class WeaponFireInfoTest {
         when(mockWeapon.getDesc()).thenReturn("Gauss Rifle (C)");
     }
 
-    @Test
-    public void testInitDamage() {
-        final double DELTA = 0.00001;
-
+    private WeaponFireInfo setupWFI() {
         WeaponFireInfo testWeaponFireInfo = spy(new WeaponFireInfo(mockPrincess));
         testWeaponFireInfo.setShooter(mockShooter);
         testWeaponFireInfo.setShooterState(mockShooterState);
@@ -170,13 +167,22 @@ public class WeaponFireInfoTest {
         testWeaponFireInfo.setTargetState(mockTargetState);
         testWeaponFireInfo.setWeapon(mockWeapon);
         testWeaponFireInfo.setGame(mockGame);
+        return testWeaponFireInfo;
+    }
+    @Test
+    public void testInitDamage() {
+        final double DELTA = 0.00001;
+        final double ROLL_TWO = 0.028;
+        final double CRIT_COUNT = 0.611;
+
+        WeaponFireInfo testWeaponFireInfo = setupWFI();
 
         // Test a medium laser vs light target with a to hit roll of 6.
         setupMediumLaser();
         setupLightTarget();
         double expectedMaxDamage = mockWeaponType.getDamage();
         double expectedProbabilityToHit = Compute.oddsAbove(mockToHitSix.getValue()) / 100;
-        double expectedCriticals = 0.02460;
+        double expectedCriticals = ROLL_TWO * CRIT_COUNT * expectedProbabilityToHit;
         double expectedKill = 0;
         doReturn(mockToHitSix).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
@@ -184,68 +190,72 @@ public class WeaponFireInfoTest {
         when(mockShooter.getEquipment(anyInt())).thenReturn(mockWeapon);
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
-        assertEquals(expectedMaxDamage, testWeaponFireInfo.getExpectedDamageOnHit());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
+        assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(), testWeaponFireInfo.getExpectedDamageOnHit());
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
 
         // Test a PPC vs light target with a to hit roll of 8.
         setupPPC();
+        testWeaponFireInfo = setupWFI();
         setupLightTarget();
         expectedMaxDamage = mockWeaponType.getDamage();
         expectedProbabilityToHit = Compute.oddsAbove(mockToHitEight.getValue()) / 100;
-        expectedCriticals = 0.01867;
-        expectedKill = 0.01155;
+        expectedCriticals = 0.0141773; // differs following first setup due to location destruction potential
+        expectedKill = 0.0;
         doReturn(mockToHitEight).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
         doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
-        assertEquals(expectedMaxDamage, testWeaponFireInfo.getExpectedDamageOnHit());
+        assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(), testWeaponFireInfo.getExpectedDamageOnHit());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
 
         // Test a Gauss Rifle vs a light target with a to hit roll of 6.
         setupCGR();
+        testWeaponFireInfo = setupWFI();
         setupLightTarget();
         expectedMaxDamage = mockWeaponType.getDamage();
         expectedProbabilityToHit = Compute.oddsAbove(mockToHitSix.getValue()) / 100;
-        expectedCriticals = 0.46129;
+        expectedCriticals = 0.0324; // differs following first setup due to location destruction potential
         expectedKill = 0.02005;
         doReturn(mockToHitSix).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
         doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
-        assertEquals(expectedMaxDamage, testWeaponFireInfo.getExpectedDamageOnHit());
+        assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(), testWeaponFireInfo.getExpectedDamageOnHit());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
 
         // Test a Gauss Rifle vs. a medium target with a to hit roll of 8.
         setupCGR();
+        testWeaponFireInfo = setupWFI();
         setupMediumTarget();
         expectedMaxDamage = mockWeaponType.getDamage();
         expectedProbabilityToHit = Compute.oddsAbove(mockToHitEight.getValue()) / 100;
-        expectedCriticals = 0.01867;
-        expectedKill = 0.01155;
+        expectedCriticals = ROLL_TWO * CRIT_COUNT * expectedProbabilityToHit;
+        expectedKill = 0.0;
         doReturn(mockToHitEight).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
         doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
-        assertEquals(expectedMaxDamage, testWeaponFireInfo.getExpectedDamageOnHit());
+        assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(), testWeaponFireInfo.getExpectedDamageOnHit());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
 
         // Test a medium laser vs. a medium target with no chance to hit.
         setupMediumLaser();
+        testWeaponFireInfo = setupWFI();
         setupMediumTarget();
         expectedMaxDamage = 0;
         expectedProbabilityToHit = Compute.oddsAbove(mockToHitThirteen.getValue()) / 100;
-        expectedCriticals = 0;
+        expectedCriticals = ROLL_TWO * CRIT_COUNT * expectedProbabilityToHit;
         expectedKill = 0;
         doReturn(mockToHitThirteen).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();

--- a/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
@@ -79,7 +79,7 @@ public class WeaponFireInfoTest {
 
         mockFireControl = mock(FireControl.class);
         when(mockFireControl.guessToHitModifierForWeapon(any(Entity.class), any(EntityState.class),
-                any(Targetable.class), any(EntityState.class), any(Mounted.class), any(Game.class)))
+                any(Targetable.class), any(EntityState.class), any(Mounted.class), any(Mounted.class), any(Game.class)))
                 .thenReturn(mockToHitEight);
 
         mockPrincess = mock(Princess.class);

--- a/megamek/unittests/megamek/common/ComputeArtilleryTest.java
+++ b/megamek/unittests/megamek/common/ComputeArtilleryTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2000-2005 - Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common;
+
+import megamek.common.options.GameOptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Vector;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Martin "sleet01" Metke
+ * @since 2024/02/12 2138 PST
+ */
+public class ComputeArtilleryTest {
+    @BeforeAll
+    public static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @Test
+    public void testSimpleLeadCalculations() {
+        // Test lead from various locations against various speeds.
+        Coords shooterPos = new Coords(15, 0);
+        Coords targetPos = new Coords(15, 33);
+
+        // Immobile target
+        Coords leadPos = Compute.calculateArtilleryLead(targetPos, 0, 0);
+        assertTrue(leadPos.equals(targetPos));
+
+        // MP 1 target
+        leadPos = Compute.calculateArtilleryLead(targetPos, 0, 1);
+        assertTrue(leadPos.getX() == targetPos.getX());
+        assertTrue(leadPos.getY() == targetPos.getY() - 1);
+
+        // MP 4 target with flight time == 1
+        leadPos = Compute.calculateArtilleryLead(targetPos, 0, 8);
+        assertTrue(leadPos.getX() == targetPos.getX());
+        assertTrue(leadPos.getY() == targetPos.getY() - 8);
+
+        // MP 8 target moving away
+        leadPos = Compute.calculateArtilleryLead(targetPos, 3, 16);
+        assertTrue(leadPos.getX() == targetPos.getX());
+        assertTrue(leadPos.getY() == targetPos.getY() + 16);
+
+        // MP 5 target moving NW; x <- 10, y ^ (10/2 + 1)
+        leadPos = Compute.calculateArtilleryLead(targetPos, 5, 10);
+        assertEquals(leadPos.getX(), targetPos.getX() - 10);
+        assertEquals(leadPos.getY(), targetPos.getY() - 5);
+
+        // Reversed fire, MP 2, flight time 1
+        leadPos = Compute.calculateArtilleryLead(shooterPos, 3, 4);
+        assertEquals(leadPos.getX(), shooterPos.getX());
+        assertEquals(leadPos.getY(), shooterPos.getY() + 4);
+    }
+
+    private void setupTarget(Entity target, Coords targetPos, Coords oldTargetPos) {
+        when(target.getPosition()).thenReturn(targetPos);
+        when(target.getPriorPosition()).thenReturn(oldTargetPos);
+
+    }
+    @Test
+    public void testComplexCalculateLead() {
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        Game mockGame = mock(Game.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+
+        Entity shooter = mock(Entity.class);
+        Entity target = mock(Entity.class);
+        Coords shooterPos = new Coords(15, 0);
+        when(shooter.getPosition()).thenReturn(shooterPos);
+
+        // Immobile target <1 map sheet away to the S (3) direction
+        setupTarget(target, new Coords(15, 17), new Coords(15, 17));
+        Coords leadPos = Compute.calculateArtilleryLead(mockGame, shooter, target, false);
+        assertEquals(15, leadPos.getX());
+        assertEquals(17, leadPos.getY());
+
+        // Mobile target <1 map sheet away to the S (3) direction, speed 4, non-homing
+        setupTarget(target, new Coords(15, 17), new Coords(15, 21));
+        leadPos = Compute.calculateArtilleryLead(mockGame, shooter, target, false);
+        assertEquals(15, leadPos.getX());
+        assertEquals(13, leadPos.getY());
+
+        // Mobile target 1 map sheet away to the S (3) direction, speed 4, non-homing
+        setupTarget(target, new Coords(15, 25), new Coords(15, 29));
+        leadPos = Compute.calculateArtilleryLead(mockGame, shooter, target, false);
+        assertEquals(15, leadPos.getX());
+        assertEquals(17, leadPos.getY());
+
+        // Mobile target 1 map sheet away to the S (3) direction, speed 4, homing, should be closer to shooter
+        // for better chance to catch mobile unit in TAG-able area
+        setupTarget(target, new Coords(15, 25), new Coords(15, 29));
+        leadPos = Compute.calculateArtilleryLead(mockGame, shooter, target, true);
+        assertEquals(15, leadPos.getX());
+        assertEquals(13, leadPos.getY());
+
+        // Mobile target 1 map sheet away to the NE (1) direction, speed 4, non-homing
+        shooterPos = new Coords(0, 35);
+        when(shooter.getPosition()).thenReturn(shooterPos);
+        setupTarget(target, new Coords(32, 1), new Coords(36, 0));
+        leadPos = Compute.calculateArtilleryLead(mockGame, shooter, target, false);
+        assertEquals(24, leadPos.getX());
+        assertEquals(5, leadPos.getY());
+    }
+}


### PR DESCRIPTION
This PR adds alternate ammo selection for Princess, based on the existing toHit guessing and calculations, by allowing her to iterate over every weapon _and_ all its ammo, if applicable, when calculating utility of various actions.

Currently, Princess has no conception of what ammunition is available to units other than whatever ammo is currently loaded.  She neither knows about nor accounts for switching ammo, either by her own units or by enemy units, with two small exceptions:

1. When calling `getPreferredAmmo()` for attacks she is _already planning to execute_, Princess can switch ammunition.
2. When an enemy switches ammunition for its weapons, she can incorporate that info into planning her _next_ turn's movement - but she cannot foresee it.

In case 1, the weapon in question must have already had sufficient range to attack the target; currently Princess can't switch ammos to extend a weapon's range, so the number of situations in which Princess can _currently_ take advantage of ammo switching is limited.  Also, this function must explicitly define a situation in which one ammunition should be taken over another, and how to effect that switch; it does not cover all available options.  The new code, however, will utilize the existing attack utility calculations and should not need to be expanded even if new weapons or munition types are added - it will just work.

In case 2, it is currently possible, although rare, that two opposing Princesses will both be able to take advantage of ammo switching via `getPreferredAmmo()` and switch their loaded ammo for some of their weapons; in such a case, the new ammo will be considered in future calculations but both Princesses will effectively "forget" that the _original_ ammo type ever existed, so while being able to adapt to each others' choices, neither will be able to switch back very easily.

The work here allows Princess to iterate over every valid, available ammo type for each ammunition-reliant weapon when:
- assessing possible moves for her forces,
- predicting incoming enemy fire while moving,
- deciding how to actually allocate fire _after_ movement has occurred.

It also adds:
- More consideration for expected damage when calculating shots (as opposed to quick guessing, for pathfinding)
- Higher aversion to friendly fire with artillery / AE weapons (doubling the negative weight of damage to friendlies in assessing utility)
- More accurate assessment of ADA Missile utility during the Indirect phase, when an Arrow IV unit may wish to hold off on firing in order to make ADA Missile direct-fire attacks later in the turn.
- A `getAmmo()` call that returns only the ammo valid for a passed-in weapon
- Additional info in the mouse-over display for declared attacks; these now include the ammo utilized.
- Some additional logging, specifically covering `try/except` clauses that contained pernicious bugs.

These improvements will affect all ammunition-fed weapons, including artillery, if the unit that will fire has more than one ammunition type loaded for any of its weapons.  Otherwise, the logic will not be affected.

While this requires a measurable amount of additional calculation (now iterating over all weapons _and_ all available ammo for those weapons multiple times every turn for every unit on the field), I have made attempts to pare down the total amount of calculations, and so far speed does not seem to be adversely affected (in my limited testing).  I've added several early escape paths in calculations, skipping of already-fired weapons (such as Artillery or TAG), and changed some locations where we repeatedly extract objects from the `game` via ID lookup to just pass in the objects themselves.

**Testing done:**
1) ran all MM and MHQ unit tests,
2) added a few new unit tests to show that the specific cases from the original issue are covered properly,
3) ran a wide mix of unit types in human-bot and bot-bot matches utilizing multiple alternate munitions for every class of weapon:
- Missiles: SRMs, LRMs, MMLs, ATMs, MRMs, Thunderbolts, Streaks
- Ballistics: ACs, LACs, U/ACs, Gausses, HAGs, Rifles, LB-Xs, MGs, Artillery Cannons
- Energy: PPCs, Lasers, Flamers, TAG
- Bombs: AE, Arrow IV, TAG pod
- Artillery (on- and off-board): HE, Copperhead, AIV, AIV Homing

**Future work:**
- There is an opportunity to combine at least part of the various versions of *Plan() functions to use the same inner loop, so that future work will require less boilerplate.  I didn't do this as the differences between each are subtle and it is not immediately necessary.
- The entirety of code called by or contained within `calculateFiringTurn()` could be put into a class, with various subclasses, and Princess would then attach an instance of one of these to herself.  In this way we could make Princess's ability to calculate toHit and expected damage data a tunable knob for adjusting her difficulty level.
- TAG planning really should be separate from Indirect Fire planning, especially now that the TAG sub-phase can now include torso twisting.  I've marked the appropriate location with a TODO.
- Princess still won't have much idea what to do with support munitions like Smoke or Thunder/ FASCAM, as she lacks any way to assess their utility.  This could likely be implemented in a low-weight fashion by caching projected incoming fire results or enemy movent paths, and assigning a utility score for blocking those hexes off, since Princess already runs those calculations every turn to guess what opponents will do.

Close #4952 