### PR TITLE
Fix parsing of protomech ammo ammounts

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKProtoFile.java
+++ b/megamek/src/megamek/common/loaders/BLKProtoFile.java
@@ -154,7 +154,7 @@ public class BLKProtoFile extends BLKFile implements IMechLoader {
             }
 
             // ProtoMech Ammo comes in non-standard amounts.
-            int ammoIndex = equipName.indexOf(" (");
+            int ammoIndex = equipName.lastIndexOf(" (");
             int shotsCount = 0;
             if (ammoIndex > 0) {
                 // Try to get the number of shots.


### PR DESCRIPTION
Since protomech ammo is per-shot, the number of shots is in parentheses at the end of the equipment line in the block file. When looking for the line it checks for the first parenthesis rather than the last one, which causes an error with ammo types that include the munition type in parentheses in the name.

Fixes MegaMek/megameklab#1304