### PR TITLE
Make EntityListFile.writeEntityList public

### DIFF
--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -680,7 +680,7 @@ public class EntityListFile {
         }
     }
 
-    private static void writeEntityList(Writer output, ArrayList<Entity> list) throws IOException {
+    public static void writeEntityList(Writer output, ArrayList<Entity> list) throws IOException {
         // Walk through the list of entities.
         Iterator<Entity> items = list.iterator();
         while (items.hasNext()) {


### PR DESCRIPTION
This is a very small PR to make the `EntityListFile.writeEntityList()` method public. This is a possible first step to merging the entity read/write methods across MM/MHQ. I also need it in the more immediate term to fix problems with BotForce in MekHQ which does not properly read in all of the new deployment information for entities. I could add that deployment information to the MHQ reader/writer but it looks like we are trying to move away from that as I note from the comments at the top of `MHQXMLUtility.writeEntityToXmlString`, which read:

```java
* TODO : This is dumb and we should just use EntityListFile.writeEntityList.
* TODO : Some of this may want to be back-ported into entity itself in MM and then
* TODO : re-factored out of EntityListFile.
```

I already have a code change in place for MHQ to fix this problem from the MHQ side, but this method needs to be public first. 