### PR TITLE
Fix 5229: Multi-Trac units not firing energy weapons

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2598,7 +2598,8 @@ public class FireControl {
                                                                              ammoConservation);
             final FiringPlan plan = determineBestFiringPlan(parameters);
 
-            LogManager.getLogger().info(shooter.getDisplayName() + " at " + enemy
+            // Debug logging; Princess does her own info logging
+            LogManager.getLogger().debug(shooter.getDisplayName() + " at " + enemy
                     .getDisplayName() + " - Best Firing Plan: " + plan.getDebugDescription(true));
             if ((null == bestPlan) || (plan.getUtility() > bestPlan.getUtility())) {
                 bestPlan = plan;

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2598,9 +2598,6 @@ public class FireControl {
                                                                              ammoConservation);
             final FiringPlan plan = determineBestFiringPlan(parameters);
 
-            // Debug logging; Princess does her own info logging
-            LogManager.getLogger().debug(shooter.getDisplayName() + " at " + enemy
-                    .getDisplayName() + " - Best Firing Plan: " + plan.getDebugDescription(true));
             if ((null == bestPlan) || (plan.getUtility() > bestPlan.getUtility())) {
                 bestPlan = plan;
             }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3612,7 +3612,7 @@ public class FireControl {
      * @param wtype that uses ammo that is not tracked, or not actually ammo
      * @return true if wtype doesn't actually track ammo
      */
-    private static boolean effectivelyAmmoless(WeaponType wtype) {
+    protected static boolean effectivelyAmmoless(WeaponType wtype) {
         List<Integer> atypes = Arrays.asList(
                 AmmoType.T_NA,
                 AmmoType.T_INFANTRY

--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -79,10 +79,6 @@ public class MultiTargetFireControl extends FireControl {
 
             if (currentPlan.getUtility() > bestPlan.getUtility()) {
                 bestPlan = currentPlan;
-
-                // Debug logging; Princess does her own info-level logging
-                LogManager.getLogger().debug(shooter.getDisplayName() + " - Best Firing Plan: " +
-                        bestPlan.getDebugDescription(true));
             }
 
             // check the plan where the shooter flips its arms

--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -79,6 +79,7 @@ public class MultiTargetFireControl extends FireControl {
 
             if (currentPlan.getUtility() > bestPlan.getUtility()) {
                 bestPlan = currentPlan;
+
                 // Debug logging; Princess does her own info-level logging
                 LogManager.getLogger().debug(shooter.getDisplayName() + " - Best Firing Plan: " +
                         bestPlan.getDebugDescription(true));
@@ -122,7 +123,7 @@ public class MultiTargetFireControl extends FireControl {
                 continue;
             }
 
-            if (((WeaponType) weapon.getType()).getAmmoType() == AmmoType.T_NA) {
+            if (effectivelyAmmoless((WeaponType) weapon.getType())) {
                 betterShot = buildWeaponFireInfo(shooter, target, weapon, null, owner.getGame(), false);
             } else {
                 ArrayList<Mounted> ammos;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -609,8 +609,9 @@ public class Princess extends BotClient {
                     getFireControl(shooter).loadAmmo(shooter, plan);
                     plan.sortPlan();
 
+                    // FireControl instances will handle debug logging
                     LogManager.getLogger().info(shooter.getDisplayName() + " - Best Firing Plan: " +
-                            plan.getDebugDescription(LogManager.getLogger().getLevel().isLessSpecificThan(Level.DEBUG)));
+                            plan.getDebugDescription(false));
 
                     // Add expected damage from the chosen FiringPlan to the
                     // damageMap for the target enemy.

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -40,8 +40,10 @@ import megamek.common.util.BoardUtilities;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.StopSwarmAttack;
+import org.apache.commons.logging.impl.Log4JLogger;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.text.DecimalFormat;
@@ -552,13 +554,14 @@ public class Princess extends BotClient {
     @Override
     protected void calculateFiringTurn() {
         final Entity shooter;
+        final Logger logger = LogManager.getLogger();
         try {
             // get the first entity that can act this turn make sure weapons
             // are loaded
             shooter = getEntityToFire(fireControlState);
         } catch (Exception e) {
             // If we fail to get the shooter, literally nothing can be done.
-            LogManager.getLogger().error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
             return;
         }
 
@@ -587,13 +590,13 @@ public class Princess extends BotClient {
                         skipFiring = true;
                     }
                 } finally {
-                    LogManager.getLogger().info(msg.toString());
+                    logger.info(msg.toString());
                 }
             }
 
             if (shooter.isHidden()) {
                 skipFiring = true;
-                LogManager.getLogger().info("Hidden unit skips firing.");
+                logger.info("Hidden unit skips firing.");
             }
 
             // calculating a firing plan is somewhat expensive, so
@@ -609,9 +612,11 @@ public class Princess extends BotClient {
                     getFireControl(shooter).loadAmmo(shooter, plan);
                     plan.sortPlan();
 
-                    // FireControl instances will handle debug logging
-                    LogManager.getLogger().info(shooter.getDisplayName() + " - Best Firing Plan: " +
+                    // Log info and debug at different levels
+                    logger.info(shooter.getDisplayName() + " - Best Firing Plan: " +
                             plan.getDebugDescription(false));
+                    logger.debug(shooter.getDisplayName() + " - Detailed Best Firing Plan: " +
+                            plan.getDebugDescription(true));
 
                     // Add expected damage from the chosen FiringPlan to the
                     // damageMap for the target enemy.
@@ -646,7 +651,7 @@ public class Princess extends BotClient {
                     sendAttackData(shooter.getId(), actions);
                     return;
                 } else {
-                    LogManager.getLogger().info("No best firing plan for " + shooter.getDisplayName());
+                    logger.info("No best firing plan for " + shooter.getDisplayName());
                 }
             }
 
@@ -662,7 +667,7 @@ public class Princess extends BotClient {
                         .findFirst()
                         .orElse(null);
                 if (stopSwarmWeapon == null) {
-                    LogManager.getLogger().error("Failed to find a Stop Swarm Weapon while Swarming a unit, which should not be possible.");
+                    logger.error("Failed to find a Stop Swarm Weapon while Swarming a unit, which should not be possible.");
                 } else {
                     miscPlan = new Vector<>();
                     miscPlan.add(new WeaponAttackAction(shooter.getId(), shooter.getSwarmTargetId(),
@@ -699,7 +704,7 @@ public class Princess extends BotClient {
 
             sendAttackData(shooter.getId(), miscPlan);
         } catch (Exception e) {
-            LogManager.getLogger().error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
             // Don't lock up, just skip this entity.
             Vector<EntityAction> fallback = new Vector<>();
             sendAttackData(shooter.getId(), fallback);


### PR DESCRIPTION
There were a couple issues in the MultiTargetFireControl planning track:

1. Energy weapons, or any weapon that doesn't actually track ammunition, would be skipped due to the way iterating over ammo was set up.
2. All firing plans were being assessed as if the shooter were an Aerospace unit, which include much stricter heat penalties.  As a result, Princess would be much less likely to fire multiple high-heat weapons in the same turn, even for 'Mechs.

TODO: since MultiTargetFireControl iterates over every target, for every weapon, for every _possible arc_, there is a good chance that we are calculating the same to-hit chances several times for given target-weapon pairings.  We could speed this up by caching results in a map, similar to TAGging is now being tracked.

This should not affect Energy-only Bay Weapons.

Testing:
- Ran all 3 projects' unit tests,
- Ran version of fix on provided save game,
- Created new game for full fix with multiple Multi-Trac units.

Close: #5229 