### PR TITLE
Prevent drop shadows for multihex units

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
@@ -263,7 +263,7 @@ public class EntityImage {
 
             // Generate rotated images for the unit and for a wreck
             fImage = rotateImage(fImage, i);
-            if (GUIP.getShadowMap()) {
+            if (GUIP.getShadowMap() && isSingleHex) {
                 facings[i] = applyDropShadow(fImage);
             } else {
                 facings[i] = fImage;


### PR DESCRIPTION
drop shadows on landed DS don't work correctly. Removing them for now.