### PR TITLE
Industrial tripod cockpit

### DIFF
--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -620,6 +620,8 @@ SystemType.Cockpit.COCKPIT_QUADVEE=Quadvee\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL=Superheavy\ Industrial\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE=Superheavy\ Command\ Console
 SystemType.Cockpit.COCKPIT_SMALL_COMMAND_CONSOLE=Small\ Command\ Console
+SystemType.Cockpit.COCKPIT_TRIPOD_INDUSTRIAN=Tripod Industrial Cockpit
+SystemType.Cockpit.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL=Superheavy Industrial Tripod Cockpit
 
 BayType.STANDARD_CARGO=Cargo
 BayType.LIQUID_CARGO=Liquid Cargo

--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -620,7 +620,7 @@ SystemType.Cockpit.COCKPIT_QUADVEE=Quadvee\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_INDUSTRIAL=Superheavy\ Industrial\ Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE=Superheavy\ Command\ Console
 SystemType.Cockpit.COCKPIT_SMALL_COMMAND_CONSOLE=Small\ Command\ Console
-SystemType.Cockpit.COCKPIT_TRIPOD_INDUSTRIAN=Tripod Industrial Cockpit
+SystemType.Cockpit.COCKPIT_TRIPOD_INDUSTRIAL=Tripod Industrial Cockpit
 SystemType.Cockpit.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL=Superheavy Industrial Tripod Cockpit
 
 BayType.STANDARD_CARGO=Cargo

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -334,10 +334,10 @@ public class FireControl {
 
         if (shooter instanceof Mech) {
             final Mech shooterMech = (Mech) shooter;
-            if (Mech.COCKPIT_INDUSTRIAL == shooterMech.getCockpitType()) {
-                toHitData.addModifier(TH_INDUSTRIAL);
-            } else if (Mech.COCKPIT_PRIMITIVE_INDUSTRIAL == shooterMech.getCockpitType()) {
+            if (Mech.COCKPIT_PRIMITIVE_INDUSTRIAL == shooterMech.getCockpitType()) {
                 toHitData.addModifier(TH_PRIMATIVE_INDUSTRIAL);
+            } else if (!shooterMech.hasAdvancedFireControl()) {
+                toHitData.addModifier(TH_INDUSTRIAL);
             }
         }
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -4631,7 +4631,7 @@ public abstract class Mech extends Entity {
         } else if (this instanceof TripodMech) {
             setCockpitType(isIndustrial() ? COCKPIT_TRIPOD_INDUSTRIAL : COCKPIT_TRIPOD);
         } else {
-            setCockpitType(COCKPIT_STANDARD);
+            setCockpitType(isIndustrial() ? COCKPIT_INDUSTRIAL : COCKPIT_STANDARD);
         }
 
         return true;

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -177,7 +177,7 @@ public abstract class Mech extends Entity {
     public static final String[] COCKPIT_SHORT_STRING = { "Standard", "Small",
             "Command Console", "Torso Mounted", "Dual", "Industrial",
             "Primitive", "Primitive Industrial", "Superheavy",
-            "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
+            "Superheavy Tripod", "Tripod", "Interface", "VRPP", "Quadvee",
             "Superheavy Industrial", "Superheavy Command",
             "Small Command", "Tripod Industrial", "Superheavy Tripod Industrial" };
 

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -161,6 +161,10 @@ public abstract class Mech extends Entity {
 
     public static final int COCKPIT_SMALL_COMMAND_CONSOLE = 16;
 
+    public static final int COCKPIT_TRIPOD_INDUSTRIAL = 17;
+
+    public static final int COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL = 18;
+
     public static final String[] COCKPIT_STRING = { "Standard Cockpit",
             "Small Cockpit", "Command Console", "Torso-Mounted Cockpit",
             "Dual Cockpit", "Industrial Cockpit", "Primitive Cockpit",
@@ -168,14 +172,14 @@ public abstract class Mech extends Entity {
             "Superheavy Tripod Cockpit", "Tripod Cockpit", "Interface Cockpit",
             "Virtual Reality Piloting Pod", "QuadVee Cockpit",
             "Superheavy Industrial Cockpit", "Superheavy Command Console",
-        "Small Command Console"};
+            "Small Command Console", "Tripod Industrial Cockpit", "Superheavy Tripod Industrial Cockpit" };
 
     public static final String[] COCKPIT_SHORT_STRING = { "Standard", "Small",
             "Command Console", "Torso Mounted", "Dual", "Industrial",
             "Primitive", "Primitive Industrial", "Superheavy",
             "Superheavy Tripod", "Tripod", "Interface", "VRRP", "Quadvee",
             "Superheavy Industrial", "Superheavy Command",
-            "Small Command"};
+            "Small Command", "Tripod Industrial", "Superheavy Tripod Industrial" };
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
 
@@ -326,9 +330,11 @@ public abstract class Mech extends Entity {
 
         switch (inCockpitType) {
             case COCKPIT_TRIPOD:
+            case COCKPIT_TRIPOD_INDUSTRIAL:
                 setCrew(new Crew(CrewType.TRIPOD));
                 break;
             case COCKPIT_SUPERHEAVY_TRIPOD:
+            case COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL:
                 setCrew(new Crew(CrewType.SUPERHEAVY_TRIPOD));
                 break;
             case COCKPIT_DUAL:
@@ -3067,6 +3073,16 @@ public abstract class Mech extends Entity {
                 .setPrototypeFactions(F_FS).setProductionFactions(F_FS, F_CJF)
                 .setAvailability(RATING_X, RATING_X, RATING_E, RATING_D)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Small Command Console
+            new TechAdvancement(TECH_BASE_IS).setISAdvancement(3130, 3135)
+                    .setISApproximate(true, false).setTechRating(RATING_E)
+                    .setPrototypeFactions(F_RS).setProductionFactions(F_RS)
+                    .setAvailability(RATING_X, RATING_F, RATING_X, RATING_F)
+                    .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Superheavy tripod
+            new TechAdvancement(TECH_BASE_IS).setISAdvancement(2590, 2702)
+                    .setISApproximate(true, false).setTechRating(RATING_F)
+                    .setPrototypeFactions(F_TH).setProductionFactions(F_TH)
+                    .setAvailability(RATING_X, RATING_X, RATING_X, RATING_F)
+                    .setStaticTechLevel(SimpleTechLevel.ADVANCED), //Tripod
     };
 
     // Advanced fire control for industrial mechs is implemented with a standard cockpit,
@@ -3087,9 +3103,6 @@ public abstract class Mech extends Entity {
     }
 
     public TechAdvancement getCockpitTechAdvancement() {
-        if (isIndustrial() && (getCockpitType() == COCKPIT_STANDARD)) {
-            return getIndustrialAdvFireConTA();
-        }
         return getCockpitTechAdvancement(getCockpitType());
     }
 
@@ -3126,6 +3139,9 @@ public abstract class Mech extends Entity {
         }
         if (getCockpitTechAdvancement() != null) {
             ctl.addComponent(getCockpitTechAdvancement());
+        }
+        if (isIndustrial() && hasAdvancedFireControl()) {
+            ctl.addComponent(getIndustrialAdvFireConTA());
         }
         if (hasFullHeadEject()) {
             ctl.addComponent(getFullHeadEjectAdvancement());
@@ -3921,18 +3937,26 @@ public abstract class Mech extends Entity {
         return Mech.getGyroTypeString(getGyroType());
     }
 
-    public String getCockpitTypeString() {
-        if (isIndustrial()) {
-            switch (getCockpitType()) {
+    public static String getCockpitTypeString(int cockpitType, boolean industrial) {
+        if (industrial) {
+            switch (cockpitType) {
                 case COCKPIT_STANDARD:
                     return Mech.getCockpitTypeString(COCKPIT_INDUSTRIAL) + " (Adv. FCS)";
                 case COCKPIT_PRIMITIVE:
                     return Mech.getCockpitTypeString(COCKPIT_PRIMITIVE_INDUSTRIAL) + " (Adv. FCS)";
                 case COCKPIT_SUPERHEAVY:
                     return Mech.getCockpitTypeString(COCKPIT_SUPERHEAVY_INDUSTRIAL) + " (Adv. FCS)";
+                case COCKPIT_TRIPOD:
+                    return Mech.getCockpitTypeString(COCKPIT_TRIPOD_INDUSTRIAL) + " (Adv. FCS)";
+                case COCKPIT_SUPERHEAVY_TRIPOD:
+                    return Mech.getCockpitTypeString(COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL) + " (Adv. FCS)";
             }
         }
-        return Mech.getCockpitTypeString(getCockpitType());
+        return Mech.getCockpitTypeString(cockpitType);
+    }
+
+    public String getCockpitTypeString() {
+        return getCockpitTypeString(getCockpitType(), isIndustrial());
     }
 
     public static String getGyroTypeString(int inGyroType) {
@@ -4084,6 +4108,12 @@ public abstract class Mech extends Entity {
             case COCKPIT_SMALL_COMMAND_CONSOLE:
                 inName = "COCKPIT_SMALL_COMMAND_CONSOLE";
                 break;
+            case COCKPIT_TRIPOD_INDUSTRIAL:
+                inName = "COCKPIT_TRIPOD_INDUSTRIAL";
+                break;
+            case COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL:
+                inName = "COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL";
+                break;
             default:
                 inName = "COCKPIT_UNKNOWN";
         }
@@ -4092,6 +4122,14 @@ public abstract class Mech extends Entity {
             return result;
         }
         return inName;
+    }
+
+    public boolean hasAdvancedFireControl() {
+        return (cockpitType != COCKPIT_INDUSTRIAL)
+                && (cockpitType != COCKPIT_PRIMITIVE_INDUSTRIAL)
+                && (cockpitType != COCKPIT_SUPERHEAVY_INDUSTRIAL)
+                && (cockpitType != COCKPIT_TRIPOD_INDUSTRIAL)
+                && (cockpitType != COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL);
     }
 
     @Override
@@ -4584,14 +4622,14 @@ public abstract class Mech extends Entity {
                 SYSTEM_LIFE_SUPPORT));
         if (isSuperHeavy()) {
             if (this instanceof TripodMech) {
-            setCockpitType(COCKPIT_SUPERHEAVY_TRIPOD);
+                setCockpitType(isIndustrial() ? COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL : COCKPIT_SUPERHEAVY_TRIPOD);
             } else if (isIndustrial()) {
                 setCockpitType(COCKPIT_SUPERHEAVY_INDUSTRIAL);
             } else {
                 setCockpitType(COCKPIT_SUPERHEAVY);
             }
         } else if (this instanceof TripodMech) {
-            setCockpitType(COCKPIT_TRIPOD);
+            setCockpitType(isIndustrial() ? COCKPIT_TRIPOD_INDUSTRIAL : COCKPIT_TRIPOD);
         } else {
             setCockpitType(COCKPIT_STANDARD);
         }
@@ -6395,7 +6433,7 @@ public abstract class Mech extends Entity {
     }
 
     public static Map<Integer, String> getAllCockpitCodeName() {
-        Map<Integer, String> result = new HashMap();
+        Map<Integer, String> result = new HashMap<>();
 
         result.put(COCKPIT_STANDARD, getCockpitDisplayString(COCKPIT_STANDARD));
         result.put(COCKPIT_SMALL, getCockpitDisplayString(COCKPIT_SMALL));
@@ -6414,6 +6452,8 @@ public abstract class Mech extends Entity {
         result.put(COCKPIT_SUPERHEAVY_INDUSTRIAL, getCockpitDisplayString(COCKPIT_SUPERHEAVY_INDUSTRIAL));
         result.put(COCKPIT_SUPERHEAVY_COMMAND_CONSOLE, getCockpitDisplayString(COCKPIT_SUPERHEAVY_COMMAND_CONSOLE));
         result.put(COCKPIT_SMALL_COMMAND_CONSOLE, getCockpitDisplayString(COCKPIT_SMALL_COMMAND_CONSOLE));
+        result.put(COCKPIT_TRIPOD_INDUSTRIAL, getCockpitDisplayString(COCKPIT_TRIPOD_INDUSTRIAL));
+        result.put(COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL, getCockpitDisplayString(COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL));
         result.put(COCKPIT_UNKNOWN, getCockpitDisplayString(COCKPIT_UNKNOWN));
 
         return result;

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3438,13 +3438,11 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.HeavyArmor"));
         }
 
-        // industrial cockpit: +1 to hit
-        if ((ae instanceof Mech) && (((Mech) ae).getCockpitType() == Mech.COCKPIT_INDUSTRIAL)) {
-            toHit.addModifier(1, Messages.getString("WeaponAttackAction.IndustrialNoAfc"));
-        }
-        // primitive industrial cockpit: +2 to hit
+        // industrial cockpit: +1 to hit, +2 for primitive
         if ((ae instanceof Mech) && (((Mech) ae).getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL)) {
             toHit.addModifier(2, Messages.getString("WeaponAttackAction.PrimIndustrialNoAfc"));
+        } else if ((ae instanceof Mech) && !((Mech) ae).hasAdvancedFireControl()) {
+            toHit.addModifier(1, Messages.getString("WeaponAttackAction.IndustrialNoAfc"));
         }
 
         // primitive industrial cockpit with advanced firing control: +1 to hit

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASMekSpecialAbilityConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASMekSpecialAbilityConverter.java
@@ -66,7 +66,7 @@ public class ASMekSpecialAbilityConverter extends ASSpecialAbilityConverter {
         }
 
         if (mek.isIndustrial()) {
-            if (mek.getCockpitType() == Mech.COCKPIT_STANDARD) {
+            if (mek.hasAdvancedFireControl()) {
                 assign(cockpitName, AFC);
             } else {
                 assign(cockpitName, BFC);

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -361,8 +361,7 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
 
     @Override
     protected void processOffensiveTypeModifier() {
-        if ((mek.getCockpitType() == Mech.COCKPIT_INDUSTRIAL)
-                || (mek.getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL)) {
+        if (!mek.hasAdvancedFireControl()) {
             // Industrial Meks without AFC multiplay their offensive rating with 0.9
             bvReport.addLine("Fire Control Modifier:",
                     formatForReport(offensiveValue) + " x 0.9",

--- a/megamek/src/megamek/common/cost/MekCostCalculator.java
+++ b/megamek/src/megamek/common/cost/MekCostCalculator.java
@@ -30,38 +30,54 @@ public class MekCostCalculator {
         int i = 0;
 
         double cockpitCost;
-        if (mek.getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED) {
-            cockpitCost = 750000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_DUAL) {
-            // Solaris VII - The Game World (German) This is not actually canonical as it
-            // has never been repeated in any English language source including Tech Manual
-            cockpitCost = 40000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_COMMAND_CONSOLE) {
-            // Command Consoles are listed as a cost of 500,000.
-            // That appears to be in addition to the primary cockpit.
-            cockpitCost = 700000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_SMALL) {
-            cockpitCost = 175000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_VRRP) {
-            cockpitCost = 1250000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_INDUSTRIAL) {
-            cockpitCost = 100000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_TRIPOD) {
-            cockpitCost = 400000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_QUADVEE) {
-            cockpitCost = 375000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_SUPERHEAVY) {
-            cockpitCost = 300000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
-            // The cost is the sum of both superheavy cockpit and command console
-            cockpitCost = 800000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_TRIPOD) {
-            cockpitCost = 500000;
-        } else if (mek.getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
-            // The cost is the sum of both small and command console
-            cockpitCost = 675000;
-        } else {
-            cockpitCost = 200000;
+        switch (mek.getCockpitType()) {
+            case Mech.COCKPIT_TORSO_MOUNTED:
+                cockpitCost = 750000;
+                break;
+            case Mech.COCKPIT_DUAL:
+                // Solaris VII - The Game World (German) This is not actually canonical as it
+                // has never been repeated in any English language source including Tech Manual
+                cockpitCost = 40000;
+                break;
+            case Mech.COCKPIT_COMMAND_CONSOLE:
+                // Command Consoles are listed as a cost of 500,000.
+                // That appears to be in addition to the primary cockpit.
+                cockpitCost = 700000;
+                break;
+            case Mech.COCKPIT_SMALL:
+                cockpitCost = 175000;
+                break;
+            case Mech.COCKPIT_VRRP:
+                cockpitCost = 1250000;
+                break;
+            case Mech.COCKPIT_INDUSTRIAL:
+            case Mech.COCKPIT_PRIMITIVE_INDUSTRIAL:
+                cockpitCost = 100000;
+                break;
+            case Mech.COCKPIT_TRIPOD:
+            case Mech.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL:
+                cockpitCost = 400000;
+                break;
+            case Mech.COCKPIT_TRIPOD_INDUSTRIAL:
+            case Mech.COCKPIT_SUPERHEAVY:
+                cockpitCost = 300000;
+                break;
+            case Mech.COCKPIT_QUADVEE:
+                cockpitCost = 375000;
+                break;
+            case Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+                // The cost is the sum of both superheavy cockpit and command console
+                cockpitCost = 800000;
+                break;
+            case Mech.COCKPIT_SUPERHEAVY_TRIPOD:
+                cockpitCost = 500000;
+                break;
+            case Mech.COCKPIT_SMALL_COMMAND_CONSOLE:
+                // The cost is the sum of both small and command console
+                cockpitCost = 675000;
+                break;
+            default:
+                cockpitCost = 200000;
         }
         if (mek.hasEiCockpit()
                 && ((null != mek.getCrew()) && mek.hasAbility(OptionsConstants.UNOFF_EI_IMPLANT))) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -206,42 +206,34 @@ public class TestMech extends TestEntity {
     }
     
     public double getWeightCockpit() {
-        double weight = 3.0;
-        if (mech.getCockpitType() == Mech.COCKPIT_SMALL) {
-            weight = 2.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_TORSO_MOUNTED) {
-            weight = 4.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_COMMAND_CONSOLE) {
-            // Technically, it's two separate 3-ton pieces of equipment.
-            // We're ignoring that and returning the total, because it's easier.
-            weight = 6.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_DUAL) {
-            // Solaris VII - The Game World (German) This is not actually
-            // canonical as it
-            // has never been repeated in any English language source including
-            // Tech Manual
-            weight = 4.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_PRIMITIVE) {
-            weight = 5.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL) {
-            weight = 5.0;
-        } else if ((mech.getCockpitType() == Mech.COCKPIT_SUPERHEAVY) || (mech.getCockpitType() == Mech.COCKPIT_TRIPOD)) {
-            weight = 4.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_TRIPOD) {
-            weight = 5.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_INTERFACE) {
-            weight = 4.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_QUADVEE) {
-            weight = 4.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE) {
-            // Like as normal command console, it is technically two seperate 4-ton and 3-ton pieces of equipment.
-            weight = 7.0;
-        } else if (mech.getCockpitType() == Mech.COCKPIT_SMALL_COMMAND_CONSOLE) {
-            // Like as normal command console, it is technically two seperate 2-ton and 3-ton pieces of equipment. 
-            weight = 5.0;
+        switch (mech.getCockpitType()) {
+            case Mech.COCKPIT_SMALL:
+                return 2.0;
+            case Mech.COCKPIT_TORSO_MOUNTED:
+            case Mech.COCKPIT_DUAL:
+            case Mech.COCKPIT_SUPERHEAVY:
+            case Mech.COCKPIT_SUPERHEAVY_INDUSTRIAL:
+            case Mech.COCKPIT_TRIPOD:
+            case Mech.COCKPIT_TRIPOD_INDUSTRIAL:
+            case Mech.COCKPIT_INTERFACE:
+            case Mech.COCKPIT_QUADVEE:
+                return 4.0;
+            case Mech.COCKPIT_PRIMITIVE:
+            case Mech.COCKPIT_PRIMITIVE_INDUSTRIAL:
+            case Mech.COCKPIT_SUPERHEAVY_TRIPOD:
+            case Mech.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL:
+            case Mech.COCKPIT_SMALL_COMMAND_CONSOLE:
+                return 5.0;
+            case Mech.COCKPIT_COMMAND_CONSOLE:
+                return 6.0;
+            case Mech.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+                return 7.0;
+            case Mech.COCKPIT_STANDARD:
+            case Mech.COCKPIT_INDUSTRIAL:
+            case Mech.COCKPIT_VRRP:
+            default:
+                return 3.0;
         }
-
-        return weight;
     }
 
     public double getWeightGyro() {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1018,8 +1018,7 @@ public class TestMech extends TestEntity {
                     buff.append("industrial mech can't mount ").append(misc.getName()).append("\n");
                     illegal = true;                    
                 }
-                if ((mech.getCockpitType() == Mech.COCKPIT_INDUSTRIAL
-                        || mech.getCockpitType() == Mech.COCKPIT_PRIMITIVE_INDUSTRIAL)
+                if (!mech.hasAdvancedFireControl()
                     && (misc.hasFlag(MiscType.F_TARGCOMP)
                         || misc.hasFlag(MiscType.F_ARTEMIS)
                         || misc.hasFlag(MiscType.F_ARTEMIS_PROTO)

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -991,6 +991,7 @@ public class FireControlTest {
         // Test the most vanilla case we can.
         when(mockShooterState.isProne()).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_ANTI_AIR))).thenReturn(false);
+        when(((Mech) mockShooter).hasAdvancedFireControl()).thenReturn(true);
         when(mockTargetState.isImmobile()).thenReturn(false);
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_NONE);
         when(mockTargetState.getPosition()).thenReturn(new Coords(10, 0));
@@ -1028,7 +1029,7 @@ public class FireControlTest {
                 mockShooter, mockShooterState, mockFighter, mockFighterState, 10, mockGame));
 
         // Test industrial mechs.
-        when(((Mech) mockShooter).getCockpitType()).thenReturn(Mech.COCKPIT_INDUSTRIAL);
+        when(((Mech) mockShooter).hasAdvancedFireControl()).thenReturn(false);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_INDUSTRIAL);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
@@ -1039,6 +1040,7 @@ public class FireControlTest {
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
                 mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
         when(((Mech) mockShooter).getCockpitType()).thenReturn(Mech.COCKPIT_STANDARD);
+        when(((Mech) mockShooter).hasAdvancedFireControl()).thenReturn(true);
 
         // Test attacking a superheavy mech.
         when(((Mech) mockTarget).getCockpitType()).thenReturn(Mech.COCKPIT_SUPERHEAVY);


### PR DESCRIPTION
Adds industrial cockpits for tripod mechs, to distinguish between those that have basic fire control and those that have active.

Also adds a `hasActiveFireControl` method to `Mech` and uses this instead of cockpit comparisons elsewhere in the code. I don't think any of the checks for basic fire control are currently checking for superheavy industrial, which means that they currently get the advantage of active fire control.

This is part of a fix for Megamek/megameklab#1315.