### PR TITLE
log cleanup

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
@@ -1004,7 +1004,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
     static class CBRenderer<T> extends DefaultListCellRenderer {
         private static final long serialVersionUID = 4895258839502183158L;
 
-        private String nullVal = Messages.getString("ForceGeneratorDialog.default");
+        private String nullVal;
         private Function<T,String> toString;
 
         public CBRenderer(String nullVal) {

--- a/megamek/src/megamek/common/net/connections/SendQueue.java
+++ b/megamek/src/megamek/common/net/connections/SendQueue.java
@@ -56,9 +56,11 @@ class SendQueue {
     }
 
     public void reportContents() {
-        final String sb = queue.stream()
-                .map(p -> '\n' + p.getCommand().toString()).collect(
-                        Collectors.joining("", "Contents of Send Queue:\n", ""));
-        LogManager.getLogger().warn(sb);
+        if (!queue.isEmpty()) {
+            final String sb = queue.stream()
+                    .map(p -> '\n' + p.getCommand().toString()).collect(
+                            Collectors.joining("", "Contents of Send Queue:\n", ""));
+            LogManager.getLogger().warn(sb);
+        }
     }
 }


### PR DESCRIPTION
Removes an error message from the log (missing i18n; but the message assignment is redundant anyway) as well as send queue dumps when the queue is empty