### PR TITLE
[Typo] Replaced Instances of Incindiary with Incendiary

### DIFF
--- a/megamek/docs/RAT Stuff/rat-generator.txt
+++ b/megamek/docs/RAT Stuff/rat-generator.txt
@@ -183,7 +183,7 @@ Warship
         infantry_support - commonly found supporting infantry formations
         ew_support - carries additional electronics for ECM, scanning, or command functions
         spotter - carries TAG or equivalent, such as C3 master
-        incindiary - can easily set fires
+        incendiary - can easily set fires
         mag_clamp - battle armor or ProtoMek with magnetic clamps
         artillery - carries tube artillery or artillery cannon
         missile_artillery - carries missile artillery, typically Arrow IV

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -20,7 +20,7 @@ import megamek.common.UnitType;
 
 /**
  * Used to adjust availability to conform to a particular mission role.
- * 
+ *
  * @author Neoancient
  */
 public enum MissionRole {
@@ -44,8 +44,8 @@ public enum MissionRole {
     /* Infantry roles */
     MARINE, MOUNTAINEER, XCT, PARATROOPER, ANTI_MEK, FIELD_GUN,
     /* allows artillery but does not filter out all other roles */
-    MIXED_ARTILLERY; 
-    
+    MIXED_ARTILLERY;
+
     public boolean fitsUnitType(int unitType) {
         switch (this) {
             case RECON:
@@ -151,7 +151,7 @@ public enum MissionRole {
                 return false;
         }
     }
-    
+
     public static Double adjustAvailabilityByRole(double avRating,
                                                   Collection<MissionRole> desiredRoles,
                                                   ModelRecord mRec, int year, int strictness) {
@@ -604,7 +604,7 @@ public enum MissionRole {
                 (mRec.getRoles().contains(ARTILLERY) && !desiredRoles.contains(ARTILLERY)
                         && !desiredRoles.contains(MIXED_ARTILLERY));
     }
-    
+
     public static MissionRole parseRole(String role) {
         switch (role.toLowerCase().replace("_", " ")) {
             case "recon":
@@ -627,7 +627,6 @@ public enum MissionRole {
             case "raider":
                 return RAIDER;
             case "incendiary":
-            case "incindiary":
                 return INCENDIARY;
             case "ew support":
                 return EW_SUPPORT;
@@ -724,7 +723,7 @@ public enum MissionRole {
                 return null;
         }
     }
-    
+
     @Override
     public String toString() {
         return name().toLowerCase();

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -54,7 +54,7 @@ public class ModelRecord extends AbstractUnitRecord {
     private double longRange; //proportion of weapon BV with range >= 20 hexes
     private int speed;
     private double ammoRequirement; //used to determine suitability for raider role
-    private boolean incendiary; //used to determine suitability for incindiary role
+    private boolean incendiary; //used to determine suitability for incendiary role
     private boolean apWeapons; //used to determine suitability for anti-infantry role
 
     private boolean mechanizedBA;

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 /**
  * Controls to set options for force generator.
- * 
+ *
  * @author Neoancient
  */
 public class ForceGeneratorOptionsView extends JPanel implements FocusListener, ActionListener {
@@ -61,7 +61,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
     private JCheckBox chkRoleInfantrySupport;
     private JCheckBox chkRoleCavalry;
     private JCheckBox chkRoleRaider;
-    private JCheckBox chkRoleIncindiary;
+    private JCheckBox chkRoleIncendiary;
     private JCheckBox chkRoleAntiAircraft;
     private JCheckBox chkRoleAntiInfantry;
     private JCheckBox chkRoleArtillery;
@@ -328,10 +328,10 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
         gbc.gridy = 1;
         panGroundRole.add(chkRoleRaider, gbc);
 
-        chkRoleIncindiary = createMissionRoleCheck(MissionRole.INCENDIARY);
+        chkRoleIncendiary = createMissionRoleCheck(MissionRole.INCENDIARY);
         gbc.gridx = 1;
         gbc.gridy = 1;
-        panGroundRole.add(chkRoleIncindiary, gbc);
+        panGroundRole.add(chkRoleIncendiary, gbc);
 
         chkRoleAntiAircraft = createMissionRoleCheck(MissionRole.ANTI_AIRCRAFT);
         gbc.gridx = 2;
@@ -474,7 +474,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
                     if (chkRoleRaider.isSelected()) {
                         fd.getRoles().add(MissionRole.RAIDER);
                     }
-                    if (chkRoleIncindiary.isSelected()) {
+                    if (chkRoleIncendiary.isSelected()) {
                         fd.getRoles().add(MissionRole.INCENDIARY);
                     }
                     if (chkRoleAntiAircraft.isSelected()) {
@@ -904,7 +904,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
 
     /**
      * Searches recursively for nodes that are flagged with C3 networks and configures them.
-     * 
+     *
      * @param fd
      */
     private void configureNetworks(ForceDescriptor fd) {


### PR DESCRIPTION
### Current Implementation
There are around 7 instances of 'incindiary' used across mm.

### Problem
This appears to be a typo. It looks like this is a known issue, as there is a case included for it in `megamek/src/megamek/client/ratgenerator/MissionRole.java`

<img width="265" alt="image" src="https://github.com/MegaMek/megamek/assets/103902653/d8cad3d4-2c13-4215-a168-33ca212c3921">

This appears to be isolated to mm, as I found no instances of its use in mml or mhq.

### Solution
All instances of 'incindiary' have been replaced by 'incendiary', maintaining capitalization, where applicable.