### PR TITLE
Fix MML 1365: Sponson Turrets not being included in TechLevel calcs

### DIFF
--- a/megamek/src/megamek/common/CompositeTechLevel.java
+++ b/megamek/src/megamek/common/CompositeTechLevel.java
@@ -17,12 +17,12 @@ import java.util.stream.Collectors;
 
 /**
  * Determines tech level dates based on tech progression of components.
- * 
+ *
  * @author Neoancient
  *
  */
 public class CompositeTechLevel implements ITechnology, Serializable {
-    private static final long serialVersionUID = -2591881133085092725L;    
+    private static final long serialVersionUID = -2591881133085092725L;
 
     private final boolean clan;
     private final boolean mixed;
@@ -35,10 +35,10 @@ public class CompositeTechLevel implements ITechnology, Serializable {
     private int techRating;
     private int[] availability;
     private int earliest;
-    
+
     // Provides a set tech level for non-era-based use.
     private SimpleTechLevel staticTechLevel = SimpleTechLevel.INTRO;
-    
+
     /**
      * @param initialTA - the base tech advancement for the composite equipment
      * @param clan - whether the equipment tech base is Clan
@@ -83,14 +83,14 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         staticTechLevel = initialTA.getStaticTechLevel();
     }
-    
+
     /**
-     * @param en 
+     * @param en
      */
     public CompositeTechLevel(Entity en, int techFaction) {
         this(en.getConstructionTechAdvancement(), en.isClan(), en.isMixedTech(), en.getYear(), techFaction);
     }
-    
+
     /**
      * @return - the experimental tech date range, formatted as a string
      */
@@ -107,7 +107,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         return new DateRange(experimental, end).toString();
     }
-    
+
     /**
      * @return - the advanced tech date range, formatted as a string
      */
@@ -122,7 +122,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         return new DateRange(advanced, end).toString();
     }
-    
+
     /**
      * @return - the standard tech date range, formatted as a string
      */
@@ -133,7 +133,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         return new DateRange(standard).toString();
     }
-    
+
     /**
      * @return - the range(s) of dates when the tech is extinct
      */
@@ -144,7 +144,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         return extinct.stream().map(DateRange::toString).collect(Collectors.joining(", "));
     }
-    
+
     /**
      * Adjust the dates for various tech levels to account for the tech advancement of a new component.
      * @param tech - the advancement for the new component
@@ -154,7 +154,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         int prodDate = mixed?tech.getProductionDate() : tech.getProductionDate(clan, techFaction);
         int commonDate = mixed?tech.getCommonDate() : tech.getCommonDate(clan);
         earliest = Math.max(earliest, tech.getIntroductionDate(clan, techFaction));
-        
+
         staticTechLevel = SimpleTechLevel.max(staticTechLevel, tech.getStaticTechLevel());
         //If this record is blank we ignore it
         if (protoDate == DATE_NONE
@@ -184,7 +184,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
                 }
             }
         }
-        
+
         if (protoDate != DATE_NONE) {
             /* If there was no previous prototype stage, part of either the advanced or standard
              * tech ranges may need to be converted to experimental
@@ -192,21 +192,26 @@ public class CompositeTechLevel implements ITechnology, Serializable {
             if (experimental == null) {
                 if (advanced != null && prodDate > advanced) {
                     experimental = advanced;
-                } else if (standard != null && prodDate > standard) {
-                    experimental = standard;
+                } else if (standard != null)  {
                     advanced = null;
+                    if (prodDate > standard) {
+                        experimental = standard;
+                    } else if (protoDate <= standard) {
+                        // Tech never went into production, experimental straight to common
+                        experimental = protoDate;
+                    }
                 }
             } else {
                 experimental = Math.max(experimental, protoDate);
             }
         }
-        
+
         if (prodDate != DATE_NONE) {
             /*If all previous tech had no advanced date but had a common date (either started common or
              * went straight from prototype to common), a chunk of the previous standard range can
              * become advanced.
              */
