### PR TITLE
Set crew requirements for units with Drone OS to 0

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -33,7 +33,6 @@ import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.mgs.MGWeapon;
 import megamek.server.Server;
 import megamek.server.SmokeCloud;
-import org.apache.commons.logging.Log;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.*;
@@ -7144,6 +7143,10 @@ public class Compute {
 
     // Taken from MekHQ, assumptions are whatever Taharqa made for there - Dylan
     public static int getTotalGunnerNeeds(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
+
         if (entity instanceof SmallCraft || entity instanceof Jumpship) {
             int nStandardW = 0;
             int nCapitalW = 0;
@@ -7176,6 +7179,9 @@ public class Compute {
 
     // Taken from MekHQ, assumptions are whatever Taharqa made for there - Dylan
     public static int getAeroCrewNeeds(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
         if (entity instanceof Dropship) {
             if (((Dropship) entity).isMilitary()) {
                 return 4 + (int) Math.ceil(entity.getWeight() / 5000.0);
@@ -7199,6 +7205,10 @@ public class Compute {
      * @return       The minimum base crew
      */
     public static int getSVBaseCrewNeeds(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
+
         if (entity.isTrailer() && (entity.getEngine().getEngineType() == Engine.NONE)) {
             return 0;
         }
@@ -7232,6 +7242,10 @@ public class Compute {
      * @return       The number of gunners required.
      */
     public static int getSupportVehicleGunnerNeeds(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
+
         final boolean advFireCon = entity.hasMisc(MiscType.F_ADVANCED_FIRECONTROL);
         final boolean basicFireCon = !advFireCon && entity.hasMisc(MiscType.F_BASIC_FIRECONTROL);
         if (entity.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
@@ -7284,6 +7298,10 @@ public class Compute {
      * @return       The number of additional crew required
      */
     public static int getAdditionalNonGunner(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
+
         int crew = 0;
         for (Mounted m : entity.getMisc()) {
             if (m.getType().hasFlag(MiscType.F_COMMUNICATIONS)) {
@@ -7296,7 +7314,7 @@ public class Compute {
                 crew += 5 * (int) m.getSize();
             }
         }
-        if (entity.isSuperHeavy()) {
+        if (entity instanceof Mech && entity.isSuperHeavy()) {
             // Tactical Officer
             return 1;
         }
@@ -7305,6 +7323,10 @@ public class Compute {
 
     // Taken from MekHQ, assumptions are whatever Taharqa made for there - Dylan
     public static int getFullCrewSize(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
+
         if (entity.isSupportVehicle()) {
             int crew = getSVBaseCrewNeeds(entity) + getSupportVehicleGunnerNeeds(entity)
                     + getAdditionalNonGunner(entity);
@@ -7349,6 +7371,9 @@ public class Compute {
 
     // Taken from MekHQ, assumptions are whatever Taharqa made for there - Dylan
     public static int getTotalDriverNeeds(Entity entity) {
+        if (entity.hasDroneOs()) {
+            return 0;
+        }
         //Fix for MHQ Bug #3. Space stations have as much need for pilots as jumpships do.
         if (entity instanceof SpaceStation) {
             return 2;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -5558,6 +5558,13 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
+     * Returns whether this entity has a Drone Operating System
+     */
+    public boolean hasDroneOs() {
+        return getMisc().stream().anyMatch(m -> (m.getType() instanceof MiscType) && m.getType().hasFlag(MiscType.F_DRONE_OPERATING_SYSTEM));
+    }
+
+    /**
      * Returns wether or not this entity has a Targeting Computer.
      */
     public boolean hasTargComp() {


### PR DESCRIPTION
Fixes MegaMek/megameklab#1446.

I haven't tested this in gameplay for drone units, but my understanding is that crew requirements don't matter for gameplay, and the Drone Operating System is construction-only anyway.

This at least makes that construction slightly more correct.

While I was poking around in the crew code, I fixed an unrelated bug I spotted, which is that the Tactical Officer for superheavy mechs was erroneously being given to every other kind of superheavy unit.