### PR TITLE
Code cleanup

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
@@ -758,8 +758,7 @@ class SystemPanel extends PicMap implements ItemListener, ActionListener, ListSe
                     m_bDumpAmmo.setEnabled(true);
                 }
                 int round = client.getGame().getRoundCount();
-                boolean inSquadron = ((en instanceof Aero) && ((Aero) en)
-                        .isInASquadron());
+                boolean inSquadron = en.isPartOfFighterSquadron();
                 if ((m != null) && bOwner && m.hasModes()) {
                     if (!m.isInoperable() && !m.isDumping()
                             && (en.isActive() || en.isActive(round) || inSquadron)

--- a/megamek/src/megamek/common/AeroSpaceFighter.java
+++ b/megamek/src/megamek/common/AeroSpaceFighter.java
@@ -19,15 +19,6 @@
 
 package megamek.common;
 
-import megamek.client.ui.swing.calculationReport.CalculationReport;
-import megamek.common.cost.AeroCostCalculator;
-import megamek.common.enums.AimingMode;
-import megamek.common.options.OptionsConstants;
-import org.apache.logging.log4j.LogManager;
-
-import java.text.NumberFormat;
-import java.util.*;
-
 /**
  * AeroSpaceFighter subclass of Aero that encapsulates Fighter functionality
  */
@@ -53,11 +44,6 @@ public class AeroSpaceFighter extends Aero {
     }
 
     @Override
-    public boolean isInASquadron() {
-        return game.getEntity(getTransportId()) instanceof FighterSquadron;
-    }
-
-    @Override
     public int reduceMPByBombLoad(int t) {
         return Math.max(0, t - (int) Math.ceil(getExternalBombPoints() / 5.0));
     }
@@ -65,57 +51,6 @@ public class AeroSpaceFighter extends Aero {
     @Override
     public boolean isSpheroid() {
         return false;
-    }
-
-    // Damage a fighter that was part of a squadron when splitting it. Per
-    // StratOps pg. 32 & 34
-    @Override
-    public void doDisbandDamage() {
-
-        int dealt = 0;
-
-        // Check for critical threshold and if so damage all armor on one facing
-        // of the fighter completely,
-        // reduce SI by half, and mark three engine hits.
-        if (isDestroyed() || isDoomed()) {
-            int loc = Compute.randomInt(4);
-            dealt = getArmor(loc);
-            setArmor(0, loc);
-            int finalSI = Math.min(getSI(), getSI() / 2);
-            dealt += getSI() - finalSI;
-            setSI(finalSI);
-            setEngineHits(Math.max(3, getEngineHits()));
-        }
-
-        // Move on to actual damage...
-        int damage = getCap0Armor() - getCapArmor();
-        // Fix for #587. Only multiply if Aero Sanity is off
-        if ((null != game) && !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
-            damage *= 10;
-        }
-        damage -= dealt; // We already dealt a bunch of damage, move on.
-        if (damage < 1) {
-            return;
-        }
-        int hits = (int) Math.ceil(damage / 5.0);
-        int damPerHit = 5;
-        for (int i = 0; i < hits; i++) {
-            int loc = Compute.randomInt(4);
-            // Fix for #587. Apply in 5 point groups unless damage remainder is less.
-            setArmor(getArmor(loc) - Math.min(damPerHit, damage), loc);
-            // We did too much damage, so we need to damage the SI, but we wont
-            // reduce the SI below 1 here
-            // unless the fighter is destroyed.
-            if (getArmor(loc) < 0) {
-                if (getSI() > 1) {
-                    int si = getSI() + (getArmor(loc) / 2);
-                    si = Math.max(si, isDestroyed() || isDoomed() ? 0 : 1);
-                    setSI(si);
-                }
-                setArmor(0, loc);
-            }
-            damage -= damPerHit;
-        }
     }
 
     /**
@@ -144,11 +79,6 @@ public class AeroSpaceFighter extends Aero {
                 }
             }
         }
-    }
-
-    @Override
-    public boolean isAero() {
-        return true;
     }
 
     @Override

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -46,10 +46,10 @@ public class Jumpship extends Aero {
     
     // The percentage of the total unit weight taken up by the drive core. The value
     // given for primitive assumes a 30ly range, but the final value has to be computed.
-    private static double[] DRIVE_CORE_WEIGHT_PCT = { 0.95, 0.4525, 0.5, 0.0, 0.95 };
+    private static final double[] DRIVE_CORE_WEIGHT_PCT = { 0.95, 0.4525, 0.5, 0.0, 0.95 };
 
-    private static String[] LOCATION_ABBRS = { "NOS", "FLS", "FRS", "AFT", "ALS", "ARS", "HULL" };
-    private static String[] LOCATION_NAMES = { "Nose", "Left Front Side", "Right Front Side",
+    private static final String[] LOCATION_ABBRS = { "NOS", "FLS", "FRS", "AFT", "ALS", "ARS", "HULL" };
+    private static final String[] LOCATION_NAMES = { "Nose", "Left Front Side", "Right Front Side",
             "Aft", "Aft Left Side", "Aft Right Side", "Hull" };
 
     // K-F Drive Stuff
@@ -93,17 +93,17 @@ public class Jumpship extends Aero {
      * we just stored the number of standard, large and huge grav decks, and could not specify the exact size of the
      * deck.
      */
-    private List<Integer> gravDecks = new ArrayList<>();
+    private final List<Integer> gravDecks = new ArrayList<>();
     
     /**
      * Keep track of all of the grav decks and their damage status
      *
      * Stores the number of hits on each grav deck by the index value from the list gravDecks
      */
-    private Map<Integer,Integer> damagedGravDecks = new HashMap<>();
+    private final Map<Integer,Integer> damagedGravDecks = new HashMap<>();
 
     // station-keeping thrust and accumulated thrust
-    private double stationThrust = 0.2;
+    private final double stationThrust = 0.2;
     private double accumulatedThrust = 0.0;
 
     public Jumpship() {
@@ -125,7 +125,7 @@ public class Jumpship extends Aero {
 
     // ASEW Missile Effects, per location
     // Values correspond to Locations: NOS, FLS, FRS, AFT, ALS, ARS
-    private int[] asewAffectedTurns = { 0, 0, 0, 0, 0, 0 };
+    private final int[] asewAffectedTurns = { 0, 0, 0, 0, 0, 0 };
     
     /*
      * Accessor for the asewAffectedTurns array, which may be different for inheriting classes.
@@ -272,7 +272,6 @@ public class Jumpship extends Aero {
                 toReturn.append(", ");
             }
             toReturn.append(Messages.getString("Jumpship.lfBatteryDamageString"));
-            first = false;
         }
         return toReturn.toString();
     }
@@ -396,7 +395,7 @@ public class Jumpship extends Aero {
      * Old style for setting the number of grav decks.  This allows the user to specify N standard grav decks, which
      * will get added at a default value.
      *
-     * @param n
+     * @param n The number of grav decks
      */
     public void setGravDeck(int n) {
         for (int i = 0; i < n; i++) {
@@ -422,7 +421,7 @@ public class Jumpship extends Aero {
      * Old style method for adding N large grav decks. A default value is chosen that is half-way
      * between the standard and huge sizes.
      *
-     * @param n
+     * @param n The number of grav decks
      */
     public void setGravDeckLarge(int n) {
         for (int i = 0; i < n; i++) {
@@ -449,7 +448,7 @@ public class Jumpship extends Aero {
      * Old style method for adding N huge grav decks. A default value is chosen that is the current
      * large maximum plus half that value.
      *
-     * @param n
+     * @param n The number of grav decks
      */
     public void setGravDeckHuge(int n) {
         for (int i = 0; i < n; i++) {
@@ -588,9 +587,7 @@ public class Jumpship extends Aero {
     }
 
     /**
-     * Returns the number of marines assigned to a unit
-     * Used for abandoning a unit
-     * @return
+     * @return the number of marines assigned to a unit; Used for abandoning a unit
      */
     @Override
     public int getNMarines() {
@@ -676,27 +673,22 @@ public class Jumpship extends Aero {
     
     //Methods for dealing with the K-F Drive, Sail and L-F Battery
     
-    //Set the current KF Drive integrity
     public void setKFIntegrity(int kf) {
         kf_integrity = kf;
     }
     
-    //Return the current KF Drive integrity
     public int getKFIntegrity() {
         return kf_integrity;
     }
     
-    //Set the original/undamaged KF Drive integrity
     public void setOKFIntegrity(int kf) {
         original_kf_integrity = kf;
     }
     
-    //Return the original/undamaged KF Drive integrity
     public int getOKFIntegrity() {
         return original_kf_integrity;
     }
     
-    //Return the damage taken to the KF Drive
     public int getKFDriveDamage() {
         return (getOKFIntegrity() - getKFIntegrity());
     }
@@ -711,7 +703,6 @@ public class Jumpship extends Aero {
                 || getKFFieldInitiatorHit());
     }
     
-    //Set the portion of the total drive integrity represented by the helium tanks
     public void setKFHeliumTankIntegrity(int ht) {
         helium_tankage = ht;
     }
@@ -721,87 +712,70 @@ public class Jumpship extends Aero {
         return helium_tankage;
     }
     
-    //Record a hit on the KF Drive Helium Tank
     public void setKFHeliumTankHit(boolean hit) {
         heliumTankHit = hit;
     }
     
-    //Return the status of the KF Drive Helium Tank
     public boolean getKFHeliumTankHit() {
         return heliumTankHit;
     }
     
-    //Record a hit on the KF Drive Coil
     public void setKFDriveCoilHit(boolean hit) {
         driveCoilHit = hit;
     }
     
-    //Return the status of the KF Drive Coil
     public boolean getKFDriveCoilHit() {
         return driveCoilHit;
     }
     
-    //Record a hit on the KF Field Initiator
     public void setKFFieldInitiatorHit(boolean hit) {
         fieldInitiatorHit = hit;
     }
     
-    //Return the status of the KF Field Initiator
     public boolean getKFFieldInitiatorHit() {
         return fieldInitiatorHit;
     }
     
-    //Record a hit on the KF Charging System
     public void setKFChargingSystemHit(boolean hit) {
         chargingSystemHit = hit;
     }
     
-    //Return the status of the KF Charging System
     public boolean getKFChargingSystemHit() {
         return chargingSystemHit;
     }
     
-    //Record a hit on the KF Drive Controller
     public void setKFDriveControllerHit(boolean hit) {
         driveControllerHit = hit;
     }
     
-    //Return the status of the KF Drive Controller
     public boolean getKFDriveControllerHit() {
         return driveControllerHit;
     }
     
-    //Return the status of the LF Battery
     public boolean getLFBatteryHit() {
         return lfBatteryHit;
     }
     
-    //Record a hit on the LF Battery
     public void setLFBatteryHit(boolean hit) {
         lfBatteryHit = hit;
     }
     
-    //Set the original/undamaged Jump Sail integrity
     public void setOSailIntegrity(int sail) {
         original_sail_integrity = sail;
     }
     
-    //Return the original/undamaged Jump Sail integrity
     public int getOSailIntegrity() {
         return original_sail_integrity;
     }
     
-    //Return the damage taken to the Jump Sail
     public int getSailDamage() {
         return (getOSailIntegrity() - getSailIntegrity());
     }
 
-    //Set the current integrity of the jump sail
     public void setSailIntegrity(int sail) {
         sail_integrity = sail;
     }
     
-    //Return the current integrity of the jump sail
     public int getSailIntegrity() {
         return sail_integrity;
     }
@@ -877,7 +851,7 @@ public class Jumpship extends Aero {
     public int getWeaponArc(int wn) {
         final Mounted mounted = getEquipment(wn);
 
-        int arc = Compute.ARC_NOSE;
+        int arc;
         switch (mounted.getLocation()) {
             case LOC_NOSE:
                 if (mounted.isInWaypointLaunchMode()) {
@@ -1108,13 +1082,12 @@ public class Jumpship extends Aero {
     }
 
     public boolean hasWeaponInArc(int loc) {
-        boolean hasWeapons = false;
         for (Mounted weap : getWeaponList()) {
             if (weap.getLocation() == loc) {
-                hasWeapons = true;
+                return true;
             }
         }
-        return hasWeapons;
+        return false;
     }
 
     public double getFuelPerTon() {
@@ -1173,11 +1146,6 @@ public class Jumpship extends Aero {
         return true;
     }
 
-    @Override
-    public boolean doomedInSpace() {
-        return false;
-    }
-
     /**
      * need to check bay location before loading ammo
      */
@@ -1205,11 +1173,6 @@ public class Jumpship extends Aero {
         return success;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see megamek.common.Entity#getIniBonus()
-     */
     @Override
     public int getHQIniBonus() {
         // large craft are considered to have > 7 tons comm equipment
@@ -1217,9 +1180,6 @@ public class Jumpship extends Aero {
         return 2;
     }
 
-    /**
-     * what location is opposite the given one
-     */
     @Override
     public int getOppositeLocation(int loc) {
         switch (loc) {
@@ -1305,7 +1265,7 @@ public class Jumpship extends Aero {
         // thrust. So once you
         // get 1 thrust point, you have to spend it before you can accumulate
         // more
-        if (isDeployed() && (isBattleStation() == true)) {
+        if (isDeployed() && isBattleStation()) {
             setAccumulatedThrust(1);
         }
 
@@ -1410,16 +1370,6 @@ public class Jumpship extends Aero {
     @Override
     public boolean usesWeaponBays() {
         return true;
-    }
-
-    @Override
-    public boolean isFighter() {
-        return false;
-    }
-
-    @Override
-    public boolean isAerospaceFighter() {
-        return false;
     }
 
     @Override

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -575,13 +575,10 @@ public class Tank extends Entity {
     @Override
     public boolean isImmobileForJump() {
         // *Can* jump unless 0 Jump MP, or 1+ Jump MP but engine is critted, or crew unconscious/dead.
-        boolean jumpImmobile = (
-                super.isImmobile(true) ||
+        return super.isImmobile(true) ||
                 super.isPermanentlyImmobilized(true) ||
                 (getJumpMP() == 0) ||
-                (isEngineHit())
-        );
-        return jumpImmobile;
+                isEngineHit();
     }
 
     @Override
@@ -1721,13 +1718,13 @@ public class Tank extends Entity {
         return true;
     }
 
-    @Override
     /**
      * Checks to see if a Tank is capable of going hull-down.  This is true if
      * hull-down rules are enabled and the Tank is in a fortified hex.
      *
      *  @return True if hull-down is enabled and the Tank is in a fortified hex.
      */
+    @Override
     public boolean canGoHullDown() {
         // MoveStep line 2179 performs this same check
         // performing it here will allow us to disable the Hulldown button
@@ -2896,13 +2893,7 @@ public class Tank extends Entity {
     @Override
     public void setHullDown(boolean down) {
         super.setHullDown(down);
-        if ((getMovedBackwards() == true) && (down == true)) {
-            m_bBackedIntoHullDown = true;
-        } else if ((getMovedBackwards() == false) && (down == true)) {
-            m_bBackedIntoHullDown = false;
-        } else if (down == false) {
-            m_bBackedIntoHullDown = false;
-        }
+        m_bBackedIntoHullDown = getMovedBackwards() && down;
     }
 
     /**

--- a/megamek/src/megamek/common/VTOL.java
+++ b/megamek/src/megamek/common/VTOL.java
@@ -31,13 +31,12 @@ public class VTOL extends Tank implements IBomber {
     public static final int LOC_ROTOR = 5;
     public static final int LOC_TURRET = 6;
     public static final int LOC_TURRET_2 = 7;
-    public static final int LOC_NUM = 8;
 
     // VTOLs can have at most one (chin) turret, sponsons don't count and dual
     // turrets aren't allowed.
-    private static String[] LOCATION_ABBRS = { "BD", "FR", "RS", "LS", "RR",
+    private final static String[] LOCATION_ABBRS = { "BD", "FR", "RS", "LS", "RR",
             "RO", "TU" };
-    private static String[] LOCATION_NAMES = { "Body", "Front", "Right",
+    private static final String[] LOCATION_NAMES = { "Body", "Front", "Right",
             "Left", "Rear", "Rotor", "Turret"};
 
     // critical hits
@@ -83,7 +82,7 @@ public class VTOL extends Tank implements IBomber {
     protected int[] extBombChoices = new int[BombType.B_NUM];
 
     private Targetable bombTarget = null;
-    private List<Coords> strafingCoords = new ArrayList<>();
+    private final List<Coords> strafingCoords = new ArrayList<>();
 
     @Override
     public PilotingRollData checkSkid(EntityMovementType moveType, Hex prevHex, EntityMovementType overallMoveType,
@@ -140,11 +139,6 @@ public class VTOL extends Tank implements IBomber {
         return false;
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see megamek.common.Tank#isRepairable()
-     */
     @Override
     public boolean isRepairable() {
         boolean retval = isSalvage();
@@ -239,14 +233,9 @@ public class VTOL extends Tank implements IBomber {
     }
 
     @Override
-    public boolean doomedInAtmosphere() {
-        return true;
-    }
-
-    @Override
     public boolean isBomber() {
         return (game != null)
-                && (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_VTOL_ATTACKS));
+                && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_VTOL_ATTACKS);
     }
 
     @Override
@@ -258,11 +247,11 @@ public class VTOL extends Tank implements IBomber {
     public int getMaxExtBombPoints() {
         return (int) Math.round(getWeight() / 5);
     }
+
     @Override
     public int getMaxIntBombPoints() {
         return 0;
     }
-
 
     @Override
     public int getMaxBombPoints() {
@@ -302,12 +291,12 @@ public class VTOL extends Tank implements IBomber {
     }
 
     @Override
-    public void setUsedInternalBombs(int b){
+    public void setUsedInternalBombs(int b) {
         // Do nothing
     }
 
     @Override
-    public void increaseUsedInternalBombs(int b){
+    public void increaseUsedInternalBombs(int b) {
         // Do nothing
     }
 
@@ -339,11 +328,6 @@ public class VTOL extends Tank implements IBomber {
     @Override
     public boolean isNightwalker() {
         return false;
-    }
-
-    @Override
-    public boolean doomedInSpace() {
-        return true;
     }
 
     @Override
@@ -683,12 +667,9 @@ public class VTOL extends Tank implements IBomber {
         return roll;
     }
 
-        @Override
+    @Override
     public int height() {
-        if (isSuperHeavy()) {
-            return 1;
-        }
-        return 0;
+        return isSuperHeavy() ? 1 : 0;
     }
 
     @Override
@@ -698,11 +679,7 @@ public class VTOL extends Tank implements IBomber {
 
     @Override
     public int locations() {
-        if (m_bHasNoTurret) {
-            return 6;
-        } else {
-            return 7;
-        }
+        return m_bHasNoTurret ? 6 : 7;
     }
 
     @Override
@@ -725,13 +702,6 @@ public class VTOL extends Tank implements IBomber {
         }
     }
 
-    /**
-     * Used to determine the draw priority of different Entity subclasses.
-     * This allows different unit types to always be draw above/below other
-     * types.
-     *
-     * @return
-     */
     @Override
     public int getSpriteDrawPriority() {
         return 8;

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -27,8 +27,8 @@ public class Warship extends Jumpship {
     public static final int LOC_LBS = 7;
     public static final int LOC_RBS = 8;
 
-    private static String[] LOCATION_ABBRS = { "NOS", "FLS", "FRS", "AFT", "ALS", "ARS", "HULL", "LBS", "RBS" };
-    private static String[] LOCATION_NAMES = { "Nose", "Left Front Side", "Right Front Side",
+    private static final String[] LOCATION_ABBRS = { "NOS", "FLS", "FRS", "AFT", "ALS", "ARS", "HULL", "LBS", "RBS" };
+    private static final String[] LOCATION_NAMES = { "Nose", "Left Front Side", "Right Front Side",
             "Aft", "Aft Left Side", "Aft Right Side", "Hull", "Left Broadsides", "Right Broadsides" };
 
     public Warship() {
@@ -44,7 +44,7 @@ public class Warship extends Jumpship {
 
     // ASEW Missile Effects, per location
     // Values correspond to Locations, as seen above: NOS, FLS, FRS, AFT, ALS, ARS, LBS, RBS
-    private int[] asewAffectedTurns = { 0, 0, 0, 0, 0, 0, 0, 0 };
+    private final int[] asewAffectedTurns = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
     /*
      * Accessor for the asewAffectedTurns array, which may be different for inheriting classes.
@@ -108,7 +108,7 @@ public class Warship extends Jumpship {
     public int getWeaponArc(int wn) {
         final Mounted mounted = getEquipment(wn);
         
-        int arc = Compute.ARC_NOSE;
+        int arc;
         switch (mounted.getLocation()) {
             case LOC_NOSE:
                 if (mounted.isInWaypointLaunchMode()) {
@@ -277,10 +277,6 @@ public class Warship extends Jumpship {
         setSecondaryFacing(getFacing());
     }
     
-    /**
-     * Utility function that handles situations where a facing change
-     * has some kind of permanent effect on the entity.
-     */
     @Override
     public void postProcessFacingChange() {
         mpUsed += 2;

--- a/megamek/src/megamek/common/options/Quirks.java
+++ b/megamek/src/megamek/common/options/Quirks.java
@@ -247,7 +247,7 @@ public class Quirks extends AbstractOptions {
 		                    QUIRK_NEG_PROTOTYPE,        QUIRK_NEG_SENSOR_GHOSTS);
         }
 
-        if (en instanceof Aero || en instanceof FixedWingSupport) {
+        if (en instanceof Aero) {
             if (quirk.isAnyOf(
             		QUIRK_POS_ATMO_FLYER, 		QUIRK_POS_COMBAT_COMPUTER, 		QUIRK_POS_EASY_MAINTAIN,
                     QUIRK_POS_EASY_PILOT, 		QUIRK_POS_GOOD_REP_1, 			QUIRK_POS_GOOD_REP_2,


### PR DESCRIPTION
This is only a cleanup, no intended other changes. Removes unused methods and methods that are identical their super (as determined by the IDE in a combined MHQ/MML/MM setting), unnecessary/duplicated comments, a duplicate method to determine if a fighter is in a squadron; also makes Aero abstract as it no longer represents ASF and should not be instantiated.