### PR TITLE
Close loopholes that allow off-board arty to attempt Flak attacks at …

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7412,7 +7412,10 @@ public class Compute {
     }
 
     public static boolean isFlakAttack(Entity attacker, Entity target) {
-        boolean validLocation = !(attacker.isSpaceborne() || target.isSpaceborne());
+        boolean validLocation = !(attacker.isSpaceborne()
+                || target.isSpaceborne()
+                || attacker.isOffBoard()
+                || target.isOffBoard());
         return validLocation && (target.isAirborne() || target.isAirborneVTOLorWIGE());
     }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1761,10 +1761,15 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
             // Arty shots have to be with arty, non arty shots with non arty.
             if (wtype.hasFlag(WeaponType.F_ARTILLERY)) {
+
+                // Don't allow Artillery Flak attacks by off-board artillery.
+                if (te != null && te.isAirborne() && ae.isOffBoard()) {
+                    return Messages.getString("WeaponAttackAction.ArtyAttacksOnly");
+                }
+
                 // check artillery is targeted appropriately for its ammo
                 // Artillery only targets hexes unless making a direct fire flak shot or using
                 // homing ammo.
-
                 if ((ttype != Targetable.TYPE_HEX_ARTILLERY) && (ttype != Targetable.TYPE_MINEFIELD_CLEAR)
                         && !(isArtilleryFLAK || (atype != null && atype.countsAsFlak())) && !isHoming && !target.isOffBoard()) {
                     return Messages.getString("WeaponAttackAction.ArtyAttacksOnly");
@@ -1829,6 +1834,9 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
             // Direct-fire artillery attacks.
             if (isArtilleryDirect) {
+                if (ae.isOffBoard()) {
+                    return Messages.getString("WeaponAttackAction.ArtyAttacksOnly");
+                }
                 // Cruise missiles cannot make direct-fire attacks
                 if (isCruiseMissile) {
                     return Messages.getString("WeaponAttackAction.NoDirectCruiseMissile");

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -185,8 +185,18 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                 gameManager.deliverArtillerySmoke(targetPos, vPhaseReport);
                 return false;
             } else if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_FAE)) {
-                AreaEffectHelper.processFuelAirDamage(targetPos,
-                        ammoType, ae, vPhaseReport, gameManager);
+                // Currently Artillery Cannons _can_ make Flak attacks using FAE munitions
+                // If this is an ASF Flak attack we know we hit an entity by itself in the air,
+                // so just hit it for full damage.
+                if (asfFlak) {
+                    AreaEffectHelper.artilleryDamageEntity((Entity) target, ammoType.getRackSize(), null,
+                            0, false, asfFlak, isFlak, target.getElevation(),
+                            targetPos, atype, targetPos, false, ae, null, target.getElevation(),
+                            vPhaseReport, gameManager);
+                } else {
+                    AreaEffectHelper.processFuelAirDamage(targetPos,
+                            ammoType, ae, vPhaseReport, gameManager);
+                }
 
                 return false;
             }


### PR DESCRIPTION
…on-board Aeros.

Noticed this while testing another fix with a pair of large combined-arms forces run by Princess: off-board artillery units firing munitions that get the Flak bonus were targeting Aerospace units during the Indirect phase.

This is wrong for two reasons (see TacOps: AR):

1. Flak attacks are direct fire, not indirect.
2. An artillery unit has to be on the same map or board as the target Aerospace unit to use direct Flak attacks.

This closes two avenues for targeting Aerospace with Indirect attacks from off-board (but does not deter indirect attacks at, say, airborne VTOLs).

Testing:
- Ran all 3 projects' unit tests.
- Tested with manual and bot-controlled off-board artillery units targeting on-board ASFs, Dropships, and VTOLs.