### PR TITLE
Make SI damage round naturally and have minimum of 1

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -22627,14 +22627,10 @@ public class GameManager implements IGameManager {
 
                     // divide damage in half
                     // do not divide by half if it is an ammo explosion
+                    // Minimum SI damage is now 1 (per errata: https://bg.battletech.com/forums/index.php?topic=81913.0 )
                     if (!ammoExplosion && !nukeS2S
                             && !game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_SANITY)) {
-                        damage /= 2;
-                    }
-
-                    // this should result in a crit
-                    // but only if it really did damage after rounding down
-                    if (damage > 0) {
+                        damage = (int) Math.round(damage / 2.0);
                         critSI = true;
                     }
 


### PR DESCRIPTION
Per the ruling here: https://bg.battletech.com/forums/index.php?topic=81913.0
and confirmed on the CGL Discord here: https://discord.com/channels/1157414258133442710/1200547291321339924/1220749492773720195

Aerospace SI damage should be rounded naturally to a minimum of 1.
This patch implements that functionality.

Testing:
- Ran all 3 projects' unit tests
- Fired LBX cluster rounds at a variety of Aerospace units with armor lowered or removed to confirm minimum damage value applies

Close #5273