### PR TITLE
Reduce connections between Player/Team and Game/Entity

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1432,6 +1432,7 @@ public class Client implements IClientCommandHandler {
 
                     if (player != null) {
                         player.setDone(c.getBooleanValue(1));
+                        game.processGameEvent(new GamePlayerChangeEvent(player, player));
                     }
                     break;
                 case PRINCESS_SETTINGS:

--- a/megamek/src/megamek/client/bot/princess/Precognition.java
+++ b/megamek/src/megamek/client/bot/princess/Precognition.java
@@ -117,6 +117,7 @@ public class Precognition implements Runnable {
                     final Player player = getPlayer(c.getIntValue(0));
                     if (player != null) {
                         player.setDone(c.getBooleanValue(1));
+                        game.processGameEvent(new GamePlayerChangeEvent(player, player));
                     }
                     break;
                 case PLAYER_ADD:

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15731,4 +15731,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         }
         return -1;
     }
+
+    @Override
+    public boolean countForStrengthSum() {
+        return !isDestroyed() && !isTrapped() && !isPartOfFighterSquadron();
+    }
 }

--- a/megamek/src/megamek/common/InGameObject.java
+++ b/megamek/src/megamek/common/InGameObject.java
@@ -61,4 +61,17 @@ public interface InGameObject extends BTObject {
      * @return The current battle strength (BV/PV)
      */
     int getStrength();
+
+    /**
+     * Returns true when the current (remaining) battle strength of this unit/object should be
+     * counted for a strength sum, e.g. if it should count for the summed battle value of a player
+     * or team. This may be false when the unit is destroyed or trapped or otherwise permanently kept from
+     * acting or when it is part of a unit group and its strength will be counted through
+     * that unit group (e.g. FighterSquadrons). See {@link #getStrength()}.
+     *
+     * @return True when the strength of this should be counted in a strength sum
+     */
+    default boolean countForStrengthSum() {
+        return true;
+    }
 }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -1,32 +1,39 @@
 /*
- * MegaMek - Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2000-2004 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 package megamek.common;
 
 import megamek.client.ui.swing.util.PlayerColour;
-import megamek.common.event.GamePlayerChangeEvent;
 import megamek.common.icons.Camouflage;
 import megamek.common.options.OptionsConstants;
 
-import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.Vector;
 
 /**
  * Represents a player in the game.
+ *
+ * Note that Player should be usable for any type of game (TW, AS, BF, SBF) and therefore should not
+ * make any direct use of Game, Entity, AlphaStrikeElement etc., instead using IGame and InGameObject if necessary.
  */
 public final class Player extends TurnOrdered {
+
     //region Variable Declarations
     private static final long serialVersionUID = 6828849559007455761L;
 
@@ -35,11 +42,11 @@ public final class Player extends TurnOrdered {
     public static final int TEAM_UNASSIGNED = -1;
     public static final String[] TEAM_NAMES = {"No Team", "Team 1", "Team 2", "Team 3", "Team 4", "Team 5"};
 
-    private transient Game game;
+    private transient IGame game;
 
     private String name;
     private String email;
-    private int id;
+    private final int id;
 
     private int team = TEAM_NONE;
 
@@ -219,7 +226,6 @@ public final class Player extends TurnOrdered {
 
     public void setDone(boolean done) {
         this.done = done;
-        game.processGameEvent(new GamePlayerChangeEvent(this, this));
     }
 
     public boolean isGhost() {
@@ -477,86 +483,6 @@ public final class Player extends TurnOrdered {
         artyAutoHitHexes.add(c);
     }
 
-    public boolean hasTAG() {
-        for (Iterator<Entity> e = game.getSelectedEntities(new EntitySelector() {
-                    private final int ownerId = getId();
-
-                    @Override
-                    public boolean accept(Entity entity) {
-                        if (entity.getOwner() == null) {
-                            return false;
-                        }
-                        return ownerId == entity.getOwner().getId();
-                    }
-                }); e.hasNext(); ) {
-            Entity m = e.next();
-            if (m.hasTAG()) {
-                return true;
-            }
-            // A player can't be on two teams.
-        }
-        return false;
-    }
-
-    public int getEntityCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped()).count());
-    }
-
-    public int getUnitCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitDamageCount(int damageLevel) {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == damageLevel) && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitDestroyedCount() {
-        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> this.equals(entity.getOwner()) && entity.isDestroyed() && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitCrewEjectedCount() {
-        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitCrewTrappedCount() {
-        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> this.equals(entity.getOwner()) && entity.isDestroyed() && !entity.getCrew().isDead() && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getUnitCrewKilledCount() {
-        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> this.equals(entity.getOwner()) && entity.getCrew().isDead() && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
-    }
-
-    public int getEjectedCrewCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
-                        (((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() == Entity.NONE) ||
-                                ((entity instanceof EjectedCrew) && !(entity instanceof MechWarrior)))).count());
-    }
-
-    public int getEjectedCrewPickedUpByTeamCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
-                        ((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() != Entity.NONE && game.getEntity(((MechWarrior) entity).getPickedUpById()).getOwner().getTeam() == this.getTeam())).count());
-    }
-
-    public int getEjectedCrewPickedUpByEnemyTeamCount() {
-        return Math.toIntExact(game.getPlayerEntities(this, false).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
-                        ((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() != Entity.NONE && game.getEntity(((MechWarrior) entity).getPickedUpById()).getOwner().getTeam() != this.getTeam())).count());
-    }
-
-    public int getEjectedCrewKilledCount() {
-        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
-                .filter(entity -> entity.getOwner().equals(this) && entity.isDestroyed() && (entity instanceof EjectedCrew)).count());
-    }
-
     public int getInitialEntityCount() {
         return initialEntityCount;
     }
