### PR TITLE
Java LookAndFeels restriction and default

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -1785,7 +1785,9 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
             uiThemes.removeAllItems();
             for (LookAndFeelInfo lafInfo : UIManager.getInstalledLookAndFeels()) {
-                uiThemes.addItem(new UITheme(lafInfo.getClassName(), lafInfo.getName()));
+                if (GUIPreferences.isSupportedLookAndFeel(lafInfo)) {
+                    uiThemes.addItem(new UITheme(lafInfo.getClassName(), lafInfo.getName()));
+                }
             }
             uiThemes.setSelectedItem(new UITheme(GUIP.getUITheme()));
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -740,7 +740,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(SKIN_FILE, "BW - Default.xml");
         store.setDefault(SOFTCENTER, false);
         store.setDefault(AUTOCENTER, true);
-        store.setDefault(UI_THEME, UIManager.getSystemLookAndFeelClassName());
+        store.setDefault(UI_THEME, "com.formdev.flatlaf.FlatDarculaLaf");
 
         store.setDefault(RAT_TECH_LEVEL, 0);
         store.setDefault(RAT_BV_MIN, "5800");
@@ -3224,4 +3224,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return Color.BLUE;
     }
     //endregion Colours
+
+    /** @return True when the MM suite supports the given laf, currently all formdev "Flat ..." and the system default. */
+    public static boolean isSupportedLookAndFeel(UIManager.LookAndFeelInfo lookAndFeelInfo) {
+        return lookAndFeelInfo.getClassName().toLowerCase().contains("formdev")
+                || UIManager.getSystemLookAndFeelClassName().equals(lookAndFeelInfo.getClassName());
+    }
 }


### PR DESCRIPTION
This aims to reduce UI problems, UI design effort and make the MM suite look a little more modern by default.
Judging from Hammer's recent poll about look and feels and an earlier poll about light and dark modes, this PR restricts the choosable look and feels to FlatLafs (all 4, light and dark) as well as the system default, and sets the default to Flat Darcula as the most used one (practically evenly matched with Flat Dark)