-            
+
             if (advanced == null) {
                 if (standard != null && commonDate > standard) {
                     advanced = standard;
@@ -220,10 +225,10 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         if (standard != null) {
             standard = Math.max(standard, commonDate);
         }
-        
+
         addExtinctionRange(mixed?tech.getExtinctionDate() : tech.getExtinctionDate(clan, techFaction),
                 mixed?tech.getReintroductionDate() : tech.getReintroductionDate(clan, techFaction));
-        
+
         techRating = Math.max(techRating, tech.getTechRating());
         for (int era = 0; era < ERA_NUM; era++) {
             int av = tech.getBaseAvailability(era);
@@ -233,7 +238,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
                     && (techFaction < F_CLAN)
                     && (techFaction != F_CS)
                     && ITechnology.getTechEra(tech.getIntroductionDate()) == ERA_SW) {
-                av = RATING_X; 
+                av = RATING_X;
             }
             // IS base cannot include Clan tech before 3050; after 3050 av is +1.
             if (!clan && tech.isClan()) {
@@ -246,7 +251,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
             availability[era] = Math.max(availability[era], av);
         }
     }
-    
+
     /**
      * @param year
      * @return - the TechConstants tech level for a particular year
@@ -271,11 +276,11 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         return TechConstants.T_TECH_UNKNOWN;
     }
-    
+
     /**
      * Adds new range to collection of extinction ranges then checks for overlapping ranges
      * and merges them.
-     * 
+     *
      * @param start - first year of new extinction range
      * @param end - reintroduction date of new extinction range, or DATE_NONE if never reintroduced
      */
@@ -306,25 +311,25 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         extinct = merged;
     }
