### PR TITLE
Fix for 5189: now that the WAA tracks an ammoId, it needs updated when forced to reload

### DIFF
--- a/megamek/src/megamek/common/weapons/AmmoWeapon.java
+++ b/megamek/src/megamek/common/weapons/AmmoWeapon.java
@@ -1,14 +1,14 @@
 /*
  * MegaMek - Copyright (C) 2004, 2005 Ben Mazur (bmazur@sev.org)
  *
- * This program is free software; you can redistribute it and/or modify it 
- * under the terms of the GNU General Public License as published by the Free 
- * Software Foundation; either version 2 of the License, or (at your option) 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
  * any later version.
  *
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
 package megamek.common.weapons;
@@ -34,7 +34,7 @@ public abstract class AmmoWeapon extends Weapon {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.Weapon#fire(megamek.common.actions.WeaponAttackAction
      * , megamek.common.Game)
@@ -55,12 +55,14 @@ public abstract class AmmoWeapon extends Weapon {
         if (ammo == null || ammo.getUsableShotsLeft() < 1) {
             ae.loadWeaponWithSameAmmo(weapon);
             ammo = weapon.getLinked();
+            // We need to make the WAA ammoId match the new ammo bin
+            waa.setAmmoId(ae.getEquipmentNum(ammo));
         }
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
      * megamek.common.actions.WeaponAttackAction, megamek.common.Game)


### PR DESCRIPTION
Root cause was the addition of an ammoId field in the WAA (used for Princess' ammo selection calculations and notification of ammo changes by Princess), combined with the situation where a prior WAA used the last shot in a bin linked to two or more ammo-based weapons.

Fix is to update the ammoId in the WAA whenever a bin is swapped _during attack processing_ due to ammo exhaustion.  If the weapon is truly dry, the ammoId lookup will return -1, and the correct toHit "impossible" reason will be returned.

Testing:
- Ran all unit tests across all 3 projects.
- Tested ammo bin switching for both Princess and human player.

Close #5189 