### PR TITLE
Use full chassis in the OfficialUnitList.txt

### DIFF
--- a/megamek/src/megamek/common/commandline/MegaMekCommandLineParser.java
+++ b/megamek/src/megamek/common/commandline/MegaMekCommandLineParser.java
@@ -452,7 +452,7 @@ public class MegaMekCommandLineParser extends AbstractCommandLineParser {
                         bw.write(",");
                         bw.write(Integer.toString(unit.getJumpMp()));
                     } else {
-                        bw.write(unit.getChassis()
+                        bw.write(unit.getFullChassis()
                                 + (unit.getModel().isBlank() ? "|" : " " + unit.getModel() + "|"));
                     }
                     bw.newLine();


### PR DESCRIPTION
Writes the full chassis to the OfficialUnitList.txt to fix the check for canon units which compares based on entity.getShortNameRaw() which includes the full chassis, e.g. Mad Cat (Timber Wolf)

Fixes #5191 