### PR TITLE
Fix 5204: Fighter Squadron weapon crits and group damage application

### DIFF
--- a/megamek/src/megamek/common/AeroSpaceFighter.java
+++ b/megamek/src/megamek/common/AeroSpaceFighter.java
@@ -53,15 +53,28 @@ public class AeroSpaceFighter extends Aero {
         return false;
     }
 
+    @Override
+    public boolean isBomber() {
+        return true;
+    }
+
+    @Override
+    public boolean isFighter() {
+        return true;
+    }
+
+    @Override
+    public boolean isAerospaceFighter() {
+        return true;
+    }
+
     /**
-     * Damage a capital fighter's weapons. WeaponGroups are damaged by critical hits.
-     * This matches up the individual fighter's weapons and critical slots and damages those
-     * for MHQ resolution
-     * @param loc - Int corresponding to the location struck
+     * Method to enable mass location damaging, mainly for Fighter Squadrons
+     * @param loc that every fighter in the squadron needs to damage, for MekHQ tracking
      */
-    public void damageCapFighterWeapons(int loc) {
-        for (Mounted weapon : weaponList) {
-            if (weapon.getLocation() == loc) {
+    public void damageLocation(int loc) {
+        weaponList.stream().filter(x -> x.getLocation() == loc).forEach(
+            (weapon)-> {
                 //Damage the weapon
                 weapon.setHit(true);
                 //Damage the critical slot
@@ -78,22 +91,7 @@ public class AeroSpaceFighter extends Aero {
                     }
                 }
             }
-        }
-    }
-
-    @Override
-    public boolean isBomber() {
-        return true;
-    }
-
-    @Override
-    public boolean isFighter() {
-        return true;
-    }
-
-    @Override
-    public boolean isAerospaceFighter() {
-        return true;
+        );
     }
 
     @Override

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -625,6 +625,8 @@ public class FighterSquadron extends AeroSpaceFighter {
             // Add the unit to our squadron.
             fighters.add(unit.getId());
         }
+        // FighterSquadrons should handle this collectively
+        unit.setTransportId(id);
 
         if (!getGame().getPhase().isLounge()) {
             computeSquadronBombLoadout(); // this calls updateWeaponGroups() and loadAllWeapons()
@@ -646,6 +648,7 @@ public class FighterSquadron extends AeroSpaceFighter {
             loadAllWeapons();
         }
         updateSkills();
+        unit.setTransportId(Entity.NONE);
         return success;
     }
 
@@ -750,4 +753,31 @@ public class FighterSquadron extends AeroSpaceFighter {
     public boolean isCapitalScale() {
         return true;
     }
+
+    /** Override of Entity method.
+     *  This needs to be set or we can't do a reverse lookup from a Capital Fighter to its Squadron.
+     * @param transportId - the <code>int</code> ID of our transport. The ID is
+     *                    <b>not</b> validated. This value should be
+     *                    <code>Entity.NONE</code> if this unit has been unloaded.
+     */
+    @Override
+    public void setTransportId(int transportId) {
+       fighters.stream().map(fid -> game.getEntity(fid))
+               .forEach(f -> f.setTransportId(transportId));
+    }
+
+    /**
+     * Damage a capital fighter's weapons. WeaponGroups are damaged by critical hits.
+     * This matches up the individual fighter's weapons and critical slots and damages those
+     * for MHQ resolution
+     * @param loc - Int corresponding to the location struck
+     */
+    public void damageCapFighterWeapons(int loc) {
+        for (int fid: fighters) {
+            AeroSpaceFighter fighter = (AeroSpaceFighter) game.getEntity(fid);
+            fighter.damageLocation(loc);
+
+        }
+    }
+
 }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -25137,12 +25137,13 @@ public class GameManager implements IGameManager {
                     }
                 }
             case Aero.CRIT_WEAPON:
-                if (aero.isCapitalFighter()) {
-                    FighterSquadron cf = (FighterSquadron) aero;
+                FighterSquadron cf = (FighterSquadron) game.getEntity(aero.getTransportId());
+                if (aero.isCapitalFighter() && cf != null) {
+                    // The Squadron should be set as the "transport" of the Squadron members, but may be null
                     boolean destroyAll = false;
                     // CRIT_WEAPON damages the capital fighter/squadron's weapon groups
-                    // Go ahead and map damage for the fighter's weapon criticals for MHQ
-                    // resolution.
+                    // TODO: Go ahead and map damage for the fighters' weapon criticals for MHQ resolution.
+                    // (Currently this is not working as the Capital Fighter has no weapons of its own, only groups.
                     cf.damageCapFighterWeapons(loc);
                     if ((loc == Aero.LOC_NOSE) || (loc == Aero.LOC_AFT)) {
                         destroyAll = true;


### PR DESCRIPTION
This fixes the NPE caused when Capital Fighters take weapon crits; it also:
- completes the missing squadron addition functionality (required to properly get the FighterSquadron back from a single Capital Fighter in the squadron);
- implements part of the currently-broken Squadron-wide damage application (used for tracking damage for MekHQ purposes, reportedly).

The other problem from that issue, Warships unable to engage at Medium or greater range, could not be reproduced and was likely fixed in a previous PR.

TODO: There is still a lot of work to do on Capital Fighters:

1. Weapon crits may or may not actually halve the damage for wings after a Weapon Critical is applied.
2. I have no idea how to split units off from a Squadron other than letting them die.
3. It looks like arbitrary squadron sizes are allowed, but I have not confirmed this yet.
4. Unknown how well single-fighter Capital Fighters will actually operate.

Testing:

- Ran all 3 projects' unit tests
- Loaded the failing save in 0.49.18, exported the units as MULs, loaded into 0.49.19 with and without fixes for comparison

Close #5204 