### PR TITLE
Add disconnectQuietly flag to ClientGUI

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -286,6 +286,9 @@ public class ClientGUI extends JPanel implements BoardViewListener,
     private MiniReportDisplay miniReportDisplay;
     private MiniReportDisplayDialog miniReportDisplayDialog;
 
+    /** Boolean indicating whether client should be disconnected without a pop-up warning **/
+    private boolean disconnectQuietly = false;
+
     /**
      * The <code>JPanel</code> containing the main display area.
      */
@@ -431,6 +434,10 @@ public class ClientGUI extends JPanel implements BoardViewListener,
 
     public void setPlayerListDialog(final PlayerListDialog playerListDialog) {
         this.playerListDialog = playerListDialog;
+    }
+
+    public void setDisconnectQuietly(boolean quietly) {
+        disconnectQuietly = quietly;
     }
 
     /**
@@ -2259,8 +2266,10 @@ public class ClientGUI extends JPanel implements BoardViewListener,
 
         @Override
         public void gamePlayerDisconnected(GamePlayerDisconnectedEvent evt) {
-            doAlertDialog(Messages.getString("ClientGUI.Disconnected.message"),
-                    Messages.getString("ClientGUI.Disconnected.title"), JOptionPane.ERROR_MESSAGE);
+            if(!disconnectQuietly) {
+                doAlertDialog(Messages.getString("ClientGUI.Disconnected.message"),
+                        Messages.getString("ClientGUI.Disconnected.title"), JOptionPane.ERROR_MESSAGE);
+            }
             frame.setVisible(false);
             die();
         }


### PR DESCRIPTION
This is a quality of life improvement for MekHQ users. It adds a disconnectQuietly flag to the ClientGUI and when a disconnect event is detected, it only pops up the "Disconnected!" dialog when this is a set to false. Once this is merged, I will then make a change to GameThread in MekHQ to set this to true. This will prevent the disconnect popup when users are resolving scenarios in MekHQ, which is annoying and unnecessary. 