### PR TITLE
checks for enemy hidden units

### DIFF
--- a/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
@@ -19,7 +19,12 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.swing.tooltip.EntityActionLog;
+import megamek.common.Entity;
+import megamek.common.EntityVisibilityUtils;
+import megamek.common.Game;
+import megamek.common.Player;
 import megamek.common.actions.*;
+import megamek.common.options.OptionsConstants;
 
 import java.util.*;
 
@@ -85,5 +90,17 @@ public abstract class AttackPhaseDisplay extends ActionPhaseDisplay {
     {
         attacks.add(entityAction);
         updateDonePanel();
+    }
+
+    protected boolean shouldShowTarget(Game game, Player localPlayer, Entity target, Entity ce) {
+        boolean friendlyFire = game.getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE);
+        boolean enemyTarget = target.getOwner().isEnemyOf(ce.getOwner());
+        boolean friendlyFireOrEnemyTarget =  friendlyFire || enemyTarget;
+        boolean NotEnemyTargetOrVisible = !enemyTarget
+                || EntityVisibilityUtils.detectedOrHasVisual(localPlayer, game, target);
+        return (target.getId() != ce.getId())
+                && friendlyFireOrEnemyTarget
+                && NotEnemyTargetOrVisible
+                && target.isTargetable();
     }
 }

--- a/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
@@ -26,10 +26,6 @@ import megamek.common.Player;
 import megamek.common.actions.*;
 import megamek.common.options.OptionsConstants;
 