-    
+
     public static class DateRange implements Serializable, Comparable<DateRange> {
         private static final long serialVersionUID = 3144194494591950878L;
-        
+
         Integer start = null;
         Integer end = null;
         boolean startApproximate = false;
         boolean endApproximate = false;
-        
+
         DateRange(int start, int end) {
             this.start = start;
             this.end = end == DATE_NONE? null : end;
         }
-        
+
         DateRange(int start) {
             this.start = start;
             this.end = null;
         }
-        
+
         String formatYear(int year, boolean approximate) {
             if (year == DATE_PS) {
                 return "PS";
@@ -337,7 +342,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
                 return Integer.toString(year);
             }
         }
-        
+
         @Override
         public String toString() {
             if (start == null) {
@@ -359,13 +364,13 @@ public class CompositeTechLevel implements ITechnology, Serializable {
             }
             return sb.toString();
         }
-        
+
         @Override
         public int compareTo(DateRange other) {
             return start.compareTo(other.start);
         }
     }
-    
+
     @Override
     public int getTechBase() {
         return isClan() ? TECH_BASE_CLAN : TECH_BASE_IS;
@@ -385,7 +390,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
     public int getIntroductionDate() {
         return introYear;
     }
-    
+
     public int getEarliestTechDate() {
         return earliest;
     }
@@ -436,7 +441,7 @@ public class CompositeTechLevel implements ITechnology, Serializable {
         }
         return availability[era];
     }
-    
+
     @Override
     public SimpleTechLevel getStaticTechLevel() {
         return staticTechLevel;

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -8617,8 +8617,8 @@ public class MiscType extends EquipmentType {
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setTechRating(RATING_B).setAvailability(RATING_F, RATING_F, RATING_F, RATING_D)
-                .setAdvancement(DATE_PS, DATE_NONE, 3079, DATE_NONE, DATE_NONE)
-                .setApproximate(false, false, true, false, false)
+                .setAdvancement(DATE_PS, 3079, 3080, DATE_NONE, DATE_NONE)
+                .setApproximate(false, true, false, false, false)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
         return misc;
     }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -8617,8 +8617,8 @@ public class MiscType extends EquipmentType {
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TECH_BASE_ALL)
                 .setTechRating(RATING_B).setAvailability(RATING_F, RATING_F, RATING_F, RATING_D)
-                .setAdvancement(DATE_PS, 3079, 3080, DATE_NONE, DATE_NONE)
-                .setApproximate(false, true, false, false, false)
+                .setAdvancement(DATE_PS, DATE_NONE, 3079, DATE_NONE, DATE_NONE)
+                .setApproximate(false, false, true, false, false)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
         return misc;
     }

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -109,6 +109,8 @@ public class Tank extends Entity {
                 ToHitData.SIDE_LEFT, LOC_LEFT,
                 ToHitData.SIDE_RIGHT, LOC_RIGHT,
                 ToHitData.SIDE_REAR, LOC_REAR);
+    protected boolean hasSponsons = false;
+    protected boolean hasPintle = false;
 
     @Override
     public int getUnitType() {
@@ -272,6 +274,9 @@ public class Tank extends Entity {
         super.addSystemTechAdvancement(ctl);
         if (!hasNoDualTurret()) {
             ctl.addComponent(getDualTurretTA());
+        }
+        if (hasSponsons) {
+            ctl.addComponent(EquipmentType.get(EquipmentTypeLookup.SPONSON_TURRET).getTechAdvancement());
         }
     }
 
@@ -1835,6 +1840,9 @@ public class Tank extends Entity {
                 && mounted.getType().hasFlag(MiscType.F_JUMP_JET)) {
             setOriginalJumpMP(getOriginalJumpMP() + 1);
         }
+        // Track unusual turrets for tech calculations
+        hasSponsons |= mounted.isSponsonTurretMounted();
+        hasPintle |= mounted.isPintleTurretMounted();
     }
 
     /**

--- a/megamek/src/megamek/common/loaders/BLKTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKTankFile.java
@@ -23,9 +23,9 @@ import org.apache.logging.log4j.LogManager;
  * @since April 6, 2002, 2:06 AM
  */
 public class BLKTankFile extends BLKFile implements IMechLoader {
-    
+
     private boolean superheavy = false;
-    
+
     public BLKTankFile(BuildingBlock bb) {
         dataFile = bb;
     }
@@ -203,9 +203,8 @@ public class BLKTankFile extends BLKFile implements IMechLoader {
                 t.setArmorTechLevel(dataFile.getDataAsInt(t.getLocationName(i) + "_armor_type")[0], i);
             }
         }
-        
+
         t.autoSetInternal();
-        t.recalculateTechAdvancement();
 
         if (superheavy) {
             loadEquipment(t, "Front", Tank.LOC_FRONT);
@@ -277,6 +276,7 @@ public class BLKTankFile extends BLKFile implements IMechLoader {
         if (dataFile.exists("trailer")) {
             t.setTrailer(true);
         }
+        t.recalculateTechAdvancement();
         loadQuirks(t);
         return t;
     }


### PR DESCRIPTION
This is an MM fix for an MML  bug that affected MHQ, but leaving that aside...

There were several issues here:

1. The entry for Sponson Turrets was out of date, and missing more recent info from the latest TRO/source erratas.
2. Tank BLK file loading does its final tech level calculations _prior_ to loading any equipment.  There may be another refresh in Entity or Tank after all weapons are added, but _only_ for weapons.
3. Sponson turrets (and pintle mounts) were not ever considered for calculating TechLevel in the first place.

This PR fixes those issues, at least for Sponson Turrets.  Pintle mounts are just always available from PS onward, so should not need composite Tech Advancement handling.

NOTE: if, in the future, a piece of equipment is found that should - but does not - affect the Tech Level or availability eras, check all the *TechAdvancement() functions and _ensure_ that it is actually handled!  There is probably a lot of equipment that should be, but isn't.

Testing:

1. Verified that ~3012-to-3025-era vehicles mounting all-Standard equipment with Sponson Turrets appear under various tech and era limitations that should allow them (per the original bug), both in MM and MHQ.
2. Ran all unit tests for all three projects.
3. Sampled existing canon vehicles with Sponson Turrets to confirm that the updates have not changed their availability.

Close MegaMek/megameklab#1365