@@ -570,39 +496,26 @@ public final class Player extends TurnOrdered {
     }
 
     /**
-     * @return The combined Battle Value of all the player's current assets.
+     * Returns the combined strength (Battle Value/PV) of all the player's usable assets. This includes only
+     * units that should count according to {@link InGameObject#countForStrengthSum()}.
+     *
+     * @return The combined strength (BV/PV) of all the player's assets
      */
     public int getBV() {
-        return game.getPlayerEntities(this, true).stream()
-                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped())
-                .mapToInt(Entity::calculateBattleValue).sum();
+        return game.getInGameObjects().stream()
+                .filter(this::isMyUnit)
+                .filter(InGameObject::countForStrengthSum)
+                .mapToInt(InGameObject::getStrength).sum();
     }
 
     /**
-     * get the total BV (unmodified by force size mod) for the units of this
-     * player that have fled the field
+     * Returns true when the given unit belongs to this Player.
      *
-     * @return the BV
+     * @param unit The unit
+     * @return True when the unit belongs to "me", this Player
      */
-    public int getFledBV() {
-        //TODO: I'm not sure how squadrons are treated here - see getBV()
-        return game.getPlayerRetreatedEntities(this).stream()
-                .filter(entity -> !entity.isDestroyed())
-                .mapToInt(Entity::calculateBattleValue).sum();
-    }
-
-    public int getFledUnitsCount() {
-        //TODO: I'm not sure how squadrons are treated here - see getBV()
-        return Math.toIntExact(game.getPlayerRetreatedEntities(this).stream()
-                .filter(entity -> !entity.isDestroyed() && !(entity instanceof EjectedCrew))
-                .mapToInt(Entity::calculateBattleValue).count());
-    }
-
-    public int getFledEjectedCrew() {
-        //TODO: I'm not sure how squadrons are treated here - see getBV()
-        return Math.toIntExact(game.getPlayerRetreatedEntities(this).stream()
-                .filter(entity -> !entity.isDestroyed() && (entity instanceof EjectedCrew))
-                .mapToInt(Entity::calculateBattleValue).count());
+    public boolean isMyUnit(InGameObject unit) {
+        return unit.getOwnerId() == id;
     }
 
     public int getInitialBV() {
@@ -639,21 +552,18 @@ public final class Player extends TurnOrdered {
      * @return the bonus to this player's initiative rolls granted by his units
      */
     public int getTurnInitBonus() {
-        int bonus = 0;
         if (game == null) {
             return 0;
         }
-        if (game.getEntitiesVector() == null) {
-            return 0;
-        }
-        
-        // per TacOps:AR page 162-163, only the highest bonus should available should be used.
-        for (Entity entity : game.getEntitiesVector()) {
-            if (entity.getOwner().equals(this)) {
+
+        int bonus = 0;
+        for (InGameObject object : game.getInGameObjects()) {
+            if (object instanceof Entity && ((Entity) object).getOwner().equals(this)) {
+                Entity entity = (Entity) object;
                 if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_MOBILE_HQS)) {
                     bonus = Math.max(entity.getHQIniBonus(), bonus);
                 }
-                
+
                 bonus = Math.max(bonus, entity.getQuirkIniBonus());
             }
         }
@@ -665,60 +575,40 @@ public final class Player extends TurnOrdered {
      * (i.e. the 'commander')
      */
     public int getCommandBonus() {
-        int commandb = 0;
-        
         if (game == null) {
             return 0;
         }
-        
-        for (Entity entity : game.getEntitiesVector()) {
-            if ((null != entity.getOwner())
-                    && entity.getOwner().equals(this)
-                    && !entity.isDestroyed()
-                    && entity.isDeployed()
-                    && !entity.isOffBoard()
-                    && entity.getCrew().isActive()
-                    && !entity.isCaptured()
-                    && !(entity instanceof MechWarrior)) {
-                int bonus = 0;
-                if (game.getOptions().booleanOption(OptionsConstants.RPG_COMMAND_INIT)) {
-                    bonus = entity.getCrew().getCommandBonus();
-                }
-                //Even if the RPG option is not enabled, we still get the command bonus provided by special equipment.
-                //Since we are not designating a single force commander at this point, we assume a superheavy tripod
-                //is the force commander if that gives the highest bonus.
-                if (entity.hasCommandConsoleBonus() || entity.getCrew().hasActiveTechOfficer()) {
-                    bonus += 2;
-                }
-                //Once we've gotten the status of the command console (if any), reset the flag that tracks
-                //the previous turn's action.
-                if (bonus > commandb) {
-                    commandb = bonus;
+        int commandb = 0;
+        for (InGameObject unit : game.getInGameObjects()) {
+            if (unit instanceof Entity) {
+                Entity entity = (Entity) unit;
+                if ((null != entity.getOwner())
+                        && entity.getOwner().equals(this)
+                        && !entity.isDestroyed()
+                        && entity.isDeployed()
+                        && !entity.isOffBoard()
+                        && entity.getCrew().isActive()
+                        && !entity.isCaptured()
+                        && !(entity instanceof MechWarrior)) {
+                    int bonus = 0;
+                    if (game.getOptions().booleanOption(OptionsConstants.RPG_COMMAND_INIT)) {
+                        bonus = entity.getCrew().getCommandBonus();
+                    }
+                    //Even if the RPG option is not enabled, we still get the command bonus provided by special equipment.
+                    //Since we are not designating a single force commander at this point, we assume a superheavy tripod
+                    //is the force commander if that gives the highest bonus.
+                    if (entity.hasCommandConsoleBonus() || entity.getCrew().hasActiveTechOfficer()) {
+                        bonus += 2;
+                    }
+                    //Once we've gotten the status of the command console (if any), reset the flag that tracks
+                    //the previous turn's action.
+                    if (bonus > commandb) {
+                        commandb = bonus;
+                    }
                 }
             }
         }
         return commandb;
-    }
-
-    /**
-     * cycle through entities on team and collect all the airborne VTOL/WIGE
-     *
-     * @return a vector of relevant entity ids
-     */
-    public Vector<Integer> getAirborneVTOL() {
-        // a vector of unit ids
-        Vector<Integer> units = new Vector<>();
-        for (Entity entity : game.getEntitiesVector()) {
-            if (entity.getOwner().equals(this)) {
-                if (((entity instanceof VTOL)
-                     || (entity.getMovementMode() == EntityMovementMode.WIGE)) &&
-                    (!entity.isDestroyed()) &&
-                    (entity.getElevation() > 0)) {
-                    units.add(entity.getId());
-                }
-            }
-        }
-        return units;
     }
 
     public String getColorForPlayer() {
@@ -726,10 +616,9 @@ public final class Player extends TurnOrdered {
     }
 
     /**
-     * Un-sets any data that may be considered private.
-     *
-     * This method clears any data that should not be transmitted to other players from the server,
-     * such as email addresses.
+     * Clears any data from this Player that should not be transmitted to other players from the server,
+     * such as email addresses. Note that this changes this Player's data permanently and should typically
+     * be done to a copy of the player, see {@link #copy()}.
      */
     public void redactPrivateData() {
         this.email = null;
@@ -760,11 +649,8 @@ public final class Player extends TurnOrdered {
         return id;
     }
 
-    /**
-     * TODO : I should be a clone override, not my own method
-     */
     public Player copy() {
-        var copy = new Player(this.id, this.name);
+        var copy = new Player(id, name);
 
         copy.email = email;
 

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -65,11 +65,6 @@ public final class Team extends TurnOrdered {
         return nonObserverPlayers().size();
     }
 
-    /** Removes all players from this team. */
-    public void resetTeam() {
-        players.clear();
-    }
-
     /** Adds the given player to this team. Null players will not be added. */
     public void addPlayer(@Nullable Player player) {
         if (player != null) {
@@ -209,11 +204,6 @@ public final class Team extends TurnOrdered {
     @Override
     public String toString() {
         return (getId() == Player.TEAM_NONE) ? "No Team" : "Team " + getId();
-    }
-
-    // TODO : this is Total Warfare specific, remove from Team
-    public boolean hasTAG() {
-        return players.stream().anyMatch(Player::hasTAG);
     }
 
     /** @return The best initiative among the team's players. */

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -215,48 +215,39 @@ public class GameManager implements IGameManager {
             LogManager.getLogger().error("Attempted to set game to incorrect class.");
             return;
         }
-        // game listeners are transient so we need to save and restore them
-        Vector<GameListener> gameListenersClone = new Vector<>(getGame().getGameListeners());
-
         game = (Game) g;
-
-        for (GameListener listener : gameListenersClone) {
-            getGame().addGameListener(listener);
-        }
 
         List<Integer> orphanEntities = new ArrayList<>();
 
         // reattach the transient fields and ghost the players
-        for (Iterator<Entity> e = game.getEntities(); e.hasNext(); ) {
-            Entity ent = e.next();
-            ent.setGame(game);
+        for (Entity entity : game.getEntitiesVector()) {
+            entity.setGame(game);
 
-            if (ent.getOwner() == null) {
-                orphanEntities.add(ent.getId());
+            if (entity.getOwner() == null) {
+                orphanEntities.add(entity.getId());
                 continue;
             }
 
-            if (ent instanceof Mech) {
-                ((Mech) ent).setBAGrabBars();
-                ((Mech) ent).setProtomechClampMounts();
+            if (entity instanceof Mech) {
+                ((Mech) entity).setBAGrabBars();
+                ((Mech) entity).setProtomechClampMounts();
             }
-            if (ent instanceof Tank) {
-                ((Tank) ent).setBAGrabBars();
+            if (entity instanceof Tank) {
+                ((Tank) entity).setBAGrabBars();
             }
         }
 
         game.removeEntities(orphanEntities, IEntityRemovalConditions.REMOVE_UNKNOWN);
 
         game.setOutOfGameEntitiesVector(game.getOutOfGameEntitiesVector());
-        for (Enumeration<Player> e = game.getPlayers(); e.hasMoreElements(); ) {
-            Player p = e.nextElement();
-            p.setGame(game);
-            p.setGhost(true);
+        for (Player player : game.getPlayersList()) {
+            player.setGame(game);
+            player.setGhost(true);
         }
+
         // might need to restore weapon type for some attacks that take multiple
         // turns (like artillery)
-        for (Enumeration<AttackHandler> a = game.getAttacks(); a.hasMoreElements(); ) {
-            AttackHandler handler = a.nextElement();
+        for (AttackHandler handler : game.getAttacksVector()) {
             if (handler instanceof WeaponHandler) {
                 ((WeaponHandler) handler).restore();
             }
@@ -1685,23 +1676,23 @@ public class GameManager implements IGameManager {
             BVCountHelper bvcPlayer = new BVCountHelper();
             bvcPlayer.bv = player.getBV();
             bvcPlayer.bvInitial = player.getInitialBV();
-            bvcPlayer.bvFled = player.getFledBV();
-            bvcPlayer.unitsCount = player.getUnitCount();
+            bvcPlayer.bvFled = ServerReportsHelper.getFledBV(player, game);
+            bvcPlayer.unitsCount = ServerReportsHelper.getUnitCount(player, game);
             bvcPlayer.unitsInitialCount = player.getInitialEntityCount();
-            bvcPlayer.unitsLightDamageCount = player.getUnitDamageCount(Entity.DMG_LIGHT);
-            bvcPlayer.unitsModerateDamageCount = player.getUnitDamageCount(Entity.DMG_MODERATE);
-            bvcPlayer.unitsHeavyDamageCount = player.getUnitDamageCount(Entity.DMG_HEAVY);
-            bvcPlayer.unitsCrippledCount = player.getUnitDamageCount(Entity.DMG_CRIPPLED);
-            bvcPlayer.unitsDestroyedCount =  player.getUnitDestroyedCount();
-            bvcPlayer.unitsCrewEjectedCount = player.getUnitCrewEjectedCount();
-            bvcPlayer.unitsCrewTrappedCount = player.getUnitCrewTrappedCount();
-            bvcPlayer.unitsCrewKilledCount = player.getUnitCrewKilledCount();
-            bvcPlayer.unitsFledCount = player.getFledUnitsCount();
-            bvcPlayer.ejectedCrewActiveCount = player.getEjectedCrewCount();
-            bvcPlayer.ejectedCrewPickedUpByTeamCount =  player.getEjectedCrewPickedUpByTeamCount();
-            bvcPlayer.ejectedCrewPickedUpByEnemyTeamCount = player.getEjectedCrewPickedUpByEnemyTeamCount();
-            bvcPlayer.ejectedCrewKilledCount = player.getEjectedCrewKilledCount();
-            bvcPlayer.ejectedCrewFledCount = player.getFledEjectedCrew();
+            bvcPlayer.unitsLightDamageCount = ServerReportsHelper.getUnitDamageCount(player, Entity.DMG_LIGHT, game);
+            bvcPlayer.unitsModerateDamageCount = ServerReportsHelper.getUnitDamageCount(player, Entity.DMG_MODERATE, game);
+            bvcPlayer.unitsHeavyDamageCount = ServerReportsHelper.getUnitDamageCount(player, Entity.DMG_HEAVY, game);
+            bvcPlayer.unitsCrippledCount = ServerReportsHelper.getUnitDamageCount(player, Entity.DMG_CRIPPLED, game);
+            bvcPlayer.unitsDestroyedCount =  ServerReportsHelper.getUnitDestroyedCount(player, game);
+            bvcPlayer.unitsCrewEjectedCount = ServerReportsHelper.getUnitCrewEjectedCount(player, game);
+            bvcPlayer.unitsCrewTrappedCount = ServerReportsHelper.getUnitCrewTrappedCount(player, game);
+            bvcPlayer.unitsCrewKilledCount = ServerReportsHelper.getUnitCrewKilledCount(player, game);
+            bvcPlayer.unitsFledCount = ServerReportsHelper.getFledUnitsCount(player, game);
+            bvcPlayer.ejectedCrewActiveCount = ServerReportsHelper.getEjectedCrewCount(player, game);
+            bvcPlayer.ejectedCrewPickedUpByTeamCount =  ServerReportsHelper.getEjectedCrewPickedUpByTeamCount(player, game);
+            bvcPlayer.ejectedCrewPickedUpByEnemyTeamCount = ServerReportsHelper.getEjectedCrewPickedUpByEnemyTeamCount(player, game);
+            bvcPlayer.ejectedCrewKilledCount = ServerReportsHelper.getEjectedCrewKilledCount(player, game);
+            bvcPlayer.ejectedCrewFledCount = ServerReportsHelper.getFledEjectedCrew(player, game);
 
             playerReport.addAll(bvReport(player.getColorForPlayer(), player.getId(), bvcPlayer, checkBlind));
 
@@ -2206,7 +2197,8 @@ public class GameManager implements IGameManager {
     public void calculatePlayerInitialCounts() {
         for (final Enumeration<Player> players = game.getPlayers(); players.hasMoreElements(); ) {
             final Player player = players.nextElement();
-            player.setInitialEntityCount(player.getEntityCount());
+            player.setInitialEntityCount(Math.toIntExact(game.getPlayerEntities(player, false).stream()
+                    .filter(entity -> !entity.isDestroyed() && !entity.isTrapped()).count()));
             player.setInitialBV(player.getBV());
         }
     }
@@ -34809,10 +34801,18 @@ public class GameManager implements IGameManager {
      * @return a vector of relevant entity ids
      */
     public Vector<Integer> getAirborneVTOL(Team team) {
-        // a vector of unit ids
         Vector<Integer> units = new Vector<>();
-        for (Player player : team.players()) {
-            units.addAll(player.getAirborneVTOL());
+        for (Entity entity : game.getEntitiesVector()) {
+            for (Player player : team.players()) {
+                if (entity.getOwner().equals(player)) {
+                    if (((entity instanceof VTOL)
+                            || (entity.getMovementMode() == EntityMovementMode.WIGE)) &&
+                            (!entity.isDestroyed()) &&
+                            (entity.getElevation() > 0)) {
+                        units.add(entity.getId());
+                    }
+                }
+            }
         }
         return units;
     }

--- a/megamek/src/megamek/server/ServerReportsHelper.java
+++ b/megamek/src/megamek/server/ServerReportsHelper.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.server;
+
+import megamek.common.*;
+
+public class ServerReportsHelper {
+
+    public static int getUnitCount(Player player, Game game) {
+        return Math.toIntExact(game.getPlayerEntities(player, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public static int getUnitDamageCount(Player player, int damageLevel, Game game) {
+        return Math.toIntExact(game.getPlayerEntities(player, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() && (entity.getDamageLevel() == damageLevel)
+                        && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public static int getUnitDestroyedCount(Player player, Game game) {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> player.equals(entity.getOwner()) && entity.isDestroyed() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public static int getUnitCrewEjectedCount(Player player, Game game) {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> player.equals(entity.getOwner()) && entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public static int getUnitCrewTrappedCount(Player player, Game game) {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> player.equals(entity.getOwner()) && entity.isDestroyed() && !entity.getCrew().isDead()
+                        && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public static int getUnitCrewKilledCount(Player player, Game game) {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> player.equals(entity.getOwner()) && entity.getCrew().isDead()
+                        && !entity.getCrew().isEjected() && !(entity instanceof EjectedCrew)).count());
+    }
+
+    public static int getEjectedCrewCount(Player player, Game game) {
+        return Math.toIntExact(game.getPlayerEntities(player, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
+                        (((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() == Entity.NONE) ||
+                                ((entity instanceof EjectedCrew) && !(entity instanceof MechWarrior)))).count());
+    }
+
+    public static int getEjectedCrewPickedUpByTeamCount(Player player, Game game) {
+        return Math.toIntExact(game.getPlayerEntities(player, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
+                        ((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() != Entity.NONE
+                                && game.getEntity(((MechWarrior) entity).getPickedUpById()).getOwner().getTeam() == player.getTeam())).count());
+    }
+
+    public static int getEjectedCrewPickedUpByEnemyTeamCount(Player player, Game game) {
+        return Math.toIntExact(game.getPlayerEntities(player, false).stream()
+                .filter(entity -> !entity.isDestroyed() && !entity.isTrapped() &&
+                        ((entity instanceof MechWarrior) && ((MechWarrior) entity).getPickedUpById() != Entity.NONE
+                                && game.getEntity(((MechWarrior) entity).getPickedUpById()).getOwner().getTeam() != player.getTeam())).count());
+    }
+
+    public static int getEjectedCrewKilledCount(Player player, Game game) {
+        return Math.toIntExact(game.getOutOfGameEntitiesVector().stream()
+                .filter(entity -> entity.getOwner().equals(player) && entity.isDestroyed() && (entity instanceof EjectedCrew)).count());
+    }
+
+    /**
+     * get the total BV (unmodified by force size mod) for the units of this
+     * player that have fled the field
+     *
+     * @return the BV
+     * @param player
+     */
+    public static int getFledBV(Player player, Game game) {
+        //TODO: I'm not sure how squadrons are treated here - see getBV()
+        return game.getPlayerRetreatedEntities(player).stream()
+                .filter(entity -> !entity.isDestroyed())
+                .mapToInt(Entity::calculateBattleValue).sum();
+    }
+
+    public static int getFledUnitsCount(Player player, Game game) {
+        //TODO: I'm not sure how squadrons are treated here - see getBV()
+        return Math.toIntExact(game.getPlayerRetreatedEntities(player).stream()
+                .filter(entity -> !entity.isDestroyed() && !(entity instanceof EjectedCrew))
+                .mapToInt(Entity::calculateBattleValue).count());
+    }
+
+    public static int getFledEjectedCrew(Player player, Game game) {
+        //TODO: I'm not sure how squadrons are treated here - see getBV()
+        return Math.toIntExact(game.getPlayerRetreatedEntities(player).stream()
+                .filter(entity -> !entity.isDestroyed() && (entity instanceof EjectedCrew))
+                .mapToInt(Entity::calculateBattleValue).count());
+    }
+
+    private ServerReportsHelper() { }
+}

--- a/megamek/unittests/megamek/server/victory/GameManagerTest.java
+++ b/megamek/unittests/megamek/server/victory/GameManagerTest.java
@@ -27,8 +27,11 @@ public class GameManagerTest {
         Forces testForces = new Forces(testGame);
         when(testGame.getGameListeners()).thenReturn(new Vector<>());
         when(testGame.getEntities()).thenReturn(Collections.emptyIterator());
+        when(testGame.getEntitiesVector()).thenReturn(Collections.emptyList());
         when(testGame.getPlayers()).thenReturn(Collections.emptyEnumeration());
+        when(testGame.getPlayersList()).thenReturn(Collections.emptyList());
         when(testGame.getAttacks()).thenReturn(Collections.emptyEnumeration());
+        when(testGame.getAttacksVector()).thenReturn(new Vector<>());
         when(testGame.getForces()).thenReturn(testForces);
         when(testGame.getOptions()).thenReturn(new GameOptions());
         return testGame;


### PR DESCRIPTION
This is mostly a refactor to reduce connection between Player/Team and the TW classes Entity/Game to facilitate other game types (in some distant future). 
- Some methods were not used and were deleted. 
- Some methods have been moved into a ServerHelper class as they were only used by GameManager.
- Player is changed to use IGame instead of Game; for the BV sum I added countForStrengthSum() to InGameObject, see its comment

One change is worth noting (and I hope I'm not making an error): I had to remove the firePlayerChangeEvent from Player.setDone() and move it to the callers. Most calls were by the GameManager. I don't think there are any game-listeners server-side, nor can I imagine a good use for them there and so I did not add the event fire there. Also, I removed a bit of code that re-added listeners to a new Game that is set in the GameManager, the reason being they're transient. I could not think of a situation where old game listeners should be re-added to a new game server-side (set by a new scenario or game load or new game start; the game object is never replaced while the game's running). Nor are there any game listeners present in the test game I started. MekHQ adds a game listener only to the client's game.