### PR TITLE
Fix SH and Tripod crew total calculation (for MHQ Hangar model)

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7296,6 +7296,10 @@ public class Compute {
                 crew += 5 * (int) m.getSize();
             }
         }
+        if (entity.isSuperHeavy()) {
+            // Tactical Officer
+            return 1;
+        }
         return crew;
     }
 
@@ -7336,6 +7340,8 @@ public class Compute {
             return ((Infantry) entity).getSquadCount() * ((Infantry) entity).getSquadSize();
         } else if (entity instanceof Jumpship || entity instanceof SmallCraft) {
             return getAeroCrewNeeds(entity) + getTotalGunnerNeeds(entity);
+        } else if (entity.isSuperHeavy() || entity.isTripodMek()) {
+            return getTotalDriverNeeds(entity) + getTotalGunnerNeeds(entity) + getAdditionalNonGunner(entity);
         } else {
             return 1;
         }


### PR DESCRIPTION
Ensures that the total number of crew required by Tripod and SuperHeavy meks is calculated correctly.
Part of MegaMek/MekHQ#3775

Testing:
- Ran unit tests for all 3 projects (several still failing for MekHQ, unrelated)
- Confirmed MekHQ total unit counts for relevant mek types now correct.