### PR TITLE
Per Issue #5168, implementing lower Arty IDF to-hit for range 17 and under

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4986,7 +4986,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
     private static ToHitData artilleryIndirectToHit(Entity ae, Targetable target,
                   ToHitData toHit, WeaponType wtype, Mounted weapon, SpecialResolutionTracker srt) {
 
-        int mod = 7;
+        // See MegaMek/megamek#5168
+        int mod = (ae.getPosition().distance(target.getPosition()) <= 17) ? 4 : 7;
         if (ae.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ATTACKER)) {
             mod--;
         }


### PR DESCRIPTION
Examining the posts and rules referenced in #5168, it does look like we need two Indirect Artillery Fire mods:
1. Indirect Artillery Fire at ranges <= 17: +4
2. Indirect Artillery Fire at ranges >= 18: +7
(Note: there is no minimum range for _indirect_ artillery fire, only for direct artillery fire)

Testing: 
- Re-ran _all_ projects' unit tests.
- Tested with tube and missile artillery units at 18+ and 1-17

Close #5168