### PR TITLE
Improved MissionRole Switch Cases & Role List

### DIFF
--- a/megamek/docs/RAT Stuff/rat-generator.txt
+++ b/megamek/docs/RAT Stuff/rat-generator.txt
@@ -183,7 +183,7 @@ Warship
         infantry_support or inf_support - commonly found supporting infantry formations
         ew_support - carries additional electronics for ECM, scanning, or command functions
         spotter - carries TAG or equivalent, such as C3 master
-        incindiary - can easily set fires
+        incendiary - can easily set fires
         mag_clamp - battle armor or ProtoMek with magnetic clamps
         artillery - carries tube artillery or artillery cannon
         missile_artillery - carries missile artillery, typically Arrow IV

--- a/megamek/docs/RAT Stuff/rat-generator.txt
+++ b/megamek/docs/RAT Stuff/rat-generator.txt
@@ -216,7 +216,7 @@ Warship
         ba_carrier - has battle armor bays
         mechanized_ba - eligible to be carried by Omni units as mechanized BA
         tug - has tug adaptor
-        pocket warship - pocket warship DropShip
+        pocket_warship - pocket warship DropShip
         corvette - WarShip class
         destroyer - WarShip class
         frigate - WarShip class

--- a/megamek/docs/RAT Stuff/rat-generator.txt
+++ b/megamek/docs/RAT Stuff/rat-generator.txt
@@ -180,7 +180,7 @@ Warship
         comma-separated list of roles the variant was designed for. Supported values are:
         fire_support - focus on long range firepower
         sr_fire_support - focus on short range firepower
-        infantry_support - commonly found supporting infantry formations
+        infantry_support or inf_support - commonly found supporting infantry formations
         ew_support - carries additional electronics for ECM, scanning, or command functions
         spotter - carries TAG or equivalent, such as C3 master
         incindiary - can easily set fires
@@ -216,7 +216,7 @@ Warship
         ba_carrier - has battle armor bays
         mechanized_ba - eligible to be carried by Omni units as mechanized BA
         tug - has tug adaptor
-        pocket ws - pocket warship DropShip
+        pocket warship - pocket warship DropShip
         corvette - WarShip class
         destroyer - WarShip class
         frigate - WarShip class

--- a/megamek/docs/RAT Stuff/rat-generator.txt
+++ b/megamek/docs/RAT Stuff/rat-generator.txt
@@ -214,6 +214,7 @@ Warship
         infantry_carrier - has infantry bays
         troop_carrier - has both infantry and vehicle bays
         ba_carrier - has battle armor bays
+        mechanized_ba - eligible to be carried by Omni units as mechanized BA
         tug - has tug adaptor
         pocket ws - pocket warship DropShip
         corvette - WarShip class

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -20,7 +20,7 @@ import megamek.common.UnitType;
 
 /**
  * Used to adjust availability to conform to a particular mission role.
- * 
+ *
  * @author Neoancient
  */
 public enum MissionRole {
@@ -44,8 +44,8 @@ public enum MissionRole {
     /* Infantry roles */
     MARINE, MOUNTAINEER, XCT, PARATROOPER, ANTI_MEK, FIELD_GUN,
     /* allows artillery but does not filter out all other roles */
-    MIXED_ARTILLERY; 
-    
+    MIXED_ARTILLERY;
+
     public boolean fitsUnitType(int unitType) {
         switch (this) {
             case RECON:
@@ -151,7 +151,7 @@ public enum MissionRole {
                 return false;
         }
     }
-    
+
     public static Double adjustAvailabilityByRole(double avRating,
                                                   Collection<MissionRole> desiredRoles,
                                                   ModelRecord mRec, int year, int strictness) {
@@ -604,7 +604,7 @@ public enum MissionRole {
                 (mRec.getRoles().contains(ARTILLERY) && !desiredRoles.contains(ARTILLERY)
                         && !desiredRoles.contains(MIXED_ARTILLERY));
     }
-    
+
     public static MissionRole parseRole(String role) {
         switch (role.toLowerCase().replace("_", " ")) {
             case "recon":
@@ -635,15 +635,12 @@ public enum MissionRole {
                 return ARTILLERY;
             case "missile artillery":
                 return MISSILE_ARTILLERY;
-            case "anti-aircraft":
             case "anti aircraft":
                 return ANTI_AIRCRAFT;
-            case "anti-infantry":
             case "anti infantry":
                 return ANTI_INFANTRY;
             case "apc":
                 return APC;
-            case "spec ops":
             case "specops":
                 return SPECOPS;
             case "cargo":
@@ -680,7 +677,6 @@ public enum MissionRole {
                 return TUG;
             case "troop carrier":
                 return TROOP_CARRIER;
-            case "pocket ws":
             case "pocket warship":
                 return POCKET_WARSHIP;
             case "corvette":
@@ -703,7 +699,6 @@ public enum MissionRole {
                 return XCT;
             case "paratrooper":
                 return PARATROOPER;
-            case "anti-mek":
             case "anti mek":
                 return ANTI_MEK;
             case "omni":
@@ -724,7 +719,7 @@ public enum MissionRole {
                 return null;
         }
     }
-    
+
     @Override
     public String toString() {
         return name().toLowerCase();


### PR DESCRIPTION
### Problem
Currently there are a number of unused roles listed as viable cases in `megamek/src/megamek/client/ratgenerator/MissionRole.java`.

There are also missing or incorrect roles listed in `megamek/docs/RAT Stuff/rat-generator.txt`.

## Solutions
### MissionRole.java
I have gone through and removed any unused cases.

### rat-generator.txt
I have clarified that either `infantry_support` or `inf_support` are accepted cases for the infantry support role. Both are in use and, while it might be advantageous to unify everything to use the same case, that is beyond the scope of this PR.

I have replaced 'incindiary' with 'incendiary' as the suggested case for units that can set fires. In #5288 Nick suggested we leave uses of 'incindiary' intact, however replacement in this instance leaves other uses intact while ensuring that future uses of the case are using the correct spelling. As this is user facing, I also wanted to ensure that the spelling was correct.

I have added the missing `mechanized_ba` role and assigned it the definition `eligible to be carried by Omni units as mechanized BA`.

I changed `pocket ws` to `pocket_warship`, as while `pocket ws` would have been accepted, its only use is in `rat-generator.txt` so by changing it to `pocket_warship` I was able to remove that case from `MissionRole.java`.

### Note
This initially started out as an attempt to investigate #5267. However, upon investigation, I found that existing functions relied upon the cases (when used) as currently implemented. As I was unable to find which functions were reliant on the current role cases, I opted instead to just leave the class intact and to only tidy things up so that we weren't checking for unused cases.