### PR TITLE
Add test to ensure every unit can load

### DIFF
--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -36,12 +36,12 @@ import java.util.zip.ZipFile;
  * @author arlith
  */
 public class MechSummaryCache {
-    
+
     public interface Listener {
         void doneLoading();
     }
 
-    private static final String FILENAME_UNITS_CACHE = "units.cache";
+    public static final String FILENAME_UNITS_CACHE = "units.cache";
     public static final String FILENAME_LOOKUP = "name_changes.txt";
 
     private static final List<String> SUPPORTED_FILE_EXTENSIONS =

--- a/megamek/unittests/megamek/common/loaders/CacheRebuildTest.java
+++ b/megamek/unittests/megamek/common/loaders/CacheRebuildTest.java
@@ -1,0 +1,30 @@
+package megamek.common.loaders;
+
+import megamek.common.MechSummaryCache;
+import megamek.common.util.fileUtils.MegaMekFile;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+public class CacheRebuildTest {
+    /**
+     * Tests that every single unit can load successfully
+     */
+    @Test
+    public void testCacheRebuild() {
+        File file = new MegaMekFile(MechSummaryCache.getUnitCacheDir(),
+            MechSummaryCache.FILENAME_UNITS_CACHE).getFile();
+        if (file.exists()) {
+            // Ensure the cache really is cleared
+            assertTrue(file.delete());
+        }
+        MechSummaryCache instance = MechSummaryCache.getInstance(true);
+        // Make sure no units failed loading
+        assertTrue(instance.getFailedFiles().isEmpty());
+        // Sanity check to make sure the loader thread didn't fail outright
+        assertTrue(instance.getAllMechs().length > 100);
+    }
+}


### PR DESCRIPTION
As part of the testing process, build the unit cache. This ensures that every single unit can be loaded successfully, even if not correctly. This would prevent issues like #5237. 