### PR TITLE
Fix MML #1429: MegaMek side of fix for MML NPE in Aero Equipment tab

### DIFF
--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -608,28 +608,33 @@ public class WeaponType extends EquipmentType {
     }
 
     public int getMaxRange(Mounted weapon) {
+        if (weapon == null) {
+            return getMaxRange();
+        }
         return getMaxRange(weapon, weapon.getLinked());
     }
 
+    public int getMaxRange() {
+        return maxRange;
+    }
+
     public int getMaxRange(Mounted weapon, Mounted ammo) {
-        if (null != weapon) {
-            if (getAmmoType() == AmmoType.T_ATM) {
-                AmmoType ammoType = (AmmoType) ammo.getType();
-                if ((ammoType.getAmmoType() == AmmoType.T_ATM)
-                        && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
-                    return RANGE_EXT;
-                } else if ((ammoType.getAmmoType() == AmmoType.T_ATM)
-                        && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE))) {
-                    return RANGE_SHORT;
-                }
+        if (getAmmoType() == AmmoType.T_ATM) {
+            AmmoType ammoType = (AmmoType) ammo.getType();
+            if ((ammoType.getAmmoType() == AmmoType.T_ATM)
+                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
+                return RANGE_EXT;
+            } else if ((ammoType.getAmmoType() == AmmoType.T_ATM)
+                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE))) {
+                return RANGE_SHORT;
             }
-            if (getAmmoType() == AmmoType.T_MML) {
-                AmmoType ammoType = (AmmoType) ammo.getType();
-                if (ammoType.hasFlag(AmmoType.F_MML_LRM) || (getAmmoType() == AmmoType.T_LRM_TORPEDO)) {
-                    return RANGE_LONG;
-                } else {
-                    return RANGE_SHORT;
-                }
+        }
+        if (getAmmoType() == AmmoType.T_MML) {
+            AmmoType ammoType = (AmmoType) ammo.getType();
+            if (ammoType.hasFlag(AmmoType.F_MML_LRM) || (getAmmoType() == AmmoType.T_LRM_TORPEDO)) {
+                return RANGE_LONG;
+            } else {
+                return RANGE_SHORT;
             }
         }
         return maxRange;


### PR DESCRIPTION
This is the MM fix for MegaMek/megameklab#1429; what I thought was a guard check against weapon being `null` was actually a form of overloading that's used exclusively by the megameklab UI to select AV range bands when displaying equipment.

I've created a bare getter that returns the value that UI builder needs, and added a check to call it if the weapon passed to `wtype.getRanges()` is null.

Testing:
- Re-ran existing MM unit tests.
- Tested all Aerospace subclasses in MML

I'd like to add a unit test to MegaMekLab to make sure that this doesn't regress but I need some help on that, so for now this should be sufficient.

Close MegaMek/megameklab#1429