### PR TITLE
Fix #5112: Very simple pilot hits editing in configuration dialog

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1500,6 +1500,7 @@ CustomMechDialog.labMountain=Mountain Infantry Training?
 CustomMechDialog.chkMissing=Crewmember absent
 CustomMechDialog.labName=Name:
 CustomMechDialog.labNick=Nickname:
+CustomMechDialog.labHits=Hits:
 CustomMechDialog.labOffBoard=Deploy Offboard?
 CustomMechDialog.labOffBoardDirection=Offboard Direction:
 CustomMechDialog.labOffBoardDistance=Offboard Distance in hexes:

--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -688,6 +688,7 @@ public class CustomMechDialog extends AbstractButtonDialog implements ActionList
             for (int i = 0; i < entities.get(0).getCrew().getSlotCount(); i++) {
                 String name = panCrewMember[i].getPilotName();
                 String nick = panCrewMember[i].getNickname();
+                String hits = panCrewMember[i].getHits();
                 Gender gender = panCrewMember[i].getGender();
                 if (gender == Gender.RANDOMIZE) {
                     gender = entities.get(0).getCrew().getGender(i);
@@ -786,6 +787,7 @@ public class CustomMechDialog extends AbstractButtonDialog implements ActionList
                 entity.getCrew().setToughness(tough, i);
                 entity.getCrew().setName(name, i);
                 entity.getCrew().setNickname(nick, i);
+                entity.getCrew().setHits(Integer.parseInt(hits), i);
                 entity.getCrew().setGender(gender, i);
                 entity.getCrew().setPortrait(panCrewMember[i].getPortrait().clone(), i);
                 if (backup >= 0) {

--- a/megamek/src/megamek/client/ui/swing/CustomPilotView.java
+++ b/megamek/src/megamek/client/ui/swing/CustomPilotView.java
@@ -37,7 +37,7 @@ import java.util.List;
  * Controls for customizing crew in the chat lounge. For most crew types this is part of the pilot tab.
  * For multi-crew cockpits there is a separate tab for each crew member and another that shows common options
  * for the entire crew.
- * 
+ *
  * @author Neoancient
  */
 public class CustomPilotView extends JPanel {
@@ -49,6 +49,7 @@ public class CustomPilotView extends JPanel {
     private final JCheckBox chkMissing = new JCheckBox(Messages.getString("CustomMechDialog.chkMissing"));
     private final JTextField fldName = new JTextField(20);
     private final JTextField fldNick = new JTextField(20);
+    private final JTextField fldHits = new JTextField(5);
     private final JTextField fldGunnery = new JTextField(3);
     private final JTextField fldGunneryL = new JTextField(3);
     private final JTextField fldGunneryM = new JTextField(3);
@@ -61,9 +62,9 @@ public class CustomPilotView extends JPanel {
     private final JTextField fldPilotingAero = new JTextField(3);
     private final JTextField fldArtillery = new JTextField(3);
     private final JTextField fldTough = new JTextField(3);
-    
+
     private final JComboBox<String> cbBackup = new JComboBox<>();
-    
+
     private final List<Entity> entityUnitNum = new ArrayList<>();
     private final JComboBox<String> choUnitNum = new JComboBox<>();
 
@@ -73,7 +74,7 @@ public class CustomPilotView extends JPanel {
         this.entity = entity;
         setLayout(new GridBagLayout());
         JLabel label;
-        
+
         if (entity.getCrew().getSlotCount() > 1) {
             chkMissing.setActionCommand("missing");
             chkMissing.addActionListener(parent);
@@ -81,7 +82,7 @@ public class CustomPilotView extends JPanel {
             chkMissing.setSelected(entity.getCrew().isMissing(slot));
             add(chkMissing, GBC.eop());
         }
-        
+
         JButton portraitButton = new JButton();
         portraitButton.setPreferredSize(new Dimension(72, 72));
         portraitButton.setName("portrait");
@@ -129,8 +130,13 @@ public class CustomPilotView extends JPanel {
 
         label = new JLabel(Messages.getString("CustomMechDialog.labNick"), SwingConstants.RIGHT);
         add(label, GBC.std());
-        add(fldNick, GBC.eop());
+        add(fldNick, GBC.eol());
         fldNick.setText(entity.getCrew().getNickname(slot));
+
+        label = new JLabel(Messages.getString("CustomMechDialog.labHits"), SwingConstants.RIGHT);
+        add(label, GBC.std());
+        add(fldHits, GBC.eop());
+        fldHits.setText(String.valueOf(entity.getCrew().getHits()));
 
         if (parent.getClientGUI().getClient().getGame().getOptions().booleanOption(OptionsConstants.RPG_RPG_GUNNERY)) {
             label = new JLabel(Messages.getString("CustomMechDialog.labGunneryL"), SwingConstants.RIGHT);
@@ -144,7 +150,7 @@ public class CustomPilotView extends JPanel {
             label = new JLabel(Messages.getString("CustomMechDialog.labGunneryB"), SwingConstants.RIGHT);
             add(label, GBC.std());
             add(fldGunneryB, GBC.eol());
-            
+
             if (entity.getCrew() instanceof LAMPilot) {
                 label = new JLabel(Messages.getString("CustomMechDialog.labGunneryAeroL"), SwingConstants.RIGHT);
                 add(label, GBC.std());
@@ -225,7 +231,7 @@ public class CustomPilotView extends JPanel {
             add(fldTough, GBC.eop());
         }
         fldTough.setText(Integer.toString(entity.getCrew().getToughness(slot)));
-        
+
         if (entity.getCrew().getSlotCount() > 2) {
             for (int i = 0; i < entity.getCrew().getSlotCount(); i++) {
                 if (i != slot) {
@@ -283,6 +289,7 @@ public class CustomPilotView extends JPanel {
         if (!editable) {
             fldName.setEnabled(false);
             fldNick.setEnabled(false);
+            fldHits.setEnabled(false);
             fldGunnery.setEnabled(false);
             fldGunneryL.setEnabled(false);
             fldGunneryM.setEnabled(false);
@@ -299,7 +306,7 @@ public class CustomPilotView extends JPanel {
 
         missingToggled();
     }
-    
+
     /**
      * Populate the list of entities in other units from the given enumeration.
      *
@@ -330,63 +337,80 @@ public class CustomPilotView extends JPanel {
         }
         choUnitNum.setSelectedIndex(0);
     }
-    
+
     public boolean getMissing() {
         return chkMissing.isSelected();
     }
-    
+
     public String getPilotName() {
         return fldName.getText();
     }
-    
+
     public String getNickname() {
         return fldNick.getText();
+    }
+
+    public String getHits() {
+        int hits;
+        try {
+            hits = Integer.parseInt(fldHits.getText());
+            if (hits < 0) {
+                hits = 0;
+            } else if (hits > 5) {
+                hits = 6;
+            }
+        } catch (NumberFormatException e) {
+            hits = 0;
+        }
+        // Update field then return
+        fldHits.setText(String.valueOf(hits));
+        return fldHits.getText();
     }
 
     public Gender getGender() {
         return gender;
     }
-    
+
     public int getGunnery() {
         return Integer.parseInt(fldGunnery.getText());
     }
-    
+
     public int getGunneryL() {
         return Integer.parseInt(fldGunneryL.getText());
     }
-    
+
     public int getGunneryM() {
         return Integer.parseInt(fldGunneryM.getText());
     }
-    
+
     public int getGunneryB() {
         return Integer.parseInt(fldGunneryB.getText());
     }
-    
+
     public int getGunneryAero() {
         return Integer.parseInt(fldGunneryAero.getText());
     }
-    
+
     public int getGunneryAeroL() {
         return Integer.parseInt(fldGunneryAeroL.getText());
     }
-    
+
     public int getGunneryAeroM() {
         return Integer.parseInt(fldGunneryAeroM.getText());
     }
-    
+
     public int getGunneryAeroB() {
         return Integer.parseInt(fldGunneryAeroB.getText());
     }
-    
+
     public int getArtillery() {
         return Integer.parseInt(fldArtillery.getText());
     }
-    
+
     public int getPiloting() {
         return Integer.parseInt(fldPiloting.getText());
     }
-    
+
     public int getPilotingAero() {
         return Integer.parseInt(fldPilotingAero.getText());
     }


### PR DESCRIPTION
This just adds editing of the existing crew/pilot "hits" field already stored in entities and in MUL files.

Testing:
- Ran existing unit tests
- Added one of every valid unit type; editing hits on the pilot worked (unsure if this is correct for Battle Armor?)
- Manually verified handling of out-of-range text in the new field (-1, -999, 3.5, 1000000, "Dead"); only 0-6 allowed currently.
- Verified that MUL files save and load the edited Hits count.
- Verified that subsequently loading units into a game applies their Hits count, including killing units starting with 6 hits.

<img width="387" alt="image" src="https://github.com/MegaMek/megamek/assets/22018319/21bb7dbb-1f6d-42a6-a65b-27999cd17230">

The above unit was loaded from a MUL, edited, saved to a different MUL, loaded again, deployed, and shows the edited Hits value.

<img width="673" alt="image" src="https://github.com/MegaMek/megamek/assets/22018319/b09209d9-f236-48b0-9dd2-7db091025b93">

Configuration dialog editing in action...

Close #5112 