### PR TITLE
Load data from story arcs

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
@@ -81,6 +81,20 @@ public class MMStaticDirectoryManager {
                     DirectoryItems userDirPortraits = new DirectoryItems(portraitUserDir, new ImageFileFactory());
                     portraitDirectory.merge(userDirPortraits);
                 }
+
+                // check for portraits in story arcs subdirectories
+                File storyarcsDir = Configuration.storyarcsDir();
+                if(storyarcsDir.exists() && storyarcsDir.isDirectory()) {
+                    for (File file : storyarcsDir.listFiles()) {
+                        if (file.isDirectory()) {
+                            File storyArcPortraitDir = new File(file.getPath() + "/data/images/portraits");
+                            if (storyArcPortraitDir.exists() && storyArcPortraitDir.isDirectory()) {
+                                DirectoryItems storyArcPortraits = new DirectoryItems(storyArcPortraitDir, new ImageFileFactory());
+                                portraitDirectory.merge(storyArcPortraits);
+                            }
+                        }
+                    }
+                }
             } catch (Exception e) {
                 LogManager.getLogger().error("Could not parse the portraits directory!", e);
             }
@@ -106,6 +120,20 @@ public class MMStaticDirectoryManager {
                 if (!userDir.isBlank() && camoUserDir.isDirectory()) {
                     DirectoryItems userDirCamo = new DirectoryItems(camoUserDir, new ScaledImageFileFactory());
                     camouflageDirectory.merge(userDirCamo);
+                }
+
+                // check for camouflage in story arcs subdirectories
+                File storyarcsDir = Configuration.storyarcsDir();
+                if(storyarcsDir.exists() && storyarcsDir.isDirectory()) {
+                    for (File file : storyarcsDir.listFiles()) {
+                        if (file.isDirectory()) {
+                            File storyArcCamoDir = new File(file.getPath() + "/data/images/camo");
+                            if (storyArcCamoDir.exists() && storyArcCamoDir.isDirectory()) {
+                                DirectoryItems storyArcCamo = new DirectoryItems(storyArcCamoDir, new ScaledImageFileFactory());
+                                camouflageDirectory.merge(storyArcCamo);
+                            }
+                        }
+                    }
                 }
             } catch (Exception e) {
                 LogManager.getLogger().error("Could not parse the camo directory!", e);

--- a/megamek/src/megamek/common/Configuration.java
+++ b/megamek/src/megamek/common/Configuration.java
@@ -92,6 +92,9 @@ public final class Configuration {
     /** The default force generator directory name (under the data directory). */
     private static final String DEFAULT_DIR_NAME_FONTS = "fonts";
 
+    /** The default story arcs directory name (under the data directory). */
+    private static final String DEFAULT_DIR_NAME_STORY_ARCS = "storyarcs";
+
     // **************************************************************************
     // These are all directories that normally appear under 'data/images'.
 
@@ -484,6 +487,15 @@ public final class Configuration {
      */
     public static File portraitImagesDir() {
         return new File(imagesDir(), DEFAULT_DIR_NAME_PORTRAIT_IMAGES);
+    }
+
+    /**
+     * Return the story arcs directory, which is relative to the directory.
+     *
+     * @return {@link File} containing the path to the portrait directory.
+     */
+    public static File storyarcsDir() {
+        return new File(dataDir(), DEFAULT_DIR_NAME_STORY_ARCS);
     }
 
     /**

--- a/megamek/src/megamek/common/MechSummaryCache.java
+++ b/megamek/src/megamek/common/MechSummaryCache.java
@@ -270,6 +270,19 @@ public class MechSummaryCache {
             bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, userDataUnits2, ignoreUnofficial);
         }
 
+        // load units from story arcs
+        File storyarcsDir = Configuration.storyarcsDir();
+        if(storyarcsDir.exists() && storyarcsDir.isDirectory()) {
+            for (File file : storyarcsDir.listFiles()) {
+                if (file.isDirectory()) {
+                    File storyArcUnitsDir = new File(file.getPath() + "/data/mechfiles");
+                    if(storyArcUnitsDir.exists() && storyArcUnitsDir.isDirectory()) {
+                        bNeedsUpdate |= loadMechsFromDirectory(vMechs, sKnownFiles, lLastCheck, storyArcUnitsDir, ignoreUnofficial);
+                    }
+                }
+            }
+        }
+
         // save updated cache back to disk
         if (bNeedsUpdate) {
             saveCache(vMechs);


### PR DESCRIPTION
(Note: this is a revision of PR #5265 on a clean fork without junk commits)

This PR is related to MegaMek/mekhq#2997, but needs to be handled separately because it involves megamek rather than mekhq code. Creators will in many cases want to load custom data such as portraits, camos, force logos, and customized mechs to be used in the story arc, but these will need to be loaded by megamek to be accessible. That is the purpose of this PR. It adds code to loop through subdirectories in the `data/storyarcs` directory to look for the following things and loads them:

* portraits (must be in subdirectory `data/images/portraits`, relative to the story arc top-level directory).
* camo (must be in subdirectory `data/images/camo`, relative to the story arc top-level directory). An additional complexity here is that the images must actually be in subfolders of `data/images/camo` for this to work. This seems to be a general limitation of camo images. If you try to put images directly in the main `data/images/camo` and not in a subdirectory they will not work either. Might be a bug?
* custom units (must be in subdirectory `data/mechfiles` relative to the story arc top-level directory). 

I was also thinking about doing boards, but these appear to be much more complicated, so I am gong to hold off on that for the moment. 

I also want to allow for custom force logos, but that is a mekhq issue so it will be handled from there. 