### PR TITLE
Use IGame in TurnOrdered

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -329,20 +329,6 @@ public class Game extends AbstractGame implements Serializable {
     }
 
     /**
-     * @return a player's team, which may be null if they do not have a team
-     */
-    public @Nullable Team getTeamForPlayer(Player p) {
-        for (Team team : teams) {
-            for (Player player : team.players()) {
-                if (player.equals(p)) {
-                    return team;
-                }
-            }
-        }
-        return null;
-    }
-
-    /**
      * Set up the teams vector. Each player on a team (Team 1 .. Team X) is
      * placed in the appropriate vector. Any player on 'No Team', is placed in
      * their own object

--- a/megamek/src/megamek/common/IGame.java
+++ b/megamek/src/megamek/common/IGame.java
@@ -93,6 +93,15 @@ public interface IGame {
 
     void setupTeams();
 
+    @Nullable default Team getTeamForPlayer(Player player) {
+        for (Team team : getTeams()) {
+            if (team.hasPlayer(player)) {
+                return team;
+            }
+        }
+        return null;
+    }
+
     // UNITS //////////////
 
     /** @return The next free id for InGameObjects (units and others). */

--- a/megamek/src/megamek/common/ITurnOrdered.java
+++ b/megamek/src/megamek/common/ITurnOrdered.java
@@ -29,13 +29,13 @@ public interface ITurnOrdered extends Serializable {
      * @return the <code>int</code> number of "normal" turns this item should
      *         take in a phase.
      */
-    int getNormalTurns(Game game);
+    int getNormalTurns(IGame game);
 
     int getOtherTurns();
 
     int getEvenTurns();
 
-    int getMultiTurns(Game game);
+    int getMultiTurns(IGame game);
 
     int getSpaceStationTurns();
 

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -52,6 +52,10 @@ public final class Team extends TurnOrdered {
         return players.isEmpty();
     }
 
+    public boolean hasPlayer(Player player) {
+        return players.contains(player);
+    }
+
     public List<Player> players() {
         return new ArrayList<>(players);
     }
@@ -133,7 +137,7 @@ public final class Team extends TurnOrdered {
      *         take in a phase.
      */
     @Override
-    public int getNormalTurns(Game game) {
+    public int getNormalTurns(IGame game) {
         int normalTurns = getMultiTurns(game) + getOtherTurns();
         return (normalTurns == 0) ? getEvenTurns() : normalTurns;
     }
@@ -149,7 +153,7 @@ public final class Team extends TurnOrdered {
     }
 
     @Override
-    public int getMultiTurns(Game game) {
+    public int getMultiTurns(IGame game) {
         return players.stream().mapToInt(p -> p.getMultiTurns(game)).sum();
     }
 

--- a/megamek/src/megamek/common/TurnOrdered.java
+++ b/megamek/src/megamek/common/TurnOrdered.java
@@ -48,7 +48,7 @@ public abstract class TurnOrdered implements ITurnOrdered {
      *         take in a phase.
      */
     @Override
-    public int getNormalTurns(Game game) {
+    public int getNormalTurns(IGame game) {
         return getMultiTurns(game) + getOtherTurns();
     }
 
@@ -63,7 +63,7 @@ public abstract class TurnOrdered implements ITurnOrdered {
     }
 
     @Override
-    public int getMultiTurns(Game game) {
+    public int getMultiTurns(IGame game) {
         int turns = 0;
         // turns_multi is transient, so it could be null
         if (turns_multi == null) {
@@ -312,13 +312,10 @@ public abstract class TurnOrdered implements ITurnOrdered {
                 for (ITurnOrdered item : v) {
                     if (!item.equals(winningElement)) {
                         int newBonus = 0;
-                        boolean observer = false;
+                        boolean observer = ((item instanceof Player) && ((Player) item).isObserver())
+                                || ((item instanceof Team) && ((Team) item).isObserverTeam());
                         // Observers don't have initiative, and they don't get initiative compensation
-                        if (((item instanceof Player) && ((Player) item).isObserver())
-                                || ((item instanceof Team) && ((Team) item).isObserverTeam())) {
-                            observer = true;
-                        }
-                        
+
                         if (!item.equals(lastRoundInitWinner) && !observer) {
                             newBonus = item.getInitCompensationBonus() + 1;
                         }
@@ -340,7 +337,7 @@ public abstract class TurnOrdered implements ITurnOrdered {
      * 
      * @param v
      *            A vector of items that need to have turns.
-     * @param rerollRequests
+     * @param rerollRequests null when there should be no re-rolls
      * @param bInitCompBonus
      *            A flag that determines whether initiative compensation bonus
      *            should be used: used to prevent one side getting long init win
@@ -411,7 +408,7 @@ public abstract class TurnOrdered implements ITurnOrdered {
     /**
      * This takes a Vector of TurnOrdered and generates a TurnVector.
      */
-    public static TurnVectors generateTurnOrder(List<? extends ITurnOrdered> v, Game game) {
+    public static TurnVectors generateTurnOrder(List<? extends ITurnOrdered> v, IGame game) {
         int[] num_even_turns = new int[v.size()];
         int[] num_normal_turns = new int[v.size()];
         int[] num_space_station_turns = new int[v.size()];


### PR DESCRIPTION
Replaces Game with IGame in and around TurnOrdered where possible and moves a method up to IGame. 