### PR TITLE
Fix 5193: Weapon Bays only work at Short Range

### DIFF
--- a/megamek/src/megamek/common/weapons/bayweapons/BayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/BayWeapon.java
@@ -13,13 +13,7 @@
  */
 package megamek.common.weapons.bayweapons;
 
-import megamek.common.Entity;
-import megamek.common.Game;
-import megamek.common.Mounted;
-import megamek.common.SimpleTechLevel;
-import megamek.common.TechAdvancement;
-import megamek.common.ToHitData;
-import megamek.common.WeaponType;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.weapons.AttackHandler;
 import megamek.common.weapons.BayWeaponHandler;
@@ -56,7 +50,7 @@ public abstract class BayWeapon extends Weapon {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
      * megamek.common.actions.WeaponAttackAction, megamek.common.Game)
@@ -66,9 +60,14 @@ public abstract class BayWeapon extends Weapon {
             WeaponAttackAction waa, Game game, GameManager manager) {
         return new BayWeaponHandler(toHit, waa, game, manager);
     }
-    
+
     @Override
     public int getMaxRange(Mounted weapon) {
+        return this.getMaxRange(weapon, null);
+    }
+
+    @Override
+    public int getMaxRange(Mounted weapon, Mounted ammo) {
         int mrange = RANGE_SHORT;
         Entity ae = weapon.getEntity();
         if (null != ae) {

--- a/megamek/src/megamek/common/weapons/bayweapons/BayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/BayWeapon.java
@@ -63,7 +63,7 @@ public abstract class BayWeapon extends Weapon {
 
     @Override
     public int getMaxRange(Mounted weapon) {
-        return this.getMaxRange(weapon, null);
+        return getMaxRange(weapon, null);
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
@@ -122,6 +122,11 @@ public abstract class InfantryWeapon extends Weapon {
 
     @Override
     public int getMaxRange(Mounted weapon) {
+        return this.getMaxRange(weapon, null);
+    }
+
+    @Override
+    public int getMaxRange(Mounted weapon, Mounted ammo) {
         for (int range = RangeType.RANGE_EXTREME; range >= RangeType.RANGE_SHORT; range--) {
             if (infantryRange * 3 > AIRBORNE_WEAPON_RANGES[range - 1]) {
                 return range;

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
@@ -122,7 +122,7 @@ public abstract class InfantryWeapon extends Weapon {
 
     @Override
     public int getMaxRange(Mounted weapon) {
-        return this.getMaxRange(weapon, null);
+        return getMaxRange(weapon, null);
     }
 
     @Override

--- a/megamek/unittests/megamek/common/WeaponTypeTest.java
+++ b/megamek/unittests/megamek/common/WeaponTypeTest.java
@@ -18,13 +18,31 @@
  */
 package megamek.common;
 
+import megamek.common.weapons.Weapon;
+import megamek.common.weapons.bayweapons.BayWeapon;
+import megamek.common.weapons.bayweapons.PPCBayWeapon;
+import megamek.common.weapons.ppc.ISERPPC;
+import megamek.common.weapons.ppc.PPCWeapon;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Enumeration;
+import java.util.Vector;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class WeaponTypeTest {
+
+    private Entity mockEntity = mock(Entity.class);
+
+    @BeforeAll
+    static void before(){
+        EquipmentType.initializeTypes();
+    }
+
     @Test
     public void testArtemisCompatibleFlag() {
         for (Enumeration<EquipmentType> e = EquipmentType.getAllTypes(); e.hasMoreElements(); ) {
@@ -44,5 +62,38 @@ public class WeaponTypeTest {
                         || (atype == AmmoType.T_LRM_TORPEDO_COMBO));
             }
         }
+    }
+
+    private Mounted setupBayWeapon(String name){
+        EquipmentType etype = EquipmentType.get(name);
+        Mounted weapon = new Mounted(mockEntity, etype);
+        Mounted bWeapon = new Mounted(mockEntity, ((WeaponType) weapon.getType()).getBayType());
+        bWeapon.addWeaponToBay(mockEntity.getEquipmentNum(weapon));
+        when(mockEntity.getEquipment(anyInt())).thenReturn(weapon);
+
+        return bWeapon;
+    }
+
+    @Test
+    public void testWeaponBaysGetCorrectMaxRanges() {
+        Mounted ppcbay = setupBayWeapon("ISERPPC");
+        WeaponType wtype = (WeaponType) ppcbay.getType();
+        assertEquals(RangeType.RANGE_LONG, wtype.getMaxRange(ppcbay));
+
+        Mounted erplasbay = setupBayWeapon("CLERLargePulseLaser");
+        wtype = (WeaponType) erplasbay.getType();
+        assertEquals(RangeType.RANGE_LONG, wtype.getMaxRange(erplasbay ));
+
+        Mounted islplasbay = setupBayWeapon("ISLargePulseLaser");
+        wtype = (WeaponType) islplasbay.getType();
+        assertEquals(RangeType.RANGE_MEDIUM, wtype.getMaxRange(islplasbay));
+
+        Mounted ersmlasbay = setupBayWeapon("CLERSmallLaser");
+        wtype = (WeaponType) ersmlasbay.getType();
+        assertEquals(RangeType.RANGE_SHORT, wtype.getMaxRange(ersmlasbay));
+
+        Mounted islgaussbay = setupBayWeapon("ISLightGaussRifle");
+        wtype = (WeaponType) islgaussbay .getType();
+        assertEquals(RangeType.RANGE_EXTREME, wtype.getMaxRange(islgaussbay ));
     }
 }


### PR DESCRIPTION
This was more fallout from changing the getMaxRange() function signature: BayWeapon and InfantryWeapon both were overriding the single-argument version, so switching to the two-argument version caused the base WeaponType function to be called instead.

Testing:
- Added a new unit test to confirm override is working correctly.
- Re-ran all unit tests (some MekHQ tests still failing, unrelated).
- Tested using @pheonixstorm 's save and confirmed correct ranges on various weapon bays.

Close #5193 