-import java.util.*;
-
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-
 public abstract class AttackPhaseDisplay extends ActionPhaseDisplay {
     // client list of attacks user has input
     protected EntityActionLog attacks;

--- a/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
@@ -19,12 +19,15 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.swing.tooltip.EntityActionLog;
-import megamek.common.Entity;
-import megamek.common.EntityVisibilityUtils;
-import megamek.common.Game;
-import megamek.common.Player;
+import megamek.common.*;
 import megamek.common.actions.*;
 import megamek.common.options.OptionsConstants;
+import megamek.common.util.FiringSolution;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public abstract class AttackPhaseDisplay extends ActionPhaseDisplay {
     // client list of attacks user has input
@@ -86,6 +89,39 @@ public abstract class AttackPhaseDisplay extends ActionPhaseDisplay {
     {
         attacks.add(entityAction);
         updateDonePanel();
+    }
+
+    public void setFiringSolutions(Entity ce) {
+        // If no Entity is selected, exit
+        if (ce.getId() == Entity.NONE) {
+            return;
+        }
+
+        Game game = clientgui.getClient().getGame();
+        Player localPlayer = clientgui.getClient().getLocalPlayer();
+        if (!GUIP.getFiringSolutions()) {
+            return;
+        }
+
+        // Determine which entities are spotted
+        Set<Integer> spottedEntities = new HashSet<>();
+        for (Entity target : game.getEntitiesVector()) {
+            if (!target.isEnemyOf(ce) && target.isSpotting()) {
+                spottedEntities.add(target.getSpotTargetId());
+            }
+        }
+
+        // Calculate firing solutions
+        Map<Integer, FiringSolution> fs = new HashMap<>();
+        for (Entity target : game.getEntitiesVector()) {
+            if (shouldShowTarget(game, localPlayer, target, ce)) {
+                ToHitData thd = WeaponAttackAction.toHit(game, ce.getId(), target);
+                thd.setLocation(target.getPosition());
+                thd.setRange(ce.getPosition().distance(target.getPosition()));
+                fs.put(target.getId(), new FiringSolution(thd, spottedEntities.contains(target.getId())));
+            }
+        }
+        clientgui.getBoardView().setFiringSolutions(ce, fs);
     }
 
     protected boolean shouldShowTarget(Game game, Player localPlayer, Entity target, Entity ce) {

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -964,7 +964,7 @@ public class ClientGUI extends JPanel implements BoardViewListener,
                     bv.clearFiringSolutionData();
                 } else {
                     if (curPanel instanceof FiringDisplay) {
-                        ((FiringDisplay) curPanel).setFiringSolutions();
+                        ((FiringDisplay) curPanel).setFiringSolutions(((FiringDisplay) curPanel).ce());
                     }
                 }
                 bv.refreshDisplayables();

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -846,43 +846,10 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         }
 
         if (GUIP.getFiringSolutions()) {
-            setFiringSolutions();
+            setFiringSolutions(ce());
         } else {
             clientgui.getBoardView().clearFiringSolutionData();
         }
-    }
-
-    public void setFiringSolutions() {
-        // If no Entity is selected, exit
-        if (cen == Entity.NONE) {
-            return;
-        }
-
-        Game game = clientgui.getClient().getGame();
-        Player localPlayer = clientgui.getClient().getLocalPlayer();
-        if (!GUIP.getFiringSolutions()) {
-            return;
-        }
-
-        // Determine which entities are spotted
-        Set<Integer> spottedEntities = new HashSet<>();
-        for (Entity target : game.getEntitiesVector()) {
-            if (!target.isEnemyOf(ce()) && target.isSpotting()) {
-                spottedEntities.add(target.getSpotTargetId());
-            }
-        }
-
-        // Calculate firing solutions
-        Map<Integer, FiringSolution> fs = new HashMap<>();
-        for (Entity target : game.getEntitiesVector()) {
-            if (shouldShowTarget(game, localPlayer, target, ce())) {
-                ToHitData thd = WeaponAttackAction.toHit(game, cen, target);
-                thd.setLocation(target.getPosition());
-                thd.setRange(ce().getPosition().distance(target.getPosition()));
-                fs.put(target.getId(), new FiringSolution(thd, spottedEntities.contains(target.getId())));
-            }
-        }
-        clientgui.getBoardView().setFiringSolutions(ce(), fs);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -16,8 +16,6 @@ package megamek.client.ui.swing;
 
 import megamek.client.event.BoardViewEvent;
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.tooltip.UnitToolTip;
-import megamek.client.ui.swing.unitDisplay.WeaponPanel;
 import megamek.client.ui.swing.util.CommandAction;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.MegaMekController;
@@ -39,8 +37,6 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import java.awt.event.*;
 import java.util.*;
-
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 
 public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, ListSelectionListener {
     private static final long serialVersionUID = -5586388490027013723L;

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -879,12 +879,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         // Calculate firing solutions
         Map<Integer, FiringSolution> fs = new HashMap<>();
         for (Entity target : game.getEntitiesVector()) {
-            boolean friendlyFire = game.getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE);
-            boolean enemyTarget = target.getOwner().isEnemyOf(ce().getOwner());
-            if ((target.getId() != cen)
-                    && (friendlyFire || enemyTarget)
-                    && (!enemyTarget || EntityVisibilityUtils.detectedOrHasVisual(localPlayer, game, target))
-                    && target.isTargetable()) {
+            if (shouldShowTarget(game, localPlayer, target, ce())) {
                 ToHitData thd = WeaponAttackAction.toHit(game, cen, target);
                 thd.setLocation(target.getPosition());
                 thd.setRange(ce().getPosition().distance(target.getPosition()));

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -17,7 +17,6 @@ import megamek.client.Client;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.FiringDisplay.FiringCommand;
-import megamek.client.ui.swing.unitDisplay.WeaponPanel;
 import megamek.client.ui.swing.util.CommandAction;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.MegaMekController;
@@ -40,9 +39,6 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import java.awt.event.*;
 import java.util.*;
-
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-import static megamek.client.ui.swing.util.UIUtil.uiLightViolet;
 
 /**
  * Targeting Phase Display. Breaks naming convention because TargetingDisplay is too easy to confuse

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -663,8 +663,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements
             boolean enemyTarget = target.getOwner().isEnemyOf(ce().getOwner());
             if ((target.getId() != cen)
                 && (friendlyFire || enemyTarget)
-                && (!enemyTarget || target.hasSeenEntity(localPlayer)
-                    || target.hasDetectedEntity(localPlayer))
+                && (!enemyTarget || EntityVisibilityUtils.detectedOrHasVisual(localPlayer, game, target))
                 && target.isTargetable()) {
                 ToHitData thd = WeaponAttackAction.toHit(game, cen, target);
                 thd.setLocation(target.getPosition());

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -623,46 +623,13 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements
             setFireModeEnabled(true);
 
             if (GUIP.getFiringSolutions() && !ce().isOffBoard()) {
-                setFiringSolutions();
+                setFiringSolutions(ce());
             } else {
                 clientgui.getBoardView().clearFiringSolutionData();
             }
         } else {
             LogManager.getLogger().error("Tried to select non-existent entity: " + en);
         }
-    }
-
-    public void setFiringSolutions() {
-        // If no Entity is selected, exit
-        if (cen == Entity.NONE) {
-            return;
-        }
-
-        Game game = clientgui.getClient().getGame();
-        Player localPlayer = clientgui.getClient().getLocalPlayer();
-        if (!GUIP.getFiringSolutions()) {
-            return;
-        }
-
-        // Determine which entities are spotted
-        Set<Integer> spottedEntities = new HashSet<>();
-        for (Entity target : game.getEntitiesVector()) {
-            if (!target.isEnemyOf(ce()) && target.isSpotting()) {
-                spottedEntities.add(target.getSpotTargetId());
-            }
-        }
-
-        // Calculate firing solutions
-        Map<Integer, FiringSolution> fs = new HashMap<>();
-        for (Entity target : game.getEntitiesVector()) {
-            if (shouldShowTarget(game, localPlayer, target, ce())) {
-                ToHitData thd = WeaponAttackAction.toHit(game, cen, target);
-                thd.setLocation(target.getPosition());
-                thd.setRange(ce().getPosition().distance(target.getPosition()));
-                fs.put(target.getId(), new FiringSolution(thd, spottedEntities.contains(target.getId())));
-            }
-        }
-        clientgui.getBoardView().setFiringSolutions(ce(), fs);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -659,12 +659,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements
         // Calculate firing solutions
         Map<Integer, FiringSolution> fs = new HashMap<>();
         for (Entity target : game.getEntitiesVector()) {
-            boolean friendlyFire = game.getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE);
-            boolean enemyTarget = target.getOwner().isEnemyOf(ce().getOwner());
-            if ((target.getId() != cen)
-                && (friendlyFire || enemyTarget)
-                && (!enemyTarget || EntityVisibilityUtils.detectedOrHasVisual(localPlayer, game, target))
-                && target.isTargetable()) {
+            if (shouldShowTarget(game, localPlayer, target, ce())) {
                 ToHitData thd = WeaponAttackAction.toHit(game, cen, target);
                 thd.setLocation(target.getPosition());
                 thd.setRange(ce().getPosition().distance(target.getPosition()));

--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
@@ -24,7 +24,6 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
-import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.*;
 import megamek.common.force.Force;
 import megamek.common.options.GameOptions;

--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
@@ -56,6 +56,8 @@ class ForceDisplayMekCellFormatter {
         GameOptions options = game.getOptions();
         Player localPlayer = client.getLocalPlayer();
         Player owner = entity.getOwner();
+        boolean showAsUnknown = owner.isEnemyOf(localPlayer)
+                && !EntityVisibilityUtils.detectedOrHasVisual(localPlayer, clientGUI.getClient().getGame(), entity);
 
         if (entity.isSensorReturn(localPlayer)) {
             String value = "<NOBR>&nbsp;&nbsp;";
@@ -82,7 +84,7 @@ class ForceDisplayMekCellFormatter {
             uType = DOT_SPACER + uType + DOT_SPACER;
             value += guiScaledFontHTML() + uType + "</FONT>";;
             return UnitToolTip.wrapWithHTML(value);
-        } else if (!entity.isVisibleToEnemy()) {
+        } else if (showAsUnknown) {
             return "";
         }
 

--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekTreeRenderer.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekTreeRenderer.java
@@ -25,6 +25,7 @@ import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Configuration;
 import megamek.common.Entity;
+import megamek.common.EntityVisibilityUtils;
 import megamek.common.Player;
 import megamek.common.force.Force;
 import megamek.common.icons.Camouflage;
@@ -75,7 +76,7 @@ public class ForceDisplayMekTreeRenderer extends DefaultTreeCellRenderer {
             setText(ForceDisplayMekCellFormatter.formatUnitCompact(entity, clientGUI));
             int size = UIUtil.scaleForGUI(20);
             boolean showAsUnknown = owner.isEnemyOf(localPlayer)
-                    && !entity.isVisibleToEnemy();
+                    && !EntityVisibilityUtils.detectedOrHasVisual(localPlayer, clientGUI.getClient().getGame(), entity);
             if (showAsUnknown) {
                 setIcon(getToolkit().getImage(UNKNOWN_UNIT), size - 5);
             } else {


### PR DESCRIPTION
- during tag phase, hide to-hit / distance sprites for enemy hidden units
- in force display hide unit information for enemy hidden units

fixes #5228
