### PR TITLE
EntityImage: Handle unknown elevation exceptions

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
@@ -197,13 +197,7 @@ public class EntityImage {
         decal = getDamageDecal(entity, secondaryPos);
         smoke = getSmokeImage(entity, secondaryPos);
         unitHeight = entity.height();
-        int elevation = 0;
-        try {
-            elevation = entity.getElevation();
-        } catch (Exception ignored) {
-            // do nothing; use 0 as elevation
-        }
-        unitElevation = elevation;
+        unitElevation = entity.getElevation();
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
@@ -197,7 +197,13 @@ public class EntityImage {
         decal = getDamageDecal(entity, secondaryPos);
         smoke = getSmokeImage(entity, secondaryPos);
         unitHeight = entity.height();
-        unitElevation = entity.getElevation();
+        int elevation = 0;
+        try {
+            elevation = entity.getElevation();
+        } catch (Exception ignored) {
+            // do nothing; use 0 as elevation
+        }
+        unitElevation = elevation;
     }
 
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2141,11 +2141,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             return game.getEntity(getTransportId()).getElevation();
         }
 
-        if ((null == getPosition()) && (isDeployed())) {
-            throw new IllegalStateException("Entity #" + getId()
-                                            + " does not know its position.");
-        }
-
         if (isOffBoard()) {
             return 0;
         }


### PR DESCRIPTION
Entity.getElevation throws an exception when the unit has no elevation (e.g. offboard).
Fixes #5214 