### PR TITLE
SV armor weight and space calculations

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10866,7 +10866,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         } else {
             ArmorType armor = ArmorType.forEntity(this);
             if (armor.hasFlag(MiscType.F_SUPPORT_VEE_BAR_ARMOR)) {
-                double total = armor.getSVWeightPerPoint(getArmorTechRating());
+                double total = getTotalOArmor() * armor.getSVWeightPerPoint(getArmorTechRating());
                 return RoundWeight.standard(total, this);
             } else {
                 double armorPerTon = ArmorType.forEntity(this).getPointsPerTon(this);

--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -66,7 +66,7 @@ public class ArmorType extends MiscType {
     }
 
     public static Map<Integer, String> getAllArmorCodeName() {
-        Map<Integer, String> result = new HashMap();
+        Map<Integer, String> result = new HashMap<>();
 
         for (ArmorType armorType : allTypes) {
             result.put(armorType.getArmorType(), getArmorTypeName(armorType.getArmorType()));
@@ -191,6 +191,9 @@ public class ArmorType extends MiscType {
         omniFixedOnly = true;
         spreadable = true;
         bv = 0;
+        criticals = 0;
+        tankslots = 0;
+        svslots = 0;
     }
 
     /**


### PR DESCRIPTION
Fixes two issues with SV armor:
1. I left out the multiplier that accounts for the number of points when calculating the armor weight, resulting in the weight always being calculated for a single point.
2. The svslots field in EquipmentType is initialized to -1, which is supposed to indicate that it uses the mech slots value. ArmorType sets all the values explicitly when they are not zero, so I added initialization to zero in the constructor.

Fixes MegaMek/megameklab#1430.