### PR TITLE
Fix for infantry skipping non-ammo-fed infantry weapons during attack phase

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1202,7 +1202,7 @@ public class FireControl {
                 String shootingCheck;
 
                 // Energy / ammo-independent weapons
-                if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
+                if (effectivelyAmmoless(wtype)) {
                     shootingCheck = checkGuess(shooter, enemy, weapon, null, game);
                     if (null != shootingCheck) {
                         ret.append(shootingCheck);
@@ -1653,7 +1653,7 @@ public class FireControl {
             WeaponFireInfo bestShoot = null;
 
             // Energy / ammo-independent weapons
-            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
+            if (effectivelyAmmoless(wtype)) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, true);
             } else {
                 // For certain weapon types, look over all their loaded ammos
@@ -1802,7 +1802,7 @@ public class FireControl {
             WeaponFireInfo bestShoot = null;
 
             // Energy / ammo-independent weapons
-            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
+            if (effectivelyAmmoless(wtype)) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
                 // For certain weapon types, look over all their loaded ammos
@@ -1977,7 +1977,7 @@ public class FireControl {
             WeaponFireInfo bestShoot = null;
 
             // Energy / ammo-independent weapons
-            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
+            if (effectivelyAmmoless(wtype)) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
                 // Check _all_ ammunition for _all_ weapons here.
@@ -2637,7 +2637,7 @@ public class FireControl {
             int bestBracket = RangeType.RANGE_OUT;
 
             // For energy weapons / ammo-independent weapons
-            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(weaponType.getAmmoType())) {
+            if (effectivelyAmmoless(weaponType)) {
                 bestBracket = RangeType.rangeBracket(range,
                         weaponType.getRanges(weapon),
                         useExtremeRange,
@@ -2722,7 +2722,7 @@ public class FireControl {
             final WeaponType weaponType = (WeaponType) currentWeapon.getType();
 
             // Skip weapons that don't use ammo.
-            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(weaponType.getAmmoType())) {
+            if (effectivelyAmmoless(weaponType)) {
                 continue;
             }
 
@@ -3604,5 +3604,18 @@ public class FireControl {
         }
 
         return -1;
+    }
+
+    /**
+     *
+     * @param wtype that uses ammo that is not tracked, or not actually ammo
+     * @return true if wtype doesn't actually track ammo
+     */
+    private static boolean effectivelyAmmoless(WeaponType wtype) {
+        List<Integer> atypes = Arrays.asList(
+                AmmoType.T_NA,
+                AmmoType.T_INFANTRY
+        );
+        return atypes.contains(wtype.getAmmoType());
     }
 }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1202,7 +1202,7 @@ public class FireControl {
                 String shootingCheck;
 
                 // Energy / ammo-independent weapons
-                if (AmmoType.T_NA == wtype.getAmmoType()) {
+                if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
                     shootingCheck = checkGuess(shooter, enemy, weapon, null, game);
                     if (null != shootingCheck) {
                         ret.append(shootingCheck);
@@ -1653,7 +1653,7 @@ public class FireControl {
             WeaponFireInfo bestShoot = null;
 
             // Energy / ammo-independent weapons
-            if (AmmoType.T_NA == wtype.getAmmoType()) {
+            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, true);
             } else {
                 // For certain weapon types, look over all their loaded ammos
@@ -1802,7 +1802,7 @@ public class FireControl {
             WeaponFireInfo bestShoot = null;
 
             // Energy / ammo-independent weapons
-            if (AmmoType.T_NA == wtype.getAmmoType()) {
+            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
                 // For certain weapon types, look over all their loaded ammos
@@ -1977,7 +1977,7 @@ public class FireControl {
             WeaponFireInfo bestShoot = null;
 
             // Energy / ammo-independent weapons
-            if (AmmoType.T_NA == wtype.getAmmoType()) {
+            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(wtype.getAmmoType())) {
                 bestShoot = buildWeaponFireInfo(shooter, target, weapon, null, game, false);
             } else {
                 // Check _all_ ammunition for _all_ weapons here.
@@ -2637,7 +2637,7 @@ public class FireControl {
             int bestBracket = RangeType.RANGE_OUT;
 
             // For energy weapons / ammo-independent weapons
-            if (AmmoType.T_NA == weaponType.getAmmoType()) {
+            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(weaponType.getAmmoType())) {
                 bestBracket = RangeType.rangeBracket(range,
                         weaponType.getRanges(weapon),
                         useExtremeRange,
@@ -2722,7 +2722,7 @@ public class FireControl {
             final WeaponType weaponType = (WeaponType) currentWeapon.getType();
 
             // Skip weapons that don't use ammo.
-            if (AmmoType.T_NA == weaponType.getAmmoType()) {
+            if (Arrays.asList(AmmoType.T_NA, AmmoType.T_INFANTRY).contains(weaponType.getAmmoType())) {
                 continue;
             }
 


### PR DESCRIPTION
This was caused by the assumption that Infantry weapons would use AmmoType `T_NA`, like energy weapons.
Instead they use `T_INFANTRY`, because of course.

Fix is to check for both types when skipping ammo selection in the attack planning portion of the Attack phase.  The guess code, used during movement planning, appears to be working correctly.

Testing:
- Ran all three projects' unit tests.
- Let Princess annihilate some 'mechs with beast-mounted infantry.

Close #5224 