### PR TITLE
Fix 3882 (MM part): ASFs not tracked correctly in MHQ

### DIFF
--- a/megamek/data/forcegenerator/2398.xml
+++ b/megamek/data/forcegenerator/2398.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2398' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2398' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2398' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2398' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:2</salvage>
@@ -46,7 +46,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2398' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2398' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2398' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2398' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -59,7 +59,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2398' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2398' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:6,LA:10,FWL:9,FS:3,DC:2</salvage>
@@ -229,7 +229,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:8</availability>
@@ -301,7 +301,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:2,OA:1,LA:2,FWL:8,IS:1,FS:1,DC:1,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:8</availability>
@@ -360,7 +360,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Firebird' unitType='Aero'>
+	<chassis name='Firebird' unitType='AeroSpaceFighter'>
 		<availability>CC:4,TC:2</availability>
 		<model name='FR-1'>
 			<availability>General:8</availability>
@@ -417,7 +417,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>TH:4</availability>
 		<model name='HMR-HA'>
 			<availability>TH:8</availability>
@@ -662,7 +662,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>

--- a/megamek/data/forcegenerator/2440.xml
+++ b/megamek/data/forcegenerator/2440.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2440' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2440' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2440' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2440' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:2,DC:1</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2440' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2440' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2440' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2440' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2440' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2440' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:9,FWL:9,FS:4,DC:2</salvage>
@@ -274,7 +274,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:1,IS:1,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:8</availability>
@@ -361,7 +361,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:1,DC:1,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:8</availability>
@@ -433,7 +433,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Firebird' unitType='Aero'>
+	<chassis name='Firebird' unitType='AeroSpaceFighter'>
 		<availability>CC:1,TC:1</availability>
 		<model name='FR-1'>
 			<availability>General:8</availability>
@@ -490,7 +490,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>TH:5</availability>
 		<model name='HMR-HA'>
 			<availability>TH:8</availability>
@@ -790,7 +790,7 @@
 			<availability>IS:5,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>

--- a/megamek/data/forcegenerator/2460.xml
+++ b/megamek/data/forcegenerator/2460.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2460' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2460' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2460' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2460' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:2,DC:2</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2460' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2460' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2460' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2460' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2460' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2460' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:10,FS:4,DC:3</salvage>
@@ -280,7 +280,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:1,IS:1,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:8</availability>
@@ -390,7 +390,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:6</availability>
@@ -525,7 +525,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>TH:7</availability>
 		<model name='HMR-HA'>
 			<availability>TH:8</availability>
@@ -623,7 +623,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:8</availability>
@@ -875,7 +875,7 @@
 			<availability>IS:4,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
@@ -932,7 +932,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:4</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>

--- a/megamek/data/forcegenerator/2470.xml
+++ b/megamek/data/forcegenerator/2470.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2470' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2470' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2470' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2470' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:6,FWL:5,DC:1</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2470' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2470' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2470' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2470' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2470' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2470' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -300,7 +300,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:1,IS:1,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:7</availability>
@@ -432,7 +432,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:5</availability>
@@ -585,7 +585,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:2,TH:7,LA:1,FWL:2,IS:1,FS:2,DC:2</availability>
 		<model name='HMR-HA'>
 			<availability>TH:6</availability>
@@ -771,7 +771,7 @@
 			<availability>General:1-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:8</availability>
@@ -1053,13 +1053,13 @@
 			<availability>IS:3,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -1113,7 +1113,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>LA:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -1141,7 +1141,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:1,DC:1</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>

--- a/megamek/data/forcegenerator/2490.xml
+++ b/megamek/data/forcegenerator/2490.xml
@@ -29,7 +29,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2490' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2490' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2490' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2490' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:7,FWL:2</salvage>
@@ -47,7 +47,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2490' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2490' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2490' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2490' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -60,7 +60,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2490' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2490' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -347,7 +347,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8</availability>
 		<model name='CNT-1A'>
 			<availability>General:6</availability>
@@ -507,7 +507,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,OA:1,LA:3,FWL:8,IS:1,FS:2,DC:2,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:4</availability>
@@ -738,7 +738,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
 		<model name='HMR-HA'>
 			<availability>TH:5</availability>
@@ -949,7 +949,7 @@
 			<availability>General:1-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:6</availability>
@@ -1329,7 +1329,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>DC:6-</availability>
 		<model name='SB-26'>
 			<availability>DC:8</availability>
@@ -1338,7 +1338,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -1351,7 +1351,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -1430,7 +1430,7 @@
 			<availability>TH:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -1467,7 +1467,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:2,DC:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>

--- a/megamek/data/forcegenerator/2520.xml
+++ b/megamek/data/forcegenerator/2520.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2520' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2520' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2520' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2520' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>TH:7,FWL:3,DC:2</salvage>
@@ -49,7 +49,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2520' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2520' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2520' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2520' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -59,7 +59,7 @@
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>FS:7</salvage>
-		<weightDistribution era='2520' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2520' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -423,7 +423,7 @@
 			<availability>TH:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:3,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:6</availability>
@@ -621,7 +621,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,OA:1,LA:3,FWL:8,IS:1,FS:3,DC:3,TC:1</availability>
 		<model name='EGL-R1'>
 			<availability>General:2</availability>
@@ -886,7 +886,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:3,TH:7,LA:2,FWL:3,IS:2,FS:3,DC:3</availability>
 		<model name='HMR-HA'>
 			<availability>TH:4</availability>
@@ -1108,7 +1108,7 @@
 			<availability>General:1-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8</availability>
 		<model name='LTN-G14'>
 			<availability>CC:4</availability>
@@ -1145,7 +1145,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>LA:6</availability>
 		<model name='LCF-R15'>
 			<availability>LA:6,General:6,Periphery.Deep:6,MERC:8,Periphery:6</availability>
@@ -1553,7 +1553,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:5-,OA:5-,LA:5-,FWL:5-,IS:5-,Periphery.Deep:5-,FS:5-,MERC:5-,DC:6-,Periphery:5-</availability>
 		<model name='SB-26'>
 			<availability>DC:6</availability>
@@ -1562,7 +1562,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -1575,7 +1575,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FWL:2,FS:2,MERC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -1611,7 +1611,7 @@
 			<availability>TH:5,IS:3,TC:5,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>TH:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -1671,7 +1671,7 @@
 			<availability>TH:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>LA:9,FWL:2,DC:3</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -1719,7 +1719,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:2,DC:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -1797,7 +1797,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>RWR:6</availability>
 		<model name='VLC-3N'>
 			<availability>General:8</availability>

--- a/megamek/data/forcegenerator/2571.xml
+++ b/megamek/data/forcegenerator/2571.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2571' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2571' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2571' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:7,SL:5,FWL:2,RWR:2,DC:3</salvage>
@@ -49,7 +49,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2571' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2571' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2571' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -61,11 +61,11 @@
 		<salvage pct='5'>CC:10,LA:10,FWL:9,FS:4,DC:7</salvage>
 		<weightDistribution era='2571' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2571' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2571' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>CC:6,SL:10,FS:9</salvage>
-		<weightDistribution era='2571' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2571' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:3,LA:10,FWL:9,FS:4,DC:3</salvage>
@@ -552,7 +552,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -594,7 +594,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:6,Periphery.ME:3,FWL:4,SL.R:6,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -608,7 +608,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,OA:1,LA:3,SL:6,FWL:3,RWR:1,FS:3,MERC:3,DC:3,Periphery:1,TC:1</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -869,7 +869,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,OA:1,LA:4,SL:5,FWL:8,IS:2,FS:4,DC:4,TC:2</availability>
 		<model name='EGL-R4'>
 			<availability>LA:6,General:3,FS:6</availability>
@@ -1228,7 +1228,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:1,OA:1,TH:7,LA:3,SL:7,FWL:4,IS:3,FS:4,DC:4,TC:1</availability>
 		<model name='HMR-HC'>
 			<availability>TH:6,SL:5,IS:8</availability>
@@ -1390,7 +1390,7 @@
 			<availability>CC:1,IS:2,DC:1,Periphery:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>SL:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -1577,7 +1577,7 @@
 			<availability>LA:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,SL:5</availability>
 		<model name='LTN-G14'>
 			<availability>CC:2,Periphery.Deep:4,Periphery:4</availability>
@@ -1642,7 +1642,7 @@
 			<availability>MOC:3,OA:3,TH:4,LA:3,SL:4,FWL:3,RWR:2,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,Periphery.R:2,OA:1,LA:8,Periphery.MW:2,MERC:3,Periphery:1,TC:1</availability>
 		<model name='LCF-R15'>
 			<availability>LA:6,General:6,Periphery.Deep:6,MERC:8,Periphery:6</availability>
@@ -2187,7 +2187,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>SL:7</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -2222,7 +2222,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>SL:4</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
@@ -2254,7 +2254,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-26'>
 			<availability>DC:4</availability>
@@ -2270,7 +2270,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:6,IS:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,OA:4,LA:6,SL:8,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -2295,7 +2295,7 @@
 			<availability>CC:2,TH:2,LA:2,FWL:2,FS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,Periphery.R:3,OA:3,LA:4,FWL:3,FS:3,MERC:3,DC:3,Periphery:3,TC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -2340,7 +2340,7 @@
 			<availability>TH:6,IS:4,TC:5,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:2,RWR:1,MERC:2,Periphery.OS:1,FS:2,Periphery:1,TC:1,OA:1,TH:5,LA:2,Periphery.HR:1,SL:6,FWL:2,SL.R:6,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -2369,7 +2369,7 @@
 			<availability>MOC:1,OA:1,IS:1,TC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>TH:6,DC:4</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -2416,7 +2416,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>CC:3,LA:3,SL:6,FWL:2,FS:3,MERC:2,DC:2</availability>
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
@@ -2459,7 +2459,7 @@
 			<availability>SL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:8</availability>
@@ -2471,7 +2471,7 @@
 			<availability>SL:8,FWL:8+,IS:8+,SL.R:8,FS:8+,DC:8+</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,OA:5,LA:9,SL:7,IS:5,FWL:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -2516,7 +2516,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:4</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -2540,7 +2540,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5,MERC:1,DC:1</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -2625,7 +2625,7 @@
 			<availability>SL:8,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>RWR:6</availability>
 		<model name='VLC-3N'>
 			<availability>General:8</availability>

--- a/megamek/data/forcegenerator/2650.xml
+++ b/megamek/data/forcegenerator/2650.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2650' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2650' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2650' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:10,SL:10,FWL:4,RWR:2,DC:4</salvage>
@@ -49,7 +49,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2650' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2650' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2650' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -61,11 +61,11 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:3,DC:6</salvage>
 		<weightDistribution era='2650' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2650' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2650' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:1,SL:1,FS:10</salvage>
-		<weightDistribution era='2650' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2650' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:7,LA:10,FWL:7,FS:2,DC:5</salvage>
@@ -198,7 +198,7 @@
 	</faction>
 	<faction key='RWR.HG'>
 		<pctSL>0,0,3,5,10</pctSL>
-		<pctSL unitType='Aero'>0,0,3,5,10</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,0,3,5,10</pctSL>
 		<pctSL unitType='Vehicle'>0,0,3,5,10</pctSL>
 		<salvage pct='5'>LA:10,SL:2</salvage>
 	</faction>
@@ -582,7 +582,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -634,7 +634,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:2,TC:4,OA:4,LA:4,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,SL.R:4,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -648,7 +648,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:8,FWL:4,RWR:2,FS:4,MERC:4,DC:3,Periphery:2,TC:2</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -878,7 +878,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:2,LA:4,SL:5,FWL:8,IS:3,RWR:2,FS:4,DC:4,Periphery:2,TC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1213,7 +1213,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:2,SL:8,IS:2,FWL:8,RWR:2,FS:2,MERC:2,TC:2,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:6</availability>
@@ -1269,7 +1269,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,TH:6,LA:4,SL:7,FWL:4,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
 		<model name='HMR-HC'>
 			<availability>TH:5,SL:4,IS:8</availability>
@@ -1454,7 +1454,7 @@
 			<availability>CC:2,IS:5,DC:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:2,LA:2,SL:7,FWL:2,IS:2,FWL.OH:2,RWR:2,FS:2,DC:2,TC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -1658,7 +1658,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery.Deep:4,Periphery:4</availability>
@@ -1730,7 +1730,7 @@
 			<availability>MOC:4,OA:4,TH:6,LA:5,SL:6,FWL:5,RWR:3,FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
@@ -2350,7 +2350,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,SL:8</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -2406,7 +2406,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,OA:2,LA:4,SL:5,FWL:4,IS:3,RWR:2,FS:3,DC:3,TC:2</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
@@ -2447,7 +2447,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:8,SL.R:8</availability>
@@ -2463,7 +2463,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:7,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -2497,7 +2497,7 @@
 			<availability>LA:4+,SL:6,FWL:4+,SL.R:8,RWR:4,FS:4+,MERC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:4,OA:5,LA:4,FWL:3,Periphery.Deep:4,FS:3,MERC:3,DC:3,Periphery:4,TC:4</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -2549,7 +2549,7 @@
 			<availability>TH:4,IS:4,TC:5,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:3,Periphery:3,TC:2,OA:2,TH:5,LA:3,Periphery.HR:3,SL:6,FWL:3,SL.R:5,DC:3</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -2584,7 +2584,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>TH:4,DC:6</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -2639,13 +2639,13 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,RWR:2,MERC:3,Periphery.OS:2,FS:4,TC:2,Periphery:1,OA:2,LA:4,Periphery.HR:2,SL:8,FWL:3,DC:3</availability>
 		<model name='STU-K5'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>SL:7</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -2699,7 +2699,7 @@
 			<availability>SL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:8</availability>
@@ -2711,7 +2711,7 @@
 			<availability>SL:8,FWL:8+,IS:8+,SL.R:8,RWR:8,FS:8+,DC:8+</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,OA:5,LA:9,SL:7,IS:5,FWL:5,Periphery.Deep:5,FS:5,Periphery:5,TC:5,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -2734,7 +2734,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>SL:8</availability>
 		<model name='THK-33'>
 			<availability>General:3</availability>
@@ -2770,7 +2770,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:5</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -2794,7 +2794,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:5</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -2896,7 +2896,7 @@
 			<availability>SL:6,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>RWR:6</availability>
 		<model name='VLC-3N'>
 			<availability>General:6</availability>

--- a/megamek/data/forcegenerator/2700.xml
+++ b/megamek/data/forcegenerator/2700.xml
@@ -28,7 +28,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2700' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2700' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2700' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:10,SL:10,FWL:4,RWR:2,DC:5</salvage>
@@ -50,7 +50,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2700' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2700' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2700' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -62,11 +62,11 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:3,DC:6</salvage>
 		<weightDistribution era='2700' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2700' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2700' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:1,SL:1,FS:10</salvage>
-		<weightDistribution era='2700' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2700' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:7,LA:10,FWL:7,FS:2,DC:5</salvage>
@@ -221,7 +221,7 @@
 	</faction>
 	<faction key='RWR.HG'>
 		<pctSL>0,0,2,3,5</pctSL>
-		<pctSL unitType='Aero'>0,0,2,3,5</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,0,2,3,5</pctSL>
 		<pctSL unitType='Vehicle'>0,0,2,3,5</pctSL>
 		<salvage pct='5'>LA:10,SL:2</salvage>
 	</faction>
@@ -298,7 +298,7 @@
 			<availability>CC:2,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:2+,LA:2+,SL:6,FWL:2+,IS:2+,FS:2+,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,SL.R:4</availability>
@@ -660,7 +660,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:8,MERC:5,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -715,7 +715,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:3,TC:4,OA:4,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -729,7 +729,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,FWL:4,RWR:3,FS:4,MERC:4,DC:4,Periphery:2,TC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -969,7 +969,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1059,7 +1059,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OA:3,LA:4,SL:4,IS:4,FWL:8,RWR:3,FS:4,Periphery:3,TC:4,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1438,7 +1438,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:6</availability>
@@ -1510,7 +1510,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4,OA:4,TH:5,LA:5,SL:7,FWL:5,IS:5,RWR:4,FS:5,DC:5,TC:4</availability>
 		<model name='HMR-HC'>
 			<availability>TH:4,SL:2,IS:8</availability>
@@ -1610,7 +1610,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>SL:5</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1623,7 +1623,7 @@
 			<availability>IS:4,SL.R:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:4-,OA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1737,7 +1737,7 @@
 			<availability>CC:3,IS:7,DC:3,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:7,FWL:3,IS:3,FWL.OH:3,RWR:2,FS:3,DC:3,TC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2006,7 +2006,7 @@
 			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2092,7 +2092,7 @@
 			<availability>MOC:4,OA:4,TH:8,LA:6,SL:8,FWL:6,RWR:3,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
@@ -2844,7 +2844,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,SL:8</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -2924,7 +2924,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:8</availability>
@@ -2976,7 +2976,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:8,SL.R:6</availability>
@@ -2998,7 +2998,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3041,7 +3041,7 @@
 			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,Periphery.R:4,OA:4,LA:4,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3109,7 +3109,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>SL:5</availability>
 		<model name='SPD-502'>
 			<availability>General:8,SL.R:6</availability>
@@ -3118,7 +3118,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:4,Periphery:3,TC:2,OA:2,TH:6,LA:3,Periphery.HR:3,SL:5-,FWL:3,SL.R:3,DC:3</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3159,7 +3159,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>DC:6</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -3203,7 +3203,7 @@
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:5,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:2,LA:2,SL:2,FWL:2,IS:2,FS:2,MERC:2,DC:2</availability>
 		<model name='F-90'>
 			<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
@@ -3231,7 +3231,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,RWR:2,MERC:4,Periphery.OS:2,FS:5,TC:2,Periphery:2,OA:2,LA:5,Periphery.HR:2,SL:8,FWL:4,DC:4</availability>
 		<model name='STU-K10'>
 			<availability>FS.DMM:8</availability>
@@ -3243,7 +3243,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:2,SL:9,FWL:2,RWR:2,FS:2,MERC:2,DC:3,TC:2</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3297,7 +3297,7 @@
 			<availability>SL.R:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:3</availability>
 		<model name='TR-5'>
 			<availability>CC:8</availability>
@@ -3319,7 +3319,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3356,7 +3356,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:4,SL:9,FWL:3,RWR:2,FS:2,MERC:2,DC:2,TC:2</availability>
 		<model name='THK-33'>
 			<availability>General:1</availability>
@@ -3415,13 +3415,13 @@
 			<availability>SL:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:2,SL:7,FWL:3,RWR:3,FS:4,MERC:4,DC:4,TC:3</availability>
 		<model name='TRN-3T'>
 			<availability>OA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
@@ -3451,7 +3451,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3571,7 +3571,7 @@
 			<availability>SL:4,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,OA:3,RWR:6,TC:3</availability>
 		<model name='VLC-3N'>
 			<availability>General:4</availability>
@@ -3757,7 +3757,7 @@
 			<availability>General:4,SL.R:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,OA:2,LA:3,SL:4,FWL:3,IS:3,RWR:2,FS:3,DC:4,Periphery:2,TC:2</availability>
 		<model name='ZRO-114'>
 			<availability>General:8,SL.R:6</availability>

--- a/megamek/data/forcegenerator/2765.xml
+++ b/megamek/data/forcegenerator/2765.xml
@@ -31,7 +31,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2765' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2765' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2765' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>TH:10,SL:10,FWL:8,RWR:6,DC:7</salvage>
@@ -58,7 +58,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2765' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2765' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2765' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -70,11 +70,11 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:4,DC:6</salvage>
 		<weightDistribution era='2765' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2765' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2765' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,SL:2,FS:10</salvage>
-		<weightDistribution era='2765' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2765' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:9,LA:10,FWL:7,FS:3,DC:5</salvage>
@@ -233,13 +233,13 @@
 	</faction>
 	<faction key='RWR.HG'>
 		<pctSL>0,0,1,2,5</pctSL>
-		<pctSL unitType='Aero'>0,0,1,2,5</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,0,1,2,5</pctSL>
 		<pctSL unitType='Vehicle'>0,0,1,2,5</pctSL>
 		<salvage pct='5'>LA:10,SL:2,SL.R:1</salvage>
 	</faction>
 	<faction key='RWR.TC'>
 		<pctSL>30,40</pctSL>
-		<pctSL unitType='Aero'>30,40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>30,40</pctSL>
 		<pctSL unitType='Vehicle'>30,40</pctSL>
 		<salvage pct='7'>SL:8,SL.R:2</salvage>
 	</faction>
@@ -318,7 +318,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:5+,LA:5+,SL:7,FWL:5+,IS:4+,RWR:3+,FS:5+,DC:5+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,SL.R:4</availability>
@@ -703,7 +703,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,IS:2,FS:6,MERC:4,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -761,7 +761,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,RWR:5,FS:4,MERC:4,Periphery:3,TC:5,OA:5,LA:4,Periphery.MW:4,SL:4-,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -775,7 +775,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,OA:3,LA:5,SL:7,FWL:5,RWR:3,MERC:5,FS:5,Periphery:2,TC:3,DC:4</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -921,7 +921,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>SL:6</availability>
 		<model name='CSR-V12'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
@@ -1038,7 +1038,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1131,7 +1131,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OA:4,LA:4,SL:4-,IS:4,FWL:8,RWR:4,FS:4,Periphery:3,TC:4,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1512,7 +1512,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:5</availability>
@@ -1584,7 +1584,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:4,OA:4,TH:5,LA:6,SL:7,FWL:6,IS:6,RWR:4,FS:6,DC:6,TC:4</availability>
 		<model name='HMR-HC'>
 			<availability>TH:4,IS:8</availability>
@@ -1684,7 +1684,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2+,OA:2+,LA:2,SL:5,FWL:2,IS:2,RWR:2,FS:2,DC:2,TC:2+</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1697,7 +1697,7 @@
 			<availability>IS:4,SL.R:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1811,7 +1811,7 @@
 			<availability>CC:4,IS:8,DC:4,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,IS:3,FWL:4,FWL.OH:4,RWR:3,FS:4,TC:3,DC:4</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2108,7 +2108,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:3,FS:3,DC:3,Periphery:2,TC:2</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2194,7 +2194,7 @@
 			<availability>MOC:4,OA:4,TH:8,LA:5,SL:8,FWL:5,RWR:5,FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
@@ -3001,7 +3001,7 @@
 			<availability>FWL:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,SL:8,IS:2,RWR:3,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>General:8,SL.R:8</availability>
@@ -3085,7 +3085,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,OA:3,LA:5,SL:5,FWL:5,IS:4,RWR:3,FS:4,DC:4,TC:3</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,SL.R:7</availability>
@@ -3137,7 +3137,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:6,SL.R:4</availability>
@@ -3159,7 +3159,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3206,7 +3206,7 @@
 			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,Periphery.R:4,OA:4,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3261,7 +3261,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3301,7 +3301,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>SL:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,SL.R:5</availability>
@@ -3310,7 +3310,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,RWR:2,MERC:4,Periphery.OS:4,FS:5,Periphery:4,TC:2,OA:2,TH:6,LA:4,Periphery.HR:4,SL:5-,FWL:4,SL.R:2,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3362,7 +3362,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>DC:3</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -3413,7 +3413,7 @@
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,IS:4,RWR:2,MERC:4,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:4,DC:4</availability>
 		<model name='F-90'>
 			<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
@@ -3441,7 +3441,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,RWR:3,MERC:4,Periphery.OS:3,FS:5,TC:3,Periphery:2,OA:3,LA:5,Periphery.HR:3,SL:8,FWL:4,DC:4</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3453,7 +3453,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3,OA:3,SL:9,FWL:4,RWR:3,FS:4,MERC:4,DC:5,TC:3</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3507,7 +3507,7 @@
 			<availability>SL.R:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:3</availability>
 		<model name='TR-5'>
 			<availability>CC:6</availability>
@@ -3535,7 +3535,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:7,Periphery:6,TC:7,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3572,7 +3572,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,OA:3,LA:6,SL:9,FWL:5,RWR:3,FS:3,MERC:3,DC:3,TC:3</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -3624,13 +3624,13 @@
 			<availability>SL:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:5,OA:5,LA:3,SL:7,FWL:4,RWR:5,FS:6,MERC:6,DC:6,TC:5</availability>
 		<model name='TRN-3T'>
 			<availability>OA:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
@@ -3660,7 +3660,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3780,7 +3780,7 @@
 			<availability>SL:2,IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,RWR:8,Periphery:2,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -3984,7 +3984,7 @@
 			<availability>General:4,SL.R:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:3,SL:6,IS:3,FWL:3,RWR:2,FS:3,Periphery:2,TC:2,DC:5</availability>
 		<model name='ZRO-114'>
 			<availability>General:8,SL.R:5</availability>

--- a/megamek/data/forcegenerator/2780.xml
+++ b/megamek/data/forcegenerator/2780.xml
@@ -35,7 +35,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2780' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2780' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2780' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='5'>FWL:10,Periphery:2,DC:9</salvage>
@@ -61,7 +61,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2780' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2780' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2780' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,SL:5,FWL:2,FS:2,DC:2</salvage>
@@ -70,12 +70,12 @@
 		<salvage pct='5'>CC:8,LA:10,FWL:7,FS:4,DC:6</salvage>
 		<weightDistribution era='2780' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2780' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2780' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='SLIE'/>
 	<faction key='TC'>
 		<salvage pct='6'>CC:6,SL:10,FS:10</salvage>
-		<weightDistribution era='2780' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2780' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TH'>
 		<salvage pct='5'>CC:16,LA:20,FWL:14,FS:8,DC:12</salvage>
@@ -315,7 +315,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:6+,LA:6+,SL:7,FWL:7+,IS:5+,NIOPS:7,FS:6+,DC:6+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,SL.R:4</availability>
@@ -699,7 +699,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -757,7 +757,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:5,SL:2-,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -775,7 +775,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,OA:3,LA:8,SL:7,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -917,7 +917,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,OA:3,LA:4,SL:6,FWL:5,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,DC:3</availability>
 		<model name='CSR-V12'>
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
@@ -1047,7 +1047,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1140,7 +1140,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,OA:4,LA:4,SL:4-,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1524,7 +1524,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,SL.R:4</availability>
@@ -1602,7 +1602,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:4,OA:4,LA:6,SL:7,IS:6,FWL:6,NIOPS:7,FS:6,CIR:4,TC:4,DC:6</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -1705,7 +1705,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3+,OA:3+,LA:4,SL:6,IS:3,FWL:4,NIOPS:6,FS:4,TC:3+,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1718,7 +1718,7 @@
 			<availability>IS:4,NIOPS:4,SL.R:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1832,7 +1832,7 @@
 			<availability>CC:5,CS:5,IS:8,MERC:6,DC:5,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,OA:3,LA:6,SL:7,FWL:6,NIOPS:6,DC:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2150,7 +2150,7 @@
 			<availability>SL.R:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,IS:3,FWL:2,NIOPS:5-,FS:3,Periphery:2,TC:2,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2236,7 +2236,7 @@
 			<availability>MOC:4,CS:6,OA:4,SLIE:5,LA:4,SL:6,FWL:4,FS:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
@@ -3000,7 +3000,7 @@
 			<availability>FWL:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>OA:2,LA:6,SL:8,IS:3,NIOPS:8,MERC:3</availability>
 		<model name='RPR-100'>
 			<availability>General:8,NIOPS:8,SL.R:7</availability>
@@ -3077,7 +3077,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:4,SL:5,IS:4,FWL:4,NIOPS:4,FS:3,CIR:2,TC:3,DC:3</availability>
 		<model name='RGU-133E'>
 			<availability>General:8,NIOPS:8,SL.R:6</availability>
@@ -3125,7 +3125,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,SL:4</availability>
@@ -3147,7 +3147,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,OA:6,LA:6,SL:5,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3194,7 +3194,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3262,7 +3262,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3302,7 +3302,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>OA:2,SL:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,SL.R:4</availability>
@@ -3311,7 +3311,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,OA:3,LA:4,Periphery.HR:4,SL:4-,FWL:2,NIOPS:3,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3363,7 +3363,7 @@
 			<availability>MOC:2,OA:2,IS:2,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>DC:2</availability>
 		<model name='S-2B'>
 			<availability>General:8</availability>
@@ -3414,7 +3414,7 @@
 			<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,OA:2,LA:6,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 		<model name='F-90'>
 			<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
@@ -3436,7 +3436,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,SL:7,FWL:3,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3448,7 +3448,7 @@
 			<availability>SL.R:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3,OA:3,LA:2,SL:9,FWL:4,NIOPS:8,FS:4,MERC:4,DC:5,TC:3</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3496,7 +3496,7 @@
 			<availability>SL.R:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:5</availability>
@@ -3528,7 +3528,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,OA:6,LA:8,SL:5,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3568,7 +3568,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:2,OA:2,LA:6,SL:9,FWL:5,NIOPS:9,FS:3,MERC:3,CIR:1,TC:2,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -3606,7 +3606,7 @@
 			<availability>SLIE:8,SL:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -3623,7 +3623,7 @@
 			<availability>CC:2,MOC:2,NIOPS:2,FWL:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:5,OA:5,LA:3,SL:7,FWL:4,NIOPS:7,FS:6,MERC:6,CIR:4,TC:5,DC:6</availability>
 		<model name='TRN-3T'>
 			<availability>OA:7,SL:8,IS:7,NIOPS:8,Periphery.Deep:7,SL.R:4,Periphery:7</availability>
@@ -3649,7 +3649,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3769,7 +3769,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -3986,7 +3986,7 @@
 			<availability>General:3,SL.R:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:2,LA:2,SL:6,IS:2,FWL:2,NIOPS:5,FS:2,Periphery:2,TC:2,DC:4</availability>
 		<model name='ZRO-114'>
 			<availability>General:8,NIOPS:8,SL.R:4</availability>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -56,7 +56,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2807' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2807' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2807' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2807' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<salvage pct='6'>FWL:10,Periphery:2,DC:9</salvage>
@@ -81,14 +81,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2807' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2807' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2807' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2807' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='6'>CC:6,FS:10</salvage>
-		<weightDistribution era='2807' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2807' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -322,7 +322,7 @@
 			<availability>CS:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6+,CS:7,LA:6+,FWL:7+,IS:5+,NIOPS:7,FS:6+,DC:6+</availability>
 		<model name='AHB-443'>
 			<availability>General:8</availability>
@@ -699,7 +699,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -764,7 +764,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -782,7 +782,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:6,CC:5,OA:3,LA:8,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -920,7 +920,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:6,CC:3,OA:3,LA:4,FWL:5,MERC:3,FS:6,CIR:2,Periphery:2,TC:3,DC:3</availability>
 		<model name='CSR-V12'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1056,7 +1056,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1161,7 +1161,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1582,7 +1582,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>PP:6,General:6</availability>
@@ -1657,7 +1657,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:4,IS:6,FS:6,CIR:4,TC:4,CS:7,OA:4,LA:6,FWL:6,NIOPS:7,DC:6</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -1767,7 +1767,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:4,MOC:3+,CS:6,OA:3+,LA:4,IS:3,FWL:4,NIOPS:6,FS:4,TC:3+,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -1780,7 +1780,7 @@
 			<availability>CS:4,PP:4,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -1920,7 +1920,7 @@
 			<availability>CS:6,CLAN:7,IS:8,MERC:6,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:3,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,FWL:6,NIOPS:6,DC:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2226,7 +2226,7 @@
 			<availability>PP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:8,MOC:2,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2313,7 +2313,7 @@
 			<availability>MOC:4,CS:6,OA:4,IS:6,MERC:2,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
@@ -3072,7 +3072,7 @@
 			<availability>FWL:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>PP:8,CS:8,OA:3,LA:6,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3141,7 +3141,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,FWL:4,NIOPS:4,DC:3</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3198,7 +3198,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -3217,7 +3217,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3280,7 +3280,7 @@
 			<availability>PP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3306,7 +3306,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3318,7 +3318,7 @@
 			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:6</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:8</availability>
@@ -3357,7 +3357,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3397,7 +3397,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CS:6,OA:3,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8</availability>
@@ -3406,7 +3406,7 @@
 			<availability>PP:4,CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3499,7 +3499,7 @@
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -3521,7 +3521,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3533,7 +3533,7 @@
 			<availability>PP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:2,MOC:3,CS:8,OA:3,LA:2,FWL:4,NIOPS:8,FS:4,MERC:4,TC:3,DC:5</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -3584,7 +3584,7 @@
 			<availability>PP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:4</availability>
@@ -3616,7 +3616,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -3663,7 +3663,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:5,MOC:2,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,LA:6,FWL:5,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -3701,7 +3701,7 @@
 			<availability>CS:5+</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -3718,7 +3718,7 @@
 			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:5,FS:6,MERC:6,CIR:4,TC:5,CS:7,OA:5,LA:3,FWL:4,NIOPS:7,DC:6</availability>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:6,IS:6,NIOPS:8,Periphery.Deep:6,Periphery:6</availability>
@@ -3748,7 +3748,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -3875,7 +3875,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4082,7 +4082,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,PP:6,CC:1,IS:1,FS:1,TC:2,Periphery:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:4</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -16,7 +16,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2815' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2815' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2815' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -40,9 +40,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
@@ -79,9 +79,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
@@ -148,9 +148,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
@@ -159,9 +159,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='5'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
@@ -224,7 +224,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2815' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2815' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2815' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'></salvage>
@@ -255,14 +255,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2815' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2815' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2815' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:6,FS:10</salvage>
-		<weightDistribution era='2815' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -361,9 +361,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -506,7 +506,7 @@
 			<availability>CS:8,General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:5+,CS:7,LA:5+,CLAN:7,FWL:7+,IS:4+,NIOPS:7,FS:5+,DC:5+</availability>
 		<model name='AHB-443'>
 			<availability>General:8</availability>
@@ -906,7 +906,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:4,Periphery.Deep:4,FS:5,MERC:3,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:5</availability>
@@ -974,7 +974,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -992,7 +992,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:5,MOC:3,CLAN:5,FS:5,MERC:5,CIR:3,Periphery:2,TC:3,OA:3,LA:8,FWL:6,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -1253,7 +1253,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:3,MOC:3,CLAN:5,FS:6,MERC:3,CIR:2,Periphery:2,TC:3,OA:3,LA:4,FWL:5,DC:3</availability>
 		<model name='CSR-V12'>
 			<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1395,7 +1395,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='F-77'>
 			<availability>FWL:8</availability>
@@ -1500,7 +1500,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -1933,7 +1933,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>PP:6,General:6</availability>
@@ -2008,7 +2008,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,PP:7,CC:5,CLAN:7,IS:5,FS:5,CIR:4,TC:4,CS:7,OA:4,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2118,7 +2118,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -2131,7 +2131,7 @@
 			<availability>CS:4,PP:4,CLAN:2,IS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2274,7 +2274,7 @@
 			<availability>CS:7,CLAN:7,IS:8,MERC:6,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,CNC:7,FWL:6,NIOPS:6,DC:6</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -2590,7 +2590,7 @@
 			<availability>PP:4,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:3</availability>
@@ -2677,7 +2677,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:2,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
@@ -3464,7 +3464,7 @@
 			<availability>MOC:6,OA:6,FWL:8,DC:8,TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>PP:8,CS:8,OA:3,LA:6,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3497,7 +3497,7 @@
 			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:4,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3545,7 +3545,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:3,MOC:2,CLAN:4,IS:3,FS:3,CIR:2,TC:2,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:2</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -3605,7 +3605,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:5-,MOC:5-,OA:5-,LA:5-,CLAN:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -3630,7 +3630,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3700,7 +3700,7 @@
 			<availability>PP:2,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3726,7 +3726,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3738,7 +3738,7 @@
 			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:8</availability>
@@ -3777,7 +3777,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:2,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3817,7 +3817,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>PP:6,CS:6,OA:3,CSR:6,CLAN:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8</availability>
@@ -3826,7 +3826,7 @@
 			<availability>PP:4,CS:4,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -3922,7 +3922,7 @@
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -3944,7 +3944,7 @@
 			<availability>CC:8,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,PP:8,CC:4,CLAN:6,MERC:4,Periphery.OS:3,FS:6,CIR:2,TC:3,Periphery:2,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -3964,7 +3964,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,PP:9,CC:2+,CLAN:9,MERC:3+,FS:3+,TC:2+,CS:8,OA:3,LA:2,FWL:3+,NIOPS:8,DC:4+</availability>
 		<model name='SWF-606'>
 			<availability>General:8</availability>
@@ -4018,7 +4018,7 @@
 			<availability>PP:2,CLAN:8,CGS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:4-</availability>
@@ -4050,7 +4050,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>PP:5,CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4100,7 +4100,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>PP:9,CC:5,MOC:2,CLAN:9,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:6,FWL:5,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4141,7 +4141,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -4158,7 +4158,7 @@
 			<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
 		<model name='TRN-3T'>
 			<availability>PP:8,CS:8,OA:5+,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
@@ -4191,7 +4191,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4318,7 +4318,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4531,7 +4531,7 @@
 			<availability>CHH:4,General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -16,7 +16,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2823' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2823' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2823' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -40,9 +40,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,9</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
@@ -79,9 +79,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,10,15</pctClan>
-		<pctSL unitType='Aero'>100,100,95,90,85</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,10,15</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,90,85</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
@@ -148,9 +148,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
@@ -159,9 +159,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
@@ -224,7 +224,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2823' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2823' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2823' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'></salvage>
@@ -252,14 +252,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2823' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2823' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2823' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:6,FS:10</salvage>
-		<weightDistribution era='2823' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -361,9 +361,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -375,9 +375,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -410,9 +410,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>100,100,100,100,100</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>100,100,100,100,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,100,100</pctSL>
 		<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 		<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -576,7 +576,7 @@
 			<availability>CS:8,General:5,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:5+,CS:7,LA:5+,CLAN:7,FWL:6+,IS:4+,NIOPS:7,FS:5+,DC:5+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -983,7 +983,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:3,Periphery.Deep:4,FS:4,MERC:2,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1057,7 +1057,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:5</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1078,7 +1078,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,OA:3,LA:8,CLAN:5,FWL:5,FS:5,MERC:4,CIR:3,Periphery:2,TC:3,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
@@ -1360,7 +1360,7 @@
 			<availability>General:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1590,7 +1590,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2021,7 +2021,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:6,CLAN:4</availability>
@@ -2107,7 +2107,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,CLAN:7,IS:5,FS:5,CIR:3,TC:3,CS:7,OA:3,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2214,7 +2214,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -2227,7 +2227,7 @@
 			<availability>CS:4,CLAN:2,IS:2,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2381,7 +2381,7 @@
 			<availability>CS:7,CLAN:7,IS:8,MERC:6,TC:7,Periphery:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
@@ -2713,7 +2713,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2800,7 +2800,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3611,7 +3611,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:3,LA:5,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
@@ -3650,7 +3650,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3701,7 +3701,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
@@ -3752,7 +3752,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -3777,7 +3777,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,OA:6,LA:5,CLAN:4,IS:5,FWL:5,MERC:5,FS:5,Periphery:5,TC:5,DC:5</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3863,7 +3863,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3889,7 +3889,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3901,7 +3901,7 @@
 			<availability>General:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -3940,7 +3940,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -3980,7 +3980,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:6,CLAN:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -3989,7 +3989,7 @@
 			<availability>CS:4,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4103,7 +4103,7 @@
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4128,7 +4128,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4163,7 +4163,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:2+,CLAN:9,FWL:3+,NIOPS:8,MERC:3+,FS:3+,TC:2+,DC:4+</availability>
 		<model name='SWF-606'>
 			<availability>General:8,CLAN:6</availability>
@@ -4214,7 +4214,7 @@
 			<availability>CLAN:8,CGS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:3-</availability>
@@ -4246,7 +4246,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4302,7 +4302,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4343,7 +4343,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -4363,7 +4363,7 @@
 			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:2,TC:4,CS:7,OA:4,LA:2,FWL:3,NIOPS:7,DC:5</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:5+,CLAN:6,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
@@ -4396,7 +4396,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4545,7 +4545,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4742,7 +4742,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:4,CIH:4,CSR:4,CLAN:4,CFM:4,CSJ:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4776,7 +4776,7 @@
 			<availability>CHH:4,General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:3,Periphery:1,TC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -22,7 +22,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2830' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2830' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2830' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -46,9 +46,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,15,20</pctClan>
 		<pctSL>100,100,90,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,15,25</pctClan>
-		<pctSL unitType='Aero'>100,100,95,85,75</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,15,25</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,85,75</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -85,9 +85,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,15,20</pctClan>
 		<pctSL>100,100,90,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,10,15</pctClan>
-		<pctSL unitType='Aero'>100,100,95,90,85</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,10,15</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,90,85</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:1,CWI:3,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
@@ -154,9 +154,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,15,20</pctClan>
 		<pctSL>100,100,100,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,20,30</pctClan>
-		<pctSL unitType='Aero'>100,100,95,80,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,20,30</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,80,70</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:1,CHH:7,CIH:7,CSV:5,CFM:7,CCO:7,CGS:1,CSA:1,CDS:3,CW:3,CWI:1,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
@@ -165,9 +165,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,20,30</pctClan>
 		<pctSL>100,100,100,80,70</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,25,20</pctClan>
-		<pctSL unitType='Aero'>100,100,100,75,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,25,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,75,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,90,90</pctSL>
 		<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:3,CGS:5,CDS:5,CW:10,CSJ:1,CMG:3,CJF:10,CGB:3,CB:1</salvage>
@@ -222,7 +222,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2830' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2830' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2830' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -250,14 +250,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2830' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2830' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2830' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,FS:10</salvage>
-		<weightDistribution era='2830' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -363,9 +363,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -377,9 +377,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,15,20</pctClan>
 		<pctSL>100,100,100,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,15,20</pctClan>
-		<pctSL unitType='Aero'>100,100,100,85,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,15,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,85,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -412,9 +412,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,15,20</pctClan>
 		<pctSL>100,100,100,85,80</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,15,20</pctClan>
-		<pctSL unitType='Aero'>100,100,100,85,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,15,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,100,85,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 		<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
@@ -575,7 +575,7 @@
 			<availability>CS:8,General:5,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:4+,CS:7,LA:4+,CLAN:7,FWL:6+,IS:3+,NIOPS:7,FS:4+,DC:4+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -998,7 +998,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,IS:3,Periphery.Deep:4,FS:4,MERC:2,Periphery:4</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1072,7 +1072,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1093,7 +1093,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,OA:3,LA:8,CLAN:4,FWL:5,MERC:4,FS:5,CIR:3,TC:3,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1379,7 +1379,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1612,7 +1612,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2057,7 +2057,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:5,CLAN:4</availability>
@@ -2150,7 +2150,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:3,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2257,7 +2257,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
 		<model name='HCT-213B'>
 			<roles>recon</roles>
@@ -2270,7 +2270,7 @@
 			<availability>CS:4,CLAN:2,IS:2,NIOPS:4,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2446,7 +2446,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:6,CNC:6</availability>
@@ -2786,7 +2786,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -2879,7 +2879,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3712,7 +3712,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:3,LA:5,CLAN:8,IS:4,NIOPS:8,MERC:4</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:6,General:5,NIOPS:8</availability>
@@ -3748,7 +3748,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
@@ -3799,7 +3799,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
@@ -3850,7 +3850,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -3875,7 +3875,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,OA:6,LA:4,CLAN:4,IS:4,FWL:4,MERC:4,FS:4,TC:4,Periphery:4,DC:5</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -3961,7 +3961,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -3993,7 +3993,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4005,7 +4005,7 @@
 			<availability>General:8,CLAN:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4044,7 +4044,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4084,7 +4084,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:6,CLAN:6,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4093,7 +4093,7 @@
 			<availability>CS:4,CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4201,7 +4201,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4226,7 +4226,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,Periphery:2,TC:3,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:2</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4261,7 +4261,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:2+,CLAN:9,FWL:3+,NIOPS:8,MERC:3+,FS:3+,TC:2+,DC:3+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:6</availability>
@@ -4315,7 +4315,7 @@
 			<availability>CLAN:8,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:2-</availability>
@@ -4347,7 +4347,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4403,7 +4403,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4444,7 +4444,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-9'>
 			<availability>CC:8</availability>
@@ -4464,7 +4464,7 @@
 			<availability>CC:4,CS:2,MOC:4,FWL:4,NIOPS:2,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,CIR:2,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:4+,CLAN:6,IS:4+,NIOPS:8,Periphery.Deep:4+,BAN:8,Periphery:4+</availability>
@@ -4497,7 +4497,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:2</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4646,7 +4646,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,OA:4,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -4846,7 +4846,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:4,CIH:4,CSR:4,CLAN:4,CFM:4,CSJ:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4877,7 +4877,7 @@
 			<availability>CHH:4,General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:5,OA:1,CLAN:6,NIOPS:5,DC:2,Periphery:1,TC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -24,7 +24,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2835' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2835' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2835' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -48,9 +48,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,15,30,40</pctClan>
 		<pctSL>100,100,85,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,25,40</pctClan>
-		<pctSL unitType='Aero'>100,100,90,75,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,25,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,75,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:7,CDS:1,CW:5,CBS:2,CNC:7,CJF:5,CGB:2,CB:1</salvage>
@@ -87,9 +87,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,15,20,35</pctClan>
 		<pctSL>100,100,85,80,65</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,15,20</pctClan>
-		<pctSL unitType='Aero'>100,100,90,85,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,15,20</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,85,80</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:2,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
@@ -156,9 +156,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,30,40</pctClan>
 		<pctSL>90,90,90,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,40,50</pctClan>
-		<pctSL unitType='Aero'>100,100,85,60,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,40,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,60,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:7,CIH:10,CSV:4,CFM:7,CCO:10,CGS:1,CSA:2,CDS:7,CW:10,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
@@ -167,9 +167,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,10,30,40</pctClan>
 		<pctSL>100,100,90,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,90,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
 		<salvage pct='10'>CCC:3,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:4,CGS:4,CDS:4,CW:10,CNC:3,CSJ:1,CMG:2,CJF:10,CGB:3,CB:2</salvage>
@@ -216,7 +216,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2835' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2835' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2835' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -244,14 +244,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2835' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2835' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2835' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,FS:10</salvage>
-		<weightDistribution era='2835' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -356,9 +356,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -370,9 +370,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,5,30,40</pctClan>
 		<pctSL>100,100,95,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,95,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -405,9 +405,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,5,30,40</pctClan>
 		<pctSL>100,100,95,70,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,5,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,95,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,5,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,95,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -572,7 +572,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:4+,CS:7,LA:4+,CLAN:7,FWL:5+,IS:3+,NIOPS:7,FS:4+,DC:4+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1039,7 +1039,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:3,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1073,7 +1073,7 @@
 			<availability>CFM:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1119,7 +1119,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:4</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1140,7 +1140,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:4,FWL:4,MERC:3,FS:4,CIR:2,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1438,7 +1438,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1677,7 +1677,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2126,7 +2126,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
 		<model name='GTHA-100'>
 			<availability>General:4,CLAN:3</availability>
@@ -2238,7 +2238,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:2,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2354,7 +2354,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:3+,CLAN:5,IS:3,FS:3,TC:3+,CS:6,OA:3+,LA:3,CNC:5,FWL:2,NIOPS:6,DC:3</availability>
 		<model name='HCT-212'>
 			<availability>LA:6,IS:6,FS:6,Periphery:6</availability>
@@ -2370,7 +2370,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:3-,OA:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2495,7 +2495,7 @@
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2565,7 +2565,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,CNC:6,FWL:5,NIOPS:6,DC:4</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:5,CNC:5</availability>
@@ -2587,7 +2587,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2938,7 +2938,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:2</availability>
@@ -3044,7 +3044,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:6,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3966,7 +3966,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:3,LA:4,CLAN:7,IS:3,NIOPS:8,MERC:3</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:5,General:3+,NIOPS:8</availability>
@@ -4007,7 +4007,7 @@
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:3,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4064,7 +4064,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:3,CS:4,OA:3,LA:3,CLAN:3,FWL:3,IS:3,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
@@ -4115,7 +4115,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:4</availability>
@@ -4140,7 +4140,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,OA:5,LA:3,CLAN:2,IS:4,FWL:3,MERC:4,FS:4,TC:4,Periphery:4,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4226,7 +4226,7 @@
 			<availability>CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4265,7 +4265,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4283,7 +4283,7 @@
 			<availability>General:8,CLAN:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4330,7 +4330,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4383,7 +4383,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:5,CLAN:5,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4392,7 +4392,7 @@
 			<availability>CS:4,CLAN:7,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4500,7 +4500,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:2,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4529,7 +4529,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4577,7 +4577,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:2+,CC:1+,CS:8,OA:3,LA:1+,CLAN:9,FWL:2+,NIOPS:8,MERC:2+,FS:2+,TC:2+,DC:3+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4641,7 +4641,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-5'>
 			<availability>CC:2-</availability>
@@ -4676,7 +4676,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4738,7 +4738,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:8,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:8,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4779,7 +4779,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4802,7 +4802,7 @@
 			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:3+,CLAN:6,IS:3+,NIOPS:8,BAN:8,Periphery:3+</availability>
@@ -4835,7 +4835,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:1</availability>
 		<model name='TFN-2A'>
 			<roles>ground_support</roles>
@@ -4998,7 +4998,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,OA:4,MERC:6,Periphery:3,TC:5</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5199,7 +5199,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5230,7 +5230,7 @@
 			<availability>CHH:4,General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:2</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -24,7 +24,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2855' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2855' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2855' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -48,9 +48,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,20,35,45</pctClan>
 		<pctSL>100,100,80,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,30,50</pctClan>
-		<pctSL unitType='Aero'>100,100,85,70,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,30,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,70,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -87,9 +87,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>10,10,20,30,45</pctClan>
 		<pctSL>90,90,80,70,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,20,30</pctClan>
-		<pctSL unitType='Aero'>100,100,85,80,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,20,30</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,80,70</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
@@ -156,9 +156,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,15,35,45</pctClan>
 		<pctSL>100,100,85,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,15,55</pctClan>
-		<pctSL unitType='Aero'>100,100,80,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,15,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
@@ -167,9 +167,9 @@
 		<pctOmni>0,0,0,10,15</pctOmni>
 		<pctClan>0,0,15,40,45</pctClan>
 		<pctSL>100,100,85,60,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,40,50</pctClan>
-		<pctSL unitType='Aero'>100,100,80,60,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,40,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,60,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
 		<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -216,7 +216,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2855' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2855' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2855' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -247,14 +247,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2855' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2855' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2855' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:5,FS:10</salvage>
-		<weightDistribution era='2855' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -356,9 +356,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -370,9 +370,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,10,35,45</pctClan>
 		<pctSL>100,100,90,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,35,45</pctClan>
-		<pctSL unitType='Aero'>100,100,90,65,55</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,35,45</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,65,55</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -405,9 +405,9 @@
 		<pctOmni>0,0,0,5,10</pctOmni>
 		<pctClan>0,0,10,35,45</pctClan>
 		<pctSL>100,100,90,65,55</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,35,45</pctClan>
-		<pctSL unitType='Aero'>100,100,90,65,55</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,35,45</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,65,55</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -572,7 +572,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:3+,CS:7,LA:3+,CLAN:6,FWL:4+,IS:3+,NIOPS:7,FS:3+,DC:3+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1050,7 +1050,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:2,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1084,7 +1084,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1130,7 +1130,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1151,7 +1151,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1456,7 +1456,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1707,7 +1707,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2153,7 +2153,7 @@
 			<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='GTHA-100'>
 			<availability>General:4,CLAN:2</availability>
@@ -2265,7 +2265,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2381,7 +2381,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2397,7 +2397,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2537,7 +2537,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2607,7 +2607,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:5,IS:3,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
@@ -2629,7 +2629,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2970,7 +2970,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -3076,7 +3076,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -4012,7 +4012,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:4,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
@@ -4053,7 +4053,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4110,7 +4110,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
@@ -4161,7 +4161,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4186,7 +4186,7 @@
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:3,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:4,TC:4,Periphery:4,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4266,7 +4266,7 @@
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4305,7 +4305,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4323,7 +4323,7 @@
 			<availability>General:8,CLAN:6-,BAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4370,7 +4370,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4423,7 +4423,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:4,CLAN:4,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4432,7 +4432,7 @@
 			<availability>CS:4,CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4540,7 +4540,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4566,7 +4566,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4614,7 +4614,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>MOC:1+,CC:1+,CS:8,OA:2,LA:1+,CLAN:8,FWL:1+,NIOPS:8,MERC:1+,FS:1+,TC:1+,DC:2+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4682,7 +4682,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4723,7 +4723,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4785,7 +4785,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4822,7 +4822,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4845,7 +4845,7 @@
 			<availability>CC:6,CS:2,MOC:6,FWL:6,NIOPS:2,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
@@ -5026,7 +5026,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,OA:3,MERC:5,Periphery:3,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5227,7 +5227,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5258,7 +5258,7 @@
 			<availability>CHH:4,General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -24,7 +24,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2860' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2860' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2860' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -48,9 +48,9 @@
 		<pctOmni>0,0,0,20,25</pctOmni>
 		<pctClan>0,0,25,40,50</pctClan>
 		<pctSL>100,100,75,60,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,15</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,35,50</pctClan>
-		<pctSL unitType='Aero'>100,100,85,65,50</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,15</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,35,50</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,65,50</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -87,9 +87,9 @@
 		<pctOmni>0,0,0,15,25</pctOmni>
 		<pctClan>12,12,25,35,50</pctClan>
 		<pctSL>88,88,75,65,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,25,35</pctClan>
-		<pctSL unitType='Aero'>100,100,80,75,65</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,25,35</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,75,65</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
@@ -149,9 +149,9 @@
 		<pctOmni>0,0,0,15,30</pctOmni>
 		<pctClan>5,5,20,40,50</pctClan>
 		<pctSL>95,95,80,60,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,5,10,30</pctOmni>
-		<pctClan unitType='Aero'>0,0,25,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,75,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,5,10,30</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,25,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,75,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
@@ -160,9 +160,9 @@
 		<pctOmni>0,0,0,20,25</pctOmni>
 		<pctClan>0,0,20,45,50</pctClan>
 		<pctSL>100,100,80,55,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,20</pctOmni>
-		<pctClan unitType='Aero'>0,0,25,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,75,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,20</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,25,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,75,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
 		<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -209,7 +209,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2860' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2860' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2860' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -240,14 +240,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2860' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2860' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2860' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2860' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -349,9 +349,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -363,9 +363,9 @@
 		<pctOmni>0,0,0,10,20</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,20</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,20</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -398,9 +398,9 @@
 		<pctOmni>0,0,0,10,20</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,20</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,20</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -566,7 +566,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:3+,CS:7,LA:3+,CLAN:6,FWL:4+,IS:3+,NIOPS:7,FS:3+,DC:3+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1018,7 +1018,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:2,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1052,7 +1052,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1098,7 +1098,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1119,7 +1119,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>CMG:4</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1128,7 +1128,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:3,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1409,7 +1409,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1624,7 +1624,7 @@
 			<availability>General:5-,CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2083,7 +2083,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='GTHA-100'>
 			<availability>General:3,CLAN:2</availability>
@@ -2195,7 +2195,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2311,7 +2311,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:2,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2327,7 +2327,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2467,7 +2467,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2540,7 +2540,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:4,CNC:4</availability>
@@ -2562,7 +2562,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2892,7 +2892,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -2998,7 +2998,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3919,7 +3919,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:4,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:4,General:3+,NIOPS:8</availability>
@@ -3960,7 +3960,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4006,7 +4006,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>
@@ -4057,7 +4057,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4072,7 +4072,7 @@
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:2,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:3,TC:3,Periphery:3,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4152,7 +4152,7 @@
 			<availability>CLAN:6,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4191,7 +4191,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4209,7 +4209,7 @@
 			<availability>General:8,CLAN:4-,BAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4256,7 +4256,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4303,7 +4303,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:4,CLAN:4,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4312,7 +4312,7 @@
 			<availability>CS:4,CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4423,7 +4423,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4455,7 +4455,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4503,7 +4503,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:1+,MOC:1+,CS:8,OA:2,CLAN:8,FWL:1+,NIOPS:8,FS:1+,MERC:1+,TC:1+,DC:1+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4564,7 +4564,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4605,7 +4605,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4664,7 +4664,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4701,7 +4701,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4727,7 +4727,7 @@
 			<availability>FWL:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:6,CLAN:6,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:2+,CLAN:6,IS:2+,NIOPS:8,BAN:8,Periphery:2+</availability>
@@ -4901,7 +4901,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,OA:3,MERC:5,Periphery:3,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5102,7 +5102,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5133,7 +5133,7 @@
 			<availability>CHH:4,General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -26,7 +26,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2865' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2865' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2865' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,5,10</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,0,30,40</pctOmni>
 		<pctClan>5,5,30,45,55</pctClan>
 		<pctSL>95,95,70,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,25</pctOmni>
-		<pctClan unitType='Aero'>0,0,15,40,55</pctClan>
-		<pctSL unitType='Aero'>100,100,85,60,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,25</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,15,40,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,85,60,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
@@ -89,9 +89,9 @@
 		<pctOmni>0,0,0,15,35</pctOmni>
 		<pctClan>13,13,25,35,55</pctClan>
 		<pctSL>87,87,75,65,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,5,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,25,35</pctClan>
-		<pctSL unitType='Aero'>100,100,80,75,65</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,5,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,25,35</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,75,65</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>0,0,5,25,40</pctOmni>
 		<pctClan>5,5,20,45,55</pctClan>
 		<pctSL>95,95,80,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,20,40</pctOmni>
-		<pctClan unitType='Aero'>10,10,25,55,65</pctClan>
-		<pctSL unitType='Aero'>90,90,75,45,35</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,20,40</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,25,55,65</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,75,45,35</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>0,0,0,30,40</pctOmni>
 		<pctClan>0,0,20,45,55</pctClan>
 		<pctSL>100,100,80,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,25,35</pctOmni>
-		<pctClan unitType='Aero'>0,0,25,45,55</pctClan>
-		<pctSL unitType='Aero'>100,100,75,55,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,25,35</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,25,45,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,75,55,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
 		<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -211,7 +211,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2865' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2865' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2865' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -242,14 +242,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2865' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2865' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2865' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2865' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -351,9 +351,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -365,9 +365,9 @@
 		<pctOmni>0,0,0,15,35</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,15,35</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,15,35</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -400,9 +400,9 @@
 		<pctOmni>0,0,0,15,35</pctOmni>
 		<pctClan>0,0,10,45,55</pctClan>
 		<pctSL>100,100,90,55,45</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,15,35</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,55</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,45</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,15,35</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,55</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,45</pctSL>
 		<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 		<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
@@ -570,7 +570,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:2+,CS:7,LA:2+,CLAN:6,FWL:3+,IS:2+,NIOPS:7,FS:2+,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1015,7 +1015,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:1,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1049,7 +1049,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:6</availability>
@@ -1101,7 +1101,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1122,7 +1122,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>CMG:5,BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1131,7 +1131,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1412,7 +1412,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1627,7 +1627,7 @@
 			<availability>General:5-,CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2098,7 +2098,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
 		<model name='GTHA-100'>
 			<availability>General:3,CLAN:2</availability>
@@ -2210,7 +2210,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:2,CLAN:6,IS:2,FS:2,CIR:1,TC:1,CS:7,OA:1,LA:2,CNC:6,FWL:2,NIOPS:7,DC:2</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2326,7 +2326,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2342,7 +2342,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2491,7 +2491,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2564,7 +2564,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,CNC:5,FWL:3,NIOPS:6,DC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:3,CNC:3</availability>
@@ -2586,7 +2586,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2926,7 +2926,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:2,CLAN:3,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -3025,7 +3025,7 @@
 			<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3950,7 +3950,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:3,CLAN:6,IS:2,NIOPS:8,MERC:2</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
@@ -3991,7 +3991,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4037,7 +4037,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:2,CS:4,OA:3,LA:2,CLAN:3,FWL:2,IS:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
@@ -4088,7 +4088,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4103,7 +4103,7 @@
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:5,LA:1,CLAN:1,IS:2,FWL:1,MERC:2,FS:2,Periphery:2,TC:2,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4198,7 +4198,7 @@
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4237,7 +4237,7 @@
 			<availability>DC:9</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4255,7 +4255,7 @@
 			<availability>General:8,CLAN:2-,BAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4302,7 +4302,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4349,7 +4349,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:3,CLAN:3,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4358,7 +4358,7 @@
 			<availability>CS:4,CLAN:5,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-H5'>
 			<roles>interceptor</roles>
@@ -4462,7 +4462,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4494,7 +4494,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4542,7 +4542,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CC:1+,MOC:1+,CS:8,OA:1,CLAN:8,FWL:1+,NIOPS:8,FS:1+,MERC:1+,TC:1+,DC:1+</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4603,7 +4603,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -4644,7 +4644,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -4703,7 +4703,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -4740,7 +4740,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -4766,7 +4766,7 @@
 			<availability>MOC:4,FWL:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
@@ -4943,7 +4943,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,MERC:5,Periphery:2,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5153,7 +5153,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5184,7 +5184,7 @@
 			<availability>CHH:4,General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -26,7 +26,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2870' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2870' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2870' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,5,10</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>10,10,35,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,40,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,80,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -89,9 +89,9 @@
 		<pctOmni>0,0,0,20,40</pctOmni>
 		<pctClan>15,15,30,40,60</pctClan>
 		<pctSL>85,85,70,60,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,30</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,80,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,30</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
@@ -150,9 +150,9 @@
 		<pctOmni>0,0,20,30,50</pctOmni>
 		<pctClan>10,10,25,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>10,10,20,30,50</pctOmni>
-		<pctClan unitType='Aero'>20,20,30,60,70</pctClan>
-		<pctSL unitType='Aero'>80,80,70,40,30</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>10,10,20,30,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>20,20,30,60,70</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,80,70,40,30</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:2,CSV:4,CFM:3,CCO:5,CGS:1,CSA:1,CDS:3,CW:5,CNC:10,CSJ:2,CJF:3,CB:8</salvage>
@@ -161,9 +161,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>0,0,25,50,60</pctClan>
 		<pctSL>100,100,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,40,50</pctOmni>
-		<pctClan unitType='Aero'>10,10,30,50,60</pctClan>
-		<pctSL unitType='Aero'>90,90,70,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,30,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,70,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
 		<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
@@ -213,7 +213,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2870' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2870' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2870' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -244,14 +244,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2870' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2870' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2870' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2870' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -352,9 +352,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -364,9 +364,9 @@
 		<pctOmni>0,0,0,20,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -399,9 +399,9 @@
 		<pctOmni>0,0,0,15,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -561,7 +561,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CC:2+,CS:7,LA:1+,CLAN:6,FWL:2+,IS:1+,NIOPS:7,FS:1+,DC:1+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -781,7 +781,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1136,7 +1136,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:3,IS:1,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1178,7 +1178,7 @@
 			<availability>CFM:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:6</availability>
@@ -1230,7 +1230,7 @@
 			<availability>CC:8-,MOC:8-,OA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1251,7 +1251,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1260,7 +1260,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
@@ -1551,7 +1551,7 @@
 			<availability>IS:6-,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
@@ -1795,7 +1795,7 @@
 			<availability>General:5-,CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2290,7 +2290,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:4,CSR:3,CW:3,CLAN:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2302,7 +2302,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:9,CDS:7,Periphery.MW:1,CLAN:7,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9</availability>
 		<model name='GTHA-100'>
 			<availability>General:2,CLAN:2</availability>
@@ -2420,7 +2420,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:1,CLAN:6,IS:1,FS:1,CIR:1,TC:1,CS:7,OA:1,LA:1,CNC:6,FWL:1,NIOPS:7,DC:1</availability>
 		<model name='HMR-HC'>
 			<availability>IS:8</availability>
@@ -2536,7 +2536,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -2552,7 +2552,7 @@
 			<availability>CS:4,CLAN:2,NIOPS:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2716,7 +2716,7 @@
 			<availability>CLAN:6,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2789,7 +2789,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:1,CLAN:5,IS:1,FWL.OH:3,FS:1,TC:1,CS:6,OA:1,LA:1,CNC:5,FWL:2,NIOPS:6,DC:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:3,CNC:3</availability>
@@ -2815,7 +2815,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>CSR:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2827,7 +2827,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3045,7 +3045,7 @@
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3215,7 +3215,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:8,CLAN:3,IS:2,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 		<model name='LTN-G14'>
 			<availability>Periphery:1</availability>
@@ -3314,7 +3314,7 @@
 			<availability>MOC:2,CS:6,OA:2,IS:4,MERC:3,TC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 		<model name='LCF-R15'>
 			<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -3876,7 +3876,7 @@
 			<availability>CW:0,CLAN:8,CJF:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:5,CW:4,CLAN:3,CSJ:4</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4276,7 +4276,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:2,LA:3,CLAN:6,IS:1,NIOPS:8,MERC:1</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:3,General:3+,NIOPS:8</availability>
@@ -4323,7 +4323,7 @@
 			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
@@ -4369,7 +4369,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CC:1,CS:4,OA:2,LA:1,CLAN:3,FWL:1,IS:1,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>
@@ -4420,7 +4420,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:3</availability>
@@ -4435,7 +4435,7 @@
 			<availability>CS:6,CLAN:5,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CC:1,OA:5,LA:1,CLAN:1,IS:1,FWL:1,MERC:1,FS:1,Periphery:1,TC:1,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4540,7 +4540,7 @@
 			<availability>CLAN:4,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4585,7 +4585,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4603,7 +4603,7 @@
 			<availability>General:8,CLAN:1-,BAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>LA:8,Periphery.Deep:8,MERC:8,DC:8,Periphery:8</availability>
@@ -4654,7 +4654,7 @@
 			<availability>IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
@@ -4707,7 +4707,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:3,CLAN:3,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4716,7 +4716,7 @@
 			<availability>CS:4,CLAN:5,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -4827,7 +4827,7 @@
 			<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
@@ -4859,7 +4859,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -4914,7 +4914,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:8,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -4996,7 +4996,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5037,7 +5037,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5103,7 +5103,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -5140,7 +5140,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -5149,7 +5149,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5175,7 +5175,7 @@
 			<availability>MOC:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
@@ -5376,7 +5376,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,OA:1,MERC:5,Periphery:1,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5593,7 +5593,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5624,7 +5624,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:5,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:5,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -26,7 +26,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2900' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2900' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2900' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,5,10</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>10,10,35,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,40,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,80,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -89,9 +89,9 @@
 		<pctOmni>0,0,0,20,40</pctOmni>
 		<pctClan>20,20,30,40,60</pctClan>
 		<pctSL>80,80,70,60,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,10,30</pctOmni>
-		<pctClan unitType='Aero'>0,0,20,30,40</pctClan>
-		<pctSL unitType='Aero'>100,100,80,70,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,10,30</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,20,30,40</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,80,70,60</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
@@ -150,9 +150,9 @@
 		<pctOmni>0,0,20,30,50</pctOmni>
 		<pctClan>10,10,25,50,60</pctClan>
 		<pctSL>90,90,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>10,10,20,30,50</pctOmni>
-		<pctClan unitType='Aero'>20,20,30,60,70</pctClan>
-		<pctSL unitType='Aero'>80,80,70,40,30</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>10,10,20,30,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>20,20,30,60,70</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,80,70,40,30</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:3,CSV:3,CFM:5,CCO:5,CGS:1,CSA:2,CDS:3,CW:5,CNC:10,CSJ:2,CJF:5,CB:8</salvage>
@@ -161,9 +161,9 @@
 		<pctOmni>0,0,0,40,50</pctOmni>
 		<pctClan>0,0,25,50,60</pctClan>
 		<pctSL>100,100,75,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,40,50</pctOmni>
-		<pctClan unitType='Aero'>10,10,30,50,60</pctClan>
-		<pctSL unitType='Aero'>90,90,70,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,40,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,30,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,70,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
 		<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
@@ -213,7 +213,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2900' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2900' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2900' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,CIR:1</salvage>
@@ -247,14 +247,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2900' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2900' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2900' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:4,FS:10</salvage>
-		<weightDistribution era='2900' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -355,9 +355,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -367,9 +367,9 @@
 		<pctOmni>0,0,0,20,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -402,9 +402,9 @@
 		<pctOmni>0,0,0,15,50</pctOmni>
 		<pctClan>0,0,10,50,60</pctClan>
 		<pctSL>100,100,90,50,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,20,50</pctOmni>
-		<pctClan unitType='Aero'>0,0,10,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,90,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,20,50</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,10,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,90,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 		<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
@@ -559,7 +559,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:5,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -779,7 +779,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -897,7 +897,7 @@
 			<availability>FWL:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1163,7 +1163,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>HL:1,LA:3,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1205,7 +1205,7 @@
 			<availability>CFM:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:6</availability>
@@ -1257,7 +1257,7 @@
 			<availability>CC:8-,LA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1278,7 +1278,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1287,7 +1287,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:2,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W5'>
 			<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
@@ -1587,7 +1587,7 @@
 	<chassis name='Corone' unitType='Warship'>
 		<availability>CSR:2</availability>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -1859,7 +1859,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2354,7 +2354,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:5,CW:4,CLAN:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2366,7 +2366,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CS:9,CDS:6,Periphery.MW:1,CLAN:6,Periphery.ME:1,CNC:6,FWL:1,NIOPS:9</availability>
 		<model name='GTHA-100'>
 			<availability>General:1,CLAN:1</availability>
@@ -2481,7 +2481,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:2,CNC:2</availability>
@@ -2597,7 +2597,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -2613,7 +2613,7 @@
 			<availability>CS:4,CLAN:1,NIOPS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>CC:1-,MOC:3-,OA:3-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:8</availability>
@@ -2786,7 +2786,7 @@
 			<availability>CLAN:5,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2848,7 +2848,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:4,CNC:4,FWL:1,NIOPS:6,FWL.OH:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:2,CNC:2</availability>
@@ -2871,7 +2871,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>CSR:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2883,7 +2883,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3101,7 +3101,7 @@
 			<availability>CLAN:7,CGS:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3284,7 +3284,7 @@
 			<availability>CLAN:8,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:8,CS:5-,OA:2,LA:3,CLAN:3,IS:1,NIOPS:5-,FS:3,TC:2,Periphery:2,DC:3</availability>
 		<model name='LTN-G15'>
 			<availability>General:8,CLAN:3</availability>
@@ -3389,7 +3389,7 @@
 			<availability>MOC:2,CS:6,OA:2,IS:4,MERC:3,Periphery:2,TC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
@@ -4002,7 +4002,7 @@
 			<availability>CW:0,CLAN:8,CJF:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:5,CW:4,CSJ:4</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4404,7 +4404,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,OA:1,LA:2,CLAN:5,IS:1,NIOPS:8,MERC:1</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:2,General:3+,NIOPS:8</availability>
@@ -4445,7 +4445,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4491,7 +4491,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,CLAN:3,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:2,NIOPS:8</availability>
@@ -4561,7 +4561,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:2</availability>
@@ -4579,7 +4579,7 @@
 			<availability>IS:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:5,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4702,7 +4702,7 @@
 			<availability>CLAN:3,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:5,OA:2,HL:4,LA:8,Periphery.Deep:4,CIR:3,FS:1,Periphery:4,TC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4747,7 +4747,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4765,7 +4765,7 @@
 			<availability>General:8,CLAN:1-,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -4820,7 +4820,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -4872,7 +4872,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:3,CSR:2,CLAN:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -4881,7 +4881,7 @@
 			<availability>CS:4,CLAN:4,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -4989,7 +4989,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:6,IS:8,FS:8,Periphery:8</availability>
@@ -5021,7 +5021,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -5076,7 +5076,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:8,CSR:8,CLAN:7</availability>
@@ -5155,7 +5155,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5196,7 +5196,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5259,7 +5259,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:6,CLAN:5,FWL:1,NIOPS:9</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -5299,7 +5299,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -5308,7 +5308,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5335,7 +5335,7 @@
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,CS:7,OA:4,CSR:4,CLAN:4,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -5361,7 +5361,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:7,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5472,7 +5472,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -5537,7 +5537,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5575,7 +5575,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:4</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -5780,7 +5780,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:5,CLAN:5,CFM:5,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5802,7 +5802,7 @@
 			<availability>CHH:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:4,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -27,7 +27,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='2950' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='2950' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='2950' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,0,10,20</pctOmni>
@@ -51,9 +51,9 @@
 		<pctOmni>0,0,10,70,80</pctOmni>
 		<pctClan>10,10,50,80,90</pctClan>
 		<pctSL>90,90,50,20,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,70,80</pctOmni>
-		<pctClan unitType='Aero'>0,0,30,80,90</pctClan>
-		<pctSL unitType='Aero'>100,100,70,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,70,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,30,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,70,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -90,9 +90,9 @@
 		<pctOmni>0,0,10,40,70</pctOmni>
 		<pctClan>25,25,50,60,90</pctClan>
 		<pctSL>75,75,50,40,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,30,60</pctOmni>
-		<pctClan unitType='Aero'>0,0,40,50,60</pctClan>
-		<pctSL unitType='Aero'>100,100,60,50,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,30,60</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,40,50,60</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>100,100,60,50,40</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>15,15,50,60,80</pctOmni>
 		<pctClan>30,30,50,80,90</pctClan>
 		<pctSL>70,70,50,20,10</pctSL>
-		<pctOmni unitType='Aero'>25,25,50,60,80</pctOmni>
-		<pctClan unitType='Aero'>40,40,60,90,100</pctClan>
-		<pctSL unitType='Aero'>60,60,40,10,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>25,25,50,60,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>40,40,60,90,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>60,60,40,10,0</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:3,CFM:4,CCO:4,CSA:2,CDS:4,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>0,0,10,70,80</pctOmni>
 		<pctClan>20,20,50,80,90</pctClan>
 		<pctSL>80,80,50,20,10</pctSL>
-		<pctOmni unitType='Aero'>5,5,15,70,80</pctOmni>
-		<pctClan unitType='Aero'>50,50,50,80,90</pctClan>
-		<pctSL unitType='Aero'>50,50,50,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>5,5,15,70,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>50,50,50,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>50,50,50,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,40,40</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,60,60</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
@@ -217,7 +217,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='2950' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='2950' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='2950' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -252,14 +252,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='2950' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='2950' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='2950' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:3,FS:10</salvage>
-		<weightDistribution era='2950' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='2950' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -368,9 +368,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -381,9 +381,9 @@
 		<pctOmni>0,0,3,35,70</pctOmni>
 		<pctClan>15,15,30,80,90</pctClan>
 		<pctSL>85,85,70,20,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,5,40,80</pctOmni>
-		<pctClan unitType='Aero'>15,15,30,80,90</pctClan>
-		<pctSL unitType='Aero'>85,85,70,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,5,40,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,30,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,70,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -416,9 +416,9 @@
 		<pctOmni>0,0,3,20,70</pctOmni>
 		<pctClan>15,15,30,80,90</pctClan>
 		<pctSL>85,85,70,20,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,5,40,80</pctOmni>
-		<pctClan unitType='Aero'>15,15,30,80,90</pctClan>
-		<pctSL unitType='Aero'>85,85,70,20,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,5,40,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,30,80,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,70,20,10</pctSL>
 		<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 		<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -586,7 +586,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -816,7 +816,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CCC:6,CSR:6,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -940,7 +940,7 @@
 			<availability>FWL:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:4</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1006,7 +1006,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1266,7 +1266,7 @@
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>HL:1,LA:3,FS:4,MERC:2,Periphery:3</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1305,7 +1305,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1357,7 +1357,7 @@
 			<availability>CC:8-,LA:8-,FWL:8-,DC:8-</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1382,7 +1382,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:2</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1391,7 +1391,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:1,FWL:4,MERC:3,FS:3,CIR:2,Periphery:2,TC:2,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
@@ -1691,7 +1691,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -1959,7 +1959,7 @@
 			<availability>CLAN:3-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:7,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2470,7 +2470,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:5,CSR:4,CW:2,CLAN:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2482,7 +2482,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:6,CLAN:6,CNC:6,NIOPS:9</availability>
 		<model name='GTHA-300'>
 			<availability>CLAN:1,BAN:1</availability>
@@ -2597,7 +2597,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:5,CNC:5,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CLAN:1,CNC:1</availability>
@@ -2712,7 +2712,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -2728,7 +2728,7 @@
 			<availability>CS:4,CLAN:1,NIOPS:4,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:3-,FS:4-,MERC:5-,Periphery:3-,TC:3-,DC:1-</availability>
 		<model name='HCT-213'>
 			<availability>General:7</availability>
@@ -2917,7 +2917,7 @@
 			<availability>CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2979,7 +2979,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:3,CNC:3,NIOPS:6,FWL.OH:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CLAN:1,CNC:1</availability>
@@ -3002,7 +3002,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>CSR:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3014,7 +3014,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3242,7 +3242,7 @@
 			<availability>CLAN:6,CGS:7,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:5,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3398,7 +3398,7 @@
 			<availability>CLAN:8,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:7,CS:5-,OA:6,LA:4,CLAN:2,NIOPS:5-,FS:4,TC:3,Periphery:2,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:8,CLAN:2</availability>
@@ -3503,13 +3503,13 @@
 			<availability>CS:5-,IS:4,MERC:3,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
@@ -4162,7 +4162,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:3,CSJ:3</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4378,7 +4378,7 @@
 			<availability>IS:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Pella' unitType='Aero'>
+	<chassis name='Pella' unitType='AeroSpaceFighter'>
 		<availability>CCC:1,CCO:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -4597,7 +4597,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:1,CLAN:5,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,CLAN:1,NIOPS:8</availability>
@@ -4638,7 +4638,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4684,7 +4684,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:3,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,CLAN:1,NIOPS:8</availability>
@@ -4754,7 +4754,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8,CLAN:1</availability>
@@ -4775,7 +4775,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:4,DC:4</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -4855,7 +4855,7 @@
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:6</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4916,7 +4916,7 @@
 			<availability>CLAN:2,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:6,OA:2,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:4,TC:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -4961,7 +4961,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4979,7 +4979,7 @@
 			<availability>CLAN:1-,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5034,7 +5034,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -5086,7 +5086,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,CSR:1,CLAN:1,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5095,7 +5095,7 @@
 			<availability>CS:4,CLAN:2,BAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5199,7 +5199,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,FS:2,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:5,IS:8,FS:8,Periphery:8</availability>
@@ -5246,7 +5246,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,FS.DMM:8</availability>
@@ -5261,7 +5261,7 @@
 			<availability>CGS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -5328,7 +5328,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:7,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -5410,7 +5410,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5451,7 +5451,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5511,7 +5511,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:5,NIOPS:9</availability>
 		<model name='THK-43'>
 			<roles>escort</roles>
@@ -5551,7 +5551,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -5560,7 +5560,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5587,7 +5587,7 @@
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CC:1,MOC:1,CS:7,OA:3,CSR:2,CLAN:2,NIOPS:7,FS:1,MERC:1,DC:1,TC:1</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -5613,7 +5613,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:8,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5721,7 +5721,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -5793,7 +5793,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5846,7 +5846,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6074,7 +6074,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6103,7 +6103,7 @@
 			<availability>CHH:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:4,NIOPS:5,DC:1</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,General:8,CLAN:3,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -27,7 +27,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3019' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3019' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3019' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,20,40</pctOmni>
@@ -51,9 +51,9 @@
 		<pctOmni>0,0,20,100,100</pctOmni>
 		<pctClan>50,50,75,100,100</pctClan>
 		<pctSL>50,50,25,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,100,100</pctOmni>
-		<pctClan unitType='Aero'>2,2,40,10,100</pctClan>
-		<pctSL unitType='Aero'>98,98,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>2,2,40,10,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>98,98,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
@@ -90,9 +90,9 @@
 		<pctOmni>0,0,30,60,90</pctOmni>
 		<pctClan>40,40,70,80,100</pctClan>
 		<pctSL>60,60,30,20,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>2,2,60,70,90</pctClan>
-		<pctSL unitType='Aero'>98,98,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>2,2,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>98,98,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:3,CFM:4,CCO:4,CSA:2,CDS:4,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>60,60,80,100,100</pctClan>
 		<pctSL>40,40,20,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
@@ -217,7 +217,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3019' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3019' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3019' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,FWL:1,MH:1,CIR:4</salvage>
@@ -255,14 +255,14 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3019' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3019' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3019' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3019' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3019' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -370,9 +370,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -385,9 +385,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,50,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,50,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -420,9 +420,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,50,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,50,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -591,7 +591,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -822,7 +822,7 @@
 			<availability>CLAN:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1008,7 +1008,7 @@
 			<availability>FWL:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1074,7 +1074,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1356,7 +1356,7 @@
 			<availability>DC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1395,7 +1395,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1456,7 +1456,7 @@
 			<availability>LA:3,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1481,7 +1481,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1490,7 +1490,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:2,LA:5,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
@@ -1827,7 +1827,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2120,7 +2120,7 @@
 			<availability>CLAN:4-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2630,7 +2630,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:4,CSR:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2642,7 +2642,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:5,NIOPS:9</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:5,FWL:5,MH:5,MERC:5</availability>
@@ -2766,7 +2766,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -2881,7 +2881,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -2894,7 +2894,7 @@
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
@@ -3104,7 +3104,7 @@
 			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3160,7 +3160,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,FWL.OH:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -3176,7 +3176,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3242,7 +3242,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -3427,7 +3427,7 @@
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3605,7 +3605,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,CLAN:1,IS:3,FS:5,TC:5,Periphery:4,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -3714,13 +3714,13 @@
 			<availability>CS:4-,MERC.KH:5,MERC.WD:6,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
@@ -4406,7 +4406,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:3,CW:2,CSJ:2</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -4862,7 +4862,7 @@
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,NIOPS:8</availability>
@@ -4903,7 +4903,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
@@ -4953,7 +4953,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -5023,7 +5023,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -5044,7 +5044,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:4,DC:2</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -5124,7 +5124,7 @@
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5182,7 +5182,7 @@
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -5242,7 +5242,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5260,7 +5260,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5315,7 +5315,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -5370,7 +5370,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5379,7 +5379,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5481,7 +5481,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
@@ -5541,7 +5541,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:3,FS.DMM:8</availability>
@@ -5562,7 +5562,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:5,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -5629,7 +5629,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -5711,7 +5711,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -5752,7 +5752,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -5808,7 +5808,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
 		<model name='THK-53'>
 			<roles>escort</roles>
@@ -5844,7 +5844,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -5853,7 +5853,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -5880,7 +5880,7 @@
 			<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -5913,7 +5913,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:4,CJF:4,CGB:4</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5928,7 +5928,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6036,7 +6036,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -6108,7 +6108,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6170,7 +6170,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6405,7 +6405,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6441,7 +6441,7 @@
 			<availability>CHH:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -27,7 +27,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3028' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3028' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3028' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,40,60</pctOmni>
@@ -51,9 +51,9 @@
 		<pctOmni>0,0,22,100,100</pctOmni>
 		<pctClan>66,66,78,100,100</pctClan>
 		<pctSL>34,34,22,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>4,4,40,10,100</pctClan>
-		<pctSL unitType='Aero'>96,96,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>4,4,40,10,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>96,96,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:2,CW:7,CBS:2,CNC:10,CSJ:7,CJF:5,CGB:2,CB:3</salvage>
@@ -90,9 +90,9 @@
 		<pctOmni>0,0,32,60,92</pctOmni>
 		<pctClan>50,50,75,83,100</pctClan>
 		<pctSL>50,50,25,17,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>4,4,60,70,90</pctClan>
-		<pctSL unitType='Aero'>96,96,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>4,4,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>96,96,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
@@ -151,9 +151,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:4,CCO:4,CSA:2,CDS:10,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
@@ -162,9 +162,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>70,70,85,100,100</pctClan>
 		<pctSL>30,30,15,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:4,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
@@ -230,7 +230,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3028' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3028' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3028' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,FWL:1,MH:1,CIR:3</salvage>
@@ -270,18 +270,18 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3028' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3028' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3028' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
 	</faction>
 	<faction key='SIC'>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3028' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3028' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3028' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TFR'>
 		<salvage pct='5'></salvage>
@@ -399,9 +399,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -419,9 +419,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -454,9 +454,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -639,7 +639,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -883,7 +883,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1074,7 +1074,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1143,7 +1143,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1453,7 +1453,7 @@
 			<availability>FRR:3,DC:4:3033</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1492,7 +1492,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1563,7 +1563,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1588,7 +1588,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1597,7 +1597,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:3,CIR:2,Periphery:2,TC:2,OA:2,LA:7,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -1935,7 +1935,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2259,7 +2259,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2769,7 +2769,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:3,CSR:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2781,7 +2781,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:6,NIOPS:9</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -2905,7 +2905,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -3052,7 +3052,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -3065,7 +3065,7 @@
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
@@ -3281,7 +3281,7 @@
 			<availability>CLAN:3,BAN:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3337,7 +3337,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,FWL.OH:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -3353,7 +3353,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3416,7 +3416,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -3453,7 +3453,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:6,CLAN:4,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3629,7 +3629,7 @@
 			<availability>CLAN:5,CGS:7,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3807,7 +3807,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:3,SIC:6,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -3920,13 +3920,13 @@
 			<availability>CS:3-,MERC.KH:5,MERC.WD:5,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,TC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,DC:4</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
@@ -4606,7 +4606,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:2,CW:1,CSJ:1</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -5087,7 +5087,7 @@
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,NIOPS:8</availability>
@@ -5135,7 +5135,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -5189,7 +5189,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -5265,7 +5265,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -5286,7 +5286,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:3,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -5376,7 +5376,7 @@
 			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5434,7 +5434,7 @@
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:6,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -5494,7 +5494,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5512,7 +5512,7 @@
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5567,7 +5567,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
 		<model name='SL-15'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
@@ -5622,7 +5622,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5631,7 +5631,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5733,7 +5733,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
@@ -5793,7 +5793,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
@@ -5817,7 +5817,7 @@
 			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -5884,7 +5884,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -5966,7 +5966,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:9,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -6007,7 +6007,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -6066,7 +6066,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
 		<model name='THK-53'>
 			<roles>escort</roles>
@@ -6102,7 +6102,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:8,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -6111,7 +6111,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:3,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -6142,7 +6142,7 @@
 			<availability>FRR:2,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -6175,7 +6175,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6190,7 +6190,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6298,7 +6298,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -6376,7 +6376,7 @@
 			<availability>CC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6438,7 +6438,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -6673,7 +6673,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6709,7 +6709,7 @@
 			<availability>CHH:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -16,7 +16,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,0</pctSL>
 		<salvage pct='6'>MOC:3,FWL:5,SIC:4,FS:10,DA:8,TC:1</salvage>
-		<weightDistribution era='3039' unitType='Aero'>2,2,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>2,2,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -33,7 +33,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3039' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3039' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3039' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,40,60</pctOmni>
@@ -57,9 +57,9 @@
 		<pctOmni>0,0,25,100,100</pctOmni>
 		<pctClan>68,68,83,100,100</pctClan>
 		<pctSL>32,32,17,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,28,100,100</pctOmni>
-		<pctClan unitType='Aero'>6,6,40,100,100</pctClan>
-		<pctSL unitType='Aero'>94,94,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,28,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>6,6,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>94,94,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -96,9 +96,9 @@
 		<pctOmni>0,0,33,60,93</pctOmni>
 		<pctClan>56,56,78,85,100</pctClan>
 		<pctSL>44,44,22,15,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>6,6,60,70,90</pctClan>
-		<pctSL unitType='Aero'>94,94,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>6,6,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>94,94,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
@@ -157,9 +157,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:3,CCO:3,CSA:2,CDS:3,CW:7,CNC:10,CSJ:1,CJF:4,CB:3</salvage>
@@ -168,9 +168,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>80,80,90,100,100</pctClan>
 		<pctSL>20,20,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
@@ -242,7 +242,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3039' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3039' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3039' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -279,7 +279,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3039' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3039' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3039' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -290,11 +290,11 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,0</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3039' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3039' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3039' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FS:10</salvage>
@@ -443,9 +443,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -463,9 +463,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -498,9 +498,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>30,30,50,100,100</pctClan>
 		<pctSL>70,70,50,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,55,100</pctOmni>
-		<pctClan unitType='Aero'>30,30,60,100,100</pctClan>
-		<pctSL unitType='Aero'>70,70,40,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,55,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>30,30,60,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>70,70,40,0,0</pctSL>
 		<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -685,7 +685,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,NIOPS:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -936,7 +936,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:5,CCC:5,CSR:5,CW:5,CLAN:5,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1140,7 +1140,7 @@
 			<availability>LA:6,IS:1,FS:3,MERC:3,CIR:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1212,7 +1212,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1526,7 +1526,7 @@
 			<availability>DC:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:4,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1565,7 +1565,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -1636,7 +1636,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -1661,7 +1661,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -1670,7 +1670,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:5,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -2011,7 +2011,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2360,7 +2360,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -2899,7 +2899,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Goth' unitType='Aero'>
+	<chassis name='Goth' unitType='AeroSpaceFighter'>
 		<availability>CCC:2,CSR:1</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -2911,7 +2911,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,CLAN:5,CNC:5,FWL:8,NIOPS:9</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -3038,7 +3038,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -3212,7 +3212,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,NIOPS:6</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -3225,7 +3225,7 @@
 			<availability>CS:4,NIOPS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:6</availability>
@@ -3454,7 +3454,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3510,7 +3510,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,FWL.OH:1-</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -3526,7 +3526,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -3589,7 +3589,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -3626,7 +3626,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:7,CLAN:4,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -3835,7 +3835,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4013,7 +4013,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:4,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -4126,13 +4126,13 @@
 			<availability>CS:2-,MERC.KH:5,MERC.WD:4,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:4</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
@@ -4829,7 +4829,7 @@
 			<availability>CW:0,CLAN:8,CJF:0,BAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ogotai' unitType='Aero'>
+	<chassis name='Ogotai' unitType='AeroSpaceFighter'>
 		<availability>CDS:1</availability>
 		<model name='A'>
 			<roles>escort,interceptor</roles>
@@ -5326,7 +5326,7 @@
 			<availability>General:4,MERC:5,DC:5,Periphery:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:4,NIOPS:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,NIOPS:8</availability>
@@ -5388,7 +5388,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -5442,7 +5442,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8</availability>
@@ -5518,7 +5518,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -5530,7 +5530,7 @@
 			<availability>CS:6,NIOPS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:4,CJF:4</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5546,7 +5546,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>DC:3</availability>
 		<model name='S-3'>
 			<availability>DC:8</availability>
@@ -5564,7 +5564,7 @@
 			<availability>IS:3,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:3,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -5654,7 +5654,7 @@
 			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5715,7 +5715,7 @@
 			<availability>DC.GHO:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -5778,7 +5778,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
@@ -5802,7 +5802,7 @@
 			<availability>MERC.WD:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -5857,7 +5857,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
@@ -5909,7 +5909,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -5918,7 +5918,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-8H'>
 			<roles>interceptor</roles>
@@ -5994,7 +5994,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -6026,7 +6026,7 @@
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:8,Periphery:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 		<model name='F-90'>
 			<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
@@ -6086,7 +6086,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,TC:1,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 		<model name='STU-K10'>
 			<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
@@ -6107,7 +6107,7 @@
 			<availability>LA:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -6174,7 +6174,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -6259,7 +6259,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -6300,7 +6300,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -6365,7 +6365,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9</availability>
 		<model name='THK-53'>
 			<roles>escort</roles>
@@ -6405,7 +6405,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:2,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:2</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -6414,7 +6414,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -6449,7 +6449,7 @@
 			<availability>FWL:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:1,CSR:1,CLAN:1,NIOPS:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -6489,7 +6489,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6504,7 +6504,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6612,7 +6612,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -6690,7 +6690,7 @@
 			<availability>CC:1,SIC:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6752,7 +6752,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -7002,7 +7002,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7038,7 +7038,7 @@
 			<availability>CHH:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:3,NIOPS:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:8,CLAN:2,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -14,7 +14,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,4,12,20</pctSL>
 		<salvage pct='5'>FWL:7,SIC:4,FS:10,FC:10,TC:1</salvage>
-		<weightDistribution era='3049' unitType='Aero'>3,3,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>3,3,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -34,7 +34,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3049' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3049' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,50,75</pctOmni>
@@ -58,9 +58,9 @@
 		<pctOmni>0,0,30,100,100</pctOmni>
 		<pctClan>70,70,85,100,100</pctClan>
 		<pctSL>30,30,15,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,32,100,100</pctOmni>
-		<pctClan unitType='Aero'>8,8,40,100,100</pctClan>
-		<pctSL unitType='Aero'>92,92,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,32,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>8,8,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92,92,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -97,9 +97,9 @@
 		<pctOmni>0,0,35,65,95</pctOmni>
 		<pctClan>60,60,80,87,100</pctClan>
 		<pctSL>40,40,20,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>8,8,60,70,90</pctClan>
-		<pctSL unitType='Aero'>92,92,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>8,8,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92,92,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
@@ -158,9 +158,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:3,CCO:3,CSA:2,CDS:3,CW:7,CNC:10,CSJ:1,CJF:4,CB:3</salvage>
@@ -169,9 +169,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>80,80,95,100,100</pctClan>
 		<pctSL>20,20,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
@@ -247,7 +247,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3049' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3049' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -290,8 +290,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,0,0</pctSL>
 		<salvage pct='5'>FS:1,FC:10,DC:7</salvage>
 		<weightDistribution era='3049' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -299,7 +299,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3049' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3049' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3049' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,DC:2</salvage>
@@ -312,11 +312,11 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,4,12,20</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3049' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='TC'>
 		<salvage pct='5'>CC:2,FS:10,FC:10</salvage>
-		<weightDistribution era='3049' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3049' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TD'>
 		<salvage pct='10'>FC:10</salvage>
@@ -548,9 +548,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -577,9 +577,9 @@
 		<pctOmni>0,0,5,45,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -612,9 +612,9 @@
 		<pctOmni>0,0,5,35,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
@@ -882,7 +882,7 @@
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:2,FWL:2+,NIOPS:7,WOB:7</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1180,7 +1180,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1406,7 +1406,7 @@
 			<availability>LA:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1499,7 +1499,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -1929,7 +1929,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -1986,7 +1986,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2063,7 +2063,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:1,FRR:3,WOB:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2098,7 +2098,7 @@
 			<availability>CS:4,WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa IIC' unitType='Aero'>
+	<chassis name='Chippewa IIC' unitType='AeroSpaceFighter'>
 		<availability>BAN:1</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -2107,7 +2107,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
@@ -2484,7 +2484,7 @@
 			<availability>FC:6-,FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -2906,7 +2906,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -3529,7 +3529,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CDS:5,Periphery.MW:3,PIR:3,CLAN:5,Periphery.ME:3,CNC:5,FWL:8,NIOPS:9,WOB:9,MERC:4</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
@@ -3760,7 +3760,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:4,NIOPS:7,WOB:7,DC:2</availability>
 		<model name='HMR-HD'>
 			<availability>General:8</availability>
@@ -3944,7 +3944,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:2,NIOPS:6,WOB:6,FS:2,DC:3</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -3957,7 +3957,7 @@
 			<availability>CS:5,NIOPS:5,WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
@@ -4233,7 +4233,7 @@
 			<availability>CS:4,LA:4,WOB:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4344,7 +4344,7 @@
 			<availability>CSJ:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -4360,7 +4360,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4437,7 +4437,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -4485,7 +4485,7 @@
 			<availability>FS:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:4,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4704,7 +4704,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CGS:8,BAN:6,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -4907,7 +4907,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -5060,7 +5060,7 @@
 			<availability>MERC.KH:5,MERC.WD:3,IS:4,MERC:4,Periphery:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:8</availability>
@@ -5069,7 +5069,7 @@
 			<availability>FRR:3+,DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
 		<model name='LCF-R15'>
 			<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
@@ -6473,7 +6473,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:4+,NIOPS:8,WOB:8</availability>
@@ -6561,7 +6561,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:3,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
@@ -6633,7 +6633,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:8,General:8,NIOPS:8,WOB:6</availability>
@@ -6722,7 +6722,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -6734,7 +6734,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6750,7 +6750,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CSJ:5,DC:5</availability>
 		<model name='S-3'>
 			<availability>DC:8</availability>
@@ -6774,7 +6774,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:3,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -6882,7 +6882,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CIH:3,CFM:3,CSJ:3,CJF:7,CGS:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -6943,7 +6943,7 @@
 			<availability>DC.GHO:8,DC:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -7029,7 +7029,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
@@ -7053,7 +7053,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,FS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -7108,7 +7108,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
@@ -7172,7 +7172,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -7181,7 +7181,7 @@
 			<availability>CS:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 		<model name='SPR-6D'>
 			<availability>FS:4+</availability>
@@ -7283,7 +7283,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -7326,7 +7326,7 @@
 			<availability>FWL:4+,WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:7,LA:4,IS:7,FS:7,Periphery:7</availability>
@@ -7395,7 +7395,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:4+,FS:6+,MERC:4+</availability>
@@ -7419,7 +7419,7 @@
 			<availability>LA:3,FS:3,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -7474,7 +7474,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -7575,7 +7575,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -7616,7 +7616,7 @@
 			<availability>CHH:6,CGS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -7694,7 +7694,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:3</availability>
@@ -7737,7 +7737,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
 		<model name='TR-13'>
 			<availability>CC:8,HL:6,IS:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
@@ -7749,7 +7749,7 @@
 			<availability>General:5,FWL:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -7784,7 +7784,7 @@
 			<availability>FWL:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:3,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:4,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -7814,7 +7814,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7848,7 +7848,7 @@
 			<availability>CHH:8,CW:8,CNC:8,CFM:8,CSJ:8,CJF:8,CCO:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7975,7 +7975,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -8083,7 +8083,7 @@
 			<availability>CSV:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8145,7 +8145,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:8</availability>
@@ -8474,7 +8474,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8506,7 +8506,7 @@
 			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:6,CLAN:2,NIOPS:6,WOB:6</availability>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -13,7 +13,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,9,18,30</pctSL>
 		<salvage pct='5'>FWL:7,SIC:4,FS:10,FC:10,TC:1</salvage>
-		<weightDistribution era='3055' unitType='Aero'>3,3,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>3,3,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -34,7 +34,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3055' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3055' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,5,50,75</pctOmni>
@@ -58,9 +58,9 @@
 		<pctOmni>0,0,32,100,100</pctOmni>
 		<pctClan>76,76,88,100,100</pctClan>
 		<pctSL>24,24,12,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,36,100,100</pctOmni>
-		<pctClan unitType='Aero'>10,10,40,100,100</pctClan>
-		<pctSL unitType='Aero'>90,90,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,36,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -97,9 +97,9 @@
 		<pctOmni>0,0,35,65,98</pctOmni>
 		<pctClan>64,64,82,87,100</pctClan>
 		<pctSL>36,36,18,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CIH:5,CSV:7,CFM:7,CCO:2,CSA:3,CDS:4,CW:1,CNC:3,CSJ:2,CJF:10,CGB:1,CB:2</salvage>
@@ -158,9 +158,9 @@
 		<pctOmni>30,30,75,95,100</pctOmni>
 		<pctClan>70,70,90,100,100</pctClan>
 		<pctSL>30,30,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:3,CCO:3,CSA:2,CDS:3,CW:7,CNC:10,CSJ:1,CJF:5,CB:3</salvage>
@@ -169,9 +169,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>80,80,95,100,100</pctClan>
 		<pctSL>20,20,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,50,50</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
@@ -259,7 +259,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3055' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3055' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<salvage pct='5'>IP:10,MH:1,CIR:1</salvage>
@@ -301,8 +301,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,0,5</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,2,5</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,2,5</pctSL>
 		<salvage pct='5'>FS:1,FC:10,DC:7</salvage>
 		<weightDistribution era='3055' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -310,7 +310,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3055' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3055' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3055' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:2,DC:2</salvage>
@@ -326,7 +326,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,9,18,30</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3055' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='SKC'>
 		<salvage pct='6'>CC:10,FWL:1,CM:2,FC:3</salvage>
@@ -336,7 +336,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,0,3,6</pctSL>
 		<salvage pct='5'>CC:2,FS:10,FC:10</salvage>
-		<weightDistribution era='3055' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3055' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10,FC:3</salvage>
@@ -583,9 +583,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -612,9 +612,9 @@
 		<pctOmni>0,0,5,50,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -647,9 +647,9 @@
 		<pctOmni>0,0,5,40,100</pctOmni>
 		<pctClan>32,32,55,100,100</pctClan>
 		<pctSL>68,68,45,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,60,100</pctOmni>
-		<pctClan unitType='Aero'>32,32,65,100,100</pctClan>
-		<pctSL unitType='Aero'>68,68,35,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,60,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>32,32,65,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>68,68,35,0,0</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -934,7 +934,7 @@
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:2,FWL:3+,NIOPS:7,WOB:7,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1272,7 +1272,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1524,7 +1524,7 @@
 			<availability>LA:7+,FRR:3+,FS:6+,MERC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1626,7 +1626,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -2134,7 +2134,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -2197,7 +2197,7 @@
 			<availability>LA:4,FS:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2295,7 +2295,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2340,7 +2340,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
@@ -2726,7 +2726,7 @@
 			<availability>FC:6-,FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
@@ -3177,7 +3177,7 @@
 			<availability>CLAN:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -3971,7 +3971,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -4222,7 +4222,7 @@
 			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:4,CNC:5,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:2</availability>
@@ -4422,7 +4422,7 @@
 			<availability>PIR:6-,Periphery.Deep:6-,IS.pm:4,Periphery:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -4435,7 +4435,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
@@ -4751,7 +4751,7 @@
 			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:8,CSR:7,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4866,7 +4866,7 @@
 			<availability>CSJ:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8</availability>
@@ -4882,7 +4882,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -4959,7 +4959,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5019,7 +5019,7 @@
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5263,7 +5263,7 @@
 			<availability>MERC:5,DC:6+</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5521,7 +5521,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -5711,7 +5711,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:6</availability>
@@ -5720,7 +5720,7 @@
 			<availability>FRR:5+,MERC:2+,DC:5+</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
@@ -7326,7 +7326,7 @@
 			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
@@ -7423,7 +7423,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
@@ -7503,7 +7503,7 @@
 			<availability>CHH:8,CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
@@ -7606,7 +7606,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -7618,7 +7618,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -7634,7 +7634,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:3,CW:3,CNC:4,CSJ:5,BAN:1,CGB:3,DC:5,CWIE:3</availability>
 		<model name='S-3'>
 			<availability>DC:6</availability>
@@ -7673,7 +7673,7 @@
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:2,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -7781,7 +7781,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CIH:3,CFM:3,CSJ:3,CJF:7,CGS:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -7852,7 +7852,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2,DC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -7942,7 +7942,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
@@ -7966,7 +7966,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,FS:3,DC:8</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -8021,7 +8021,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
@@ -8092,7 +8092,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -8101,7 +8101,7 @@
 			<availability>CS:5,WOB:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
 		<model name='SPR-6D'>
 			<availability>FRR:4+,FS:6+,MERC:4+</availability>
@@ -8218,7 +8218,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -8272,7 +8272,7 @@
 			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:6,LA:4,IS:6,FS:6,Periphery:6</availability>
@@ -8376,7 +8376,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
@@ -8400,7 +8400,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -8472,7 +8472,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -8588,7 +8588,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -8638,7 +8638,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -8719,7 +8719,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:4,CLAN:3</availability>
@@ -8771,7 +8771,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
@@ -8786,7 +8786,7 @@
 			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -8821,7 +8821,7 @@
 			<availability>CC:4+,LA:3+,FRR:4+,FWL:6+,WOB:4,MH:3+,FS:4+,MERC:4+,TC:3+,DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:5,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:6,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -8879,7 +8879,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8919,7 +8919,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9053,7 +9053,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -9177,7 +9177,7 @@
 			<availability>CSR:2,CSV:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9239,7 +9239,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:6</availability>
@@ -9589,7 +9589,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9621,7 +9621,7 @@
 			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -19,7 +19,7 @@
 		<pctClan>0,0,0,1,3</pctClan>
 		<pctSL>0,4,14,22,36</pctSL>
 		<salvage pct='5'>CLAN:1,FWL:7,SIC:4,FS:10,TC:1</salvage>
-		<weightDistribution era='3058' unitType='Aero'>3,3,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>3,3,1</weightDistribution>
 	</faction>
 	<faction key='NC'>
 		<pctOmni>0,0,0,0,0</pctOmni>
@@ -45,7 +45,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3058' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3058' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,8,54,78</pctOmni>
@@ -69,9 +69,9 @@
 		<pctOmni>0,0,32,100,100</pctOmni>
 		<pctClan>78,78,89,100,100</pctClan>
 		<pctSL>22,22,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,38,100,100</pctOmni>
-		<pctClan unitType='Aero'>11,11,40,100,100</pctClan>
-		<pctSL unitType='Aero'>88,88,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,38,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>11,11,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>88,88,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
@@ -108,9 +108,9 @@
 		<pctOmni>0,0,36,66,99</pctOmni>
 		<pctClan>66,66,83,87,100</pctClan>
 		<pctSL>34,34,16,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CIH:4,CSR:0,CSV:4,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1,CB:2</salvage>
@@ -169,9 +169,9 @@
 		<pctOmni>35,35,75,95,100</pctOmni>
 		<pctClan>70,70,92,100,100</pctClan>
 		<pctSL>30,30,7,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,43,43,43</pctClan>
 		<pctSL unitType='Vehicle'>88,88,57,57,57</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10,CB:3</salvage>
@@ -180,9 +180,9 @@
 		<pctOmni>13,13,18,95,100</pctOmni>
 		<pctClan>76,76,91,100,100</pctClan>
 		<pctSL>23,23,8,0,0</pctSL>
-		<pctOmni unitType='Aero'>18,18,27,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>18,18,27,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,43,50,50</pctClan>
 		<pctSL unitType='Vehicle'>88,88,57,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
@@ -267,7 +267,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3058' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3058' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<pctOmni>0,0,2,3,4</pctOmni>
@@ -306,8 +306,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,1,4,8</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,8,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,8,10</pctSL>
 		<salvage pct='5'>FS:1,DC:7</salvage>
 		<weightDistribution era='3058' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -315,7 +315,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3058' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3058' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3058' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:2,DC:2</salvage>
@@ -331,7 +331,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,4,14,22,36</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3058' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='SKC'>
 		<salvage pct='6'>CC:10,FWL:1,CM:2</salvage>
@@ -341,7 +341,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,1,4,9</pctSL>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3058' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3058' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10</salvage>
@@ -590,9 +590,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -619,9 +619,9 @@
 		<pctOmni>0,0,5,50,100</pctOmni>
 		<pctClan>33,33,58,100,100</pctClan>
 		<pctSL>66,66,42,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,63,100</pctOmni>
-		<pctClan unitType='Aero'>33,33,68,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,32,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,63,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>33,33,68,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,32,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -654,9 +654,9 @@
 		<pctOmni>0,0,5,40,100</pctOmni>
 		<pctClan>33,33,58,100,100</pctClan>
 		<pctSL>66,66,42,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,63,100</pctOmni>
-		<pctClan unitType='Aero'>33,33,68,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,32,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,63,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>33,33,68,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,32,0,0</pctSL>
 		<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
@@ -973,7 +973,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:2,FWL:3+,NIOPS:7,WOB:7,DC:2+</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1345,7 +1345,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:4,CCC:4,CSR:4,CW:5,CLAN:4,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1610,7 +1610,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:5,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -1712,7 +1712,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6,DC:2+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -2255,7 +2255,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -2318,7 +2318,7 @@
 			<availability>LA:5,FS:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2416,7 +2416,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2461,7 +2461,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
@@ -2847,7 +2847,7 @@
 			<availability>FS:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
@@ -3348,7 +3348,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -4221,7 +4221,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
@@ -4480,7 +4480,7 @@
 			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:5,FWL:1,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:2</availability>
@@ -4692,7 +4692,7 @@
 			<availability>CC:8,CS:8,MOC:8,SIC:8,FS:8,MERC:8,TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,CNC:1,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -4705,7 +4705,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:5</availability>
@@ -5056,7 +5056,7 @@
 			<availability>CS:6,LA:6,WOB:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:7,CSR:6,CLAN:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5197,7 +5197,7 @@
 			<availability>CSJ:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:2,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:1</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:2</availability>
@@ -5213,7 +5213,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -5290,7 +5290,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -5360,7 +5360,7 @@
 			<availability>LA:3+,FS:3+,MERC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5633,7 +5633,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -5897,7 +5897,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -6109,7 +6109,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:6,MERC:3,DC:6</availability>
 		<model name='LCF-R16K'>
 			<availability>General:6</availability>
@@ -6118,7 +6118,7 @@
 			<availability>FRR:5+,MERC:2+,DC:5+</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
@@ -7856,7 +7856,7 @@
 			<availability>LA:4,FS:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:3,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:5+,NIOPS:8,WOB:8</availability>
@@ -7953,7 +7953,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
@@ -8043,7 +8043,7 @@
 			<availability>CHH:6,CSJ:6,CCO:4,CGS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:2,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:6,General:8,NIOPS:6,WOB:6</availability>
@@ -8150,7 +8150,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -8162,7 +8162,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8178,7 +8178,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:3,CW:3,CNC:4,CSJ:5,BAN:1,CGB:3,DC:5,CWIE:3</availability>
 		<model name='S-3'>
 			<availability>DC:6</availability>
@@ -8223,7 +8223,7 @@
 			<availability>LA:4,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:2,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -8375,7 +8375,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:3,CCC:2,CIH:3,CSR:2,CSV:2,CFM:3,CGS:3,CCO:2,CWIE:2,CSA:3,CW:2,CNC:2,CSJ:3,CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8446,7 +8446,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -8536,7 +8536,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:9,MERC:4,Periphery.OS:4,DC:9,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
@@ -8560,7 +8560,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:8,MERC:3,Periphery.OS:3,FS:3,DC:8,Periphery:1</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -8628,7 +8628,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 		<model name='SL-15'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
@@ -8699,7 +8699,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -8708,7 +8708,7 @@
 			<availability>CS:5,WOB:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
 		<model name='SPR-6D'>
 			<availability>FRR:4+,FS:6+,MERC:4+</availability>
@@ -8831,7 +8831,7 @@
 			<availability>CLAN:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -8885,7 +8885,7 @@
 			<availability>CC:3+,MOC:3+,FWL:6+,IS:3+,WOB:6,FS:3+,MERC:3+,DC:3+,TC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:5,LA:4,IS:5,FS:5,Periphery:5</availability>
@@ -8992,7 +8992,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:5+,FS:7+,MERC:5+</availability>
@@ -9016,7 +9016,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:2,General:2,CGB:7,CB:2</availability>
@@ -9091,7 +9091,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:6,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -9213,7 +9213,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -9270,7 +9270,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -9361,7 +9361,7 @@
 			<availability>FRR:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:5,CLAN:4,NIOPS:9,WOB:8</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:5,CLAN:4</availability>
@@ -9419,7 +9419,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:9,MOC:3,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:3</availability>
 		<model name='TR-13'>
 			<availability>CC:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
@@ -9434,7 +9434,7 @@
 			<availability>MOC:4,CC:3,SIC:2,MERC:3,TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:8,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:8,MOC:8,General:8,TC:8</availability>
@@ -9473,7 +9473,7 @@
 			<availability>DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:5,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:6,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -9535,7 +9535,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CSV:4,CLAN:6,CJF:4,BAN:3,CWIE:4,CGB:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9575,7 +9575,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9722,7 +9722,7 @@
 			<availability>LA:3,FS:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -9853,7 +9853,7 @@
 			<availability>CSR:4,CSV:4,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9915,7 +9915,7 @@
 			<availability>FRR:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:3</availability>
 		<model name='VLC-5N'>
 			<availability>General:5</availability>
@@ -10271,7 +10271,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -10324,7 +10324,7 @@
 			<availability>CHH:7,CLAN:5,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:2,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:5-,CLAN:2,NIOPS:5-,WOB:5-</availability>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -45,7 +45,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3060' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3060' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -59,9 +59,9 @@
 		<pctOmni>0,0,33,100,100</pctOmni>
 		<pctClan>80,80,90,100,100</pctClan>
 		<pctSL>20,20,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,40,100,100</pctOmni>
-		<pctClan unitType='Aero'>12,12,40,100,100</pctClan>
-		<pctSL unitType='Aero'>88,88,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,40,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>12,12,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>88,88,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2</salvage>
@@ -98,9 +98,9 @@
 		<pctOmni>0,0,38,68,100</pctOmni>
 		<pctClan>68,68,84,87,100</pctClan>
 		<pctSL>32,32,16,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:4,CSV:3,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1</salvage>
@@ -159,9 +159,9 @@
 		<pctOmni>39,39,75,96,100</pctOmni>
 		<pctClan>70,70,94,100,100</pctClan>
 		<pctSL>30,30,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>88,88,55,55,55</pctSL>
 		<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10</salvage>
@@ -170,9 +170,9 @@
 		<pctOmni>13,13,18,92,100</pctOmni>
 		<pctClan>74,74,89,100,100</pctClan>
 		<pctSL>26,26,11,0,0</pctSL>
-		<pctOmni unitType='Aero'>18,18,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>18,18,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>88,88,55,50,50</pctSL>
 		<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:8,CGB:2</salvage>
@@ -261,7 +261,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3060' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3060' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<pctOmni>0,0,4,6,7</pctOmni>
@@ -306,8 +306,8 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,2,7,10</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,0</pctOmni>
-		<pctSL unitType='Aero'>0,0,0,12,16</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,0</pctOmni>
+		<pctSL unitType='AeroSpaceFighter'>0,0,0,12,16</pctSL>
 		<salvage pct='5'>FS:1,DC:7</salvage>
 		<weightDistribution era='3060' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -315,7 +315,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3060' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3060' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3060' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:3,DC:2</salvage>
@@ -331,7 +331,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,8,18,26,40</pctSL>
 		<salvage pct='6'>CC:10</salvage>
-		<weightDistribution era='3060' unitType='Aero'>2,2,3</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>2,2,3</weightDistribution>
 	</faction>
 	<faction key='SKC'>
 		<salvage pct='6'>CC:10,FWL:1,CM:2</salvage>
@@ -341,7 +341,7 @@
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,2,6,12</pctSL>
 		<salvage pct='5'>CC:2,FS:10</salvage>
-		<weightDistribution era='3060' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3060' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10</salvage>
@@ -605,9 +605,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -634,9 +634,9 @@
 		<pctOmni>0,0,5,50,100</pctOmni>
 		<pctClan>34,34,60,100,100</pctClan>
 		<pctSL>66,66,40,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,65,100</pctOmni>
-		<pctClan unitType='Aero'>34,34,70,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,30,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,65,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>34,34,70,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,30,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
@@ -669,9 +669,9 @@
 		<pctOmni>0,0,5,40,100</pctOmni>
 		<pctClan>34,34,60,100,100</pctClan>
 		<pctSL>66,66,40,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,65,100</pctOmni>
-		<pctClan unitType='Aero'>34,34,70,100,100</pctClan>
-		<pctSL unitType='Aero'>66,66,30,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,65,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>34,34,70,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>66,66,30,0,0</pctSL>
 		<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
@@ -1046,7 +1046,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:5,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1115,7 +1115,7 @@
 			<availability>IS:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:3,CIH:3,CDS:4,CGS:3,CCO:3,CGB:3</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1558,7 +1558,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:5,CLAN:3,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -1874,7 +1874,7 @@
 			<availability>LA:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,CSJ:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -2029,7 +2029,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,DC:3+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -2726,7 +2726,7 @@
 			<availability>LA:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:2,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:4</availability>
@@ -2801,7 +2801,7 @@
 			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -2921,7 +2921,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -2975,7 +2975,7 @@
 			<availability>:0,IS:4+,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
 		<model name='CHP-W10'>
 			<availability>HL:2,SIC:6,FS:5,TC:4,Periphery:4</availability>
@@ -3390,7 +3390,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
@@ -3641,7 +3641,7 @@
 			<availability>CLAN:6-,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:5+</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4013,7 +4013,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -4039,13 +4039,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:4+</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -5068,7 +5068,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
@@ -5444,7 +5444,7 @@
 			<availability>FWL:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:4</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:3</availability>
@@ -5732,7 +5732,7 @@
 			<availability>CC:5,MOC:5,SIC:5,MERC:5,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,CNC:2,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -5745,7 +5745,7 @@
 			<availability>CS:8,NIOPS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:3-,HL:2,LA:3-,Periphery.Deep:1-,FS:3-,MERC:3-,Periphery:3-,TC:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -6156,7 +6156,7 @@
 			<availability>CC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:2+,FRR:4+</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -6193,7 +6193,7 @@
 			<availability>CS:4,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:7,CSR:6,CLAN:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6373,7 +6373,7 @@
 			<availability>CSJ:8,DC:8+:3062</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
@@ -6389,7 +6389,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -6472,7 +6472,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -6557,7 +6557,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:5,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -6871,7 +6871,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -7087,7 +7087,7 @@
 			<availability>CS:3,NIOPS:3,WOB:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>FWL:3,WOB:2</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -7217,7 +7217,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
 		<model name='LTN-G15'>
 			<availability>General:8</availability>
@@ -7477,7 +7477,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:5,MERC:3,DC:5</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5</availability>
@@ -7486,7 +7486,7 @@
 			<availability>FRR:5,MERC:2,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
 		<model name='LCF-R15'>
 			<availability>LA:2,General:2,Periphery.Deep:4,MERC:8,Periphery:2</availability>
@@ -9700,7 +9700,7 @@
 			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:8,LA:4,CLAN:3,NIOPS:8,WOB:8</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:6,NIOPS:8,WOB:8</availability>
@@ -9829,7 +9829,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:5,HL:3,LA:2,FRR:2,FWL:5,Periphery.Deep:8,SIC:5,MERC:5,DC:2,Periphery:5</availability>
@@ -9947,7 +9947,7 @@
 			<availability>CSR:4,CBS:4,CNC:3,CFM:4,CCO:3,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:5,General:8,NIOPS:5,WOB:6</availability>
@@ -10071,7 +10071,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 		<model name='SB-27'>
 			<availability>General:8</availability>
@@ -10083,7 +10083,7 @@
 			<availability>CS:6,NIOPS:6,WOB:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -10105,7 +10105,7 @@
 			<availability>FS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:4,CNC:5,CSJ:5,FS:2,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:3</availability>
@@ -10173,7 +10173,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>OA:1,FRR:1,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -10365,7 +10365,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:3,CCC:3,CIH:3,CSR:3,CSV:3,CFM:3,CGS:3,CCO:4,CWIE:4,CSA:3,CW:4,CNC:3,CSJ:3,CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10436,7 +10436,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:4,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:2,MH:2,DC:4</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -10569,7 +10569,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FRR:8,MERC:4,Periphery.OS:4,DC:8,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:2,IS:4,Periphery.Deep:8,Periphery:4</availability>
@@ -10581,7 +10581,7 @@
 			<availability>OA:4,FRR:6,MERC:4,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:3+,WOB:3+,FWL.KIS:4+,FWL.FWG:4+</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -10614,7 +10614,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:7,MERC:3,Periphery.OS:3,FS:3,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:6,LA:8,Periphery.Deep:7,MERC:8,DC:8,Periphery:8</availability>
@@ -10712,7 +10712,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
@@ -10792,7 +10792,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -10801,7 +10801,7 @@
 			<availability>CS:6,WOB:6,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
 		<model name='SPR-6D'>
 			<availability>FRR:5,FS:8,MERC:5</availability>
@@ -10978,7 +10978,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -11053,7 +11053,7 @@
 			<availability>CC:4,MOC:4,FWL:8,IS:4,WOB:8,FS:4,MERC:4,DC:4,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:4,LA:3,IS:4,FS:4,Periphery:4</availability>
@@ -11175,7 +11175,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:2,CLAN:4,SIC:4,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
@@ -11238,7 +11238,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:8</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:4,General:2,CGB:7</availability>
@@ -11325,7 +11325,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -11374,7 +11374,7 @@
 			<availability>FWL:3,IS:4,MERC:3,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:3+,DC:4+</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -11534,7 +11534,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -11603,7 +11603,7 @@
 			<availability>CC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:4-,OA:5,LA:6,FWL:5,NIOPS:4-,DC:5</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -11707,7 +11707,7 @@
 			<availability>FRR:7,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:3</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:4</availability>
@@ -11798,7 +11798,7 @@
 			<availability>CS:5+,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,FWL:3,SIC:6,MERC:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:5,HL:3,IS:5,MERC:5,Periphery:5</availability>
@@ -11813,7 +11813,7 @@
 			<availability>CC:5,MOC:5,SIC:2,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:7,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:4,SIC:7,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:7,MOC:7,General:7,TC:7</availability>
@@ -11855,7 +11855,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -11890,7 +11890,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,TC:4</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -11969,7 +11969,7 @@
 			<availability>:0,General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:4,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12036,7 +12036,7 @@
 			<availability>FRR:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -12208,7 +12208,7 @@
 			<availability>LA:2,FS:2,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -12377,7 +12377,7 @@
 			<availability>CSR:6,CSV:6,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12451,7 +12451,7 @@
 			<availability>LA:6,FRR:5,FWL:6,FS:6,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:4</availability>
@@ -12836,7 +12836,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:6,CIH:5,CSR:6,CLAN:5,CFM:6,CSJ:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -12908,7 +12908,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -23,7 +23,7 @@
 		<pctOmni>0,2,7,10,17</pctOmni>
 		<pctClan>0,0,3,5,7</pctClan>
 		<pctSL>0,11,21,29,50</pctSL>
-		<pctSL unitType='Aero'>0,8,18,25,40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>0,8,18,25,40</pctSL>
 		<pctSL unitType='Vehicle'>0,8,15,20,25</pctSL>
 		<salvage pct='5'>CLAN:2,FWL:6,CM:4,WOB:1,FS:10</salvage>
 	</faction>
@@ -51,7 +51,7 @@
 	<faction key='CLAN'>
 		<weightDistribution era='3067' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3067' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -73,9 +73,9 @@
 		<pctOmni>0,0,34,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<salvage pct='10'>CHH:2,CIH:3,CSR:3,CSV:10,CFM:5,CGS:2,CCO:10,CSA:6,CDS:3,CW:7,CBS:2,CJF:10,CGB:2</salvage>
@@ -112,9 +112,9 @@
 		<pctOmni>0,0,38,68,100</pctOmni>
 		<pctClan>68,68,84,87,100</pctClan>
 		<pctSL>32,32,16,13,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
 		<salvage pct='10'>CSA:4,CHH:3,CIH:6,CSR:1,CDS:2,CW:3,CSV:2,CFM:10,CCO:1,CJF:6</salvage>
@@ -165,9 +165,9 @@
 		<pctOmni>39,39,75,96,100</pctOmni>
 		<pctClan>70,70,94,100,100</pctClan>
 		<pctSL>30,30,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<salvage pct='10'>CSA:4,CHH:10,CCC:1,CIH:6,CDS:8,CW:10,CSV:4,CFM:4,CGS:2,CCO:4,CJF:8</salvage>
@@ -176,9 +176,9 @@
 		<pctOmni>13,13,18,92,100</pctOmni>
 		<pctClan>74,74,89,100,100</pctClan>
 		<pctSL>26,26,11,0,0</pctSL>
-		<pctOmni unitType='Aero'>18,18,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,5,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>18,18,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,5,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,50,50</pctSL>
 		<salvage pct='10'>CCC:1,CHH:2,CSR:1,CIH:5,CSV:2,CFM:10,CCO:4,CGS:3,CDS:4,CW:2,CBS:1,CJF:6,CGB:1</salvage>
@@ -270,7 +270,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3067' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3067' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='KP'>
 		<salvage pct='7'>CC:1,WOB:10,FS:2</salvage>
@@ -313,9 +313,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,6,15,21</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,0,5</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>0,0,5,20,40</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,0,5</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0,0,5,20,40</pctSL>
 		<salvage pct='5'>CSR:2,FS:1,DC:7</salvage>
 		<weightDistribution era='3067' unitType='Mek'>6,6,3,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>5,5,2,1</weightDistribution>
@@ -323,7 +323,7 @@
 	<faction key='Periphery'>
 		<weightDistribution era='3067' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3067' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3067' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<salvage pct='15'>CC:2,LA:2,FWL:2,FS:2,BAN:4,DC:2</salvage>
@@ -342,7 +342,7 @@
 		<pctClan>0,0,0,0,2</pctClan>
 		<pctSL>0,0,5,12,21</pctSL>
 		<salvage pct='5'>CC:2,CLAN:1,FS:10</salvage>
-		<weightDistribution era='3067' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3067' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TCC'>
 		<salvage pct='6'>CC:1,ST:1,CM:10</salvage>
@@ -447,7 +447,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>15</pctSL>
-		<pctSL unitType='Aero'>5</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>5</pctSL>
 		<pctSL unitType='Vehicle'>10</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -461,7 +461,7 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>4</pctClan>
 		<pctSL>60</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>50</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -497,7 +497,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>29</pctSL>
-		<pctSL unitType='Aero'>14</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>14</pctSL>
 		<pctSL unitType='Vehicle'>25</pctSL>
 		<salvage pct='5'>CLAN:2,CM:4,FWL:6,WOB:1,FS:10</salvage>
 	</faction>
@@ -598,9 +598,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 	</faction>
@@ -675,7 +675,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>23</pctSL>
-		<pctSL unitType='Aero'>20</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>20</pctSL>
 		<pctSL unitType='Vehicle'>15</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -866,7 +866,7 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>87</pctSL>
-		<pctSL unitType='Aero'>55</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>55</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -880,7 +880,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>48</pctSL>
-		<pctSL unitType='Aero'>30</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>30</pctSL>
 		<pctSL unitType='Vehicle'>20</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -919,7 +919,7 @@
 		<pctOmni>14</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>26</pctSL>
-		<pctSL unitType='Aero'>24</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>24</pctSL>
 		<pctSL unitType='Vehicle'>20</pctSL>
 		<salvage pct='5'></salvage>
 	</faction>
@@ -1055,7 +1055,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:4,NIOPS:7,WOB:7,DC:3</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1133,7 +1133,7 @@
 			<availability>IS:2,Periphery:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:4,CIH:5,CDS:6,CW:4,CNC:4,CGS:5,CCO:5,CGB:5,CB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1714,7 +1714,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:5,CLAN:3,CNC:5,BAN:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -2093,7 +2093,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:8,CNC:6,CLAN:5,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CFM:8,CGB:8</availability>
@@ -2304,7 +2304,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,CIH:6,SOC:6,CSV:8,CFM:7,CGS:6,CCO:4,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CJF:7,CGB:6,DC:3+,CB:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -3155,7 +3155,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3274,7 +3274,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5,CB:7</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3405,7 +3405,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:2</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3466,7 +3466,7 @@
 			<availability>:0,IS:4+,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
@@ -3922,7 +3922,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OA:3+,CSR:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -3959,7 +3959,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:3-,IS:5-,Periphery.Deep:8,BAN:4,Periphery:5-</availability>
@@ -4309,13 +4309,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB:4,FS:6+</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4508,13 +4508,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='F-77A'>
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4+,WOB:5+</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -4872,7 +4872,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -4901,13 +4901,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:5,FRR:3+,CNC:3,MERC:3+</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:3+,MERC:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6190,7 +6190,7 @@
 			<availability>CLAN:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6-</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:5-,FWL:5-,MH:5-,MERC:5-</availability>
@@ -6682,7 +6682,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:4</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7028,7 +7028,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:3,CNC:3,NIOPS:6,WOB:6,FS:3,DC:4</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -7044,7 +7044,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:4,FVC:2,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:2-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -7545,7 +7545,7 @@
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
 		<availability>CS:1</availability>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:3+,FRR:5+,CNC:3</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -7591,7 +7591,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7803,7 +7803,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,FWL.OH:1-,DC:2</availability>
 		<model name='IRN-SD1'>
 			<availability>General:8,CNC:4</availability>
@@ -7826,7 +7826,7 @@
 			<availability>CHH:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -7930,7 +7930,7 @@
 			<availability>WOB:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8036,7 +8036,7 @@
 			<availability>FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8448,7 +8448,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CGS:8,BAN:7,CWIE:6,CGB:8</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8756,7 +8756,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>FWL:4,WOB:3</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -8929,7 +8929,7 @@
 			<availability>CS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:6-</availability>
@@ -9262,7 +9262,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -9271,7 +9271,7 @@
 			<availability>FRR:6,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>LA:2-,General:2-,Periphery.Deep:4,MERC:8-,Periphery:2-</availability>
@@ -10893,7 +10893,7 @@
 			<availability>CLAN:1,IS:1+,WOB:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>FRR:2,CNC:2,DC:3</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12182,7 +12182,7 @@
 			<availability>FS.CMM:9,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:4,CLAN:3,NIOPS:6,WOB:6</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:5,NIOPS:8,WOB:8</availability>
@@ -12356,7 +12356,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:5,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,FVC:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 		<model name='F-100'>
 			<availability>CC:4-,FVC:5-,HL:3-,LA:2,FRR:2,FWL:5-,Periphery.Deep:8,MERC:5-,DC:2,Periphery:5-</availability>
@@ -12525,7 +12525,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
@@ -12593,7 +12593,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rusalka' unitType='Aero' omni='IS'>
+	<chassis name='Rusalka' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:5</availability>
 		<model name='S-RSL-O Invictus'>
 			<roles>interceptor</roles>
@@ -12729,7 +12729,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:2,MOC:2,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:2,MERC:2,Periphery:3-,OA:2-,LA:2,FWL:2-,DC:4</availability>
 		<model name='SB-27'>
 			<availability>General:6-</availability>
@@ -12744,7 +12744,7 @@
 			<availability>MERC:4,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -12782,7 +12782,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:6,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:3-</availability>
@@ -12856,7 +12856,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,WOB:4,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -13110,7 +13110,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:3,CCC:4,CIH:3,CSR:4,CSV:4,CLAN:3,CFM:3,CGS:3,CCO:5,CWIE:5,CSA:3,CW:5,CNC:4,CJF:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13227,7 +13227,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -13272,7 +13272,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shade' unitType='Aero' omni='IS'>
+	<chassis name='Shade' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:4</availability>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
@@ -13423,7 +13423,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
@@ -13438,7 +13438,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:4+,WOB:3+,FWL.KIS:6+,FWL.FWG:5+</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -13478,7 +13478,7 @@
 			<availability>MERC.WD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:7,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:5,LA:6,Periphery.Deep:7,MERC:7,DC:7,Periphery:7</availability>
@@ -13594,7 +13594,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
@@ -13683,7 +13683,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -13695,7 +13695,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
@@ -13927,7 +13927,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -14026,7 +14026,7 @@
 			<availability>LA:3,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
@@ -14114,7 +14114,7 @@
 			<availability>CLAN:6,General:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Striga' unitType='Aero' omni='IS'>
+	<chassis name='Striga' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6</availability>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
@@ -14175,7 +14175,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:5,Periphery.HR:2,DC:1</availability>
 		<model name='STU-D6'>
 			<availability>LA:6,FS:8,MERC:6</availability>
@@ -14245,7 +14245,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:6,General:2,CGB:7,CB:6</availability>
@@ -14354,7 +14354,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -14429,7 +14429,7 @@
 			<availability>FVC:4,IS:4,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:4+,CNC:4,DC:5+</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -14648,7 +14648,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -14738,7 +14738,7 @@
 			<availability>CC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -14875,7 +14875,7 @@
 			<availability>FRR:6-,DC:6-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:4</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:4</availability>
@@ -14994,7 +14994,7 @@
 			<availability>General:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:5-,HL:3-,IS:4-,MERC:5-,Periphery:5-</availability>
@@ -15012,7 +15012,7 @@
 			<availability>CC:7,MOC:5,MERC:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:4,Periphery.CM:3,Periphery.ME:3,FWL:3,TC:4</availability>
 		<model name='TR-10'>
 			<availability>CC:6,MOC:6,General:6,TC:6</availability>
@@ -15058,7 +15058,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -15121,7 +15121,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:4,Periphery.CM:2,Periphery.ME:2,TC:5</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -15204,7 +15204,7 @@
 			<availability>DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15268,7 +15268,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:3</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -15285,7 +15285,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -15531,7 +15531,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:5,CLAN:4,CJF:5,BAN:4,CWIE:5</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -15751,7 +15751,7 @@
 			<availability>CSR:8,CSV:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:8,CJF:9,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15837,7 +15837,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:4,CDP:2,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:3</availability>
@@ -16352,7 +16352,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CIH:5,CSR:6,CLAN:5,CFM:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16454,7 +16454,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:4-,CLAN:1,NIOPS:4-,WOB:4-</availability>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -25,7 +25,7 @@
 		<pctOmni>0,3,7,10,20</pctOmni>
 		<pctClan>0,0,3,6,10</pctClan>
 		<pctSL>10,20,40,50,75</pctSL>
-		<pctSL unitType='Aero'>7,18,32,40,62</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>7,18,32,40,62</pctSL>
 		<pctSL unitType='Vehicle'>7,15,28,30,50</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -56,7 +56,7 @@
 		<techMargin>1</techMargin>
 		<weightDistribution era='3075' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3075' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3075' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -71,9 +71,9 @@
 		<pctOmni>0,0,35,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>1</techMargin>
@@ -105,9 +105,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>60,60,80,90,100</pctClan>
 		<pctSL>40,40,20,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,35,35,35</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>1</techMargin>
@@ -153,9 +153,9 @@
 		<pctOmni>40,40,75,95,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,80,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,80,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<techMargin>1</techMargin>
@@ -165,9 +165,9 @@
 		<pctOmni>15,15,20,95,100</pctOmni>
 		<pctClan>75,75,90,100,100</pctClan>
 		<pctSL>25,25,10,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>1</techMargin>
@@ -294,7 +294,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3075' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3075' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3075' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='KP'>
 		<omniMargin>1</omniMargin>
@@ -355,9 +355,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,0,18,35,40</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,2,8</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>6,10,20,30,60</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,2,8</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>6,10,20,30,60</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
 		<salvage pct='5'>FS:10,DC:6</salvage>
@@ -369,7 +369,7 @@
 		<techMargin>1</techMargin>
 		<weightDistribution era='3075' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3075' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3075' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>1</omniMargin>
@@ -401,7 +401,7 @@
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3075' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3075' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='SOC'>
 		<techMargin>1</techMargin>
@@ -535,7 +535,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>55</pctSL>
-		<pctSL unitType='Aero'>22</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>22</pctSL>
 		<pctSL unitType='Vehicle'>32</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -553,7 +553,7 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>80</pctSL>
-		<pctSL unitType='Aero'>80</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>80</pctSL>
 		<pctSL unitType='Vehicle'>75</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -605,7 +605,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>55</pctSL>
-		<pctSL unitType='Aero'>30</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>30</pctSL>
 		<pctSL unitType='Vehicle'>37</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -747,9 +747,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>1</techMargin>
@@ -794,7 +794,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>44</pctSL>
-		<pctSL unitType='Aero'>37</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>37</pctSL>
 		<pctSL unitType='Vehicle'>28</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1080,7 +1080,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>87</pctSL>
-		<pctSL unitType='Aero'>55</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>55</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1098,7 +1098,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>65</pctSL>
-		<pctSL unitType='Aero'>40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>40</pctSL>
 		<pctSL unitType='Vehicle'>29</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1152,7 +1152,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>4</pctClan>
 		<pctSL>62</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<omniMargin>1</omniMargin>
 		<techMargin>1</techMargin>
@@ -1304,7 +1304,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:2,NIOPS:7,WOB:7,DC:2</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1392,7 +1392,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2018,7 +2018,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:3,CW:4,CLAN:3,CNC:4,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,General:6</availability>
@@ -2423,7 +2423,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:7,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2643,7 +2643,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:6,SOC:6,CSV:8,CGS:6,CCO:4,CWIE:4,CSA:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CGB:6,DC:2+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -3547,7 +3547,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3644,7 +3644,7 @@
 			<availability>LA:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3782,7 +3782,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,OA:4,FVC:2,LA:2-,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,RCM:10,DC:2-</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3843,7 +3843,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
@@ -4314,7 +4314,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OA:3+,CSR:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4354,7 +4354,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:5,FWL:1,DC:2</availability>
 		<model name='CSR-V12'>
 			<availability>HL:2-,IS:4-,Periphery.Deep:8,BAN:4,Periphery:4-</availability>
@@ -4742,13 +4742,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4946,13 +4946,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5316,7 +5316,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -5366,13 +5366,13 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FRR:3,CNC:3,MERC:3,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:3,MERC:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6768,7 +6768,7 @@
 			<availability>CLAN:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CS:8,DTA:7,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5-</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
@@ -7278,7 +7278,7 @@
 			<availability>General:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:3,CNC:4,FWL:3,NIOPS:7,WOB:7,DC:2</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7663,7 +7663,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:2,CNC:3,NIOPS:6,WOB:6,FS:2,DC:2</availability>
 		<model name='HCT-212'>
 			<availability>LA:8,FS:8</availability>
@@ -7679,7 +7679,7 @@
 			<availability>CS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -8213,7 +8213,7 @@
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
 		<availability>CS:1</availability>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:3,FRR:5,CNC:4,CGB:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8259,7 +8259,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:5,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8485,7 +8485,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:2,NIOPS:6,WOB:6,DC:1</availability>
 		<model name='CX-19'>
 			<availability>CS:2</availability>
@@ -8511,7 +8511,7 @@
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:7,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8621,7 +8621,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8727,7 +8727,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9161,7 +9161,7 @@
 			<availability>DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9482,7 +9482,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>DTA:5,FWL:5,WOB:3,RCM:5</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -9674,7 +9674,7 @@
 			<availability>CS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:5-</availability>
@@ -10021,7 +10021,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10030,7 +10030,7 @@
 			<availability>FRR:6,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:6-,Periphery:2-</availability>
@@ -11745,7 +11745,7 @@
 			<availability>CLAN:1,IS:2+,WOB:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>FRR:3,CNC:3,DC:4</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13085,7 +13085,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:4,CLAN:3,NIOPS:6,WOB:6</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
@@ -13272,7 +13272,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,RCM:8,DC:4</availability>
 		<model name='F-100'>
 			<availability>CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
@@ -13435,7 +13435,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:4,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
@@ -13518,7 +13518,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rusalka' unitType='Aero' omni='IS'>
+	<chassis name='Rusalka' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6</availability>
 		<model name='S-RSL-O Invictus'>
 			<roles>interceptor</roles>
@@ -13666,7 +13666,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:5-</availability>
@@ -13681,7 +13681,7 @@
 			<availability>MERC:5,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13719,7 +13719,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:6,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:2-</availability>
@@ -13793,7 +13793,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,WOB:4,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -14051,13 +14051,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>CSR:2</availability>
 		<model name='XR'>
 			<availability>CSR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:5,CW:5,CSV:5,CLAN:4,CNC:5,CGS:4,CJF:7,CCO:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14187,7 +14187,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14235,7 +14235,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shade' unitType='Aero' omni='IS'>
+	<chassis name='Shade' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:5</availability>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
@@ -14404,7 +14404,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -14419,7 +14419,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14456,7 +14456,7 @@
 			<availability>MERC.WD:8,CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:4,LA:4,Periphery.Deep:6,MERC:5,DC:5,Periphery:6</availability>
@@ -14568,7 +14568,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
@@ -14656,7 +14656,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -14668,7 +14668,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
@@ -14891,7 +14891,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:4</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -14909,7 +14909,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -15026,7 +15026,7 @@
 			<availability>LA:4,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
@@ -15117,7 +15117,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Striga' unitType='Aero' omni='IS'>
+	<chassis name='Striga' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
@@ -15181,7 +15181,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:4,Periphery.HR:2,DC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,FS:6,MERC:6</availability>
@@ -15255,7 +15255,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:7,CBS:6,General:2,CGB:7</availability>
@@ -15364,7 +15364,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:9,CLAN:8</availability>
@@ -15445,7 +15445,7 @@
 			<availability>DTA:6,FVC:4,IS:4,MERC:5,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:4,CNC:4,DC:5</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -15682,7 +15682,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -15778,7 +15778,7 @@
 			<availability>CC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15933,7 +15933,7 @@
 			<availability>FRR:5-,DC:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:3</availability>
@@ -16062,7 +16062,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,Periphery.CM:2,PIR:2,FWL:3,MERC:3,RCM:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:3-,HL:2-,IS:2-,MERC:3-,Periphery:4-</availability>
@@ -16080,7 +16080,7 @@
 			<availability>CC:7,MOC:5,MERC:5,RCM:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:5,MOC:5,General:6,TC:5</availability>
@@ -16129,7 +16129,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -16192,7 +16192,7 @@
 			<availability>IS:2,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FVC:2,Periphery.CM:3,Periphery.ME:3,MERC:2,TC:6,Periphery:2</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -16294,7 +16294,7 @@
 			<availability>DC:4-</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CSV:4,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16370,7 +16370,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -16387,7 +16387,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CSV:9,CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16643,7 +16643,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -16878,7 +16878,7 @@
 			<availability>CSR:8,CSV:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16964,7 +16964,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:5,CDP:2,Periphery:2,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:2</availability>
@@ -17527,7 +17527,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CSR:6,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17635,7 +17635,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:3-,CLAN:1,NIOPS:3-,WOB:3-</availability>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -25,7 +25,7 @@
 		<pctOmni>0,3,7,10,20</pctOmni>
 		<pctClan>0,0,3,6,11</pctClan>
 		<pctSL>13,27,47,56,76</pctSL>
-		<pctSL unitType='Aero'>9,21,37,46,68</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>9,21,37,46,68</pctSL>
 		<pctSL unitType='Vehicle'>9,21,31,34,56</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -56,7 +56,7 @@
 		<techMargin>2</techMargin>
 		<weightDistribution era='3078' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3078' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3078' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -71,9 +71,9 @@
 		<pctOmni>0,0,36,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>2</techMargin>
@@ -105,9 +105,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>2</techMargin>
@@ -153,9 +153,9 @@
 		<pctOmni>30,30,60,90,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,60,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,60,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<techMargin>2</techMargin>
@@ -165,9 +165,9 @@
 		<pctOmni>15,15,20,96,100</pctOmni>
 		<pctClan>75,75,91,100,100</pctClan>
 		<pctSL>25,25,8,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>2</techMargin>
@@ -320,7 +320,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3078' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3078' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3078' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='KP'>
 		<omniMargin>2</omniMargin>
@@ -394,9 +394,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,6,22,38,43</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,2,8</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>8,14,26,36,63</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,2,8</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>8,14,26,36,63</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
 		<salvage pct='5'>FS:9,DC:7</salvage>
@@ -408,7 +408,7 @@
 		<techMargin>2</techMargin>
 		<weightDistribution era='3078' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3078' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3078' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>2</omniMargin>
@@ -485,7 +485,7 @@
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3078' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3078' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TP'>
 		<pctOmni>0,3,10,14,20</pctOmni>
@@ -624,7 +624,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>63</pctSL>
-		<pctSL unitType='Aero'>26</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>26</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -642,8 +642,8 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>82</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>83</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>83</pctSL>
 		<pctClan unitType='Vehicle'>5</pctClan>
 		<pctSL unitType='Vehicle'>79</pctSL>
 		<omniMargin>2</omniMargin>
@@ -704,7 +704,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>62</pctSL>
-		<pctSL unitType='Aero'>34</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>34</pctSL>
 		<pctSL unitType='Vehicle'>40</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -846,9 +846,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>2</techMargin>
@@ -900,7 +900,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>50</pctSL>
-		<pctSL unitType='Aero'>41</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>41</pctSL>
 		<pctSL unitType='Vehicle'>31</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -966,8 +966,8 @@
 		<pctOmni>24</pctOmni>
 		<pctClan>9</pctClan>
 		<pctSL>73</pctSL>
-		<pctClan unitType='Aero'>8</pctClan>
-		<pctSL unitType='Aero'>92</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>8</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92</pctSL>
 		<pctClan unitType='Vehicle'>6</pctClan>
 		<pctSL unitType='Vehicle'>100</pctSL>
 		<omniMargin>2</omniMargin>
@@ -1214,7 +1214,7 @@
 		<pctOmni>13</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>53</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>53</pctSL>
 		<pctSL unitType='Vehicle'>39</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -1232,7 +1232,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>68</pctSL>
-		<pctSL unitType='Aero'>43</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>43</pctSL>
 		<pctSL unitType='Vehicle'>31</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -1286,7 +1286,7 @@
 		<pctOmni>11</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>71</pctSL>
-		<pctSL unitType='Aero'>55</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>55</pctSL>
 		<pctSL unitType='Vehicle'>46</pctSL>
 		<omniMargin>2</omniMargin>
 		<techMargin>2</techMargin>
@@ -1438,7 +1438,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ahab' unitType='Aero'>
+	<chassis name='Ahab' unitType='AeroSpaceFighter'>
 		<availability>CS:7,CLAN:1,FWL:1,NIOPS:4,WOB:7,DC:1</availability>
 		<model name='AHB-443'>
 			<availability>General:8,CLAN:6</availability>
@@ -1542,7 +1542,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CGS:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2193,7 +2193,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CCC:3,CSR:2,CW:4,CLAN:3,CNC:4,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,General:6</availability>
@@ -2624,7 +2624,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:4,CNC:6,CLAN:4,IS:2+,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2844,7 +2844,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CGS:6,CCO:4,CJF:7,CWIE:4,CGB:6,DC:1+</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CGS:3</availability>
@@ -3787,7 +3787,7 @@
 			<availability>LA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,WOB:3,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3884,7 +3884,7 @@
 			<availability>LA:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4025,7 +4025,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>PR:8,HL:2,DoO:10,FRR:3,DO:10,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,RFS:8,MOC:5,CC:3,WOB:6,DGM:10,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,FVC:2,LA:1-,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10,DC:1-</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4090,7 +4090,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
@@ -4564,13 +4564,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>CSR:2-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OA:3+,CSR:2</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4610,7 +4610,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:4</availability>
@@ -5001,13 +5001,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:2</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB:4,FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5205,7 +5205,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>FWL:3,DA:4</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5214,7 +5214,7 @@
 			<availability>DA:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4+,MOC:3+,WOB:5+</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5613,7 +5613,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R10'>
 			<roles>ground_support</roles>
@@ -5681,13 +5681,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FRR:3,CGB.FRR:3,CNC:2,MERC:3,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:4,MERC:2+</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7129,7 +7129,7 @@
 			<availability>CLAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DoO:7,CLAN:4,WOB:9,DO:7,DGM:7,MERC:4-,CS:8,DTA:7,SC:7,CDS:5,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,TP:7</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
@@ -7665,7 +7665,7 @@
 			<availability>General:4,MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CS:7,ROS:6,CLAN:3,CNC:4,FWL:2,NIOPS:7,WOB:7,DC:1</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -8056,7 +8056,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:1,ROS:4,CNC:2,NIOPS:6,WOB:6,FS:1,DC:1</availability>
 		<model name='HCT-212'>
 			<availability>LA:5,FS:5</availability>
@@ -8072,7 +8072,7 @@
 			<availability>CS:4,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,OA:5,FVC:3,CSR:2,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:4</availability>
@@ -8616,7 +8616,7 @@
 	<chassis name='Hurricane PA (L)' unitType='BattleArmor'>
 		<availability>CS:1</availability>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CS:3,FRR:5,CGB.FRR:5,CNC:4,CGB:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8672,7 +8672,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:3,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8902,7 +8902,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Ironsides' unitType='Aero'>
+	<chassis name='Ironsides' unitType='AeroSpaceFighter'>
 		<availability>CS:6,CLAN:1,CNC:1,NIOPS:3,WOB:6,DC:1</availability>
 		<model name='CX-19'>
 			<availability>CS:2</availability>
@@ -8928,7 +8928,7 @@
 			<availability>CHH:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:4,CLAN:4,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9056,7 +9056,7 @@
 			<availability>WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:9,CLAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9162,7 +9162,7 @@
 			<availability>FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9625,7 +9625,7 @@
 			<availability>DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CGS:7,BAN:7,CWIE:6,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9949,7 +9949,7 @@
 			<availability>WOB:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:5,WOB:3,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,DA:5,RCM:5,RFS:5</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10151,7 +10151,7 @@
 			<availability>CS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:5-</availability>
@@ -10512,7 +10512,7 @@
 			<availability>CS:8,WOB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>FRR:4,CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10521,7 +10521,7 @@
 			<availability>FRR:6,CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
@@ -10734,7 +10734,7 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Malaika' unitType='Aero'>
+	<chassis name='Malaika' unitType='AeroSpaceFighter'>
 		<availability>FWL:4-</availability>
 		<model name='BAM-1A1'>
 			<availability>General:8</availability>
@@ -12340,7 +12340,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>FRR:3,CGB.FRR:3,CNC:3,DC:4</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12510,7 +12510,7 @@
 			<availability>FS:2-,DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CGB:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13794,7 +13794,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>CS:6,LA:4,ROS:5,CLAN:3,NIOPS:6,WOB:6</availability>
 		<model name='RPR-100'>
 			<availability>CS:8,General:4,NIOPS:8,WOB:8</availability>
@@ -13987,7 +13987,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>PR:7,DoO:8,FRR:5,DO:8,FS:3,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,RFS:7,MOC:3,CC:3,WOB:6,DGM:8,MERC:2,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:1,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:4</availability>
 		<model name='F-100'>
 			<availability>CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
@@ -14163,7 +14163,7 @@
 			<availability>CGB:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rogue' unitType='Aero'>
+	<chassis name='Rogue' unitType='AeroSpaceFighter'>
 		<availability>CS:4,CLAN:1,NIOPS:2,WOB:4</availability>
 		<model name='RGU-133E'>
 			<availability>CS:4,General:8,NIOPS:4,WOB:6</availability>
@@ -14246,7 +14246,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Rusalka' unitType='Aero' omni='IS'>
+	<chassis name='Rusalka' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6</availability>
 		<model name='S-RSL-O Invictus'>
 			<roles>interceptor</roles>
@@ -14394,7 +14394,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:5-</availability>
@@ -14413,7 +14413,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14451,7 +14451,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,FRR:6,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:2-</availability>
@@ -14525,7 +14525,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>CS:4,OA:1,LA:5,FRR:4,CGB.FRR:4,ROS:5,WOB:4,DC:1</availability>
 		<model name='SL-25'>
 			<roles>ground_support</roles>
@@ -14799,13 +14799,13 @@
 			<availability>CHH:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>CSR:1</availability>
 		<model name='XR'>
 			<availability>CSR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:3,CW:5,CLAN:4,CNC:5,CGS:4,CJF:7,CCO:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14938,7 +14938,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14986,7 +14986,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shade' unitType='Aero' omni='IS'>
+	<chassis name='Shade' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:5</availability>
 		<model name='S-HA-O Invictus'>
 			<availability>General:8</availability>
@@ -15167,7 +15167,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -15182,13 +15182,13 @@
 			<availability>ROS:6,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:1</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FWL:4,WOB:4,FWL.KIS:6,FWL.FWG:5</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15225,7 +15225,7 @@
 			<availability>MERC.WD:8,CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,CGB.FRR:6,ROS:3,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>HL:4,LA:2,Periphery.Deep:7,MERC:4,DC:4,Periphery:6</availability>
@@ -15341,7 +15341,7 @@
 			<availability>IS.pm:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
@@ -15432,7 +15432,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>CS:6,OA:2,ROS:5,NIOPS:6,WOB:6</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -15444,7 +15444,7 @@
 			<availability>ROS:4,WOB:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
@@ -15685,7 +15685,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:5</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -15703,7 +15703,7 @@
 			<availability>CLAN:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Starfire' unitType='Aero'>
+	<chassis name='Starfire' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='SF-1X'>
 			<availability>FS:8</availability>
@@ -15820,7 +15820,7 @@
 			<availability>LA:4,ROS:4,MERC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:2,RFS:5,MOC:2,CC:5,IS:3,WOB:3,DGM:6,MERC:5,CIR:2,Periphery:1,TC:2,CS:3,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>CS:2-,LA:2-,IS:4-,FS:2-,Periphery:4-</availability>
@@ -15907,7 +15907,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Striga' unitType='Aero' omni='IS'>
+	<chassis name='Striga' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>WOB.SD:6,WOB:1+</availability>
 		<model name='S-STR-O Invictus'>
 			<availability>General:8</availability>
@@ -15971,7 +15971,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FRR:1,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:3,CGB.FRR:2,Periphery.HR:2,ROS:5,DC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:6,MERC:6</availability>
@@ -16045,7 +16045,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,CBS:6,General:2,CGB:7</availability>
@@ -16154,7 +16154,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CS:8,ROS:6,CLAN:5,NIOPS:8,WOB:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:5,CLAN:8</availability>
@@ -16242,7 +16242,7 @@
 			<availability>DTA:7,SC:6,FVC:2,DoO:6,MCM:6,ROS:6,IS:2,DO:6,DGM:6,TP:6,MERC:5,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FRR:4,CGB.FRR:4,CNC:4,DC:5</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -16494,7 +16494,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -16593,7 +16593,7 @@
 			<availability>CC:2,MOC:2,CC.LCC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -16760,7 +16760,7 @@
 			<availability>FRR:5-,CGB.FRR:5-,DC:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CS:9,CW:4,ROS:7,CLAN:3,NIOPS:9,WOB:8,DC:5</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6,CLAN:2</availability>
@@ -16892,7 +16892,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,PIR:1,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:3-,HL:1-,IS:1-,MERC:3-,Periphery:4-</availability>
@@ -16910,7 +16910,7 @@
 			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:2,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:4,MOC:5,General:6,TC:5</availability>
@@ -16976,7 +16976,7 @@
 			<availability>TC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>CS:7,OA:6,NIOPS:7,WOB:7</availability>
 		<model name='TRN-3T'>
 			<availability>CS:8,OA:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -17039,7 +17039,7 @@
 			<availability>IS:3,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:5,FVC:2,Periphery.CM:3,Periphery.ME:3,MERC:2,DA:2,TC:6,Periphery:2</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,TC:8</availability>
@@ -17151,7 +17151,7 @@
 			<availability>DC:3-</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CLAN:5,CJF:3,BAN:2,CWIE:3,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17227,7 +17227,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>LA:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -17244,7 +17244,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17515,7 +17515,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -17754,7 +17754,7 @@
 			<availability>CSR:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8,BAN:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17844,7 +17844,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>MERC:5,CDP:2,Periphery:3,TC:2</availability>
 		<model name='VLC-5N'>
 			<availability>General:1</availability>
@@ -18444,7 +18444,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CSR:3,CLAN:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18558,7 +18558,7 @@
 			<availability>CHH:6,CLAN:4,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>CS:5,ROS:4,CLAN:1,NIOPS:5,WOB:5</availability>
 		<model name='ZRO-114'>
 			<availability>CS:3-,CLAN:1,NIOPS:2-,WOB:3-</availability>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -20,7 +20,7 @@
 		<pctOmni>0,4,9,11,20</pctOmni>
 		<pctClan>0,0,3,7,14</pctClan>
 		<pctSL>17,38,58,65,78</pctSL>
-		<pctSL unitType='Aero'>12,26,44,54,78</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>12,26,44,54,78</pctSL>
 		<pctSL unitType='Vehicle'>12,29,36,40,65</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -35,7 +35,7 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3082' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3082' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3082' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CBS'>
 		<pctOmni>0,0,10,58,80</pctOmni>
@@ -50,9 +50,9 @@
 		<pctOmni>0,0,38,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>3</techMargin>
@@ -120,9 +120,9 @@
 		<pctOmni>20,20,30,88,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>40,40,40,95,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,20,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>40,40,40,95,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,20,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,85,55,55,55</pctSL>
 		<techMargin>3</techMargin>
@@ -132,9 +132,9 @@
 		<pctOmni>15,15,20,98,100</pctOmni>
 		<pctClan>75,75,93,100,100</pctClan>
 		<pctSL>25,25,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>3</techMargin>
@@ -221,9 +221,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>3</techMargin>
@@ -288,7 +288,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3082' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3082' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3082' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LA'>
 		<pctOmni>0,11,14,17,19</pctOmni>
@@ -355,9 +355,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,14,29,42,47</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,3,9</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>12,20,34,44,67</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,3,9</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>12,20,34,44,67</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
 		<salvage pct='5'>FS:9,DC:10</salvage>
@@ -369,7 +369,7 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3082' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3082' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3082' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>3</omniMargin>
@@ -396,9 +396,9 @@
 		<pctOmni>10,10,20,88,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,30,95,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,30,95,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>3</techMargin>
@@ -453,7 +453,7 @@
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3082' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3082' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TP'>
 		<pctOmni>0,4,11,15,22</pctOmni>
@@ -496,9 +496,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,20,35,45,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,4,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>15,25,40,50,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,4,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>15,25,40,50,70</pctSL>
 		<techMargin>3</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3082' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -588,7 +588,7 @@
 		<pctOmni>3</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>74</pctSL>
-		<pctSL unitType='Aero'>33</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>33</pctSL>
 		<pctSL unitType='Vehicle'>48</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -606,8 +606,8 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>10</pctClan>
 		<pctSL>85</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>87</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>87</pctSL>
 		<pctClan unitType='Vehicle'>5</pctClan>
 		<pctSL unitType='Vehicle'>86</pctSL>
 		<omniMargin>3</omniMargin>
@@ -668,7 +668,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>73</pctSL>
-		<pctSL unitType='Aero'>40</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>40</pctSL>
 		<pctSL unitType='Vehicle'>46</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -778,9 +778,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>3</techMargin>
@@ -824,7 +824,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>58</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>37</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -882,8 +882,8 @@
 		<pctOmni>24</pctOmni>
 		<pctClan>11</pctClan>
 		<pctSL>79</pctSL>
-		<pctClan unitType='Aero'>8</pctClan>
-		<pctSL unitType='Aero'>92</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>8</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92</pctSL>
 		<pctClan unitType='Vehicle'>6</pctClan>
 		<pctSL unitType='Vehicle'>100</pctSL>
 		<omniMargin>3</omniMargin>
@@ -1062,7 +1062,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>84</pctSL>
-		<pctSL unitType='Aero'>52</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>52</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1072,7 +1072,7 @@
 		<pctOmni>11</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>74</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>35</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1118,7 +1118,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>65</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>65</pctSL>
 		<pctSL unitType='Vehicle'>55</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1351,7 +1351,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1978,7 +1978,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:2,CCC:2,CSR:2,CW:4,CLAN:2,CNC:4,RA:1,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,General:6,RA:7</availability>
@@ -2410,7 +2410,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSR:4,ROS:2+,CNC:5,CLAN:4,IS:2+,RA:5,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2598,7 +2598,7 @@
 			<availability>DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CCO:3,CGB:6,CWIE:4</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
@@ -3502,7 +3502,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3593,7 +3593,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CBS:8,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3730,7 +3730,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:2,RA.OA:4,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:7,RFS:8,MOC:5,CC:2,DGM:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3795,7 +3795,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:3,CDP:3,TC:3</availability>
@@ -4259,13 +4259,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:2,CSR:2-,RA:3-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:3,OA:3+,CSR:2,RA:2</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4305,7 +4305,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:3,OA:3,LA:4,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
 		<model name='CSR-12D'>
 			<availability>FS:5</availability>
@@ -4674,13 +4674,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -4891,7 +4891,7 @@
 			<availability>CLAN:6,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,PR:2,MERC:2,FS:2,DTA:2,ROS:2,PG:2,FWL:3,DA:5,RCM:2,RFS:2,DC:2</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -4900,7 +4900,7 @@
 			<availability>DA:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,MOC:4,SC:3,MCM:3,DGM:3,MSC:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5256,7 +5256,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>PR:6,LA:5,ROS:6,PG:6,MERC:5,FS:3,RFS:6</availability>
@@ -5308,13 +5308,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>PR:1,LA:3,CGB.FRR:3,ROS:1,PG:1,MERC:3,FS:1,RFS:1,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:4,ROS:3,MERC:3</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6689,7 +6689,7 @@
 			<availability>RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DoO:7,CLAN:3,DO:7,DGM:7,MERC:3,DTA:7,SC:7,CDS:4,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:5,TP:7</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
@@ -7149,7 +7149,7 @@
 			<availability>General:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7531,13 +7531,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,CSR:2,HL:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:3,TC:2-,Periphery:3-,RA.OA:5,FVC:4,OA:5,LA:2-</availability>
 		<model name='HCT-213'>
 			<availability>General:3</availability>
@@ -8030,7 +8030,7 @@
 			<availability>CC:8,MOC:8,FWL:4,MERC:6,TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:3,CGB.FRR:5,ROS:4,CNC:4,MERC:3,FS:3,CGB:5,DC:3</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8068,7 +8068,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:3,CLAN:4,RA:4</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8290,7 +8290,7 @@
 			<availability>CHH:7,CW:3,ROS:3,CJF:4,CWIE:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CSR:4,CLAN:4,RA:5,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8413,7 +8413,7 @@
 			<availability>DTA:5,SC:5,MCM:5,ROS:5,DGM:5,MSC:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8519,7 +8519,7 @@
 			<availability>FS:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -8977,7 +8977,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9263,7 +9263,7 @@
 			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>PR:6,DoO:6,DO:6,FS:2,SC:6,Periphery.MW:2,Periphery.CM:2,FWL:6,MH:2,MSC:4,RFS:6,CC:2,MOC:2,DGM:6,MERC:2,DTA:6,FVC:2,LA:2,MCM:6,ROS:2,PG:6,Periphery.ME:2,TP:6,DA:6,RCM:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -9434,7 +9434,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:4-</availability>
@@ -9753,7 +9753,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -9762,7 +9762,7 @@
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,OA:1,HL:4,LA:7,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
@@ -9968,7 +9968,7 @@
 			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Malaika' unitType='Aero'>
+	<chassis name='Malaika' unitType='AeroSpaceFighter'>
 		<availability>FWL:3-</availability>
 		<model name='BAM-1A1'>
 			<availability>General:8</availability>
@@ -10615,7 +10615,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,MERC:2</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -11506,7 +11506,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,CNC:4,DC:5</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -11677,7 +11677,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA:1,CGB:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -12178,7 +12178,7 @@
 			<availability>CSR:5,CBS:7,RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:4</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -12526,7 +12526,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,SC:5,MCM:5,ROS:3,FWL:3,DGM:5,MSC:4,RCM:3,MERC:2</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -12885,7 +12885,7 @@
 			<availability>LA:1,ROS:1,FS:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
 		<model name='RPR-100'>
 			<availability>General:3,NIOPS:8</availability>
@@ -13067,7 +13067,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 		<model name='F-100'>
 			<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
@@ -13392,7 +13392,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,OA:2-,LA:4,ROS:3,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:4-</availability>
@@ -13411,7 +13411,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -13449,7 +13449,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -13458,7 +13458,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:1-</availability>
@@ -13529,7 +13529,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,CGB.FRR:4,ROS:5,DC:1</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -13793,13 +13793,13 @@
 			<availability>CJF:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>CSR:1,RA:1</availability>
 		<model name='XR'>
 			<availability>CSR:8,RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CSR:3,CW:4,CNC:5,CLAN:4,CJF:6,CCO:4,RA:4,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13889,7 +13889,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14071,7 +14071,7 @@
 			<availability>CHH:4,CDS:4,CSR:2,CW:4,ROS:8,CNC:4,CJF:4,RA:4,CGB:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -14083,13 +14083,13 @@
 			<availability>ROS:6,MERC:3,DC:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>PR:4,DoO:6,DO:6,DGM:6,DTA:4,SC:6,MCM:6,ROS:3,PG:4,FWL:5,MSC:4,TP:6,RCM:4,DA:4,RFS:4</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14129,7 +14129,7 @@
 			<availability>CDS:2,CW:6,ROS:4,CNC:6,CJF:6,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:1,OA:3,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,HL:3,Periphery.Deep:7,MERC:4,DC:4,Periphery:5</availability>
@@ -14242,7 +14242,7 @@
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
@@ -14341,7 +14341,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:2,OA:2,ROS:4,NIOPS:6,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -14353,7 +14353,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
@@ -14587,7 +14587,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:6,TC:4-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -14708,7 +14708,7 @@
 			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:4,RFS:5,MOC:3,CC:5,IS:3,DGM:6,MERC:5,TC:2,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
@@ -14834,7 +14834,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,OA:2,LA:3,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
@@ -14893,7 +14893,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,CSR:4,CBS:6,General:2,RA:7,CGB:7</availability>
@@ -14967,7 +14967,7 @@
 			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:5,DC:3</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -15023,7 +15023,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:4,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CSR:5,CLAN:8,RA:9</availability>
@@ -15122,7 +15122,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CGB.FRR:5,ROS:3,CNC:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -15322,7 +15322,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -15422,7 +15422,7 @@
 			<availability>CC:3,MOC:3,CC.LCC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -15586,7 +15586,7 @@
 			<availability>CGB.FRR:4-,DC:4-</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CW:3,ROS:7,CLAN:2,NIOPS:9,MERC:3,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
@@ -15684,7 +15684,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,PR:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
@@ -15702,7 +15702,7 @@
 			<availability>CC:7,MOC:5,PR:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:4,MOC:4,General:6,TC:4</availability>
@@ -15771,7 +15771,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,OA:6,NIOPS:7,RA:2</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,OA:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -15831,7 +15831,7 @@
 			<availability>IS:3,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:6,FVC:3,HL:1,Periphery.CM:4,Periphery.ME:4,MERC:3,DA:3,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:5,DA:5,TC:8</availability>
@@ -15946,7 +15946,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16014,7 +16014,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>PR:2,LA:5,ROS:2,PG:2,MERC:2,RFS:2,DC:2</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -16031,7 +16031,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16084,7 +16084,7 @@
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -16306,7 +16306,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -16521,7 +16521,7 @@
 			<availability>CSR:8,CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:8,BAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16599,7 +16599,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>HL:2,MERC:6,FS:4,CDP:3,Periphery:3,TC:1</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -17079,7 +17079,7 @@
 			<availability>DoO:8,DO:8,TP:8,DA:8,MERC:4,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -17145,7 +17145,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CSR:3,CLAN:5,RA:4</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17244,7 +17244,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -20,7 +20,7 @@
 		<pctOmni>0,5,10,12,20</pctOmni>
 		<pctClan>0,0,4,8,16</pctClan>
 		<pctSL>20,46,66,72,80</pctSL>
-		<pctSL unitType='Aero'>15,30,50,60,85</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>15,30,50,60,85</pctSL>
 		<pctSL unitType='Vehicle'>15,35,40,45,72</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -35,15 +35,15 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3085' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3085' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3085' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CCC'>
 		<pctOmni>0,0,40,100,100</pctOmni>
 		<pctClan>88,88,94,100,100</pctClan>
 		<pctSL>12,12,6,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,45,100,100</pctOmni>
-		<pctClan unitType='Aero'>15,15,40,100,100</pctClan>
-		<pctSL unitType='Aero'>85,85,60,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,45,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>15,15,40,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>85,85,60,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 		<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
 		<techMargin>3</techMargin>
@@ -111,9 +111,9 @@
 		<pctOmni>15,15,20,100,100</pctOmni>
 		<pctClan>75,75,95,100,100</pctClan>
 		<pctSL>25,25,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>20,20,25,100,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,95,100,100</pctClan>
-		<pctSL unitType='Aero'>80,20,95,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>20,20,25,100,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,95,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>80,20,95,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,15,45,50,50</pctClan>
 		<pctSL unitType='Vehicle'>15,85,45,50,50</pctSL>
 		<techMargin>3</techMargin>
@@ -192,9 +192,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>3</techMargin>
@@ -259,7 +259,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3085' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3085' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3085' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>3</omniMargin>
@@ -331,7 +331,7 @@
 		<techMargin>3</techMargin>
 		<weightDistribution era='3085' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3085' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3085' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>3</omniMargin>
@@ -358,9 +358,9 @@
 		<pctOmni>0,0,0,86,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,95,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,95,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>3</techMargin>
@@ -415,7 +415,7 @@
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3085' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3085' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TP'>
 		<pctOmni>0,5,12,16,24</pctOmni>
@@ -458,9 +458,9 @@
 		<pctOmni>0,0,0,0,5</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>0,20,35,45,50</pctSL>
-		<pctOmni unitType='Aero'>0,0,0,4,10</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>15,25,40,50,70</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,0,4,10</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>15,25,40,50,70</pctSL>
 		<techMargin>3</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3085' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -550,7 +550,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>83</pctSL>
-		<pctSL unitType='Aero'>39</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>39</pctSL>
 		<pctSL unitType='Vehicle'>55</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -568,8 +568,8 @@
 		<pctOmni>20</pctOmni>
 		<pctClan>12</pctClan>
 		<pctSL>88</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>5</pctClan>
 		<pctSL unitType='Vehicle'>91</pctSL>
 		<omniMargin>3</omniMargin>
@@ -630,7 +630,7 @@
 		<pctOmni>4</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>81</pctSL>
-		<pctSL unitType='Aero'>45</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>45</pctSL>
 		<pctSL unitType='Vehicle'>50</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -748,9 +748,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>3</techMargin>
@@ -794,7 +794,7 @@
 		<pctOmni>5</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>65</pctSL>
-		<pctSL unitType='Aero'>54</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>54</pctSL>
 		<pctSL unitType='Vehicle'>41</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -852,8 +852,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>12</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>8</pctClan>
-		<pctSL unitType='Aero'>92</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>8</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>92</pctSL>
 		<pctClan unitType='Vehicle'>6</pctClan>
 		<pctSL unitType='Vehicle'>100</pctSL>
 		<omniMargin>3</omniMargin>
@@ -1044,7 +1044,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>83</pctSL>
-		<pctSL unitType='Aero'>52</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>52</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1054,7 +1054,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>78</pctSL>
-		<pctSL unitType='Aero'>52</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>52</pctSL>
 		<pctSL unitType='Vehicle'>38</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1100,7 +1100,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>3</pctClan>
 		<pctSL>95</pctSL>
-		<pctSL unitType='Aero'>73</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>73</pctSL>
 		<pctSL unitType='Vehicle'>62</pctSL>
 		<omniMargin>3</omniMargin>
 		<techMargin>3</techMargin>
@@ -1345,7 +1345,7 @@
 			<availability>IS:2,Periphery:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CSA:5,CHH:5,CDS:6,CW:5,CNC:5,CSL:5,CCO:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -2002,7 +2002,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:2,CCC:2,CW:4,CLAN:2,CNC:4,RA:2,BAN:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>CSA:7,General:6,RA:7</availability>
@@ -2440,7 +2440,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:4,IS:2+,RA:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7,CGB:8</availability>
@@ -2622,7 +2622,7 @@
 			<availability>DC:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:6,CHH:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CCO:3,CGB:6,CWIE:4</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
@@ -3581,7 +3581,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:3</availability>
@@ -3672,7 +3672,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CSA:7,CCC:7,CW:5,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3812,7 +3812,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>PR:8,HL:2,DoO:10,DO:10,FS:3,RA.OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:10,RFS:8,MOC:5,CC:2,OP:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,RF:8,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -3877,7 +3877,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:3,CDP:3,TC:3</availability>
@@ -4374,13 +4374,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:3,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4420,7 +4420,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:3,LA:3,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
 		<model name='CSR-12D'>
 			<availability>FS:6</availability>
@@ -4826,13 +4826,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5043,7 +5043,7 @@
 			<availability>CLAN:6,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,PR:3,MERC:3,FS:3,DTA:3,RF:3,ROS:3,PG:3,FWL:4,DA:5,RCM:3,RFS:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5058,7 +5058,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,MOC:4,MSC:3</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5459,7 +5459,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:5,FS:6,RFS:6</availability>
@@ -5511,13 +5511,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>PR:2,RF:2,LA:3,CGB.FRR:3,ROS:2,PG:2,MERC:3,FS:2,RFS:2,CGB:3</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:5,ROS:4,MERC:3</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -6964,7 +6964,7 @@
 			<availability>RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>OP:7,DoO:7,CLAN:3,DO:7,MERC:4,DTA:7,CDS:4,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:7,TP:7</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
@@ -7440,7 +7440,7 @@
 			<availability>General:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:6,CLAN:2,CNC:3,NIOPS:7</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -7833,13 +7833,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,HL:2-,LA:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:3</availability>
@@ -8347,7 +8347,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:4,CGB.FRR:5,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8385,7 +8385,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8608,7 +8608,7 @@
 			<availability>CHH:7,CW:3,ROS:3,CJF:4,CWIE:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>CCC:6,CLAN:4,RA:7,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8742,7 +8742,7 @@
 			<availability>DTA:5,ROS:5,MSC:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -8848,7 +8848,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9308,7 +9308,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,BAN:7,CWIE:5,CGB:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9633,7 +9633,7 @@
 			<availability>CGB.FRR:2-,DC:2-</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:3,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:3,MERC:3,DTA:6,FVC:3,RF:6,LA:3,ROS:3,Periphery.MW:3,Periphery.CM:3,PG:6,Periphery.ME:3,FWL:6,MH:3,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -9810,7 +9810,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:4-</availability>
@@ -10129,13 +10129,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:4,ROS:4</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10144,7 +10144,7 @@
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,HL:4,LA:6,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:4-,Periphery:2-</availability>
@@ -10378,7 +10378,7 @@
 			<availability>MOC:4,IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Malaika' unitType='Aero'>
+	<chassis name='Malaika' unitType='AeroSpaceFighter'>
 		<availability>FWL:2-</availability>
 		<model name='BAM-1A1'>
 			<availability>General:8</availability>
@@ -11037,7 +11037,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:5,MERC:3</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -11352,7 +11352,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:4,LA:5,CWIE:4</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -12000,7 +12000,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,CNC:4,DC:5</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12174,7 +12174,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA:2,CGB:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -12681,7 +12681,7 @@
 			<availability>RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:5</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -12868,7 +12868,7 @@
 	<chassis name='Phoenix' unitType='Mek'>
 		<availability>LA:1-,MERC:2-,TC:2-,Periphery:2-</availability>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:3,MERC:3</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -13044,7 +13044,7 @@
 			<availability>CC:3,MOC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:4,ROS:4,FWL:4,MSC:5,RCM:4,MERC:3</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -13456,7 +13456,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5,CLAN:2,NIOPS:6</availability>
 		<model name='RPR-100'>
 			<availability>General:3,NIOPS:8</availability>
@@ -13635,7 +13635,7 @@
 			<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>PR:7,DoO:8,DO:8,FS:2,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:8,RFS:7,MOC:2,CC:2,OP:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,RF:7,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 		<model name='F-100'>
 			<availability>FVC:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
@@ -13807,7 +13807,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -13975,7 +13975,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:4-</availability>
@@ -13994,7 +13994,7 @@
 			<availability>DC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:8</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14032,7 +14032,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:5</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -14041,7 +14041,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CW:4,CGB.FRR:6,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-3'>
 			<availability>DC:1-</availability>
@@ -14112,7 +14112,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,CGB.FRR:4,ROS:5,DC:1</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -14285,7 +14285,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:5</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -14407,13 +14407,13 @@
 			<availability>CJF:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter'>
 		<availability>RA:1</availability>
 		<model name='XR'>
 			<availability>RA:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:3,CHH:3,CCC:5,CW:4,CNC:5,CLAN:4,CJF:6,CCO:4,RA:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14503,7 +14503,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -14742,7 +14742,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -14754,13 +14754,13 @@
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>OP:6,PR:6,DoO:6,DO:6,DTA:6,RF:6,ROS:4,PG:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -14800,7 +14800,7 @@
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,HL:3,Periphery.Deep:8,MERC:3,DC:3,Periphery:5</availability>
@@ -14917,7 +14917,7 @@
 			<availability>FVC:4,IS.pm:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
@@ -15029,7 +15029,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:2,ROS:4,NIOPS:6,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -15041,7 +15041,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
@@ -15268,7 +15268,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:6-,TC:4-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -15323,7 +15323,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:4,LA:4</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -15407,7 +15407,7 @@
 			<availability>LA:5,ROS:5,MERC:3,FS:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:6,RFS:5,MOC:3,CC:5,OP:6,IS:3,MERC:5,TC:3,DTA:6,RF:5,LA:5,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:3-,Periphery:3-</availability>
@@ -15548,7 +15548,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,LA:2,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 		<model name='STU-D6'>
 			<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
@@ -15601,7 +15601,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CSA:8,CLAN:6,BAN:6,CGB:6</availability>
 		<model name='A'>
 			<availability>CSA:7,General:2,RA:7,CGB:7</availability>
@@ -15675,7 +15675,7 @@
 			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:7,DC:5</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -15740,7 +15740,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:4,NIOPS:8</availability>
 		<model name='C'>
 			<availability>CCC:9,CLAN:8,RA:9</availability>
@@ -15842,7 +15842,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:1,CGB.FRR:5,ROS:4,CNC:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -16078,7 +16078,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -16190,7 +16190,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -16402,7 +16402,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CW:3,ROS:7,CLAN:2,NIOPS:9,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
@@ -16500,7 +16500,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,PR:3,RF:3,Periphery.CM:2,PG:3,FWL:3,MERC:3,RCM:3,RFS:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>CC:2-,MERC:2-,Periphery:3-</availability>
@@ -16518,7 +16518,7 @@
 			<availability>CC:7,MOC:5,PR:8,RF:8,PG:8,MERC:5,RCM:8,RFS:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,FWL:1,TC:3</availability>
 		<model name='TR-10'>
 			<availability>CC:3,MOC:4,General:6,TC:4</availability>
@@ -16590,7 +16590,7 @@
 			<availability>TC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,NIOPS:7,RA:3</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -16660,7 +16660,7 @@
 			<availability>IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:6,FVC:3,HL:2,Periphery.CM:4,Periphery.ME:4,MERC:3,DA:3,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -16775,7 +16775,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2,CGB:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -16843,7 +16843,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>PR:3,RF:3,LA:5,ROS:3,PG:3,MERC:3,RFS:3,DC:3</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -16860,7 +16860,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -16917,7 +16917,7 @@
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:5</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -17142,7 +17142,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:4,CLAN:3,CJF:4,BAN:4,CWIE:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -17378,7 +17378,7 @@
 			<availability>CLAN.IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:6,CJF:8,BAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17456,7 +17456,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>HL:3,Periphery.Deep:1,MERC:6,FS:4,CDP:3,Periphery:4,TC:1</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -17840,7 +17840,7 @@
 			<availability>CNC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:5</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -17980,7 +17980,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -18049,7 +18049,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18184,7 +18184,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -41,7 +41,7 @@
 		<techMargin>6</techMargin>
 		<weightDistribution era='3100' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CGB'>
 		<pctOmni>16,5,24,68,100</pctOmni>
@@ -141,9 +141,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>6</techMargin>
@@ -208,7 +208,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3100' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>6</omniMargin>
@@ -289,7 +289,7 @@
 		<upgradeMargin>3</upgradeMargin>
 		<weightDistribution era='3100' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>6</omniMargin>
@@ -312,9 +312,9 @@
 		<pctOmni>0,0,0,77,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,15,90,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,15,90,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>6</techMargin>
@@ -339,7 +339,7 @@
 		<salvage pct='6'>CC:9,LA:10,MSC:3,FS:10,DC:6</salvage>
 		<weightDistribution era='3100' unitType='Mek'>4,3,2,1</weightDistribution>
 		<weightDistribution era='3100' unitType='Tank'>3,2,1,4</weightDistribution>
-		<weightDistribution era='3100' unitType='Aero'>2,1,3,4</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>2,1,3,4</weightDistribution>
 	</faction>
 	<faction key='RIM'>
 		<omniMargin>6</omniMargin>
@@ -370,7 +370,7 @@
 		<techMargin>6</techMargin>
 		<upgradeMargin>3</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3100' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3100' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>6</omniMargin>
@@ -415,9 +415,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>10,30,40,55,60</pctSL>
-		<pctOmni unitType='Aero'>0,0,4,8,12</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>20,30,50,60,80</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,4,8,12</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,30,50,60,80</pctSL>
 		<techMargin>6</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3100' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -517,7 +517,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>45</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>45</pctSL>
 		<pctSL unitType='Vehicle'>75</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -537,8 +537,8 @@
 		<pctOmni>22</pctOmni>
 		<pctClan>14</pctClan>
 		<pctSL>86</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>8</pctClan>
 		<pctSL unitType='Vehicle'>92</pctSL>
 		<omniMargin>6</omniMargin>
@@ -603,7 +603,7 @@
 		<pctOmni>5</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>84</pctSL>
-		<pctSL unitType='Aero'>48</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>48</pctSL>
 		<pctSL unitType='Vehicle'>60</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -737,9 +737,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>6</techMargin>
@@ -787,7 +787,7 @@
 		<pctOmni>6</pctOmni>
 		<pctClan>2</pctClan>
 		<pctSL>70</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>50</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -858,8 +858,8 @@
 		<pctOmni>28</pctOmni>
 		<pctClan>14</pctClan>
 		<pctSL>86</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>6</omniMargin>
@@ -1082,7 +1082,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>48</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -1093,7 +1093,7 @@
 		<pctOmni>14</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>80</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>45</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -1145,7 +1145,7 @@
 		<pctOmni>12</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>95</pctSL>
-		<pctSL unitType='Aero'>80</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>80</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>6</omniMargin>
 		<techMargin>6</techMargin>
@@ -1419,7 +1419,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CHH:5,RD:5,CDS:6,CW:5,CNC:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1586,7 +1586,7 @@
 			<availability>DTA:6,OP:6,RF:6,FWL:6,MSC:6,DA:6,RCM:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>OP:4,ROS:3,RCM:4,MERC:3,DA:3</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2101,7 +2101,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CLAN:2,CNC:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2552,7 +2552,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CNC:5,CLAN:3,IS:3+,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7,CGB:8</availability>
@@ -2724,7 +2724,7 @@
 			<availability>DC:1+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:5,RD:5,CDS:5,CW:6,CNC:5,CJF:6,CGB:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7</availability>
@@ -3747,7 +3747,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -3854,7 +3854,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>RD:5,CW:5,CLAN:6,CJF:5,CGB:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -3997,7 +3997,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4059,7 +4059,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6,CGB:3</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4550,13 +4550,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:4,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4593,7 +4593,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -4910,7 +4910,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:5</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5026,13 +5026,13 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter'>
 		<availability>FS:1</availability>
 		<model name='DAR4-XP'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5253,7 +5253,7 @@
 			<availability>CLAN:8,IS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,RCM:3,FS:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5265,7 +5265,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:5,MOC:5,MSC:4</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5688,7 +5688,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -5744,13 +5744,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2,CGB:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7281,7 +7281,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,Periphery.MW:5,PIR:5,Periphery.ME:5,CLAN:3,CNC:4,FWL:7,MSC:7,MERC:4</availability>
 		<model name='GTHA-400'>
 			<availability>PIR:2-,FWL:2-,MH:2-,MERC:2-</availability>
@@ -7798,7 +7798,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:6,CLAN:2,CNC:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4</availability>
@@ -8209,13 +8209,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -8729,7 +8729,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CGB:5,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -8767,7 +8767,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -8977,7 +8977,7 @@
 			<availability>CHH:8,CW:4,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7,CGB:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9107,7 +9107,7 @@
 			<availability>DTA:5,ROS:5,MSC:5,MERC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9223,7 +9223,7 @@
 			<availability>FVC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:9,CW:8,CLAN:6,CWIE:7,CGB:9</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9708,7 +9708,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:5,CGB:6</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -9868,7 +9868,7 @@
 			<availability>OP:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:4</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10078,7 +10078,7 @@
 			<availability>ROS:3,CLAN:8,MERC.SI:4,BAN:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10272,7 +10272,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:3-</availability>
@@ -10605,13 +10605,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>CGB.FRR:4,ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10620,7 +10620,7 @@
 			<availability>CGB.FRR:6,ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:5,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,LA:1-,MERC:2-,Periphery:2-</availability>
@@ -11500,7 +11500,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:7,MOC:6,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -11810,7 +11810,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:5,LA:7,CWIE:5</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -12492,7 +12492,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CNC:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -12659,7 +12659,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:3,RA:2,CGB:3</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13169,7 +13169,7 @@
 			<availability>RD:8,CGB:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:8</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -13355,7 +13355,7 @@
 	<chassis name='Phoenix' unitType='Mek'>
 		<availability>MERC:1-,TC:1-,Periphery:1-</availability>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,RF:5,LA:4,MERC:4,DA:3</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -13531,7 +13531,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -13944,7 +13944,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:2</availability>
 		<model name='RPR-100'>
 			<availability>General:2</availability>
@@ -14150,7 +14150,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,OP:8,FS:2,MERC:1,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8,DC:2</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -14331,7 +14331,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:4,MERC:2</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -14499,7 +14499,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RA.OA:2-,LA:4,ROS:4,CLAN:2,IS:3-,FWL:2-,FS:3,MERC:4,Periphery:3-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:2-</availability>
@@ -14518,7 +14518,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -14556,7 +14556,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:7</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -14565,7 +14565,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>RD:4,CDS:4,CW:4,ROS:5,CNC:5,FS:4,BAN:1,CGB:4,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -14634,7 +14634,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -14861,7 +14861,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:5</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -14984,7 +14984,7 @@
 			<availability>CJF:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CHH:2,CW:4,CNC:5,CLAN:4,CJF:6,RA:5,CWIE:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -15093,7 +15093,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2,CGB:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -15337,7 +15337,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:3,FWL:4,DA:4,MERC:3</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -15349,7 +15349,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,CGB.FRR:7,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -15361,13 +15361,13 @@
 			<availability>ROS:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:6,MSC:6,RCM:6,DA:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15410,7 +15410,7 @@
 			<availability>CDS:4,CW:6,ROS:4,CNC:6,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:3,ROS:3,CGB.FRR:4,MERC:3,Periphery.OS:3,FS:1-,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,MERC:1,Periphery:4</availability>
@@ -15478,7 +15478,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:5</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -15550,7 +15550,7 @@
 			<availability>FVC:3,IS.pm:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -15666,7 +15666,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:4,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -15678,7 +15678,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -15900,7 +15900,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:5-,TC:3-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -15955,7 +15955,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:5,LA:6,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -16048,7 +16048,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -16196,7 +16196,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -16249,7 +16249,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6,CGB:5</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7,CGB:7</availability>
@@ -16320,7 +16320,7 @@
 			<availability>ROS:5,CNC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:7</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -16385,7 +16385,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -16498,7 +16498,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -16770,7 +16770,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -16882,7 +16882,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,CGB.FRR:4,IS:4,FWL:4,FS:5,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -17109,7 +17109,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CW:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CW:6</availability>
@@ -17203,7 +17203,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -17218,7 +17218,7 @@
 			<availability>CC:7,MOC:5,RF:8,MERC:5,RCM:8,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -17286,7 +17286,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -17356,7 +17356,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -17474,7 +17474,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:2,CLAN:4,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -17542,7 +17542,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -17559,7 +17559,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -17616,7 +17616,7 @@
 			<availability>CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -17862,7 +17862,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CW:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -18086,7 +18086,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18164,7 +18164,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -18559,7 +18559,7 @@
 			<availability>CNC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:7</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -18725,7 +18725,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -18797,7 +18797,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18898,7 +18898,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -18958,7 +18958,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/megamek/data/forcegenerator/3131.xml
+++ b/megamek/data/forcegenerator/3131.xml
@@ -47,7 +47,7 @@
 		<techMargin>12</techMargin>
 		<weightDistribution era='3131' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3131' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3131' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,10,82,95</pctOmni>
@@ -151,9 +151,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>12</techMargin>
@@ -218,7 +218,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3131' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3131' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3131' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>12</omniMargin>
@@ -305,7 +305,7 @@
 		<upgradeMargin>9</upgradeMargin>
 		<weightDistribution era='3131' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3131' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3131' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>12</omniMargin>
@@ -334,9 +334,9 @@
 		<pctOmni>0,0,0,60,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,80,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,80,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>12</techMargin>
@@ -425,7 +425,7 @@
 		<techMargin>12</techMargin>
 		<upgradeMargin>9</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3131' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3131' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>12</omniMargin>
@@ -479,9 +479,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>20,40,50,65,70</pctSL>
-		<pctOmni unitType='Aero'>0,4,8,10,15</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>30,40,60,70,90</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,4,8,10,15</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>30,40,60,70,90</pctSL>
 		<techMargin>12</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3131' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -599,7 +599,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>87</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -619,8 +619,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>12</omniMargin>
@@ -688,7 +688,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>72</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -850,9 +850,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>12</techMargin>
@@ -893,7 +893,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>4</pctClan>
 		<pctSL>72</pctSL>
-		<pctSL unitType='Aero'>64</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>64</pctSL>
 		<pctSL unitType='Vehicle'>60</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -973,8 +973,8 @@
 		<pctOmni>30</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>12</omniMargin>
@@ -1238,7 +1238,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>88</pctSL>
-		<pctSL unitType='Aero'>65</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>65</pctSL>
 		<pctSL unitType='Vehicle'>64</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -1249,7 +1249,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>68</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>68</pctSL>
 		<pctSL unitType='Vehicle'>60</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -1319,7 +1319,7 @@
 		<pctOmni>15</pctOmni>
 		<pctClan>7</pctClan>
 		<pctSL>93</pctSL>
-		<pctSL unitType='Aero'>85</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>85</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>12</omniMargin>
 		<techMargin>12</techMargin>
@@ -1599,7 +1599,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CW:5,CNC:5,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1766,7 +1766,7 @@
 			<availability>DTA:6,OP:6,RF:6,FWL:6,MSC:6,DA:6,RCM:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>OP:7,ROS:4,FWL:5:3139,RCM:7,MERC:4,DA:4,CP:5</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2319,7 +2319,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CW:3,CLAN:2,CNC:3,CP:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2782,7 +2782,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CNC:4,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2960,7 +2960,7 @@
 			<availability>DC:2+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CW:6,CNC:5,CP:5,CJF:6,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -4096,7 +4096,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -4203,7 +4203,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CW:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4346,7 +4346,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,CP:10,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4408,7 +4408,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4902,13 +4902,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4945,7 +4945,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5297,7 +5297,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:7</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5422,7 +5422,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5661,7 +5661,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,RCM:3,FS:3,CP:2,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5673,7 +5673,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2:3139,MSC:4,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -6100,7 +6100,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -6160,13 +6160,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7748,7 +7748,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>DTA:7,OP:7,CDS:4,ROS:7,CLAN:3,CNC:4,FWL:7,MSC:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,CNC:4,FWL:4,CP:4,MERC:4,BAN:2,Periphery:4</availability>
@@ -8321,7 +8321,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:2,CNC:3,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CNC:4,CP:4</availability>
@@ -8746,13 +8746,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -9275,7 +9275,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,CNC:4,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9313,7 +9313,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9523,7 +9523,7 @@
 			<availability>CWE:4,CHH:8,CW:4,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9687,7 +9687,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CW:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9803,7 +9803,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CW:8,CLAN:6,CWIE:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10309,7 +10309,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10472,7 +10472,7 @@
 			<availability>OP:4,MERC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10706,7 +10706,7 @@
 			<availability>ROS:3,CLAN:8,MERC.SI:4,BAN:6,DC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,CP:6,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10907,7 +10907,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -11251,13 +11251,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -11266,7 +11266,7 @@
 			<availability>ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:4,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -12221,7 +12221,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12523,7 +12523,7 @@
 			<availability>RR:1,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -13256,7 +13256,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CNC:4,CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13429,7 +13429,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13951,7 +13951,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -14134,7 +14134,7 @@
 			<availability>RD:4,ROS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>DTA:3,RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14314,7 +14314,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>DTA:5,ROS:5,FWL:5,MSC:6,RCM:5,MERC:4,CP:5</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14577,7 +14577,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Qasar' unitType='Aero'>
+	<chassis name='Qasar' unitType='AeroSpaceFighter'>
 		<availability>CNC:5</availability>
 		<model name='C'>
 			<availability>General:8</availability>
@@ -14772,7 +14772,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -15007,7 +15007,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,OP:8,FS:2,CP:8,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -15194,7 +15194,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15380,7 +15380,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15399,7 +15399,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15440,7 +15440,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:8</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -15452,7 +15452,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,CW:4,ROS:5,CNC:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -15527,7 +15527,7 @@
 			<availability>LA:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15752,7 +15752,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:7</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -15887,7 +15887,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CW:3,CNC:5,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -15998,7 +15998,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2</availability>
 		<model name='SYD-21'>
 			<roles>interceptor</roles>
@@ -16256,7 +16256,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:5,DA:5,MERC:4,CP:5</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -16268,7 +16268,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -16289,13 +16289,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>DTA:6,OP:6,RF:6,ROS:4,FWL:6,MSC:6,RCM:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -16342,7 +16342,7 @@
 			<availability>CWE:6,CDS:4,CW:6,ROS:4,CNC:6,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,ROS:3,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16421,7 +16421,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:7</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -16493,7 +16493,7 @@
 			<availability>FVC:3,IS.pm:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -16609,7 +16609,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16621,7 +16621,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -16848,7 +16848,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:4-,TC:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -16903,7 +16903,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:7,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -16996,7 +16996,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,CP:6,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -17154,7 +17154,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -17207,7 +17207,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -17287,7 +17287,7 @@
 			<availability>ROS:5,CNC:5,CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -17352,7 +17352,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17462,7 +17462,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CNC:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17747,7 +17747,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -17880,7 +17880,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -18111,7 +18111,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,CW:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6,CW:6</availability>
@@ -18220,7 +18220,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,RCM:3,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -18235,7 +18235,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5:3139,MERC:5,RCM:8,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -18307,7 +18307,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -18377,7 +18377,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -18498,7 +18498,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CW:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18569,7 +18569,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18586,7 +18586,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18649,7 +18649,7 @@
 			<availability>CWE:3,CW:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -18900,7 +18900,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CW:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -19132,7 +19132,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -19216,7 +19216,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19686,7 +19686,7 @@
 			<availability>CNC:8,CP:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -19885,7 +19885,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -19960,7 +19960,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -20069,7 +20069,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -20129,7 +20129,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -42,7 +42,7 @@
 		<techMargin>15</techMargin>
 		<weightDistribution era='3145' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3145' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3145' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,0,80,95</pctOmni>
@@ -169,7 +169,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3145' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3145' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3145' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>15</omniMargin>
@@ -233,7 +233,7 @@
 		<upgradeMargin>12</upgradeMargin>
 		<weightDistribution era='3145' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3145' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3145' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>15</omniMargin>
@@ -256,9 +256,9 @@
 		<pctOmni>0,0,0,48,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,75,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,75,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>15</techMargin>
@@ -307,9 +307,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>15</techMargin>
@@ -323,7 +323,7 @@
 		<techMargin>15</techMargin>
 		<upgradeMargin>12</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3145' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3145' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>15</omniMargin>
@@ -377,9 +377,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>30,50,60,75,80</pctSL>
-		<pctOmni unitType='Aero'>0,8,10,12,18</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>40,50,70,85,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,8,10,12,18</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>40,50,70,85,100</pctSL>
 		<techMargin>15</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3145' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -479,7 +479,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -499,8 +499,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>15</omniMargin>
@@ -568,7 +568,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -703,9 +703,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>15</techMargin>
@@ -746,7 +746,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>75</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -817,8 +817,8 @@
 		<pctOmni>32</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>15</omniMargin>
@@ -1049,7 +1049,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -1060,7 +1060,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>72</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>72</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -1130,7 +1130,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>92</pctSL>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctSL unitType='Vehicle'>84</pctSL>
 		<omniMargin>15</omniMargin>
 		<techMargin>15</techMargin>
@@ -1416,7 +1416,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1583,7 +1583,7 @@
 			<availability>RF:6,FWL:6,DA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,FWL:7,MERC:5,DA:4,CP:7</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2148,7 +2148,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2614,7 +2614,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2792,7 +2792,7 @@
 			<availability>DC:3+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -3965,7 +3965,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -4072,7 +4072,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4215,7 +4215,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4277,7 +4277,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4774,13 +4774,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4817,7 +4817,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5179,7 +5179,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5304,7 +5304,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5549,7 +5549,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,FS:3,CP:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5561,7 +5561,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -6013,7 +6013,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -6073,13 +6073,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7667,7 +7667,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,ROS:7,CLAN:3,FWL:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
@@ -8237,7 +8237,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:2,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
@@ -8671,13 +8671,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -9210,7 +9210,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9248,7 +9248,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9477,7 +9477,7 @@
 			<availability>CWE:4,CHH:8,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>MERC:3:3146,Periphery:3:3146</availability>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -9496,7 +9496,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9681,7 +9681,7 @@
 			<availability>CJF:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9797,7 +9797,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6,CWIE:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10297,7 +10297,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10446,7 +10446,7 @@
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10686,7 +10686,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10887,7 +10887,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -11234,13 +11234,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -11249,7 +11249,7 @@
 			<availability>ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -12222,7 +12222,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12535,7 +12535,7 @@
 			<availability>RR:1,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -13301,7 +13301,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13474,7 +13474,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14014,7 +14014,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -14193,7 +14193,7 @@
 			<availability>RD:4,ROS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14369,7 +14369,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14824,7 +14824,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -15077,7 +15077,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -15289,7 +15289,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15502,7 +15502,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15521,7 +15521,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15562,7 +15562,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:8</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -15574,7 +15574,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,ROS:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -15649,7 +15649,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15874,7 +15874,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -16009,7 +16009,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -16120,7 +16120,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
@@ -16371,7 +16371,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -16383,7 +16383,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -16404,13 +16404,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RF:6,ROS:4,FWL:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -16457,7 +16457,7 @@
 			<availability>CWE:6,CDS:4,ROS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,ROS:3,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16536,7 +16536,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -16608,7 +16608,7 @@
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -16742,7 +16742,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16754,7 +16754,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -16996,7 +16996,7 @@
 			<availability>SE:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -17051,7 +17051,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -17131,7 +17131,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -17310,7 +17310,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -17363,7 +17363,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -17443,7 +17443,7 @@
 			<availability>ROS:5,CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -17508,7 +17508,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17618,7 +17618,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17903,7 +17903,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -18036,7 +18036,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -18264,7 +18264,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
@@ -18366,7 +18366,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -18381,7 +18381,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -18453,7 +18453,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -18507,7 +18507,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -18628,7 +18628,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18699,7 +18699,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18716,7 +18716,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18779,7 +18779,7 @@
 			<availability>CWE:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -19033,7 +19033,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -19265,7 +19265,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -19349,7 +19349,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19844,7 +19844,7 @@
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -20058,7 +20058,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -20133,7 +20133,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -20242,7 +20242,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -20302,7 +20302,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/megamek/data/forcegenerator/3150.xml
+++ b/megamek/data/forcegenerator/3150.xml
@@ -45,7 +45,7 @@
 		<techMargin>16</techMargin>
 		<weightDistribution era='3150' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3150' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3150' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,0,80,95</pctOmni>
@@ -172,7 +172,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3150' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3150' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3150' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>16</omniMargin>
@@ -241,7 +241,7 @@
 		<upgradeMargin>13</upgradeMargin>
 		<weightDistribution era='3150' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3150' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3150' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>16</omniMargin>
@@ -264,9 +264,9 @@
 		<pctOmni>0,0,0,48,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,75,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,75,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>16</techMargin>
@@ -315,9 +315,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>16</techMargin>
@@ -341,7 +341,7 @@
 		<techMargin>16</techMargin>
 		<upgradeMargin>13</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3150' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3150' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>16</omniMargin>
@@ -400,9 +400,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>30,50,60,75,80</pctSL>
-		<pctOmni unitType='Aero'>0,8,10,12,18</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>40,50,70,85,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,8,10,12,18</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>40,50,70,85,100</pctSL>
 		<techMargin>16</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3150' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -502,7 +502,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -522,8 +522,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>16</omniMargin>
@@ -591,7 +591,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -726,9 +726,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>16</techMargin>
@@ -769,7 +769,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>75</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -840,8 +840,8 @@
 		<pctOmni>32</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>16</omniMargin>
@@ -1072,7 +1072,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -1083,7 +1083,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>72</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>72</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -1159,7 +1159,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>92</pctSL>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctSL unitType='Vehicle'>84</pctSL>
 		<omniMargin>16</omniMargin>
 		<techMargin>16</techMargin>
@@ -1466,7 +1466,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1633,7 +1633,7 @@
 			<availability>RF:6,FWL:6,DA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,FWL:7,MERC:5,DA:4,CP:7</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2198,7 +2198,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5,CWIE:3</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2664,7 +2664,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>ROS:3+,CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2842,7 +2842,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6,CWIE:3</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -4009,7 +4009,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -4116,7 +4116,7 @@
 			<availability>LA:6,ROS:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4259,7 +4259,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4321,7 +4321,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,ROS:5,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4818,13 +4818,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4861,7 +4861,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,ROS:4,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5223,7 +5223,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5348,7 +5348,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5593,7 +5593,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RF:3,ROS:3,FWL:4,DA:6,MERC:3,FS:3,CP:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5605,7 +5605,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -6057,7 +6057,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
@@ -6117,13 +6117,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,ROS:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,ROS:4,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7726,7 +7726,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,ROS:7,CLAN:3,FWL:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,ROS:6,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
@@ -8305,7 +8305,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,CLAN:2,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
@@ -8739,13 +8739,13 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat II' unitType='Aero'>
+	<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4</availability>
 		<model name='HCT-215'>
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -9281,7 +9281,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,ROS:6,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9319,7 +9319,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9557,7 +9557,7 @@
 			<availability>CWE:4,CHH:8,ROS:4,CJF:5,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>MERC:3:3146,Periphery:3:3146</availability>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -9576,7 +9576,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9761,7 +9761,7 @@
 			<availability>CJF:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9877,7 +9877,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6,CWIE:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10377,7 +10377,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10526,7 +10526,7 @@
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10763,7 +10763,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10964,7 +10964,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -11308,13 +11308,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -11323,7 +11323,7 @@
 			<availability>ROS:5,MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -12299,7 +12299,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12612,7 +12612,7 @@
 			<availability>RR:1,ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,CWIE:6</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -13378,7 +13378,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13551,7 +13551,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -14091,7 +14091,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -14270,7 +14270,7 @@
 			<availability>RD:4,ROS:2,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14450,7 +14450,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>ROS:5,FWL:6,MERC:4,CP:6</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14905,7 +14905,7 @@
 			<availability>LA:2,ROS:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,ROS:4,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -15158,7 +15158,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -15370,7 +15370,7 @@
 			<availability>LA:4,ROS:4,FS:4,CWIE:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15583,7 +15583,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15602,7 +15602,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15643,7 +15643,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sagittarii' unitType='Aero'>
+	<chassis name='Sagittarii' unitType='AeroSpaceFighter'>
 		<availability>ROS:8</availability>
 		<model name='SGT-2R'>
 			<availability>General:8</availability>
@@ -15655,7 +15655,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,ROS:5,FS:4,CP:4,BAN:1,DC:7,CWIE:4</availability>
 		<model name='S-4'>
 			<availability>ROS:6,FS:5,DC:6</availability>
@@ -15730,7 +15730,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5,ROS:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15955,7 +15955,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Schrack' unitType='Aero' omni='IS'>
+	<chassis name='Schrack' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SCK-O'>
 			<roles>interceptor</roles>
@@ -16090,7 +16090,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5,CWIE:4</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -16201,7 +16201,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
@@ -16452,7 +16452,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -16464,7 +16464,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>ROS:0,Periphery:2-</availability>
@@ -16485,13 +16485,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RF:6,ROS:4,FWL:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -16538,7 +16538,7 @@
 			<availability>CWE:6,CDS:4,ROS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,ROS:3,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16617,7 +16617,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Simurgh' unitType='Aero' omni='IS'>
+	<chassis name='Simurgh' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>ROS:8</availability>
 		<model name='SMG-O'>
 			<roles>assault</roles>
@@ -16689,7 +16689,7 @@
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 		<model name='SL-15'>
 			<availability>ROS:0,FS:0,Periphery:2-</availability>
@@ -16823,7 +16823,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,ROS:3,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16835,7 +16835,7 @@
 			<availability>ROS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
@@ -17077,7 +17077,7 @@
 			<availability>SE:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -17138,7 +17138,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -17231,7 +17231,7 @@
 			<availability>LA:6,ROS:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -17410,7 +17410,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
@@ -17463,7 +17463,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -17543,7 +17543,7 @@
 			<availability>ROS:5,CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -17608,7 +17608,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>ROS:4,CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17718,7 +17718,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,ROS:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -18006,7 +18006,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -18139,7 +18139,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -18364,7 +18364,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,ROS:6,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
@@ -18466,7 +18466,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -18481,7 +18481,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -18553,7 +18553,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -18607,7 +18607,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -18728,7 +18728,7 @@
 			<availability>ROS:8,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1,CWIE:2</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18799,7 +18799,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,ROS:4,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18816,7 +18816,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18879,7 +18879,7 @@
 			<availability>CWE:3,General:1,CWIE:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Umbra' unitType='Aero'>
+	<chassis name='Umbra' unitType='AeroSpaceFighter'>
 		<availability>ROS:6</availability>
 		<model name='RF-1'>
 			<roles>interceptor,ground_support</roles>
@@ -19133,7 +19133,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4,CWIE:3</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -19365,7 +19365,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -19449,7 +19449,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19950,7 +19950,7 @@
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -20164,7 +20164,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -20239,7 +20239,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -20348,7 +20348,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>
@@ -20408,7 +20408,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Zero' unitType='Aero'>
+	<chassis name='Zero' unitType='AeroSpaceFighter'>
 		<availability>ROS:3</availability>
 		<model name='ZRO-115'>
 			<availability>ROS:8</availability>

--- a/megamek/data/forcegenerator/3160.xml
+++ b/megamek/data/forcegenerator/3160.xml
@@ -45,7 +45,7 @@
 		<techMargin>18</techMargin>
 		<weightDistribution era='3160' unitType='Mek'>2,3,3,1</weightDistribution>
 		<weightDistribution era='3160' unitType='Tank'>4,1,3,2</weightDistribution>
-		<weightDistribution era='3160' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='CHH'>
 		<pctOmni>0,0,0,80,95</pctOmni>
@@ -163,7 +163,7 @@
 		<salvage pct='0'></salvage>
 		<weightDistribution era='3160' unitType='Mek'>3,4,2,1</weightDistribution>
 		<weightDistribution era='3160' unitType='Tank'>3,4,3,1</weightDistribution>
-		<weightDistribution era='3160' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='LL'>
 		<omniMargin>18</omniMargin>
@@ -232,7 +232,7 @@
 		<upgradeMargin>15</upgradeMargin>
 		<weightDistribution era='3160' unitType='Mek'>6,5,3,1</weightDistribution>
 		<weightDistribution era='3160' unitType='Tank'>3,4,2,1</weightDistribution>
-		<weightDistribution era='3160' unitType='Aero'>1,1,1</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 	</faction>
 	<faction key='PIR'>
 		<omniMargin>18</omniMargin>
@@ -255,9 +255,9 @@
 		<pctOmni>0,0,0,48,100</pctOmni>
 		<pctClan>70,70,95,100,100</pctClan>
 		<pctSL>30,30,5,0,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,10,75,100</pctOmni>
-		<pctClan unitType='Aero'>80,80,100,100,100</pctClan>
-		<pctSL unitType='Aero'>20,0,0,0,0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,10,75,100</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>80,80,100,100,100</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>20,0,0,0,0</pctSL>
 		<pctClan unitType='Vehicle'>15,0,45,45,45</pctClan>
 		<pctSL unitType='Vehicle'>85,0,55,55,55</pctSL>
 		<techMargin>18</techMargin>
@@ -288,9 +288,9 @@
 		<pctOmni>0,0,40,80,100</pctOmni>
 		<pctClan>54,54,77,90,100</pctClan>
 		<pctSL>46,46,23,10,0</pctSL>
-		<pctOmni unitType='Aero'>0,0,20,50,80</pctOmni>
-		<pctClan unitType='Aero'>10,10,60,70,90</pctClan>
-		<pctSL unitType='Aero'>90,90,40,30,10</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,0,20,50,80</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>10,10,60,70,90</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90,90,40,30,10</pctSL>
 		<pctClan unitType='Vehicle'>10,10,33,33,33</pctClan>
 		<pctSL unitType='Vehicle'>90,90,65,65,65</pctSL>
 		<techMargin>18</techMargin>
@@ -314,7 +314,7 @@
 		<techMargin>18</techMargin>
 		<upgradeMargin>15</upgradeMargin>
 		<salvage pct='5'>FS:10</salvage>
-		<weightDistribution era='3160' unitType='Aero'>1,2,3</weightDistribution>
+		<weightDistribution era='3160' unitType='AeroSpaceFighter'>1,2,3</weightDistribution>
 	</faction>
 	<faction key='TB'>
 		<omniMargin>18</omniMargin>
@@ -373,9 +373,9 @@
 		<pctOmni>0,0,0,0,0</pctOmni>
 		<pctClan>0,0,0,0,0</pctClan>
 		<pctSL>30,50,60,75,80</pctSL>
-		<pctOmni unitType='Aero'>0,8,10,12,18</pctOmni>
-		<pctClan unitType='Aero'>0,0,0,0,0</pctClan>
-		<pctSL unitType='Aero'>40,50,70,85,100</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0,8,10,12,18</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0,0,0,0,0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>40,50,70,85,100</pctSL>
 		<techMargin>18</techMargin>
 		<salvage pct='5'></salvage>
 		<weightDistribution era='3160' unitType='Mek'>5,5,3,1</weightDistribution>
@@ -475,7 +475,7 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>60</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>60</pctSL>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -495,8 +495,8 @@
 		<pctOmni>25</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>18</omniMargin>
@@ -564,7 +564,7 @@
 		<pctOmni>10</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>85</pctSL>
-		<pctSL unitType='Aero'>50</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>50</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -699,9 +699,9 @@
 		<pctOmni>0</pctOmni>
 		<pctClan>0</pctClan>
 		<pctSL>0</pctSL>
-		<pctOmni unitType='Aero'>0</pctOmni>
-		<pctClan unitType='Aero'>0</pctClan>
-		<pctSL unitType='Aero'>0</pctSL>
+		<pctOmni unitType='AeroSpaceFighter'>0</pctOmni>
+		<pctClan unitType='AeroSpaceFighter'>0</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>0</pctSL>
 		<pctClan unitType='Vehicle'>0</pctClan>
 		<pctSL unitType='Vehicle'>0</pctSL>
 		<techMargin>18</techMargin>
@@ -742,7 +742,7 @@
 		<pctOmni>8</pctOmni>
 		<pctClan>5</pctClan>
 		<pctSL>75</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>70</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -813,8 +813,8 @@
 		<pctOmni>32</pctOmni>
 		<pctClan>16</pctClan>
 		<pctSL>84</pctSL>
-		<pctClan unitType='Aero'>10</pctClan>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctClan unitType='AeroSpaceFighter'>10</pctClan>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctClan unitType='Vehicle'>10</pctClan>
 		<pctSL unitType='Vehicle'>90</pctSL>
 		<omniMargin>18</omniMargin>
@@ -1045,7 +1045,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>70</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>70</pctSL>
 		<pctSL unitType='Vehicle'>76</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -1056,7 +1056,7 @@
 		<pctOmni>16</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>90</pctSL>
-		<pctSL unitType='Aero'>72</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>72</pctSL>
 		<pctSL unitType='Vehicle'>80</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -1129,7 +1129,7 @@
 		<pctOmni>18</pctOmni>
 		<pctClan>8</pctClan>
 		<pctSL>92</pctSL>
-		<pctSL unitType='Aero'>90</pctSL>
+		<pctSL unitType='AeroSpaceFighter'>90</pctSL>
 		<pctSL unitType='Vehicle'>84</pctSL>
 		<omniMargin>18</omniMargin>
 		<techMargin>18</techMargin>
@@ -1430,7 +1430,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Ammon' unitType='Aero'>
+	<chassis name='Ammon' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,CHH:5,RD:5,CDS:6,CP:5</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -1587,7 +1587,7 @@
 			<availability>RF:6,FWL:6,DA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Aquila' unitType='Aero'>
+	<chassis name='Aquila' unitType='AeroSpaceFighter'>
 		<availability>FWL:7,MERC:5,DA:4,CP:7</availability>
 		<model name='AQA-1M'>
 			<availability>General:8</availability>
@@ -2112,7 +2112,7 @@
 			<availability>General:5-</availability>
 		</model>
 	</chassis>
-	<chassis name='Avar' unitType='Aero' omni='Clan'>
+	<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CP:3,RA:2,BAN:5</availability>
 		<model name='A'>
 			<availability>General:6,RA:7</availability>
@@ -2578,7 +2578,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Bashkir' unitType='Aero' omni='Clan'>
+	<chassis name='Bashkir' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:3,IS:3+,CP:4,RA:6,BAN:5</availability>
 		<model name='A'>
 			<availability>RD:8,General:7</availability>
@@ -2756,7 +2756,7 @@
 			<availability>DC:4+</availability>
 		</model>
 	</chassis>
-	<chassis name='Batu' unitType='Aero' omni='Clan'>
+	<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:6,CHH:5,RD:5,CDS:5,CP:5,CJF:6</availability>
 		<model name='A'>
 			<availability>CDS:8,General:7,CP:8</availability>
@@ -3837,7 +3837,7 @@
 			<availability>LA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Centurion' unitType='Aero'>
+	<chassis name='Centurion' unitType='AeroSpaceFighter'>
 		<availability>LA:4,FS:3,MERC:2,Periphery:2</availability>
 		<model name='CNT-1A'>
 			<availability>General:2</availability>
@@ -3944,7 +3944,7 @@
 			<availability>LA:6,FS:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Chaeronea' unitType='Aero'>
+	<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
 		<availability>CWE:5,RD:5,CLAN:6,CJF:5</availability>
 		<model name=''>
 			<availability>CLAN:5</availability>
@@ -4084,7 +4084,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Cheetah' unitType='Aero'>
+	<chassis name='Cheetah' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,Periphery.ME:4,FWL:10,DA:8</availability>
 		<model name='F-10'>
 			<roles>recon</roles>
@@ -4138,7 +4138,7 @@
 			<availability>:0,IS:4,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Chippewa' unitType='Aero'>
+	<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:1,FVC:4,RD:3,LA:8,MERC:5,FS:4,CDP:6,Periphery:2,TC:6</availability>
 		<model name='CHP-W10'>
 			<availability>FVC:2,CDP:2,TC:2</availability>
@@ -4626,13 +4626,13 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero'>
+	<chassis name='Corax' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,RA:4-</availability>
 		<model name='C'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corax' unitType='Aero' omni='IS'>
+	<chassis name='Corax' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RA.OA:5,RA:3</availability>
 		<model name='CRX-O'>
 			<availability>General:8</availability>
@@ -4669,7 +4669,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Corsair' unitType='Aero'>
+	<chassis name='Corsair' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,RA.OA:2,LA:2,CLAN:2,FS:7,MERC:2,TC:1,Periphery:2</availability>
 		<model name='CSR-12D'>
 			<availability>FS:8</availability>
@@ -5019,7 +5019,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Cutlass' unitType='Aero'>
+	<chassis name='Cutlass' unitType='AeroSpaceFighter'>
 		<availability>FS:8</availability>
 		<model name='CUT-01D'>
 			<roles>interceptor</roles>
@@ -5144,7 +5144,7 @@
 			<availability>General:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Dagger' unitType='Aero' omni='IS'>
+	<chassis name='Dagger' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>FS:6</availability>
 		<model name='DARO-1'>
 			<availability>General:6,FS:8</availability>
@@ -5389,7 +5389,7 @@
 			<availability>MERC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Deathstalker' unitType='Aero'>
+	<chassis name='Deathstalker' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RF:3,FWL:4,DA:6,MERC:3,FS:3,CP:3,DC:3</availability>
 		<model name='F-77A'>
 			<availability>General:8</availability>
@@ -5401,7 +5401,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Defiance' unitType='Aero' omni='IS'>
+	<chassis name='Defiance' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:6,MOC:6,FWL:2,CP:2</availability>
 		<model name='DFC-O'>
 			<roles>ground_support</roles>
@@ -5812,7 +5812,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eagle' unitType='Aero'>
+	<chassis name='Eagle' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
 		<model name='EGL-R11'>
 			<availability>RF:6,LA:6,MERC:6,FS:6</availability>
@@ -5872,13 +5872,13 @@
 			<availability>IS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter'>
 		<availability>RD:2,RF:2,LA:2,MERC:2,FS:2</availability>
 		<model name='EST-R3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Eisensturm' unitType='Aero' omni='IS'>
+	<chassis name='Eisensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>LA:6,MERC:4</availability>
 		<model name='EST-O'>
 			<availability>General:8</availability>
@@ -7461,7 +7461,7 @@
 			<availability>General:4,DC:0</availability>
 		</model>
 	</chassis>
-	<chassis name='Gotha' unitType='Aero'>
+	<chassis name='Gotha' unitType='AeroSpaceFighter'>
 		<availability>CDS:4,CLAN:3,FWL:7,CP:5,MERC:4</availability>
 		<model name='GTHA-500'>
 			<availability>CDS:4,FWL:3,CP:3,MERC:3,BAN:2,Periphery:3</availability>
@@ -8036,7 +8036,7 @@
 			<availability>General:6,MERC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Hammerhead' unitType='Aero'>
+	<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
 		<availability>CLAN:2,CP:3</availability>
 		<model name='HMR-HD'>
 			<availability>General:8,CP:4</availability>
@@ -8464,7 +8464,7 @@
 			<availability>CC:6,MOC:6,MERC:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hellcat' unitType='Aero'>
+	<chassis name='Hellcat' unitType='AeroSpaceFighter'>
 		<availability>MOC:2-,RA.OA:5,FVC:4,LA:2-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 		<model name='HCT-213'>
 			<availability>General:2</availability>
@@ -8990,7 +8990,7 @@
 			<availability>CC:8,MOC:8,FWL:5,MERC:6,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Huscarl' unitType='Aero' omni='IS'>
+	<chassis name='Huscarl' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RD:5,LA:4,MERC:4,FS:4,CP:4,DC:4</availability>
 		<model name='HSCL-1-O'>
 			<availability>General:8</availability>
@@ -9028,7 +9028,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Hydaspes' unitType='Aero'>
+	<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
 		<availability>CLAN:6,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9258,7 +9258,7 @@
 			<availability>CWE:4,CHH:8,CJF:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Issedone' unitType='Aero'>
+	<chassis name='Issedone' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,Periphery:3</availability>
 		<model name='A'>
 			<availability>General:4</availability>
@@ -9277,7 +9277,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Issus' unitType='Aero'>
+	<chassis name='Issus' unitType='AeroSpaceFighter'>
 		<availability>RD:6,CLAN:4,RA:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -9462,7 +9462,7 @@
 			<availability>CJF:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Jagatai' unitType='Aero' omni='Clan'>
+	<chassis name='Jagatai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -9578,7 +9578,7 @@
 			<availability>FVC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Jengiz' unitType='Aero' omni='Clan'>
+	<chassis name='Jengiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:8,RD:9,CLAN:6</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10069,7 +10069,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Kirghiz' unitType='Aero' omni='Clan'>
+	<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:6,CLAN:4,BAN:7</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -10218,7 +10218,7 @@
 			<availability>FWL:4,MERC:3,CP:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Koroshiya' unitType='Aero'>
+	<chassis name='Koroshiya' unitType='AeroSpaceFighter'>
 		<availability>DC:5</availability>
 		<model name='KOS-1A'>
 			<availability>General:8</availability>
@@ -10437,7 +10437,7 @@
 			<availability>DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Lancer' unitType='Aero'>
+	<chassis name='Lancer' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 		<model name='LX-2'>
 			<availability>General:8</availability>
@@ -10624,7 +10624,7 @@
 			<availability>CLAN:8,BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Lightning' unitType='Aero'>
+	<chassis name='Lightning' unitType='AeroSpaceFighter'>
 		<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
 		<model name='LTN-G15'>
 			<availability>General:2-</availability>
@@ -10968,13 +10968,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer III' unitType='Aero'>
+	<chassis name='Lucifer III' unitType='AeroSpaceFighter'>
 		<availability>LA:6</availability>
 		<model name='LCR-3'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer II' unitType='Aero'>
+	<chassis name='Lucifer II' unitType='AeroSpaceFighter'>
 		<availability>MERC:3,DC:4</availability>
 		<model name='LCF-R16K'>
 			<availability>General:5-</availability>
@@ -10983,7 +10983,7 @@
 			<availability>MERC:3,DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Lucifer' unitType='Aero'>
+	<chassis name='Lucifer' unitType='AeroSpaceFighter'>
 		<availability>Periphery.R:4,FVC:2,LA:3,Periphery.MW:3,Periphery:2</availability>
 		<model name='LCF-R15'>
 			<availability>FVC:2-,MERC:2-,Periphery:2-</availability>
@@ -11953,7 +11953,7 @@
 			<availability>CC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Mengqin' unitType='Aero'>
+	<chassis name='Mengqin' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:7,MERC:4</availability>
 		<model name='MNG-8L'>
 			<availability>General:8</availability>
@@ -12255,7 +12255,7 @@
 			<availability>CLAN:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Morgenstern' unitType='Aero' omni='IS'>
+	<chassis name='Morgenstern' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8</availability>
 		<model name='MR-1S'>
 			<availability>General:8</availability>
@@ -12991,7 +12991,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Oni' unitType='Aero'>
+	<chassis name='Oni' unitType='AeroSpaceFighter'>
 		<availability>CP:4,DC:6</availability>
 		<model name='ON-1'>
 			<availability>General:8</availability>
@@ -13161,7 +13161,7 @@
 			<availability>CC:4,CDS:2-,FWL:4,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Ostrogoth' unitType='Aero' omni='Clan'>
+	<chassis name='Ostrogoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:4,RA:2</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -13685,7 +13685,7 @@
 			<availability>RD:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Persepolis' unitType='Aero'>
+	<chassis name='Persepolis' unitType='AeroSpaceFighter'>
 		<availability>CJF:7</availability>
 		<model name=''>
 			<availability>General:8</availability>
@@ -13864,7 +13864,7 @@
 			<availability>RD:4,DC:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Picaroon' unitType='Aero'>
+	<chassis name='Picaroon' unitType='AeroSpaceFighter'>
 		<availability>RF:6,LA:4,MERC:4,DA:4</availability>
 		<model name='CSR-F100'>
 			<availability>General:8</availability>
@@ -14038,7 +14038,7 @@
 			<availability>CC:4,MOC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Poignard' unitType='Aero'>
+	<chassis name='Poignard' unitType='AeroSpaceFighter'>
 		<availability>FWL:6,MERC:4,CP:6</availability>
 		<model name='PGD-L3'>
 			<availability>General:4</availability>
@@ -14440,7 +14440,7 @@
 			<availability>LA:2,FS:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Rapier' unitType='Aero'>
+	<chassis name='Rapier' unitType='AeroSpaceFighter'>
 		<availability>LA:6,CLAN:1</availability>
 		<model name='RPR-100'>
 			<availability>General:1</availability>
@@ -14644,7 +14644,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Riever' unitType='Aero'>
+	<chassis name='Riever' unitType='AeroSpaceFighter'>
 		<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 		<model name='F-100'>
 			<availability>FVC:2-,Periphery:2-</availability>
@@ -14846,7 +14846,7 @@
 			<availability>LA:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Rondel' unitType='Aero'>
+	<chassis name='Rondel' unitType='AeroSpaceFighter'>
 		<availability>FS:5,MERC:3</availability>
 		<model name='RDL-01C'>
 			<availability>General:8</availability>
@@ -15051,7 +15051,7 @@
 			<availability>TC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabre' unitType='Aero'>
+	<chassis name='Sabre' unitType='AeroSpaceFighter'>
 		<availability>CC:4,MOC:4,RA.OA:2-,LA:4,CLAN:2,IS:3-,FWL:2-,FS:3,MERC:4,CP:2-,Periphery:3-,DC:5</availability>
 		<model name='SB-27'>
 			<availability>General:1-</availability>
@@ -15070,7 +15070,7 @@
 			<availability>DC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Sabutai' unitType='Aero' omni='Clan'>
+	<chassis name='Sabutai' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:7,CJF:7</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -15111,7 +15111,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sai' unitType='Aero'>
+	<chassis name='Sai' unitType='AeroSpaceFighter'>
 		<availability>CWE:4,RD:4,CDS:4,FS:4,CP:4,BAN:1,DC:7</availability>
 		<model name='S-4'>
 			<availability>FS:5,DC:6</availability>
@@ -15186,7 +15186,7 @@
 			<availability>LA:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Samurai' unitType='Aero'>
+	<chassis name='Samurai' unitType='AeroSpaceFighter'>
 		<availability>LA:5</availability>
 		<model name='SL-26'>
 			<roles>ground_support</roles>
@@ -15493,7 +15493,7 @@
 			<availability>CJF:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Scytha' unitType='Aero' omni='Clan'>
+	<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CHH:2,CLAN:4,CP:5,CJF:5,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -15601,7 +15601,7 @@
 			<availability>FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Seydlitz' unitType='Aero'>
+	<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,MH:2</availability>
 		<model name='SYD-Z1'>
 			<roles>interceptor</roles>
@@ -15849,7 +15849,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shikra' unitType='Aero'>
+	<chassis name='Shikra' unitType='AeroSpaceFighter'>
 		<availability>RF:4,FWL:6,DA:6,MERC:4,CP:6</availability>
 		<model name='SKR-4M'>
 			<availability>General:8</availability>
@@ -15861,7 +15861,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shilone' unitType='Aero'>
+	<chassis name='Shilone' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 		<model name='SL-17'>
 			<availability>Periphery:2-</availability>
@@ -15882,13 +15882,13 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter'>
 		<availability>FWL:2,CP:2</availability>
 		<model name='SHV-S'>
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Shiva' unitType='Aero' omni='IS'>
+	<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>RF:6,FWL:6,DA:6,CP:6</availability>
 		<model name='SHV-O'>
 			<availability>General:8</availability>
@@ -15935,7 +15935,7 @@
 			<availability>CWE:6,CDS:4,CP:5,CJF:6,DC:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sholagar' unitType='Aero'>
+	<chassis name='Sholagar' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:2,MERC:3,Periphery.OS:3,DC:6,Periphery:2</availability>
 		<model name='SL-21'>
 			<availability>FVC:4,Periphery:4</availability>
@@ -16050,7 +16050,7 @@
 			<availability>FVC:3,IS.pm:1</availability>
 		</model>
 	</chassis>
-	<chassis name='Slayer' unitType='Aero'>
+	<chassis name='Slayer' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:5,Periphery.DD:3,FVC:4,RD:6,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,DC:7</availability>
 		<model name='SL-15'>
 			<availability>FS:0,Periphery:2-</availability>
@@ -16184,7 +16184,7 @@
 			<availability>CLAN:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Spad' unitType='Aero'>
+	<chassis name='Spad' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,RA:1</availability>
 		<model name='SPD-502'>
 			<availability>General:8,CLAN:6</availability>
@@ -16193,7 +16193,7 @@
 			<availability>BAN:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Sparrowhawk' unitType='Aero'>
+	<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
 		<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 		<model name='SPR-6D'>
 			<availability>FVC:7,LA:5,FS:8,MERC:5</availability>
@@ -16435,7 +16435,7 @@
 			<availability>SE:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Star Dagger' unitType='Aero'>
+	<chassis name='Star Dagger' unitType='AeroSpaceFighter'>
 		<availability>CDP:2-</availability>
 		<model name='S-2'>
 			<availability>Periphery:8</availability>
@@ -16496,7 +16496,7 @@
 			<availability>FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Sternensturm' unitType='Aero' omni='IS'>
+	<chassis name='Sternensturm' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>MERC.KH:6,LA:8,MERC:2</availability>
 		<model name='STM-O'>
 			<availability>General:8</availability>
@@ -16589,7 +16589,7 @@
 			<availability>LA:6,MERC:4,FS:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Stingray' unitType='Aero'>
+	<chassis name='Stingray' unitType='AeroSpaceFighter'>
 		<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 		<model name='F-90'>
 			<availability>IS:2-,Periphery:2-</availability>
@@ -16768,7 +16768,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Stuka' unitType='Aero'>
+	<chassis name='Stuka' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:1,FVC:7,Periphery.HR:2,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 		<model name='STU-D6'>
 			<availability>FVC:4,LA:6,FS:4,MERC:6,CDP:4</availability>
@@ -16821,7 +16821,7 @@
 			<availability>General:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Sulla' unitType='Aero' omni='Clan'>
+	<chassis name='Sulla' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RD:5,CLAN:5,BAN:6</availability>
 		<model name='A'>
 			<availability>RD:7,General:2,RA:7</availability>
@@ -16901,7 +16901,7 @@
 			<availability>CP:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Suzaku' unitType='Aero'>
+	<chassis name='Suzaku' unitType='AeroSpaceFighter'>
 		<availability>DC.SL:8,DC:8</availability>
 		<model name='SU-14'>
 			<availability>General:8</availability>
@@ -16966,7 +16966,7 @@
 			<availability>General:2</availability>
 		</model>
 	</chassis>
-	<chassis name='Swift' unitType='Aero'>
+	<chassis name='Swift' unitType='AeroSpaceFighter'>
 		<availability>CLAN:4</availability>
 		<model name='C'>
 			<availability>CLAN:8,RA:9</availability>
@@ -17059,7 +17059,7 @@
 			<availability>General:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Tatsu' unitType='Aero' omni='IS'>
+	<chassis name='Tatsu' unitType='AeroSpaceFighter' omni='IS'>
 		<availability>CC:4,CP:4,DC:6</availability>
 		<model name='MIK-O'>
 			<availability>General:8</availability>
@@ -17334,7 +17334,7 @@
 			<availability>CHH:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Thrush' unitType='Aero'>
+	<chassis name='Thrush' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 		<model name='TR-7'>
 			<roles>escort,interceptor</roles>
@@ -17467,7 +17467,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Thunderbird' unitType='Aero'>
+	<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 		<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
 		<model name='TRB-D36'>
 			<roles>escort,ground_support</roles>
@@ -17671,7 +17671,7 @@
 			<availability>General:7</availability>
 		</model>
 	</chassis>
-	<chassis name='Tomahawk' unitType='Aero'>
+	<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
 		<availability>CWE:3,CLAN:2,MERC:4,DC:6</availability>
 		<model name='&apos;C&apos;'>
 			<availability>CWE:6</availability>
@@ -17745,7 +17745,7 @@
 			<availability>General:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Transgressor' unitType='Aero'>
+	<chassis name='Transgressor' unitType='AeroSpaceFighter'>
 		<availability>CC:8,MOC:5,RF:3,Periphery.CM:2,FWL:3,MERC:2,CP:3,TC:5</availability>
 		<model name='TR-13'>
 			<availability>Periphery:2-</availability>
@@ -17760,7 +17760,7 @@
 			<availability>CC:7,MOC:5,RF:8,FWL:5,MERC:5,CP:5,TC:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Transit' unitType='Aero'>
+	<chassis name='Transit' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:3,Periphery.CM:3,Periphery.ME:3,TC:3</availability>
 		<model name='TR-10'>
 			<availability>MOC:2,General:6,TC:2</availability>
@@ -17829,7 +17829,7 @@
 			<availability>TC:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Trident' unitType='Aero'>
+	<chassis name='Trident' unitType='AeroSpaceFighter'>
 		<availability>RA.OA:6,RA:4</availability>
 		<model name='TRN-3T'>
 			<availability>RA.OA:8,CLAN:6,BAN:8</availability>
@@ -17873,7 +17873,7 @@
 			<availability>IS:6,DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Troika' unitType='Aero'>
+	<chassis name='Troika' unitType='AeroSpaceFighter'>
 		<availability>CC:6,MOC:7,FVC:4,Periphery.CM:4,Periphery.ME:4,MERC:4,DA:4,TC:6,Periphery:3</availability>
 		<model name='CMT-3T'>
 			<availability>CC:8,MOC:8,MERC:8,DA:8,TC:8</availability>
@@ -17994,7 +17994,7 @@
 			<availability>DC:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Turk' unitType='Aero' omni='Clan'>
+	<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:2,CLAN:3,CJF:2,BAN:1</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18065,7 +18065,7 @@
 			<availability>General:4,FS:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Typhoon' unitType='Aero'>
+	<chassis name='Typhoon' unitType='AeroSpaceFighter'>
 		<availability>RF:4,LA:6,MERC:4,DC:4</availability>
 		<model name='TFN-5H'>
 			<roles>ground_support</roles>
@@ -18082,7 +18082,7 @@
 			<availability>IS:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Tyre' unitType='Aero'>
+	<chassis name='Tyre' unitType='AeroSpaceFighter'>
 		<availability>CLAN:7</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -18383,7 +18383,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vandal' unitType='Aero' omni='Clan'>
+	<chassis name='Vandal' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CWE:3,CLAN:2,CJF:3,BAN:4</availability>
 		<model name='A'>
 			<roles>bomber</roles>
@@ -18615,7 +18615,7 @@
 			<availability>CHH:4,RA:4</availability>
 		</model>
 	</chassis>
-	<chassis name='Visigoth' unitType='Aero' omni='Clan'>
+	<chassis name='Visigoth' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>CLAN:5,CJF:7,BAN:5</availability>
 		<model name='A'>
 			<availability>General:7</availability>
@@ -18699,7 +18699,7 @@
 			<availability>PIR:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Vulcan' unitType='Aero'>
+	<chassis name='Vulcan' unitType='AeroSpaceFighter'>
 		<availability>Periphery.Deep:4,MERC:6,FS:4,CDP:4,Periphery:6</availability>
 		<model name='VLC-6N'>
 			<availability>MERC:8</availability>
@@ -19185,7 +19185,7 @@
 			<availability>CC:8,LA:6,FWL:6,IS:6,MERC:6,CP:6</availability>
 		</model>
 	</chassis>
-	<chassis name='Wildkatze' unitType='Aero'>
+	<chassis name='Wildkatze' unitType='AeroSpaceFighter'>
 		<availability>LA:8</availability>
 		<model name='WKT-1S'>
 			<availability>General:8</availability>
@@ -19396,7 +19396,7 @@
 			<availability>General:8</availability>
 		</model>
 	</chassis>
-	<chassis name='Wusun' unitType='Aero' omni='Clan'>
+	<chassis name='Wusun' unitType='AeroSpaceFighter' omni='Clan'>
 		<availability>RA.OA:1+,RA:5</availability>
 		<model name='A'>
 			<availability>General:6</availability>
@@ -19467,7 +19467,7 @@
 			<availability>FWL:5</availability>
 		</model>
 	</chassis>
-	<chassis name='Xerxes' unitType='Aero'>
+	<chassis name='Xerxes' unitType='AeroSpaceFighter'>
 		<availability>CHH:7,CLAN:5,RA:6</availability>
 		<model name=''>
 			<availability>CLAN:8</availability>
@@ -19576,7 +19576,7 @@
 			<availability>CC:3</availability>
 		</model>
 	</chassis>
-	<chassis name='Yun' unitType='Aero'>
+	<chassis name='Yun' unitType='AeroSpaceFighter'>
 		<availability>CC:5,MOC:4</availability>
 		<model name='Y-2'>
 			<roles>apc</roles>

--- a/megamek/data/forcegenerator/faction_rules/CB.xml
+++ b/megamek/data/forcegenerator/faction_rules/CB.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3061,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3060">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3061,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3060">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>

--- a/megamek/data/forcegenerator/faction_rules/CBS.xml
+++ b/megamek/data/forcegenerator/faction_rules/CBS.xml
@@ -10,16 +10,16 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="Warship">%GALAXY%</option>
 			<option ifUnitType="Dropship|Jumpship">%STAR%</option>
-			<option ifUnitType="Aero">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
+			<option ifUnitType="AeroSpaceFighter">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -96,19 +96,19 @@
 		<attachedForces>
 			<subforceOption>
 				<option num="3" ifDateBetween="3061,"
-					rating="FL" unitType="Aero">%CLUSTER%</option>
+					rating="FL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="4" rating="FL"
-					unitType="Aero">%CLUSTER%</option>
+					unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="5" ifDateBetween=",3060"
-					rating="FL" unitType="Aero">%CLUSTER%</option>
+					rating="FL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 			</subforceOption>
 			<subforceOption>
 				<option num="2" ifDateBetween="3061,"
-					rating="SL" unitType="Aero">%CLUSTER%</option>
+					rating="SL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="3" rating="SL"
-					unitType="Aero">%CLUSTER%</option>
+					unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option num="4" ifDateBetween=",3060"
-					rating="SL" unitType="Aero">%CLUSTER%</option>
+					rating="SL" unitType="AeroSpaceFighter">%CLUSTER%</option>
 			</subforceOption>
 		</attachedForces>
 	</force>
@@ -136,7 +136,7 @@
 	one BA/infantry, and one vehicle. ASFs are attached to the naval
 	reserve.-->
 	
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 		<name>Aerospace Cluster</name>
 		<co>%STAR_COL%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CC.SIJ.xml
+++ b/megamek/data/forcegenerator/faction_rules/CC.SIJ.xml
@@ -14,14 +14,14 @@ with a wing of aerospace support and a battalion of BattleArmor. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,BattleArmor,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%COMPANY%,%LANCE%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -37,7 +37,7 @@ with a wing of aerospace support and a battalion of BattleArmor. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero" name="Aerospace Support">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter" name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="BattleArmor" name="Infantry Support">%BATTALION%</subforce>			
 		</attachedForces>
 	</force>

--- a/megamek/data/forcegenerator/faction_rules/CC.WHO.xml
+++ b/megamek/data/forcegenerator/faction_rules/CC.WHO.xml
@@ -26,7 +26,7 @@ had been upgraded to BA by that date. -->
 			<option ifUnitType="Mek">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -72,7 +72,7 @@ had been upgraded to BA by that date. -->
 			<subforce unitType="Infantry"
 					name="Infantry Support">%BATTALION%</subforce>
 			<subforceOption>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%FLIGHT%</option>
 				<option weight="3"/>
 			</subforceOption>
@@ -203,7 +203,7 @@ had been upgraded to BA by that date. -->
 		<attachedForces ifUnitType="Mek">
 			<subforce unitType="BattleArmor" augmented="1" name="Infantry Support">%BATTALION%</subforce>
 			<subforceOption>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%FLIGHT%</option>
 				<option weight="3"/>
 			</subforceOption>

--- a/megamek/data/forcegenerator/faction_rules/CC.xml
+++ b/megamek/data/forcegenerator/faction_rules/CC.xml
@@ -20,9 +20,9 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2472,">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2472,">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -33,7 +33,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%REGIMENT%,%WING%+,%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%^,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%REGIMENT%,%WING%+,%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%^,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -141,11 +141,11 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		
 		<attachedForces ifUnitType="Mek">
 			<subforceOption>
-				<option unitType="Aero" weight="2"
+				<option unitType="AeroSpaceFighter" weight="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" weight="2" num="2"
+				<option unitType="AeroSpaceFighter" weight="2" num="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" num="2"
+				<option unitType="AeroSpaceFighter" num="2"
 					name="Aerospace Support">%FLIGHT%</option>
 			</subforceOption>
 			<subforceOption ifDateBetween=",3080">
@@ -165,11 +165,11 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2540">
 			<subforceOption>
-				<option unitType="Aero" weight="2"
+				<option unitType="AeroSpaceFighter" weight="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" weight="2" num="2"
+				<option unitType="AeroSpaceFighter" weight="2" num="2"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero" num="2"
+				<option unitType="AeroSpaceFighter" num="2"
 					name="Aerospace Support">%FLIGHT%</option>
 			</subforceOption>
 			<subforceOption ifDateBetween="2472,">
@@ -911,7 +911,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%REGIMENT%" eschName="Fleet Regiment" ifUnitType="Aero">
+	<force eschelon="%REGIMENT%" eschName="Fleet Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 
 		<weightClass>
@@ -923,18 +923,18 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		<subforces>
 			<subforce role="command" augmented="1" num="2">%FLIGHT%</subforce>
 			
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -942,7 +942,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT_COLONEL%</co>
 		
 		<weightClass>
@@ -954,18 +954,18 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		<subforces>
 			<subforce role="command" augmented="1">%FLIGHT%</subforce>
 			
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H" augmented="1">%SQUADRON%</option>
 				<option weightClass="H,H,M" augmented="1">%SQUADRON%</option>
 				<option weightClass="H,H,L" augmented="1">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M" augmented="1">%SQUADRON%</option>
 				<option weightClass="M,M,M" augmented="1">%SQUADRON%</option>
 				<option weightClass="H,M,L" augmented="1">%SQUADRON%</option>
 				<option weightClass="M,M,L" augmented="1">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L" augmented="1">%SQUADRON%</option>
 				<option weightClass="M,L,L" augmented="1">%SQUADRON%</option>
 				<option weightClass="L,L,L" augmented="1">%SQUADRON%</option>
@@ -974,7 +974,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="1" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="1" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -986,16 +986,16 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		<subforces>
 			<subforce role="command" augmented="1">%FLIGHT%</subforce>
 			
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" augmented="0" weight="2">%SQUADRON%</option>
 				<option weightClass="H,M" augmented="0">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M" augmented="0">%SQUADRON%</option>
 				<option weightClass="M,L" augmented="0">%SQUADRON%</option>
 				<option weightClass="H,L" augmented="0">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L" augmented="0">%SQUADRON%</option>
 				<option weightClass="L,L" augmented="0" weight="2">%SQUADRON%</option>
 			</subforceOption>
@@ -1011,7 +1011,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifAugmented="0" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifAugmented="0" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{formation} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -1031,7 +1031,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%</option>
 				<option weightClass="H,H,M">%FLIGHT%</option>
 				<option weightClass="H,H,L">%FLIGHT%</option>
@@ -1040,7 +1040,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 				<option weightClass="H,M"
 					augmented="1">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%</option>
 				<option weightClass="M,M,M">%FLIGHT%</option>
 				<option weightClass="H,M,L">%FLIGHT%</option>
@@ -1052,7 +1052,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 				<option weightClass="H,L"
 					augmented="1">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%</option>
 				<option weightClass="M,L,L">%FLIGHT%</option>
 				<option weightClass="L,L,L">%FLIGHT%</option>
@@ -1068,7 +1068,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Triple" ifAugmented="1" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Triple" ifAugmented="1" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name ifRole="command">Command Element</name>
 		<name>Element {cardinal}</name>
 		<co>%LT%</co>
@@ -1084,7 +1084,7 @@ use of augmented 4 Vee/2 inf lances in independent armor regiments. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%FLIGHT%" eschName="Element" ifAugmented="0" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Element" ifAugmented="0" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Element {cardinal}</name>
 		<co>%LT%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CCC.xml
+++ b/megamek/data/forcegenerator/faction_rules/CCC.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -155,7 +155,7 @@
 		
 		<subforces>
 			<subforce unitType="Mek" augmented="1">%TRINARY%</subforce>
-			<subforce unitType="Aero" num="2">%BINARY%</subforce>
+			<subforce unitType="AeroSpaceFighter" num="2">%BINARY%</subforce>
 		</subforces>
 	</force>
 
@@ -165,7 +165,7 @@
 		
 		<subforces>
 			<subforce unitType="Mek" augmented="1">%TRINARY%</subforce>
-			<subforce unitType="Aero">%TRINARY%</subforce>
+			<subforce unitType="AeroSpaceFighter">%TRINARY%</subforce>
 		</subforces>
 	</force>
 
@@ -207,44 +207,44 @@
 			<subforce ifDateBetween="2872," unitType="BattleArmor"
 				>%TRINARY%</subforce>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
 		
 		<subforces ifFlags="coil">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H,H" unitType="Aero"
+				<option weightClass="H,H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,H,M" unitType="Aero"
+				<option weightClass="H,H,M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="H,H,L" unitType="Aero"
+				<option weightClass="H,H,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M,L" unitType="Aero"
+				<option weightClass="H,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,M" unitType="Aero"
+				<option weightClass="M,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L,L" unitType="Aero"
+				<option weightClass="H,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L,L" unitType="Aero"
+				<option weightClass="M,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L,L" unitType="Aero"
+				<option weightClass="L,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			
@@ -292,64 +292,64 @@
 					augmented="1">%TRINARY%</option>
 			</subforceOption>
 			<subforce weightClass="M,M"
-				unitType="Aero">%TRINARY%</subforce>
+				unitType="AeroSpaceFighter">%TRINARY%</subforce>
 		</subforces>
 		
 		<subforces ifFlags="fang">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H,H" unitType="Aero"
+				<option weightClass="H,H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,H,M" unitType="Aero"
+				<option weightClass="H,H,M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="H,H,L" unitType="Aero"
+				<option weightClass="H,H,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,M,M" unitType="Aero"
+				<option weightClass="H,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M,L" unitType="Aero"
+				<option weightClass="H,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,M" unitType="Aero"
+				<option weightClass="M,M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L,L" unitType="Aero"
+				<option weightClass="H,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero"
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L,L" unitType="Aero"
+				<option weightClass="M,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L,L" unitType="Aero"
+				<option weightClass="L,L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -374,55 +374,55 @@
 			<subforce ifDateBetween="2870," unitType="BattleArmor"
 				>%TRINARY%</subforce>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -459,37 +459,37 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -504,55 +504,55 @@
 				<option num="2" unitType="BattleArmor">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,M" unitType="Aero"
+				<option weightClass="H,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,L" unitType="Aero"
+				<option weightClass="H,L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M,L" unitType="Aero"
+				<option weightClass="M,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>

--- a/megamek/data/forcegenerator/faction_rules/CCO.xml
+++ b/megamek/data/forcegenerator/faction_rules/CCO.xml
@@ -21,9 +21,9 @@ ranked SL units.-->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3062,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3061">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3062,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3061">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -412,27 +412,27 @@ ranked SL units.-->
 			</subforceOption>		
 				
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -591,29 +591,29 @@ ranked SL units.-->
 			</subforceOption>		
 				
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>

--- a/megamek/data/forcegenerator/faction_rules/CDS.xml
+++ b/megamek/data/forcegenerator/faction_rules/CDS.xml
@@ -26,9 +26,9 @@ but with more independence.-->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3100,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3099">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3100,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3099">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -171,18 +171,18 @@ but with more independence.-->
 				
 		<subforces>
 			<subforceOption ifWeightClass="H">
-				<option weightClass="H,H,H" unitType="Aero">%TRINARY%</option>
-				<option weightClass="H,H,M" unitType="Aero">%TRINARY%</option>
+				<option weightClass="H,H,H" unitType="AeroSpaceFighter">%TRINARY%</option>
+				<option weightClass="H,H,M" unitType="AeroSpaceFighter">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,M,L" unitType="Aero" weight="3">%TRINARY%</option>
-				<option weightClass="H,L,L" unitType="Aero">%TRINARY%</option>
-				<option weightClass="M,M,M" unitType="Aero" weight="2">%TRINARY%</option>
-				<option weightClass="M,M,L" unitType="Aero" weight="2">%TRINARY%</option>
+				<option weightClass="H,M,L" unitType="AeroSpaceFighter" weight="3">%TRINARY%</option>
+				<option weightClass="H,L,L" unitType="AeroSpaceFighter">%TRINARY%</option>
+				<option weightClass="M,M,M" unitType="AeroSpaceFighter" weight="2">%TRINARY%</option>
+				<option weightClass="M,M,L" unitType="AeroSpaceFighter" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="M,L,L" unitType="Aero">%TRINARY%</option>
-				<option weightClass="L,L,L" unitType="Aero">%TRINARY%</option>
+				<option weightClass="M,L,L" unitType="AeroSpaceFighter">%TRINARY%</option>
+				<option weightClass="L,L,L" unitType="AeroSpaceFighter">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
 
@@ -398,27 +398,27 @@ but with more independence.-->
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -432,17 +432,17 @@ but with more independence.-->
 					weight="4">%TRINARY%</option>
 				<option weightClass="H" unitType="Mek"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -452,17 +452,17 @@ but with more independence.-->
 					weight="3">%TRINARY%</option>
 				<option weightClass="M" unitType="Mek"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -472,17 +472,17 @@ but with more independence.-->
 					weight="3">%TRINARY%</option>
 				<option weightClass="L" unitType="Mek"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -490,17 +490,17 @@ but with more independence.-->
 					weight="2">%TRINARY%</option>
 				<option weightClass="L" unitType="Mek"
 					weight="4">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -518,11 +518,11 @@ but with more independence.-->
 					ifRating="SL" weight="6">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="6">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -538,11 +538,11 @@ but with more independence.-->
 					ifRating="SL" weight="14">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="14">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -558,11 +558,11 @@ but with more independence.-->
 					ifRating="SL" weight="14">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="14">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -576,11 +576,11 @@ but with more independence.-->
 					ifRating="SL" weight="6">%TRINARY%</option>
 				<option ifRating="SL" unitType="Infantry"
 					ifDateBetween=",2950" weight="6">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					ifFlags="combined" weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -633,9 +633,9 @@ but with more independence.-->
 					weightClass="H" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -651,11 +651,11 @@ but with more independence.-->
 					weightClass="H" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -671,11 +671,11 @@ but with more independence.-->
 					weightClass="M" weight="4">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -689,11 +689,11 @@ but with more independence.-->
 					weightClass="M" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 			
@@ -708,9 +708,9 @@ but with more independence.-->
 					weightClass="H" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -726,11 +726,11 @@ but with more independence.-->
 					weightClass="H" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -746,11 +746,11 @@ but with more independence.-->
 					weightClass="M" weight="4">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="4">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -764,11 +764,11 @@ but with more independence.-->
 					weightClass="M" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" ifDateBetween="2870,"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 				    weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -829,27 +829,27 @@ but with more independence.-->
 		
 		<subforces generate="group">
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="1">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="2">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="1">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="3">%ELEMENT%</option>
 			</subforceOption>
 		</subforces>

--- a/megamek/data/forcegenerator/faction_rules/CFM.BG.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.BG.xml
@@ -10,14 +10,14 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -39,13 +39,13 @@
 		
 		<subforces>
 			<subforce role="command" rating="Keshik"
-				unitType="Aero">%BINARY%</subforce>
+				unitType="AeroSpaceFighter">%BINARY%</subforce>
 			<subforceOption>
 				<option num="1" rating="FL">%CLUSTER%</option>
 				<option num="2" rating="FL">%CLUSTER%</option>
 			</subforceOption>
 			<subforce num="1" rating="FL"
-				unitType="Aero">%CLUSTER%</subforce>
+				unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL"
 				flags="binary">%CLUSTER%</subforce>
@@ -62,7 +62,7 @@
 	
 	<!--One cluster has three binaries of ASF, one Mek, and one BA.-->
 	
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 		<name>Mandrill Airborne</name>
 		<co>%STAR_COL%</co>
 		
@@ -220,27 +220,27 @@
 		
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					role="command" weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					role="command" weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					role="command" weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					role="command" weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					role="command" weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					role="command" weight="3">%BINARY%</option>
 			</subforceOption>
 
@@ -261,27 +261,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 			
@@ -353,27 +353,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -390,7 +390,7 @@
 	<!--SL command binary is one star of ASF and one nova of ASF+BA.-->
 	
 	<force eschelon="%BINARY%" eschName="Binary" ifRating="SL|PG" ifRole="command"
-			ifUnitType="Aero">
+			ifUnitType="AeroSpaceFighter">
 		<name>Binary [Command]</name>
 		<co>%STAR_COL%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CFM.FT.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.FT.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -139,27 +139,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 			

--- a/megamek/data/forcegenerator/faction_rules/CFM.Kl.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.Kl.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -31,7 +31,7 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -224,19 +224,19 @@
 				<option weightClass="L,L" unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="A|H|M">

--- a/megamek/data/forcegenerator/faction_rules/CFM.MaC.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.MaC.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -30,10 +30,10 @@
 		</rating>
 		
 		<flags>
-			<option ifUnitType="null|Mek|BattleArmor|Aero" ifEschelon="%BINARY%">kindraa_command:Kindraa Command Binary</option>
+			<option ifUnitType="null|Mek|BattleArmor|AeroSpaceFighter" ifEschelon="%BINARY%">kindraa_command:Kindraa Command Binary</option>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%BINARY%">mixed:Combined Mek/Aero unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%STAR%">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%BINARY%">mixed:Combined Mek/Aero unit</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%STAR%">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -162,27 +162,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 			
@@ -297,27 +297,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="mekAeroNova" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -383,33 +383,33 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option ifRole="!command" weightClass="H" unitType="Aero"
+				<option ifRole="!command" weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option ifRole="!command" weightClass="M" unitType="Aero"
+				<option ifRole="!command" weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option ifRole="!command" weightClass="L" unitType="Aero"
+				<option ifRole="!command" weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
 				<option ifDateBetween="2870,"
 					ifAugmented="0" unitType="BattleArmor"
 					weight="6">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option ifRole="!command" weightClass="H" unitType="Aero"
+				<option ifRole="!command" weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option ifRole="!command" weightClass="M" unitType="Aero"
+				<option ifRole="!command" weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option ifRole="!command" weightClass="L" unitType="Aero"
+				<option ifRole="!command" weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 				<option ifDateBetween="2870,"
 					ifAugmented="0" unitType="BattleArmor"
 					weight="6">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option ifRole="!command" weightClass="H" unitType="Aero"
+				<option ifRole="!command" weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option ifRole="!command" weightClass="M" unitType="Aero"
+				<option ifRole="!command" weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option ifRole="!command" weightClass="L" unitType="Aero"
+				<option ifRole="!command" weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 				<option ifDateBetween="2870,"
 					ifAugmented="0" unitType="BattleArmor"

--- a/megamek/data/forcegenerator/faction_rules/CFM.MiKr.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.MiKr.xml
@@ -10,15 +10,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="BattleArmor">%CLUSTER%,%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -32,7 +32,7 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
 		</flags>
 	</toc>
 	
@@ -40,7 +40,7 @@
 		<co>%GALAXY_CMDR%</co>
 		
 		<subforces>
-			<subforce role="command" rating="Keshik" unitType="Aero"
+			<subforce role="command" rating="Keshik" unitType="AeroSpaceFighter"
 				name="Kindraa Command Binary">%BINARY%</subforce>
 			<subforceOption>
 				<option weight="3" rating="FL">%CLUSTER%</option>
@@ -53,7 +53,7 @@
 			</subforceOption>
 			<subforceOption>
 				<option weight="3" rating="FL"
-					unitType="Aero">%CLUSTER%</option>
+					unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option />
 			</subforceOption>
 			<subforceOption>
@@ -85,29 +85,29 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option unitType="Aero" augmented="1" weightClass="A"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="A"
 					role="command" weight="2">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="H"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="H"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="M"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="M"
 					role="command" weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" augmented="1" weightClass="A"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="A"
 					role="command" weight="1">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="H"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="H"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="M"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="M"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="L"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="L"
 					role="command" weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" augmented="1" weightClass="H"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="H"
 					role="command" weight="4">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="M"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="M"
 					role="command" weight="3">%BINARY%</option>
-				<option unitType="Aero" augmented="1" weightClass="L"
+				<option unitType="AeroSpaceFighter" augmented="1" weightClass="L"
 					role="command" weight="2">%BINARY%</option>
 			</subforceOption>
 			
@@ -161,7 +161,7 @@
 	
 	<!--Aerospace cluster includes two ASF trinaries and one Mek/BA
 	 trinary.-->
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 		<name ifWeightClass="H|A">Air Assault Cluster</name>
 		<name ifWeightClass="M">Air Battle Cluster</name>
 		<name ifWeightClass="L">Air Striker Cluster</name>
@@ -340,18 +340,18 @@
 			</subforceOption>			
 						
 			<subforceOption ifWeightClass="H">
-				<option unitType="Aero" weightClass="H,H"
+				<option unitType="AeroSpaceFighter" weightClass="H,H"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="H,M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H,M">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" weightClass="H,M">%BINARY%</option>
-				<option unitType="Aero" weightClass="M,M">%BINARY%</option>
-				<option unitType="Aero" weightClass="M,L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H,M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="M,M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="M,L">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" weightClass="M,L">%BINARY%</option>
-				<option unitType="Aero" weightClass="L,L"
+				<option unitType="AeroSpaceFighter" weightClass="M,L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L,L"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -382,29 +382,29 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option unitType="Mek" weightClass="A" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="A" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="2">%TRINARY%</option>
-				<option unitType="Mek" weightClass="H" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="H" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="M" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="M" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Mek" weightClass="A" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="A" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="1">%TRINARY%</option>
-				<option unitType="Mek" weightClass="H" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="H" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="M" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="M" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="L" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="L" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Mek" weightClass="H" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="H" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="4">%TRINARY%</option>
-				<option unitType="Mek" weightClass="M" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="M" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="3">%TRINARY%</option>
-				<option unitType="Mek" weightClass="L" flags="+mixedMekAero"
+				<option unitType="Mek" weightClass="L" flags="+mixedMekAeroSpaceFighter"
 					role="command" weight="2">%TRINARY%</option>
 			</subforceOption>
 
@@ -501,7 +501,7 @@
 	<!--Command trinary used for SL clusters, consisting of two
 	Mek stars and one ASF star.-->
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifFlags="mixedMekAero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifFlags="mixedMekAeroSpaceFighter">
 		<name>Trinary Command</name>
 		<co>%STAR_COL%</co>
 		
@@ -545,27 +545,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="1">%STAR%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>

--- a/megamek/data/forcegenerator/faction_rules/CFM.MiKrKl.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.MiKrKl.xml
@@ -10,15 +10,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="BattleArmor">%CLUSTER%,%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -32,8 +32,8 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%TRINARY%|%BINARY%">mixedMekAero:Combined Mek/Aero unit</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%STAR%|STAR^">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -50,7 +50,7 @@
 					faction="CFM.MiKr">%CLUSTER%</option>
 			</subforceOption>
 			<subforce num="1" rating="FL" faction="CFM.MiKr"
-				unitType="Aero">%CLUSTER%</subforce>
+				unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforce num="1" rating="FL" faction="CFM.MiKr"
 				unitType="BattleArmor">%CLUSTER%</subforce>
 			<subforceOption>

--- a/megamek/data/forcegenerator/faction_rules/CFM.P.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.P.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -121,26 +121,26 @@
 					unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="1">%BINARY%</option>
 				<option weight="12" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero" weightClass="H">%BINARY%</option>
-				<option unitType="Aero" weightClass="M">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="M">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="1">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					weight="3">%BINARY%</option>
 				<option weight="12" />
 			</subforceOption>
@@ -164,29 +164,29 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 				<option weight="12" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 				<option weight="14" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 				<option weight="12" />
 			</subforceOption>
@@ -257,11 +257,11 @@
 		
 		<attachedForces>
 			<subforceOption>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					name="Support Aero Star" weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					name="Support Aero Star" weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					name="Support Aero Star" weight="1">%STAR%</option>
 			</subforceOption>
 		</attachedForces>

--- a/megamek/data/forcegenerator/faction_rules/CFM.PBG.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.PBG.xml
@@ -10,14 +10,14 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%GALAXY%,%CLUSTER%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -47,7 +47,7 @@
 					faction="CFM.P">%CLUSTER%</option>
 			</subforceOption>
 			<subforce num="1" rating="FL" faction="CFM.BG"
-				unitType="Aero">%CLUSTER%</subforce>
+				unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL"
 				faction="CFM.BG">%CLUSTER%</subforce>
 			<subforce num="1" rating="SL" flags="binary"

--- a/megamek/data/forcegenerator/faction_rules/CFM.S.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.S.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -51,7 +51,7 @@
 		</subforces>
 	</force>
 	
-	<!-- Standard cluster includes one trinary each of Mek, Aero, BA
+	<!-- Standard cluster includes one trinary each of Mek, AeroSpaceFighter, BA
 	and an additional cluster of mixed Mek/BA-->
 	<force eschelon="%CLUSTER%" eschName="Cluster">
 		<name ifRating="FL" ifWeightClass="A|H">Assault Cluster</name>
@@ -94,27 +94,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 			

--- a/megamek/data/forcegenerator/faction_rules/CFM.xml
+++ b/megamek/data/forcegenerator/faction_rules/CFM.xml
@@ -15,15 +15,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="Dropship|Jumpship">%STAR%</option>
-			<option ifUnitType="Mek|Aero" ifDateBetween="2870,">%TRINARY%,%BINARY%,%STAR%^,%STAR%</option>
+			<option ifUnitType="Mek|AeroSpaceFighter" ifDateBetween="2870,">%TRINARY%,%BINARY%,%STAR%^,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -38,7 +38,7 @@
 		
 		<flags>
 			<option ifUnitType="null|Mek|BattleArmor" ifEschelon="%TRINARY%|%BINARY%">mixedMekBA:Combined Mek/BA unit</option>
-			<option ifUnitType="null|Mek|Aero" ifEschelon="%TRINARY%|%BINARY%">mekAeroNova:Mek+Aero Nova</option>
+			<option ifUnitType="null|Mek|AeroSpaceFighter" ifEschelon="%TRINARY%|%BINARY%">mekAeroNova:Mek+Aero Nova</option>
 		</flags>
 	</toc>
 	
@@ -132,27 +132,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -235,7 +235,7 @@
 	fighters and a star of battlearmor. There is no indication in the FM of how they
 	work together, but the Nova formation rules in Campaign Operations say the ASFs must
 	be omni, which suggests that they ride the fighters into battle and make a hot drop. -->
-	<force eschelon="%STAR%" eschName="Nova" ifAugmented="1" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Nova" ifAugmented="1" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Aero Nova</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -328,8 +328,8 @@
 		
 		<subforces>
 			<subforce flags="-mekAeroNova" augmented="0" unitType="Mek">%STAR%</subforce>
-			<subforce flags="-mekAeroNova" augmented="0" unitType="Aero" ifWeightClass="A" weightClass="H">%STAR%</subforce>
-			<subforce flags="-mekAeroNova" augmented="0" unitType="Aero" ifWeightClass="H|M|L">%STAR%</subforce>
+			<subforce flags="-mekAeroNova" augmented="0" unitType="AeroSpaceFighter" ifWeightClass="A" weightClass="H">%STAR%</subforce>
+			<subforce flags="-mekAeroNova" augmented="0" unitType="AeroSpaceFighter" ifWeightClass="H|M|L">%STAR%</subforce>
 		</subforces>
 	</force>
 

--- a/megamek/data/forcegenerator/faction_rules/CGB.xml
+++ b/megamek/data/forcegenerator/faction_rules/CGB.xml
@@ -14,15 +14,15 @@ but have a smaller aerospace arm than most other Clans. -->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%</option>
 			<option ifUnitType="Warship">%CLUSTER%</option>
 			<option ifUnitType="Mek" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Aero" ifDateBetween="3069,">%GALAXY%,%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
+			<option ifUnitType="AeroSpaceFighter" ifDateBetween="3069,">%GALAXY%,%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option ifUnitType="BattleArmor">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
@@ -78,7 +78,7 @@ but have a smaller aerospace arm than most other Clans. -->
 			<subforce rating="SL" ifDateBetween="3068,"
 				name="Rasalhague Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL" ifDateBetween="3069,"
-			    unitType="Aero"
+			    unitType="AeroSpaceFighter"
 				name="Valkyrie Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL" ifDateBetween="2950,3075"
 			    flags="zeta"
@@ -92,7 +92,7 @@ but have a smaller aerospace arm than most other Clans. -->
 	to have been reduced to two in the drive to Terra (FR:C). The two-
 	cluster size is kept in later TO&E listings.-->
 	
-	<force eschelon="%GALAXY%" eschName="Valkyrie Galaxy" ifUnitType="Aero">
+	<force eschelon="%GALAXY%" eschName="Valkyrie Galaxy" ifUnitType="AeroSpaceFighter">
 	    <name>{greek} Galaxy</name>
 	    <co>%GALAXY_CMDR%</co>
 	    
@@ -229,7 +229,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Cluster" ifUnitType="AeroSpaceFighter">
 	    <name>{ordinal} Valkyrie</name>
 	    <co>%STAR_COL%</co>
 	    
@@ -376,31 +376,31 @@ but have a smaller aerospace arm than most other Clans. -->
             resulting in many clusters having no support of their own.-->
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 				<option weight="3"/>
 				<option ifRating="SL|PG|Sol" weight="3"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 				<option weight="3"/>
 				<option ifRating="SL|PG|Sol" weight="3"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 				<option weight="3"/>
 				<option ifRating="SL|PG|Sol" weight="3"/>
@@ -474,7 +474,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		
 		<attachedForces ifRating="FL">
 		    <subforceOption>
-		        <option unitType="Aero" name="Tango Fighter Star"
+		        <option unitType="AeroSpaceFighter" name="Tango Fighter Star"
 		            weight="1">%STAR%</option>
 		        <option weight="5"/>
 		    </subforceOption>
@@ -482,7 +482,7 @@ but have a smaller aerospace arm than most other Clans. -->
 
 		<attachedForces ifRating="Keshik">
 		    <subforceOption>
-		        <option unitType="Aero" name="Tango Fighter Star"
+		        <option unitType="AeroSpaceFighter" name="Tango Fighter Star"
 		            weight="2">%STAR%</option>
 		        <option unitType="Mek" name="Tango Support Star"
 		            weight="1">%STAR%</option>
@@ -535,7 +535,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name>Fighter Trinary</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -585,7 +585,7 @@ but have a smaller aerospace arm than most other Clans. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name>Fighter Binary</name>
 		<co>%STAR_CAPTAIN%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CGS.xml
+++ b/megamek/data/forcegenerator/faction_rules/CGS.xml
@@ -17,9 +17,9 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -487,27 +487,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>		
@@ -621,8 +621,8 @@
 			</subforceOption>
 			
 			<subforceOption>
-				<option unitType="Aero" role="cargo" ifDateBetween=",2900">%STAR%</option>
-				<option weightClass="H" unitType="Aero" model="Kirghiz C" ifDateBetween="2874,">%STAR%</option>
+				<option unitType="AeroSpaceFighter" role="cargo" ifDateBetween=",2900">%STAR%</option>
+				<option weightClass="H" unitType="AeroSpaceFighter" model="Kirghiz C" ifDateBetween="2874,">%STAR%</option>
 			</subforceOption>
 		</subforces>
 	</force>		
@@ -657,21 +657,21 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="M" unitType="Aero">%STAR%</option>
-				<option weightClass="L" unitType="Aero">%STAR%</option>
+				<option weightClass="M" unitType="AeroSpaceFighter">%STAR%</option>
+				<option weightClass="L" unitType="AeroSpaceFighter">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>			
@@ -745,27 +745,27 @@
 		
 		<subforces generate="group">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="3">%ELEMENT%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="1">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="3">%ELEMENT%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H,H" unitType="Aero"
+				<option weightClass="H,H" unitType="AeroSpaceFighter"
 					weight="1">%ELEMENT%</option>
-				<option weightClass="M,M" unitType="Aero"
+				<option weightClass="M,M" unitType="AeroSpaceFighter"
 					weight="2">%ELEMENT%</option>
-				<option weightClass="L,L" unitType="Aero"
+				<option weightClass="L,L" unitType="AeroSpaceFighter"
 					weight="3">%ELEMENT%</option>
 			</subforceOption>
 		</subforces>		
@@ -847,7 +847,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{ordinal} {phonetic:parent} {name:parent} Star</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CHH.xml
+++ b/megamek/data/forcegenerator/faction_rules/CHH.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -100,9 +100,9 @@
 			</subforceOption>
 
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%TRINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 
@@ -293,27 +293,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -1232,7 +1232,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Trinary Delta</name>
 		<name>Trinary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1456,7 +1456,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Binary Delta</name>
 		<name>Binary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>

--- a/megamek/data/forcegenerator/faction_rules/CIH.xml
+++ b/megamek/data/forcegenerator/faction_rules/CIH.xml
@@ -18,9 +18,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -239,7 +239,7 @@
 		
 		<!-- Assume each cluster contains two Mek trinaries, and
 		optionally up to three additional trinaries which could be
-		Mek, Tank (SL/Sol only), Aero, or infantry.-->
+		Mek, Tank (SL/Sol only), AeroSpaceFighter, or infantry.-->
 
 		<subforces>
 			<subforceOption ifWeightClass="A">
@@ -350,40 +350,40 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2850,">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2950,">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary">%TRINARY%</option>
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2950,">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary"
 					ifDateBetween="2950,">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -758,7 +758,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command" ifRating="!Keshik">Trinary [Command]</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1036,7 +1036,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary [Command]</name>
 		<name>{ordinal:distinct} Binary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1409,7 +1409,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CJF.xml
+++ b/megamek/data/forcegenerator/faction_rules/CJF.xml
@@ -17,9 +17,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,3072">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,3072">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -406,15 +406,15 @@
 					ifAugmented="0" />
 			</subforceOption>
 
-			<!--The final trinary is usually Aero, but may rarely
+			<!--The final trinary is usually AeroSpaceFighter, but may rarely
 			be Mek (1/15)-->
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="21">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="14">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="7">%TRINARY%</option>
 				<option weightClass="H"
 					unitType="Mek" weight="2">%TRINARY%</option>
@@ -422,11 +422,11 @@
 					unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="16">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="21">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="16">%TRINARY%</option>
 				<option weightClass="H"
 					unitType="Mek" weight="1">%TRINARY%</option>
@@ -436,11 +436,11 @@
 					unitType="Mek" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="7">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="14">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="21">%TRINARY%</option>
 				<option weightClass="M"
 					unitType="Mek" weight="1">%TRINARY%</option>
@@ -566,29 +566,29 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -920,7 +920,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>Trinary {phonetic}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1178,7 +1178,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary Command</name>
 		<name>Binary {phonetic}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1751,7 +1751,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic:parent} Wing {cardinal:distinct}</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CLAN.GC.xml
+++ b/megamek/data/forcegenerator/faction_rules/CLAN.GC.xml
@@ -94,9 +94,9 @@
 			</subforceOption>
 
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="2">%TRINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 
@@ -287,27 +287,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 			
@@ -1226,7 +1226,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Trinary Delta</name>
 		<name>Trinary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1450,7 +1450,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Binary Delta</name>
 		<name>Binary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>

--- a/megamek/data/forcegenerator/faction_rules/CLAN.xml
+++ b/megamek/data/forcegenerator/faction_rules/CLAN.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -251,29 +251,29 @@
 		<!-- Possibly add trinary each of aero and battlearmor-->
 		<subforces ifRating="FL|Keshik">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option ifRating="FL" weight="1" />
 			</subforceOption>
@@ -289,33 +289,33 @@
 		
 		<subforces ifRating="SL|Sol|PG">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="3" />
 				<option ifRating="Sol" weight="3" />
 				<option ifRating="PG" weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="3" />
 				<option ifRating="Sol" weight="3" />
 				<option ifRating="PG" weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="3" />
 				<option ifRating="Sol" weight="3" />
@@ -672,7 +672,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -994,7 +994,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary [Command]</name>
 		<name>{ordinal:distinct} Binary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1364,7 +1364,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -1514,7 +1514,7 @@
 			<option weight="2">L</option>
 		</weightClass>
 		
-		<weightClass ifUnitType="Aero">
+		<weightClass ifUnitType="AeroSpaceFighter">
 			<option>H</option>
 			<option>M</option>
 			<option>L</option>
@@ -1527,7 +1527,7 @@
 			</unitType>
 		</ruleGroup>
 		
-		<subforces generate="group" ifUnitType="Tank|VTOL|Aero">
+		<subforces generate="group" ifUnitType="Tank|VTOL|AeroSpaceFighter">
 			<subforce num="2">%ELEMENT%</subforce>
 		</subforces>
 

--- a/megamek/data/forcegenerator/faction_rules/CNC.xml
+++ b/megamek/data/forcegenerator/faction_rules/CNC.xml
@@ -22,9 +22,9 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -356,27 +356,27 @@
 		
 		<subforces ifRating="FL" ifFlags="!lancer">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>			
 		</subforces>
@@ -420,27 +420,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>						
 		</subforces>
@@ -734,7 +734,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name ifRating="Keshik">{ordinal} Fighter {phonetic:parent} Command</name>
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>

--- a/megamek/data/forcegenerator/faction_rules/CS.xml
+++ b/megamek/data/forcegenerator/faction_rules/CS.xml
@@ -1613,66 +1613,66 @@
 		<subforces generate="group" ifFlags="4002|0402|0042|2202|2022|0222">
 		    <subforceOption ifWeightClass="A">
 		        <option weightClass="H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="H">
 		        <option weightClass="H,H" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="M">
 		        <option weightClass="H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="L">
 		        <option weightClass="H,H" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		</subforces>
 
 		<subforces generate="group" ifFlags="3003">
 		    <subforceOption ifWeightClass="A">
 		        <option weightClass="H,H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="H">
 		        <option weightClass="H,H,H" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L,L" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="M">
 		        <option weightClass="H,H,H" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L,L" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		    <subforceOption ifWeightClass="L">
 		        <option weightClass="H,H,H" weight="1"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="M,M,M" weight="2"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		        <option weightClass="L,L,L" weight="3"
-				    unitType="Aero">%ELEMENT%</option>
+				    unitType="AeroSpaceFighter">%ELEMENT%</option>
 		    </subforceOption>
 		</subforces>
 	</force>

--- a/megamek/data/forcegenerator/faction_rules/CSA.xml
+++ b/megamek/data/forcegenerator/faction_rules/CSA.xml
@@ -10,9 +10,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -262,11 +262,11 @@
 			</subforceOption>
 			
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
 			</subforceOption>		
 		</subforces>
 	</force>
@@ -336,9 +336,9 @@
 					unitType="Mek">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption>
-				<option unitType="Aero" weightClass="H">%TRINARY%+</option>
-				<option unitType="Aero" weightClass="M">%TRINARY%+</option>
-				<option unitType="Aero" weightClass="L">%TRINARY%+</option>
+				<option unitType="AeroSpaceFighter" weightClass="H">%TRINARY%+</option>
+				<option unitType="AeroSpaceFighter" weightClass="M">%TRINARY%+</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%TRINARY%+</option>
 			</subforceOption>		
 		</subforces>
 		
@@ -456,21 +456,21 @@
 				<option ifFlags="guards|sentinels" weight="8" />
 			</subforceOption>
 			<subforceOption ifFlags="!cavalry">
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%TRINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%TRINARY%</option>
-				<option unitType="Aero" weightClass="L">%TRINARY%</option>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="L">%TRINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="L">%STAR%</option>
+				<option unitType="AeroSpaceFighter" weightClass="L">%STAR%</option>
 			</subforceOption>		
 		</subforces>
 
@@ -572,16 +572,16 @@
 				<option unitType="Infantry">%BINARY%</option>
 			</subforceOption>
 			<subforceOption>
-				<option unitType="Aero" weightClass="H"
+				<option unitType="AeroSpaceFighter" weightClass="H"
 					weight="3">%BINARY%</option>
-				<option unitType="Aero" weightClass="M"
+				<option unitType="AeroSpaceFighter" weightClass="M"
 					weight="2">%BINARY%</option>
-				<option unitType="Aero" weightClass="L">%BINARY%</option>
-				<option unitType="Aero" weightClass="H" ifRating="SL"
+				<option unitType="AeroSpaceFighter" weightClass="L">%BINARY%</option>
+				<option unitType="AeroSpaceFighter" weightClass="H" ifRating="SL"
 					weight="3">%STAR%</option>
-				<option unitType="Aero" weightClass="M" ifRating="SL"
+				<option unitType="AeroSpaceFighter" weightClass="M" ifRating="SL"
 					weight="2">%STAR%</option>
-				<option unitType="Aero" weightClass="L"
+				<option unitType="AeroSpaceFighter" weightClass="L"
 					ifRating="SL">%STAR%</option>
 			</subforceOption>		
 		</subforces>

--- a/megamek/data/forcegenerator/faction_rules/CSJ.xml
+++ b/megamek/data/forcegenerator/faction_rules/CSJ.xml
@@ -13,9 +13,9 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3059,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3059,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -408,29 +408,29 @@
 		
 		<subforces ifRating="!Sol">
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -485,11 +485,11 @@
 					weightClass="H" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="H">
@@ -499,11 +499,11 @@
 					weightClass="H" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
@@ -513,11 +513,11 @@
 					weightClass="M" weight="2">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
@@ -527,11 +527,11 @@
 					weightClass="M" weight="3">%STAR%</option>
 				<option unitType="BattleArmor" augmented="0"
 					weightClass="L" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero" augmented="0"
+				<option unitType="AeroSpaceFighter" augmented="0"
 					weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -576,29 +576,29 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="1">%STAR%</option>
 				<option weight="6" />
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="2">%STAR%</option>
 				<option weight="7" />
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="3">%STAR%</option>
 				<option weight="6" />
 			</subforceOption>
@@ -691,7 +691,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -819,7 +819,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Binary [Command]</name>
 		<name>{ordinal:distinct} Binary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1033,7 +1033,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CSL.xml
+++ b/megamek/data/forcegenerator/faction_rules/CSL.xml
@@ -18,7 +18,7 @@
 	
 	<toc>
 		<unitType>
-			<option>null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Dropship,Jumpship</option>
+			<option>null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -138,31 +138,31 @@
 			
 			<!-- Half the FL and 1/3 the SL units get aerospace support -->
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 				<option weight="6"/>
 				<option weight="6" ifRating="SL"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 				<option weight="7"/>
 				<option weight="7" ifRating="SL"/>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 				<option weight="6"/>
 				<option weight="6" ifRating="SL"/>
@@ -941,7 +941,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Trinary Delta</name>
 		<name>Trinary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -1165,7 +1165,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter">
 		<name ifFlags="assault|cavalry|strike">Binary Delta</name>
 		<name>Binary {greek}</name>
 		<co>%STAR_CAPTAIN%</co>

--- a/megamek/data/forcegenerator/faction_rules/CSR.xml
+++ b/megamek/data/forcegenerator/faction_rules/CSR.xml
@@ -10,16 +10,16 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,">null,Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,3059">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%TOUMAN%,%GALAXY%,%CLUSTER%,%TRINARY%</option>
 			<option ifUnitType="Warship">%STAR%</option>
 			<option ifUnitType="Mek" ifDateBetween="2870,">%TRINARY%^,%TRINARY%,%BINARY%^,%BINARY%,%STAR%^,%STAR%</option>
-			<option ifUnitType="Aero">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
+			<option ifUnitType="AeroSpaceFighter">%CLUSTER%,%TRINARY%,%BINARY%,%STAR%</option>
 			<option>%TRINARY%,%BINARY%,%STAR%</option>
 		</eschelon>
 		
@@ -35,7 +35,7 @@
 		
 		<flags>
 			<option ifEschelon="%GALAXY%">proto:Zeta Galaxy (ProtoMek heavy)</option>
-			<option ifUnitType="!Aero" ifEschelon="%CLUSTER%">phalanx:Phalanx Cluster,stoop:Stoop Cluster,proto:Chausseurs Cluster</option>
+			<option ifUnitType="!AeroSpaceFighter" ifEschelon="%CLUSTER%">phalanx:Phalanx Cluster,stoop:Stoop Cluster,proto:Chausseurs Cluster</option>
 		</flags>
 	</toc>
 	
@@ -103,10 +103,10 @@
 		
 		<subforces ifRating="FL">
 			<subforce num="2">%CLUSTER%</subforce>
-			<subforce unitType="Aero">%CLUSTER%</subforce>
+			<subforce unitType="AeroSpaceFighter">%CLUSTER%</subforce>
 			<subforceOption>
 				<option flags="phalanx">%CLUSTER%</option>
-				<option unitType="Aero">%CLUSTER%</option>
+				<option unitType="AeroSpaceFighter">%CLUSTER%</option>
 				<option flags="stoop">%CLUSTER%</option>
 				<option>%CLUSTER%</option>
 			</subforceOption>
@@ -135,7 +135,7 @@
 	
 	<!-- Wing clusters have four ASF trinaries. -->
 	
-	<force eschelon="%CLUSTER%" eschName="Wing Cluster" ifUnitType="Aero">
+	<force eschelon="%CLUSTER%" eschName="Wing Cluster" ifUnitType="AeroSpaceFighter">
 		<name>Raven Wing</name>
 		<co>%STAR_COL%</co>
 		
@@ -244,27 +244,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -397,21 +397,21 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%STAR%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="M" unitType="Aero">%STAR%</option>
-				<option weightClass="L" unitType="Aero">%STAR%</option>
+				<option weightClass="M" unitType="AeroSpaceFighter">%STAR%</option>
+				<option weightClass="L" unitType="AeroSpaceFighter">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%STAR%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -506,7 +506,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name>Trinary [Fighter] {phonetic:distinct}</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -744,7 +744,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{ordinal} {name:parent}</name>
 		<co>%STAR_CMDR%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/CSV.xml
+++ b/megamek/data/forcegenerator/faction_rules/CSV.xml
@@ -10,8 +10,8 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -373,27 +373,27 @@
 
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -472,7 +472,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name>Trinary {phonetic}</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -845,7 +845,7 @@
 	distinctive. Four of the five ASFs in the star are paired as is standard in
 	ASF deployment, with one generated alone. -->
 	
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter">
 		<name>{ordinal:distinct} {phonetic:parent} Adder</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -866,7 +866,7 @@
 			</formation>
 		</ruleGroup>
 
-		<subforces generate="group" ifUnitType="Aero">
+		<subforces generate="group" ifUnitType="AeroSpaceFighter">
 			<subforceOption ifWeightClass="H">
 				<option weightClass="H" weight="2">%ELEMENT%</option>
 				<option weightClass="M">%ELEMENT%</option>

--- a/megamek/data/forcegenerator/faction_rules/CW.xml
+++ b/megamek/data/forcegenerator/faction_rules/CW.xml
@@ -14,8 +14,8 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>
@@ -360,27 +360,27 @@
 		
 		<subforces>
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="1">%TRINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="2">%TRINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					flags="+testTrinary" weight="3">%TRINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -468,27 +468,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</subforces>
@@ -585,27 +585,27 @@
 			</subforceOption>
 
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="1">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="3">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="2">%STAR%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H" weight="1">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M" weight="2">%STAR%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L" weight="3">%STAR%</option>
 			</subforceOption>
 		</attachedForces>
@@ -706,7 +706,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter">
 		<name ifRole="command">Trinary Command</name>
 		<name>{ordinal:distinct} Trinary [Fighter]</name>
 		<co>%STAR_CAPTAIN%</co>
@@ -875,27 +875,27 @@
 		
 		<subforces generate="group">
 			<subforceOption ifWeightClass="A|H">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="1">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="3">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="2">%ELEMENT%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="H,H" weight="1">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="M,M" weight="2">%ELEMENT%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					weightClass="L,L" weight="3">%ELEMENT%</option>
 			</subforceOption>
 		</subforces>

--- a/megamek/data/forcegenerator/faction_rules/CWIE.xml
+++ b/megamek/data/forcegenerator/faction_rules/CWIE.xml
@@ -15,9 +15,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocat
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3060,3084">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
-			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="3060,3084">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween="2870,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
+			<option ifDateBetween=",2869">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship,Dropship,Jumpship</option>
 		</unitType>
 		
 		<eschelon>

--- a/megamek/data/forcegenerator/faction_rules/DC.xml
+++ b/megamek/data/forcegenerator/faction_rules/DC.xml
@@ -12,9 +12,9 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2468,">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2468,">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -22,7 +22,7 @@
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -69,7 +69,7 @@
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -78,7 +78,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2515">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2468,">
 				<option ifRating="D|F"/>
@@ -436,7 +436,7 @@
 		<co>%SGT%</co>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT_COLONEL%</co>
 		
 		<weightClass>
@@ -446,7 +446,7 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,H,H">%SQUADRON%</option>
 				<option augmented="1"
@@ -454,7 +454,7 @@
 				<option augmented="1"
 					weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,M,M">%SQUADRON%</option>
 				<option augmented="1"
@@ -464,7 +464,7 @@
 				<option augmented="1"
 					weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,L,L">%SQUADRON%</option>
 				<option augmented="1"
@@ -485,7 +485,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Company" ifAugmented="1"
-			ifUnitType="Aero|Conventional Fighter">
+			ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Company</name>
 		<co>%MAJOR%</co>
 		
@@ -496,13 +496,13 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,H" weight="2">%SQUADRON%</option>
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 				<option augmented="0"
@@ -512,7 +512,7 @@
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 				<option augmented="0"
@@ -524,7 +524,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="0"
-			ifUnitType="Aero|Conventional Fighter">
+			ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{formation} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -544,7 +544,7 @@
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -552,7 +552,7 @@
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -562,7 +562,7 @@
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -575,7 +575,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/megamek/data/forcegenerator/faction_rules/FC.xml
+++ b/megamek/data/forcegenerator/faction_rules/FC.xml
@@ -11,8 +11,8 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -21,7 +21,7 @@
 			<option ifUnitType="Tank">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 			<option ifUnitType="Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		

--- a/megamek/data/forcegenerator/faction_rules/FRR.xml
+++ b/megamek/data/forcegenerator/faction_rules/FRR.xml
@@ -16,9 +16,9 @@
     
 	<toc>
 		<unitType>
-			<option ifDateBetween="3076,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="3051,3075">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3076,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="3051,3075">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -29,7 +29,7 @@
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%^,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -64,7 +64,7 @@
     	</subforces>
     	
     	<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -155,7 +155,7 @@
     chosen to follow DC organization. This gives a FRR wing 36 fighters, which puts it
     between DC (54) and standard IS (18). -->
     
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter" ifDateBetween=",3075">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween=",3075">
 		<co>%LT_COLONEL%</co>
 		
 		<weightClass>
@@ -165,7 +165,7 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,H,H">%SQUADRON%</option>
 				<option augmented="1"
@@ -173,7 +173,7 @@
 				<option augmented="1"
 					weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,M,M">%SQUADRON%</option>
 				<option augmented="1"
@@ -183,7 +183,7 @@
 				<option augmented="1"
 					weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="1"
 					weightClass="H,L,L">%SQUADRON%</option>
 				<option augmented="1"
@@ -204,7 +204,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Company" ifAugmented="1"
-	        ifDateBetween=",3075" ifUnitType="Aero|Conventional Fighter">
+	        ifDateBetween=",3075" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -214,13 +214,13 @@
 		</weightClass>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,H" weight="2">%SQUADRON%</option>
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="H,M">%SQUADRON%</option>
 				<option augmented="0"
@@ -230,7 +230,7 @@
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option augmented="0"
 					weightClass="M,L">%SQUADRON%</option>
 				<option augmented="0"
@@ -242,7 +242,7 @@
 	</force>
 	
 	<force eschelon="%SQUADRON%" eschName="Flight" ifAugmented="0"
-	        ifDateBetween=",3075" ifUnitType="Aero|Conventional Fighter">
+	        ifDateBetween=",3075" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 	    <name>{formation} Flight</name>
 		<co>%CAPTAIN%</co>
 		
@@ -262,17 +262,17 @@
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%FLIGHT%</option>
 				<option weightClass="H,M">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M">%FLIGHT%</option>
 				<option weightClass="M,M">%FLIGHT%</option>
 				<option weightClass="H,L">%FLIGHT%</option>
 				<option weightClass="M,L">%FLIGHT%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L">%FLIGHT%</option>
 				<option weightClass="L,L" weight="2">%FLIGHT%</option>
 			</subforceOption>
@@ -281,7 +281,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="Aero|Conventional Fighter" ifDateBetween=",3075">
+	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween=",3075">
 		<name>Lance {cardinal}</name>
 		<co>%LT%</co>
 		
@@ -396,27 +396,27 @@
 			</subforceOption>
 			
 			<subforceOption ifWeightClass="H|A">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="M">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
 			</subforceOption>
 			<subforceOption ifWeightClass="L">
-				<option weightClass="H" unitType="Aero"
+				<option weightClass="H" unitType="AeroSpaceFighter"
 					weight="1">%BINARY%</option>
-				<option weightClass="M" unitType="Aero"
+				<option weightClass="M" unitType="AeroSpaceFighter"
 					weight="2">%BINARY%</option>
-				<option weightClass="L" unitType="Aero"
+				<option weightClass="L" unitType="AeroSpaceFighter"
 					weight="3">%BINARY%</option>
 			</subforceOption>
 		</subforces>
@@ -469,7 +469,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="Aero|Conventional Fighter" ifDateBetween="3076,">
+	<force eschelon="%TRINARY%" eschName="Trinary" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="3076,">
 		<name>Fighter Binary</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -484,7 +484,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="Aero|Conventional Fighter" ifDateBetween="3076,">
+	<force eschelon="%BINARY%" eschName="Binary" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="3076,">
 		<name>Fighter Binary</name>
 		<co>%STAR_CAPTAIN%</co>
 		
@@ -719,7 +719,7 @@
 		</subforces>
 	</force>
 		
-	<force eschelon="%STAR%" eschName="Star" ifUnitType="Aero|Conventional Fighter" ifDateBetween="3076,">
+	<force eschelon="%STAR%" eschName="Star" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="3076,">
 		<name>{phonetic} Fighter Star</name>
 		<co>%STAR_CMDR%</co>
 		
@@ -756,7 +756,7 @@
 			<option weight="2">L</option>
 		</weightClass>
 		
-		<weightClass ifUnitType="Aero">
+		<weightClass ifUnitType="AeroSpaceFighter">
 			<option>H</option>
 			<option>M</option>
 			<option>L</option>
@@ -770,7 +770,7 @@
 			</unitType>
 		</ruleGroup>
 		
-		<subforces generate="group" ifUnitType="Tank|VTOL|Aero|Conventional Fighter">
+		<subforces generate="group" ifUnitType="Tank|VTOL|AeroSpaceFighter|Conventional Fighter">
 			<subforce num="2">%ELEMENT%</subforce>
 		</subforces>
 	</force>

--- a/megamek/data/forcegenerator/faction_rules/FS.CH.xml
+++ b/megamek/data/forcegenerator/faction_rules/FS.CH.xml
@@ -15,7 +15,7 @@ are often combined down to the company level. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,BattleArmor,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -23,7 +23,7 @@ are often combined down to the company level. -->
 			<option ifUnitType="Mek|Tank|VTOL">%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -43,7 +43,7 @@ are often combined down to the company level. -->
 				<option num="2" unitType="Tank" role="artillery" name="Artillery Support">%BATTALION%</option>
 				<option num="3" unitType="Tank" role="artillery" name="Artillery Support">%BATTALION%</option>
 			</subforceOption>
-			<subforce num="2" unitType="Aero">%WING%</subforce>
+			<subforce num="2" unitType="AeroSpaceFighter">%WING%</subforce>
 		</subforces>
 	</force>
 	

--- a/megamek/data/forcegenerator/faction_rules/FS.xml
+++ b/megamek/data/forcegenerator/faction_rules/FS.xml
@@ -15,10 +15,10 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2881,3050">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2459,2880">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2881,3050">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2459,2880">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -30,7 +30,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 			<option ifUnitType="Tank">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 			<option ifUnitType="Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
@@ -59,7 +59,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 			<subforce unitType="Mek" ifFlags="lct">%BATTALION%</subforce>
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero" num="2">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter" num="2">%WING%</subforce>
 		</subforces>
 	</force>
 
@@ -171,7 +171,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</subforces>
 		
 		<attachedForces ifTopLevel="1" ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption>
 				<option unitType="Tank" weight="4"
@@ -184,7 +184,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</attachedForces>		
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2510">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2459,">
 				<option ifRating="D|F"/>
@@ -784,7 +784,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</subforces>
 	</force>
 	
-	<force eschelon="%GROUP%" eschName="Aero Regiment" ifUnitType="Aero">
+	<force eschelon="%GROUP%" eschName="Aero Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -794,18 +794,18 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -813,7 +813,7 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -825,18 +825,18 @@ a regimental combat team. Average unit weight tends to be lighter than other fac
 		<subforces>
 			<subforce role="command">%FLIGHT%</subforce>
 		
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>

--- a/megamek/data/forcegenerator/faction_rules/FWL.xml
+++ b/megamek/data/forcegenerator/faction_rules/FWL.xml
@@ -12,16 +12,16 @@
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2470,3050">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2470,3050">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%GROUP%,%WING%+,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%GROUP%,%WING%+,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -65,7 +65,7 @@
 		</subforces>
 		
 		<attachedForces ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%REGIMENT%</subforce>
@@ -74,7 +74,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2520">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2470,">
 				<option ifRating="D|F"/>
@@ -604,7 +604,7 @@
 		<co>%SGT%</co>
 	</force>
 
-	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="Aero">
+	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -618,7 +618,7 @@
 		</subforces>
 	</force>
 
-	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Lance {cardinal}</name>
 		<co>%LT%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/HL.xml
+++ b/megamek/data/forcegenerator/faction_rules/HL.xml
@@ -25,7 +25,7 @@ would have none so I've attached a wing to each RDF. -->
 	
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -33,7 +33,7 @@ would have none so I've attached a wing to each RDF. -->
 			<option ifUnitType="Mek">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Tank|VTOL">%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%COMPANY%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -54,7 +54,7 @@ would have none so I've attached a wing to each RDF. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 	

--- a/megamek/data/forcegenerator/faction_rules/IS.xml
+++ b/megamek/data/forcegenerator/faction_rules/IS.xml
@@ -11,15 +11,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -64,7 +64,7 @@
 		</subforces>
 		
 		<attachedForces ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -73,7 +73,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2550">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2481,">
 				<option ifRating="D|F"/>
@@ -698,7 +698,7 @@
 		<co>%SGT%</co>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -708,18 +708,18 @@
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -736,7 +736,7 @@
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{formation} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -756,7 +756,7 @@
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -764,7 +764,7 @@
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -774,7 +774,7 @@
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -787,7 +787,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name ifRole="command">Command Flight</name>
 		<name>Flight {cardinal}</name>
 		<co>%LT%</co>

--- a/megamek/data/forcegenerator/faction_rules/LA.AlJ.xml
+++ b/megamek/data/forcegenerator/faction_rules/LA.AlJ.xml
@@ -17,14 +17,14 @@ that all infantry units are BattleArmor. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,BattleArmor,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%REGIMENT%,%BATTALION%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -57,7 +57,7 @@ that all infantry units are BattleArmor. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 	

--- a/megamek/data/forcegenerator/faction_rules/LA.xml
+++ b/megamek/data/forcegenerator/faction_rules/LA.xml
@@ -19,10 +19,10 @@ each Mek regiment. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="3040,3050">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2462,3039">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="3040,3050">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2462,3039">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -32,7 +32,7 @@ each Mek regiment. -->
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 			<option ifUnitType="Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
@@ -55,7 +55,7 @@ each Mek regiment. -->
 			<subforce unitType="Mek">%REGIMENT%</subforce>
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero" num="2">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter" num="2">%WING%</subforce>
 		</subforces>
 	</force>
 
@@ -114,7 +114,7 @@ each Mek regiment. -->
 		</subforces>
 		
 		<attachedForces ifTopLevel="1" ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption>
 				<option unitType="Tank" weight="8"
@@ -129,7 +129,7 @@ each Mek regiment. -->
 		</attachedForces>		
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2510">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2462,">
 				<option ifRating="D|F"/>
@@ -717,7 +717,7 @@ each Mek regiment. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="Aero">
+	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="AeroSpaceFighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -727,18 +727,18 @@ each Mek regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -746,7 +746,7 @@ each Mek regiment. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -756,18 +756,18 @@ each Mek regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>

--- a/megamek/data/forcegenerator/faction_rules/MH.xml
+++ b/megamek/data/forcegenerator/faction_rules/MH.xml
@@ -16,8 +16,8 @@ support wing (cohort). -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -25,7 +25,7 @@ support wing (cohort). -->
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -74,7 +74,7 @@ support wing (cohort). -->
 				<option num="1" flags="+auxiliary" unitType="">%REGIMENT%</option>
 			</subforceOption>
 			<subforceOption>
-				<option weight="2" unitType="Aero">%BATTALION%</option>
+				<option weight="2" unitType="AeroSpaceFighter">%BATTALION%</option>
 				<option/>
 			</subforceOption>
 		</attachedForces>
@@ -157,7 +157,7 @@ support wing (cohort). -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{latin:distinct} Ala</name>
 		<co>%MAJOR%</co>
 		
@@ -168,18 +168,18 @@ support wing (cohort). -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -382,7 +382,7 @@ support wing (cohort). -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Maniple" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Maniple" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{latin} Manipulus</name>
 		<co>%CAPTAIN%</co>
 		
@@ -393,13 +393,13 @@ support wing (cohort). -->
 		</weightClass>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%FLIGHT%
 					</option>
 				<option weightClass="H,M">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M">%FLIGHT%
@@ -409,7 +409,7 @@ support wing (cohort). -->
 				<option weightClass="M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L">%FLIGHT%
 					</option>
 				<option weightClass="L,L" weight="2">%FLIGHT%
@@ -693,7 +693,7 @@ support wing (cohort). -->
 	still fit the requirements of the capital fighter squadron rule in StratOps,
 	allowing the maniple to be split 5/5. -->
 	
-	<force eschelon="%FLIGHT%" eschName="Century" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Century" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{latin:parent} Centuria {roman}</name>
 		<co>%LT%</co>
 		
@@ -712,7 +712,7 @@ support wing (cohort). -->
 			</formation>
 		</ruleGroup>
 
-		<subforces generate="group" ifUnitType="Aero">
+		<subforces generate="group" ifUnitType="AeroSpaceFighter">
 			<subforceOption ifWeightClass="H">
 				<option weightClass="H" weight="2">%ELEMENT%</option>
 				<option weightClass="M">%ELEMENT%</option>

--- a/megamek/data/forcegenerator/faction_rules/MOC.xml
+++ b/megamek/data/forcegenerator/faction_rules/MOC.xml
@@ -21,15 +21,15 @@ expanding to a full wing per regiment by the Dark Age. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option>Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -82,28 +82,28 @@ expanding to a full wing per regiment by the Dark Age. -->
 
 		<attachedForces>
 			<subforceOption ifFaction="MOC.MRG">
-				<option unitType="Aero" ifDateBetween=",3070"
+				<option unitType="AeroSpaceFighter" ifDateBetween=",3070"
 					name="Air Guard">%FLIGHT%</option>
-				<option unitType="Aero" ifDateBetween="3056,3080"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3056,3080"
 					name="Air Guard">%SQUADRON%-</option>
-				<option unitType="Aero" ifDateBetween="3060,3090"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3060,3090"
 					name="Air Guard">%SQUADRON%</option>
-				<option unitType="Aero" ifDateBetween="3065,3110"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3065,3110"
 					name="Air Guard">%WING%-</option>
-				<option unitType="Aero" ifDateBetween="3080,"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3080,"
 					name="Air Guard">%WING%</option>
 			</subforceOption>
 			<subforceOption ifFaction="MOC.CC">
 				<option ifDateBetween=",3070"/>
-				<option unitType="Aero" ifDateBetween="3060,3075"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3060,3075"
 					name="Air Guard">%FLIGHT%</option>
-				<option unitType="Aero" ifDateBetween="3066,3085"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3066,3085"
 					name="Air Guard">%SQUADRON%-</option>
-				<option unitType="Aero" ifDateBetween="3071,3100"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3071,3100"
 					name="Air Guard">%SQUADRON%</option>
-				<option unitType="Aero" ifDateBetween="3076,"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3076,"
 					name="Air Guard">%WING%-</option>
-				<option unitType="Aero" ifDateBetween="3080,"
+				<option unitType="AeroSpaceFighter" ifDateBetween="3080,"
 					name="Air Guard">%WING%</option>
 			</subforceOption>
 			<subforceOption ifFaction="!MOC.MH">
@@ -200,7 +200,7 @@ expanding to a full wing per regiment by the Dark Age. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/megamek/data/forcegenerator/faction_rules/NC.xml
+++ b/megamek/data/forcegenerator/faction_rules/NC.xml
@@ -23,14 +23,14 @@ brigada seems reasonable. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%LANCE%</option>
 			<option ifUnitType="Infantry">%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -46,7 +46,7 @@ brigada seems reasonable. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce num="2" unitType="Aero">%WING%</subforce>
+			<subforce num="2" unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 

--- a/megamek/data/forcegenerator/faction_rules/OA.xml
+++ b/megamek/data/forcegenerator/faction_rules/OA.xml
@@ -30,10 +30,10 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">null,Aero,Mek,Tank,VTOL,Infantry,BattleArmor,Conventional Fighter</option>
-			<option ifDateBetween="2840,3050">null,Aero,Mek,Tank,VTOL,Infantry,Conventional Fighter</option>
-			<option ifDateBetween="2600,2839">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2599">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">null,AeroSpaceFighter,Mek,Tank,VTOL,Infantry,BattleArmor,Conventional Fighter</option>
+			<option ifDateBetween="2840,3050">null,AeroSpaceFighter,Mek,Tank,VTOL,Infantry,Conventional Fighter</option>
+			<option ifDateBetween="2600,2839">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2599">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -44,7 +44,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 			<option ifUnitType="Mek|Tank|VTOL">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -52,7 +52,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</rating>
 	</toc>
 	
-	<force eschelon="%GROUP%" eschName="Wing" ifUnitType="Aero|Conventional Fighter" ifDateBetween="2840,">
+	<force eschelon="%GROUP%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="2840,">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -88,7 +88,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Regiment" ifUnitType="Aero|Conventional Fighter" ifDateBetween="2840,">
+	<force eschelon="%WING%" eschName="Regiment" ifUnitType="AeroSpaceFighter|Conventional Fighter" ifDateBetween="2840,">
 		<name>{ordinal} Regiment</name>
 		<co>%MAJOR%</co>
 		
@@ -99,18 +99,18 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -127,7 +127,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -147,7 +147,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -155,7 +155,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -165,7 +165,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -178,7 +178,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Flight {cardinal}</name>
 		<co>%LT%</co>
 		
@@ -257,7 +257,7 @@ units attached to Mek regiments. 2840+ follows AMC organization. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%GROUP%</subforce>
+			<subforce unitType="AeroSpaceFighter">%GROUP%</subforce>
 		</attachedForces>
 	</force>
 	

--- a/megamek/data/forcegenerator/faction_rules/Periphery.xml
+++ b/megamek/data/forcegenerator/faction_rules/Periphery.xml
@@ -17,16 +17,16 @@ Infantry are poorly trained and equipped. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2500,3050">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2500,3050">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -73,7 +73,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2575">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2500,">
 				<option ifRating="D|F"/>
@@ -122,7 +122,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 
 		<attachedForces ifTopLevel="1">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%SQUADRON%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%REGIMENT%</subforce>
@@ -733,7 +733,7 @@ Infantry are poorly trained and equipped. -->
 		<co>%SGT%</co>
 	</force>
 	
-	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%GROUP%" eschName="Regiment" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -762,7 +762,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -772,18 +772,18 @@ Infantry are poorly trained and equipped. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -800,7 +800,7 @@ Infantry are poorly trained and equipped. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Squadron</name>
 		<co>%CAPTAIN%</co>
 		
@@ -820,7 +820,7 @@ Infantry are poorly trained and equipped. -->
 		</ruleGroup>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%FLIGHT%
 					</option>
 				<option weightClass="H,H,M">%FLIGHT%
@@ -828,7 +828,7 @@ Infantry are poorly trained and equipped. -->
 				<option weightClass="H,H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%FLIGHT%
 					</option>
 				<option weightClass="M,M,M">%FLIGHT%
@@ -838,7 +838,7 @@ Infantry are poorly trained and equipped. -->
 				<option weightClass="M,M,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%FLIGHT%
 					</option>
 				<option weightClass="M,L,L">%FLIGHT%
@@ -851,7 +851,7 @@ Infantry are poorly trained and equipped. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>Flight {cardinal}</name>
 		<co>%LT%</co>
 		

--- a/megamek/data/forcegenerator/faction_rules/RD.xml
+++ b/megamek/data/forcegenerator/faction_rules/RD.xml
@@ -34,7 +34,7 @@
 			<subforce rating="SL"
 				name="Rasalhague Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL"
-			    unitType="Aero"
+			    unitType="AeroSpaceFighter"
 				name="Valkyrie Galaxy">%GALAXY%</subforce>
 			<subforce rating="SL" faction="FRR" weightClass="H"
 				name="Tundra Galaxy">%GALAXY%</subforce>

--- a/megamek/data/forcegenerator/faction_rules/ROS.xml
+++ b/megamek/data/forcegenerator/faction_rules/ROS.xml
@@ -15,14 +15,14 @@
 
 	<toc>
 		<unitType>
-			<option>Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
+			<option>Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -71,13 +71,13 @@
 		<attachedForces ifUnitType="Mek" ifRating="!SB">
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 		
 		<attachedForces ifUnitType="Mek" ifRating="SB">
 			<subforce unitType="Tank">%REGIMENT%</subforce>
 			<subforce unitType="BattleArmor">%BATTALION%</subforce>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 	
@@ -131,7 +131,7 @@
 		<attachedForces>
 			<subforce unitType="Tank">%BRIGADE%</subforce>
 			<subforce unitType="Infantry">%BRIGADE%</subforce>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 </ruleset>

--- a/megamek/data/forcegenerator/faction_rules/RWR.xml
+++ b/megamek/data/forcegenerator/faction_rules/RWR.xml
@@ -32,9 +32,9 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2760,">null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2600,2759">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2474,2599">null,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="2760,">null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2600,2759">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2474,2599">null,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -45,7 +45,7 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 			<option ifUnitType="Mek|Tank|VTOL">%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -156,7 +156,7 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 		</subforces>
 
 		<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Infantry"
 				name="Infantry Support">%REGIMENT%</subforce>			
@@ -211,7 +211,7 @@ nations this ruleset sets IS as the parent rather than Periphery. -->
 		</subforces>
 
 		<attachedForces>
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%REGIMENT%</subforce>

--- a/megamek/data/forcegenerator/faction_rules/SL.xml
+++ b/megamek/data/forcegenerator/faction_rules/SL.xml
@@ -13,7 +13,7 @@ division where most factions organize around a regiment. -->
 	
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter,Warship</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter,Warship</option>
 		</unitType>
 		
 		<eschelon>
@@ -22,7 +22,7 @@ division where most factions organize around a regiment. -->
 			<option ifUnitType="Mek">%DIVISION%,%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%DIVISION%,%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%AIR_REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%AIR_REGIMENT%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -163,7 +163,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%AIR_REGIMENT%</subforce>
+			<subforce unitType="AeroSpaceFighter">%AIR_REGIMENT%</subforce>
 			<subforceOption>
 				<option unitType="Tank" role="artillery" name="Artillery Regiment"
 					weight="2">%REGIMENT%</option>
@@ -425,7 +425,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero" generate="group">%FLIGHT%</subforce>
+			<subforce unitType="AeroSpaceFighter" generate="group">%FLIGHT%</subforce>
 		</attachedForces>		
 	</force>
 	
@@ -775,8 +775,8 @@ division where most factions organize around a regiment. -->
 		</subforces>
 	</force>
 
-	<force eschelon="%AIR_REGIMENT%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
-		<name ifUnitType="Aero">Ground Aero Wing</name>
+	<force eschelon="%AIR_REGIMENT%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
+		<name ifUnitType="AeroSpaceFighter">Ground Aero Wing</name>
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -786,18 +786,18 @@ division where most factions organize around a regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%WING%</option>
 				<option weightClass="H,H,M">%WING%</option>
 				<option weightClass="H,H,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%WING%</option>
 				<option weightClass="M,M,M">%WING%</option>
 				<option weightClass="H,M,L">%WING%</option>
 				<option weightClass="M,M,L">%WING%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%WING%</option>
 				<option weightClass="M,L,L">%WING%</option>
 				<option weightClass="L,L,L">%WING%</option>
@@ -805,14 +805,14 @@ division where most factions organize around a regiment. -->
 			<subforce ifUnitType="Conventional Fighter" num="3">%WING%</subforce>
 		</subforces>
 		
-		<attachedForces ifUnitType="Aero">
+		<attachedForces ifUnitType="AeroSpaceFighter">
 			<subforce unitType="Conventional Fighter">%AIR_REGIMENT%</subforce>
 			<subforce unitType="Infantry" name="Engineers"
 					role="engineer">%BATTALION%</subforce>
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Group" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Group" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%MAJOR%</co>
 		
 		<weightClass>
@@ -822,18 +822,18 @@ division where most factions organize around a regiment. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H,H">%SQUADRON%</option>
 				<option weightClass="H,H,M">%SQUADRON%</option>
 				<option weightClass="H,H,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M,M">%SQUADRON%</option>
 				<option weightClass="M,M,M">%SQUADRON%</option>
 				<option weightClass="H,M,L">%SQUADRON%</option>
 				<option weightClass="M,M,L">%SQUADRON%</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,L,L">%SQUADRON%</option>
 				<option weightClass="M,L,L">%SQUADRON%</option>
 				<option weightClass="L,L,L">%SQUADRON%</option>
@@ -842,7 +842,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Squadron" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%CAPTAIN%</co>
 		
 		<weightClass>
@@ -865,7 +865,7 @@ division where most factions organize around a regiment. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/megamek/data/forcegenerator/faction_rules/SOC.xml
+++ b/megamek/data/forcegenerator/faction_rules/SOC.xml
@@ -10,7 +10,7 @@
 	
 	<toc>
 		<unitType>
-			<option>Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
+			<option>Mek,ProtoMek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -84,7 +84,7 @@
 		</weightClass>
 
 		<ruleGroup>
-			<formation ifIndex="0" ifUnitType="!Aero|Conventional Fighter">
+			<formation ifIndex="0" ifUnitType="!AeroSpaceFighter|Conventional Fighter">
 				<option weight="30">Battle</option>
 				<option weight="12" ifWeightClass="H|A">Heavy Battle</option>
 				<option weight="8" ifWeightClass="M">Medium Battle</option>
@@ -97,7 +97,7 @@
 				<option weight="1" role="+urban">Urban</option>
 			</formation>
 
-			<formation ifIndex="!0" ifUnitType="!Aero|Conventional Fighter">
+			<formation ifIndex="!0" ifUnitType="!AeroSpaceFighter|Conventional Fighter">
 				<option weight="20">Fire</option>
 				<option weight="3">Fire Support</option>
 				<option weight="2">Direct Fire</option>
@@ -211,7 +211,7 @@
 		</subforces>
 	</force>
 	
-	<force eschelon="%POINT%" eschName="Un" ifUnitType="Infantry|ProtoMek|Aero|Conventional Fighter">
+	<force eschelon="%POINT%" eschName="Un" ifUnitType="Infantry|ProtoMek|AeroSpaceFighter|Conventional Fighter">
 		<co>%POINT_CMDR%</co>
 		
 		<weightClass>

--- a/megamek/data/forcegenerator/faction_rules/TC.xml
+++ b/megamek/data/forcegenerator/faction_rules/TC.xml
@@ -16,9 +16,9 @@ types of support units attached to Mek regiments can vary widely. -->
 
 	<toc>
 		<unitType>
-			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,Aero,Conventional Fighter</option>
-			<option ifDateBetween="2481,3050">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option ifDateBetween=",2480">Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="3051,">Mek,Tank,VTOL,Infantry,BattleArmor,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween="2481,3050">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option ifDateBetween=",2480">Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
@@ -26,7 +26,7 @@ types of support units attached to Mek regiments can vary widely. -->
 			<option ifUnitType="Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%,%POINT%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%GROUP%,%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -49,11 +49,11 @@ types of support units attached to Mek regiments can vary widely. -->
 
 		<attachedForces>
 			<subforceOption>
-				<option unitType="Aero" weight="7"
+				<option unitType="AeroSpaceFighter" weight="7"
 					name="Aerospace Support">%WING%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%SQUADRON%</option>
-				<option unitType="Aero"
+				<option unitType="AeroSpaceFighter"
 					name="Aerospace Support">%GROUP%</option>
 				<option weight="3"/>
 			</subforceOption>
@@ -262,7 +262,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</subforces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2550">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2481,">
 				<option ifRating="D|F"/>
@@ -305,7 +305,7 @@ types of support units attached to Mek regiments can vary widely. -->
 	of bringing in trainers from the Outworlds Alliance, Taurian air forces are largely
 	heavy fighters in order to protect the investment in the pilot. -->
 	
-	<force eschelon="%GROUP%" eschName="Air Division" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%GROUP%" eschName="Air Division" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%COLONEL%</co>
 		
 		<weightClass>
@@ -348,7 +348,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%WING%" eschName="Wing" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%WING%" eschName="Wing" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{ordinal} Wing</name>
 		<co>%MAJOR%</co>
 		
@@ -359,13 +359,13 @@ types of support units attached to Mek regiments can vary widely. -->
 		</weightClass>
 		
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%SQUADRON%
 					</option>
 				<option weightClass="H,M">%SQUADRON%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M" weight="3">%SQUADRON%
 					</option>
 				<option weightClass="M,M" weight="2">%SQUADRON%
@@ -373,7 +373,7 @@ types of support units attached to Mek regiments can vary widely. -->
 				<option weightClass="H,L">%SQUADRON%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L" weight="2">%SQUADRON%
 					</option>
 				<option weightClass="L,L">%SQUADRON%
@@ -392,7 +392,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</attachedForces>
 	</force>
 	
-	<force eschelon="%SQUADRON%" eschName="Flight" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%SQUADRON%" eschName="Flight" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<name>{phonetic} Company</name>
 		<co>%CAPTAIN%</co>
 		
@@ -403,13 +403,13 @@ types of support units attached to Mek regiments can vary widely. -->
 		</weightClass>
 
 		<subforces>
-			<subforceOption ifWeightClass="H" ifUnitType="Aero">
+			<subforceOption ifWeightClass="H" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,H" weight="2">%FLIGHT%
 					</option>
 				<option weightClass="H,M">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="M" ifUnitType="Aero">
+			<subforceOption ifWeightClass="M" ifUnitType="AeroSpaceFighter">
 				<option weightClass="H,M" weight="3">%FLIGHT%
 					</option>
 				<option weightClass="M,M" weight="2">%FLIGHT%
@@ -417,7 +417,7 @@ types of support units attached to Mek regiments can vary widely. -->
 				<option weightClass="H,L">%FLIGHT%
 					</option>
 			</subforceOption>
-			<subforceOption ifWeightClass="L" ifUnitType="Aero">
+			<subforceOption ifWeightClass="L" ifUnitType="AeroSpaceFighter">
 				<option weightClass="M,L" weight="2">%FLIGHT%
 					</option>
 				<option weightClass="L,L">%FLIGHT%
@@ -428,7 +428,7 @@ types of support units attached to Mek regiments can vary widely. -->
 		</subforces>
 	</force>
 	
-	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="Aero|Conventional Fighter">
+	<force eschelon="%FLIGHT%" eschName="Air Lance" ifUnitType="AeroSpaceFighter|Conventional Fighter">
 		<co>%LT%</co>
 		
 		<weightClass>

--- a/megamek/data/forcegenerator/faction_rules/TH.xml
+++ b/megamek/data/forcegenerator/faction_rules/TH.xml
@@ -12,15 +12,15 @@
 	
 	<toc>
 		<unitType>
-			<option ifDateBetween="2442,">Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
-			<option>Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option ifDateBetween="2442,">Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
+			<option>Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="Mek|Tank|VTOL">%REGIMENT%,%BATTALION%,%COMPANY%,%LANCE%</option>
 			<option ifUnitType="Infantry">%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="BattleArmor">%BATTALION%,%COMPANY%,%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -65,7 +65,7 @@
 		</subforces>
 		
 		<attachedForces ifUnitType="Mek">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforce unitType="Tank"
 				name="Armor Support">%BATTALION%</subforce>
@@ -74,7 +74,7 @@
 		</attachedForces>
 
 		<attachedForces ifUnitType="Tank" ifDateBetween=",2500">
-			<subforce unitType="Aero"
+			<subforce unitType="AeroSpaceFighter"
 				name="Aerospace Support">%WING%</subforce>
 			<subforceOption ifDateBetween="2442,">
 				<option ifRating="D|F"/>

--- a/megamek/data/forcegenerator/faction_rules/UC.xml
+++ b/megamek/data/forcegenerator/faction_rules/UC.xml
@@ -23,14 +23,14 @@ but a wing per corps seemed reasonable. -->
 
 	<toc>
 		<unitType>
-			<option>null,Mek,Tank,VTOL,Infantry,Aero,Conventional Fighter</option>
+			<option>null,Mek,Tank,VTOL,Infantry,AeroSpaceFighter,Conventional Fighter</option>
 		</unitType>
 		
 		<eschelon>
 			<option ifUnitType="">%BRIGADE%,%REGIMENT%,%BATTALION%,%COMPANY%</option>
 			<option ifUnitType="Mek|Tank|VTOL">%LANCE%</option>
 			<option ifUnitType="Infantry">%PLATOON%</option>
-			<option ifUnitType="Aero|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
+			<option ifUnitType="AeroSpaceFighter|Conventional Fighter">%WING%,%SQUADRON%,%FLIGHT%</option>
 		</eschelon>
 		
 		<rating>
@@ -49,7 +49,7 @@ but a wing per corps seemed reasonable. -->
 		</subforces>
 		
 		<attachedForces>
-			<subforce unitType="Aero">%WING%</subforce>
+			<subforce unitType="AeroSpaceFighter">%WING%</subforce>
 		</attachedForces>
 	</force>
 

--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -358,7 +358,7 @@ public class FactionRecord {
 
     /**
      * Sets the target percentage for a tech category.
-     * 
+     *
      * @param category The category (omni, clan, SL/upgraded)
      * @param era      The year for which to set the tech percentage
      * @param str      A comma-separated list of percentages from the highest unit rating to the lowest.
@@ -603,7 +603,7 @@ public class FactionRecord {
 
         if ((parentFactions != null) && !parentFactions.isEmpty()) {
             pw.println("\t\t<parentFaction>" + StringEscapeUtils.escapeXml10(String.join(",", parentFactions)) + "</parentFaction>");
-        }       
+        }
         pw.println("\t</faction>");
     }
 
@@ -613,7 +613,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.OMNI).containsKey(era)
                 && !pctTech.get(TechCategory.OMNI).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctOmni>%s</pctOmni>\n", 
+                    String.format("\t\t<pctOmni>%s</pctOmni>\n",
                             pctTech.get(TechCategory.OMNI).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -622,7 +622,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.CLAN).containsKey(era)
                 && !pctTech.get(TechCategory.CLAN).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctClan>%s</pctClan>\n", 
+                    String.format("\t\t<pctClan>%s</pctClan>\n",
                             pctTech.get(TechCategory.CLAN).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -631,7 +631,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.IS_ADVANCED).containsKey(era)
                 && !pctTech.get(TechCategory.IS_ADVANCED).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctSL>%s</pctSL>\n", 
+                    String.format("\t\t<pctSL>%s</pctSL>\n",
                             pctTech.get(TechCategory.IS_ADVANCED).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -640,7 +640,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.OMNI_AERO).containsKey(era)
                 && !pctTech.get(TechCategory.OMNI_AERO).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctOmni unitType='Aero'>%s</pctOmni>\n", 
+                    String.format("\t\t<pctOmni unitType='Aero'>%s</pctOmni>\n",
                             pctTech.get(TechCategory.OMNI_AERO).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -649,7 +649,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.CLAN_AERO).containsKey(era)
                 && !pctTech.get(TechCategory.CLAN_AERO).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctClan unitType='Aero'>%s</pctClan>\n", 
+                    String.format("\t\t<pctClan unitType='Aero'>%s</pctClan>\n",
                             pctTech.get(TechCategory.CLAN_AERO).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -658,7 +658,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.IS_ADVANCED_AERO).containsKey(era)
                 && !pctTech.get(TechCategory.IS_ADVANCED_AERO).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctSL unitType='Aero'>%s</pctSL>\n", 
+                    String.format("\t\t<pctSL unitType='Aero'>%s</pctSL>\n",
                             pctTech.get(TechCategory.IS_ADVANCED_AERO).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -666,7 +666,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.CLAN_VEE).containsKey(era)
                 && !pctTech.get(TechCategory.CLAN_VEE).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctClan unitType='Vehicle'>%s</pctClan>\n", 
+                    String.format("\t\t<pctClan unitType='Vehicle'>%s</pctClan>\n",
                             pctTech.get(TechCategory.CLAN_VEE).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -675,7 +675,7 @@ public class FactionRecord {
                 && pctTech.get(TechCategory.IS_ADVANCED_VEE).containsKey(era)
                 && !pctTech.get(TechCategory.IS_ADVANCED_VEE).get(era).isEmpty()) {
             factionRecordBuilder.append(
-                    String.format("\t\t<pctSL unitType='Vehicle'>%s</pctSL>\n", 
+                    String.format("\t\t<pctSL unitType='Vehicle'>%s</pctSL>\n",
                             pctTech.get(TechCategory.IS_ADVANCED_VEE).get(era).stream().map(Object::toString)
                                 .collect(Collectors.joining(","))));
         }
@@ -713,7 +713,7 @@ public class FactionRecord {
             factionRecordBuilder.append("\t\t<salvage pct='").append(pct).append("'>")
                 .append(sj).append("</salvage>\n");
         }
-        final int[] unitWeightKeys = { UnitType.MEK, UnitType.TANK, UnitType.AERO };
+        final int[] unitWeightKeys = { UnitType.MEK, UnitType.TANK, UnitType.AEROSPACEFIGHTER };
         if (weightDistribution.containsKey(era)) {
             for (int unitType : unitWeightKeys) {
                 if (weightDistribution.get(era).containsKey(unitType)
@@ -728,7 +728,7 @@ public class FactionRecord {
                 }
             }
         }
-        
+
         if (factionRecordBuilder.length() > 0) {
             pw.println("\t<faction key='" + key + "'>");
             pw.println(factionRecordBuilder.toString().replaceFirst("\\n$", ""));
@@ -739,7 +739,7 @@ public class FactionRecord {
     }
 
     /**
-     * Checks whether the faction is active at any point from the given year to the next reference 
+     * Checks whether the faction is active at any point from the given year to the next reference
      * @param era The era start year
      * @return    Whether the faction is active
      * @see #isActiveInYear(int)
@@ -762,7 +762,7 @@ public class FactionRecord {
         }
         return false;
     }
-    
+
     /**
      * @return CSV of all names of the faction, with the original name given first followed by name
      *         changes in the format year:name
@@ -789,10 +789,10 @@ public class FactionRecord {
         }
         return sb.toString();
     }
-    
+
     /**
      * Formats the weight distribution for a given unit type in an era as a String.
-     * 
+     *
      * @param era        The game year
      * @param unitType   The type of unit
      * @return           A formatted String

--- a/megamek/src/megamek/client/ratgenerator/FormationType.java
+++ b/megamek/src/megamek/client/ratgenerator/FormationType.java
@@ -22,7 +22,7 @@ import static megamek.common.UnitRole.*;
 
 /**
  * Campaign Operations rules for force generation.
- * 
+ *
  * @author Neoancient
  */
 public class FormationType {
@@ -33,9 +33,9 @@ public class FormationType {
     public static final int FLAG_PROTOMEK = 1 << UnitType.PROTOMEK;
     public static final int FLAG_VTOL = 1 << UnitType.VTOL;
     public static final int FLAG_NAVAL = 1 << UnitType.NAVAL;
-    
+
     public static final int FLAG_CONV_FIGHTER = 1 << UnitType.CONV_FIGHTER;
-    public static final int FLAG_AERO = 1 << UnitType.AERO;
+    public static final int FLAG_AERO = 1 << UnitType.AEROSPACEFIGHTER;
     public static final int FLAG_SMALL_CRAFT = 1 << UnitType.SMALL_CRAFT;
     public static final int FLAG_DROPSHIP = 1 << UnitType.DROPSHIP;
 
@@ -48,7 +48,7 @@ public class FormationType {
             | FLAG_DROPSHIP;
     public static final int FLAG_VEHICLE = FLAG_TANK | FLAG_NAVAL | FLAG_VTOL;
     public static final int FLAG_ALL = FLAG_GROUND | FLAG_AIR;
-    
+
     private static HashMap<String, FormationType> allFormationTypes = null;
     public static FormationType getFormationType(String key) {
         if (allFormationTypes == null) {
@@ -56,32 +56,32 @@ public class FormationType {
         }
         return allFormationTypes.get(key);
     }
-    
+
     public static Collection<FormationType> getAllFormations() {
         if (allFormationTypes == null) {
             createFormationTypes();
         }
         return allFormationTypes.values();
     }
-    
+
     protected FormationType(String name) {
         this(name, name);
     }
-    
+
     protected FormationType(String name, String category) {
         this.name = name;
         this.category = category;
     }
-    
+
     private String name = "Support";
     private String category = null;
     private int allowedUnitTypes = FLAG_GROUND;
-    // Some formation types allow units not normally generated for general combat roles (e.g. artillery, cargo)  
+    // Some formation types allow units not normally generated for general combat roles (e.g. artillery, cargo)
     private EnumSet<MissionRole> missionRoles = EnumSet.noneOf(MissionRole.class);
     // If all units in the force have this role, other constraints can be ignored.
     private UnitRole idealRole = UnitRole.UNDETERMINED;
     private String exclusiveFaction = null;
-    
+
     private int minWeightClass = 0;
     private int maxWeightClass = EntityWeightClass.WEIGHT_COLOSSAL;
     // Used as a filter when generating units
@@ -89,39 +89,39 @@ public class FormationType {
     // Additional criteria that have to be fulfilled by a portion of the force
     private List<Constraint> otherCriteria = new ArrayList<>();
     private GroupingConstraint groupingCriteria = null;
-    
+
     // Provide values for the various criteria for reporting purposes
     private String mainDescription = null;
     private Map<String, Function<MechSummary,?>> reportMetrics = new HashMap<>();
-    
+
     public String getName() {
         return name;
     }
-    
+
     public String getCategory() {
         return category;
     }
-    
+
     public int getAllowedUnitTypes() {
         return allowedUnitTypes;
     }
-    
+
     public boolean isAllowedUnitType(int ut) {
         return (allowedUnitTypes & (1 << ut)) != 0;
     }
-    
+
     public boolean isGround() {
         return (allowedUnitTypes & FLAG_AERO) == 0;
     }
-    
+
     public UnitRole getIdealRole() {
         return idealRole;
     }
-    
+
     public String getExclusiveFaction() {
         return exclusiveFaction;
     }
-    
+
     public String getNameWithFaction() {
         return exclusiveFaction == null? name : name + " (" + exclusiveFaction + ")";
     }
@@ -133,52 +133,52 @@ public class FormationType {
     public int getMaxWeightClass() {
         return maxWeightClass;
     }
-    
+
     public Set<MissionRole> getMissionRoles() {
         return missionRoles;
     }
-    
+
     public Predicate<MechSummary> getMainCriteria() {
         return mainCriteria;
     }
-    
+
     public String getMainDescription() {
         return mainDescription;
     }
-    
+
     public Iterator<Constraint> getOtherCriteria() {
         return otherCriteria.iterator();
     }
-    
+
     public int getOtherCriteriaCount() {
         return otherCriteria.size();
     }
-    
+
     public Constraint getConstraint(int index) {
         return otherCriteria.get(index);
     }
-    
+
     public GroupingConstraint getGroupingCriteria() {
         return groupingCriteria;
     }
-    
+
     public int getReportMetricsSize() {
         return reportMetrics.size();
     }
-    
+
     public Iterator<String> getReportMetricKeys() {
         return reportMetrics.keySet().iterator();
     }
-    
+
     public Function<MechSummary,?> getReportMetric(String key) {
         return reportMetrics.get(key);
     }
-    
+
     private static Set<MissionRole> getMissionRoles(MechSummary ms) {
         ModelRecord mRec = RATGenerator.getInstance().getModelRecord(ms.getName());
         return mRec == null? EnumSet.noneOf(MissionRole.class) : mRec.getRoles();
     }
-    
+
     private static IntSummaryStatistics damageAtRangeStats(MechSummary ms, int range) {
         List<Integer> retVal = new ArrayList<>();
         for (int i = 0; i < ms.getEquipmentNames().size(); i++) {
@@ -211,20 +211,20 @@ public class FormationType {
         }
         return retVal.stream().mapToInt(Integer::intValue).summaryStatistics();
     }
-    
+
     private static long getDamageAtRange(MechSummary ms, int range) {
         return Math.max(0, damageAtRangeStats(ms, range).getSum());
     }
-    
+
     private static long getSingleWeaponDamageAtRange(MechSummary ms, int range) {
         return Math.max(0, damageAtRangeStats(ms, range).getMax());
     }
-    
+
     private static int getNetworkMask(MechSummary ms) {
         ModelRecord mRec = RATGenerator.getInstance().getModelRecord(ms.getName());
         return mRec == null? ModelRecord.NETWORK_NONE : mRec.getNetworkMask();
     }
-    
+
     public List<MechSummary> generateFormation(UnitTable.Parameters params, int numUnits,
             int networkMask, boolean bestEffort) {
         List<UnitTable.Parameters> p = new ArrayList<>();
@@ -233,12 +233,12 @@ public class FormationType {
         n.add(numUnits);
         return generateFormation(p, n, networkMask, bestEffort, -1, -1);
     }
-    
+
     public List<MechSummary> generateFormation(List<UnitTable.Parameters> params, List<Integer> numUnits,
             int networkMask, boolean bestEffort) {
         return generateFormation(params, numUnits, networkMask, bestEffort, -1, -1);
     }
-    
+
     public List<MechSummary> generateFormation(List<UnitTable.Parameters> params, List<Integer> numUnits,
             int networkMask, boolean bestEffort, int groupSize, int nGroups) {
         if (params.size() != numUnits.size() || params.isEmpty()) {
@@ -258,23 +258,23 @@ public class FormationType {
                 useGrouping.groupSize = 0;
             }
         }
-        
+
         List<Integer> wcs = IntStream.rangeClosed(minWeightClass,
                 Math.min(maxWeightClass, EntityWeightClass.WEIGHT_SUPER_HEAVY))
                 .boxed()
                 .collect(Collectors.toList());
         List<Integer> airWcs = wcs.stream().filter(wc -> wc < EntityWeightClass.WEIGHT_ASSAULT)
-                .collect(Collectors.toList()); 
+                .collect(Collectors.toList());
         params.forEach(p -> {
             p.getRoles().addAll(missionRoles);
             p.setWeightClasses(p.getUnitType() < UnitType.CONV_FIGHTER ? wcs : airWcs);
         });
         List<UnitTable> tables = params.stream().map(UnitTable::findTable).collect(Collectors.toList());
-        //If there are any parameter sets that cannot generate a table, return an empty list. 
+        //If there are any parameter sets that cannot generate a table, return an empty list.
         if (!tables.stream().allMatch(UnitTable::hasUnits) && !bestEffort) {
             return new ArrayList<>();
         }
-        
+
         /* Check whether we have vees or infantry that do not have the movement mode(s) set. If so,
          * we will attempt to conform them to a single type. Any that are set are ignored;
          * there is no attempt to conform to mode already in the force. If they are intended
@@ -314,7 +314,7 @@ public class FormationType {
                 }
             }
         }
-        
+
         /* Order modes in a way that those modes that are better represented are more likely to
          * be attempted first.
          */
@@ -375,7 +375,7 @@ public class FormationType {
             }
         }
         /* If we cannot meet all criteria with a specific motive type, try without respect to motive type */
-        
+
         int cUnits = numUnits.stream().mapToInt(Integer::intValue).sum();
 
         /* Simple case: all units have the same requirements. */
@@ -394,7 +394,7 @@ public class FormationType {
             }
             return retVal;
         }
-        
+
         /* Simple case: single set of parameters and single additional criterion. */
         if (params.size() == 1 && otherCriteria.size() == 1 && useGrouping == null
                 && networkMask == ModelRecord.NETWORK_NONE) {
@@ -415,7 +415,7 @@ public class FormationType {
             }
             return retVal;
         }
-        
+
         /* If a network is indicated, we decide which units are part of the network (usually
          * all, but not necessarily) and which combination to use, then assign one of them
          * to the master role if any. A company command lance has two configuration options:
@@ -427,7 +427,7 @@ public class FormationType {
         int masterType = ModelRecord.NETWORK_NONE;
         int slaveType = ModelRecord.NETWORK_NONE;
         int validNetworkUnits = FLAG_MEK | FLAG_VEHICLE | FLAG_BATTLE_ARMOR;
-        
+
         if ((networkMask & ModelRecord.NETWORK_C3_MASTER) != 0) {
             numNetworked = 4;
             numMasters = 1;
@@ -479,7 +479,7 @@ public class FormationType {
          * bit, beginning with the lowest order bit at index 0. As with networks, only one
          * bit in this section can be set.
          */
-        
+
         do {
             List<Map<Integer,Integer>> combinations;
             /* We can get here with an empty otherCriteria if there is a groupingConstraint,
@@ -695,12 +695,12 @@ public class FormationType {
                 combinations.remove(index);
             }
             numNetworked--;
-        } while (numNetworked >= 0);        
+        } while (numNetworked >= 0);
 
         List<MechSummary> onRole = tryIdealRole(params, numUnits);
         return (onRole == null) ? new ArrayList<>() : onRole;
     }
-    
+
     private Predicate<MechSummary> getFilterFromIndex(int index, int slaveType, int masterType) {
         Predicate<MechSummary> retVal = mainCriteria;
         int mask = 1 << (otherCriteria.size() - 1);
@@ -725,7 +725,7 @@ public class FormationType {
         }
         return retVal;
     }
-    
+
     /**
      * Attempts to build unit entirely on ideal role. Returns null if unsuccessful.
      */
@@ -837,15 +837,15 @@ public class FormationType {
             }
         }
         return frequencies;
-    }    
-    
+    }
+
     /**
      * Finds all possible ways to distribute criteria beyond the general formation criteria in
      * which the groups are mutually exclusive; that is, a unit can only qualify for one
      * of the criteria in the set. This is used for mixed unit types and C3 networks. While a single
      * unit could fulfill the requirements for speed and weight class, it could not function
      * as both a C3 slave and a C3 master or be both a Mek and a Tank.
-     *  
+     *
      * @param combination The current criteria distribution as generated by <code>findCombinations</code>
      * @param itemsPerGroup Array with length equal to number of groups and each value indicates
      * the number of units in that group.
@@ -939,11 +939,11 @@ public class FormationType {
         }
         return retVal;
     }
-    
+
     /**
      * Special case version of <code>findGroups</code> for matched units (such as paired ASFs).
      * Because each group has identical criteria the number of possible results can be reduced.
-     *  
+     *
      * @param combination The current criteria distribution as generated by <code>findCombinations</code>
      * @return A list of possible groupings. Each entry is a list of size() equal to numGroups.
      * The entry for each group is a map of the same format as <code>combination</code>.
@@ -1053,7 +1053,7 @@ public class FormationType {
 
         return retVal;
     }
-    
+
     /**
      * Tests whether a list of units qualifies for the formation type. Note that unit roles are
      * not available for all units.
@@ -1122,7 +1122,7 @@ public class FormationType {
         }
         return true;
     }
-    
+
     /**
      * Tests whether a list of units qualifies for the formation type. Note that unit roles are
      * not available for all units.
@@ -1338,13 +1338,13 @@ public class FormationType {
         createStrikeSquadron();
         createTransportSquadron();
     }
-    
+
     private static void createAntiMekLance() {
         FormationType ft = new FormationType("Anti-Mek");
         ft.allowedUnitTypes = FLAG_INFANTRY | FLAG_BATTLE_ARMOR;
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createAssaultLance() {
         FormationType ft = new FormationType("Assault");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1368,7 +1368,7 @@ public class FormationType {
         ft.reportMetrics.put("Damage @ 7", ms -> getDamageAtRange(ms, 7));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createAnvilLance() {
         FormationType ft = new FormationType("Anvil", "Assault");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1387,7 +1387,7 @@ public class FormationType {
         ft.reportMetrics.put("AC/SRM/LRM", ms -> ft.otherCriteria.get(0).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createFastAssaultLance() {
         FormationType ft = new FormationType("Fast Assault", "Assault");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1409,7 +1409,7 @@ public class FormationType {
         ft.reportMetrics.put("Damage @ 7", ms -> getDamageAtRange(ms, 7));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createHunterLance() {
         FormationType ft = new FormationType("Hunter", "Assault");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1419,7 +1419,7 @@ public class FormationType {
                 "Juggernaut or Ambusher"));
         allFormationTypes.put(ft.name, ft);
     }
-        
+
     private static void createBattleLance() {
         FormationType ft = new FormationType("Battle");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1452,7 +1452,7 @@ public class FormationType {
                 FormationType::checkUnitMatch, "Same model, Light");
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createMediumBattleLance() {
         FormationType ft = new FormationType("Medium Battle", "Battle");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1465,7 +1465,7 @@ public class FormationType {
                 FormationType::checkUnitMatch, "Same model, Medium");
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createHeavyBattleLance() {
         FormationType ft = new FormationType("Heavy Battle", "Battle");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1478,7 +1478,7 @@ public class FormationType {
                 FormationType::checkUnitMatch, "Same model, Heavy+");
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createRifleLance() {
         FormationType ft = new FormationType("Rifle", "Battle");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1498,7 +1498,7 @@ public class FormationType {
         ft.reportMetrics.put("AC", ms -> ft.otherCriteria.get(1).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createBerserkerLance() {
         FormationType ft = new FormationType("Berserker/Close", "Battle");
         ft.allowedUnitTypes = FLAG_MEK | FLAG_PROTOMEK;
@@ -1511,7 +1511,7 @@ public class FormationType {
                 "Brawler, Sniper, Skirmisher"));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createCommandLance() {
         FormationType ft = new FormationType("Command", "Command");
         ft.allowedUnitTypes = FLAG_MEK | FLAG_PROTOMEK;
@@ -1523,7 +1523,7 @@ public class FormationType {
                 "Brawler, Striker, Scout"));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createOrderLance() {
         FormationType ft = new FormationType("Order", "Command");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1532,7 +1532,7 @@ public class FormationType {
                 ms -> true, FormationType::checkUnitMatch, "Same model");
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createVehicleCommandLance() {
         FormationType ft = new FormationType("Vehicle Command", "Command");
         ft.allowedUnitTypes = FLAG_TANK | FLAG_VTOL | FLAG_NAVAL;
@@ -1548,7 +1548,7 @@ public class FormationType {
                 "Same model");
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createFireLance() {
         FormationType ft = new FormationType("Fire");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1558,7 +1558,7 @@ public class FormationType {
                 "Sniper, Missile Boat"));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createAntiAirLance() {
         FormationType ft = new FormationType("Anti-Air", "Fire");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1568,7 +1568,7 @@ public class FormationType {
                 "Sniper, Missile Boat"));
         ft.otherCriteria.add(new CountConstraint(2,
                 // should indicate it has anti-aircraft targeting quirk without having to load all entities
-                ms -> getMissionRoles(ms).contains(MissionRole.ANTI_AIRCRAFT) 
+                ms -> getMissionRoles(ms).contains(MissionRole.ANTI_AIRCRAFT)
                 || ms.getEquipmentNames().stream().map(EquipmentType::get)
                     .anyMatch(eq -> eq instanceof ACWeapon
                             || eq instanceof LBXACWeapon
@@ -1577,7 +1577,7 @@ public class FormationType {
         ft.reportMetrics.put("AC/LBX/Artillery/AA Quirk", ms -> ft.otherCriteria.get(1).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createArtilleryFireLance() {
         FormationType ft = new FormationType("Artillery Fire", "Fire");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1589,7 +1589,7 @@ public class FormationType {
         ft.reportMetrics.put("Artillery", ms -> ft.otherCriteria.get(0).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createDirectFireLance() {
         FormationType ft = new FormationType("Direct Fire", "Fire");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
@@ -1601,7 +1601,7 @@ public class FormationType {
         ft.reportMetrics.put("Damage @ 18", ms -> getDamageAtRange(ms, 18));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createFireSupportLance() {
         FormationType ft = new FormationType("Fire Support", "Fire");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1612,14 +1612,14 @@ public class FormationType {
         ft.reportMetrics.put("Indirect", ms -> ft.otherCriteria.get(0).criterion.test(ms));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createLightFireLance() {
         FormationType ft = new FormationType("Light Fire", "Fire");
         ft.allowedUnitTypes = FLAG_GROUND;
         ft.maxWeightClass = EntityWeightClass.WEIGHT_MEDIUM;
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createPursuitLance() {
         FormationType ft = new FormationType("Pursuit");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1631,7 +1631,7 @@ public class FormationType {
                 ms -> getSingleWeaponDamageAtRange(ms, 15) >= 5,
                 "Weapon with damage 5+ at range 15"));
         ft.reportMetrics.put("Damage @ 15", ms -> getSingleWeaponDamageAtRange(ms, 15));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createProbeLance() {
@@ -1644,7 +1644,7 @@ public class FormationType {
                 ms -> ms.getWalkMp() >= 6,
                 "Walk/Cruise 6+"));
         ft.reportMetrics.put("Damage @ 9", ms -> getDamageAtRange(ms, 9));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createSweepLance() {
@@ -1657,12 +1657,12 @@ public class FormationType {
         ft.reportMetrics.put("Damage @ 6", ms -> getDamageAtRange(ms, 6));
         allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createReconLance() {
         FormationType ft = new FormationType("Recon");
         ft.allowedUnitTypes = FLAG_GROUND;
         ft.idealRole = UnitRole.SCOUT;
-        ft.mainCriteria = ms -> ms.getWalkMp() >= 5;        
+        ft.mainCriteria = ms -> ms.getWalkMp() >= 5;
         ft.mainDescription = "Walk/Cruise 5+";
         ft.otherCriteria.add(new CountConstraint(2,
                 ms -> ms.getRole().isAnyOf(SCOUT, STRIKER),
@@ -1673,7 +1673,7 @@ public class FormationType {
     private static void createHeavyReconLance() {
         FormationType ft = new FormationType("Heavy Recon", "Recon");
         ft.allowedUnitTypes = FLAG_GROUND_NO_LIGHT;
-        ft.mainCriteria = ms -> ms.getWalkMp() >= 4;        
+        ft.mainCriteria = ms -> ms.getWalkMp() >= 4;
         ft.mainDescription = "Walk/Cruise 4+";
         ft.otherCriteria.add(new CountConstraint(2,
                 ms -> ms.getWalkMp() >= 5,
@@ -1684,7 +1684,7 @@ public class FormationType {
         ft.otherCriteria.add(new CountConstraint(1,
                 ms -> ms.getWeightClass() >= EntityWeightClass.WEIGHT_HEAVY,
                 "Heavy+"));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createLightReconLance() {
@@ -1693,9 +1693,9 @@ public class FormationType {
         ft.maxWeightClass = EntityWeightClass.WEIGHT_LIGHT;
         ft.mainCriteria = ms -> ms.getWalkMp() >= 6 && ms.getRole() == SCOUT;
         ft.mainDescription = "Walk/Cruise 6+, Scout";
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createSecurityLance() {
         FormationType ft = new FormationType("Security");
         ft.allowedUnitTypes = FLAG_GROUND;
@@ -1708,7 +1708,7 @@ public class FormationType {
         ft.otherCriteria.add(new MaxCountConstraint(1,
                 ms -> ms.getWeightClass() >= EntityWeightClass.WEIGHT_ASSAULT,
                 "Not assault"));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createStrikerCavalryLance() {
@@ -1721,7 +1721,7 @@ public class FormationType {
         ft.otherCriteria.add(new PercentConstraint(0.5,
                 ms -> ms.getRole().isAnyOf(STRIKER, SKIRMISHER),
                 "Striker, Skirmisher"));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createHammerLance() {
@@ -1731,7 +1731,7 @@ public class FormationType {
         ft.idealRole = UnitRole.STRIKER;
         ft.mainCriteria = ms -> ms.getWalkMp() >= 5;
         ft.mainDescription = "Walk/Cruise 5+";
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createHeavyStrikerCavalryLance() {
@@ -1750,7 +1750,7 @@ public class FormationType {
                 ms -> getSingleWeaponDamageAtRange(ms, 18) >= 5,
                 "Weapon with damage 5+ at range 18"));
         ft.reportMetrics.put("Damage @ 18", ms -> getSingleWeaponDamageAtRange(ms, 18));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createHordeLance() {
@@ -1760,7 +1760,7 @@ public class FormationType {
         ft.mainCriteria = ms -> getDamageAtRange(ms, 9) <= 10;
         ft.mainDescription = "Damage <= 10 at range 9";
         ft.reportMetrics.put("Damage @ 9", ms -> getDamageAtRange(ms, 9));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createLightStrikerCavalryLance() {
@@ -1776,14 +1776,14 @@ public class FormationType {
                 ms -> ms.getRole().isAnyOf(STRIKER, SKIRMISHER),
                 "Striker, Skirmisher"));
         ft.reportMetrics.put("Damage @ 18", ms -> getSingleWeaponDamageAtRange(ms, 18));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createRangerLance() {
         FormationType ft = new FormationType("Ranger", "Striker/Cavalry");
         ft.allowedUnitTypes = FLAG_GROUND;
         ft.maxWeightClass = EntityWeightClass.WEIGHT_HEAVY;
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createUrbanLance() {
@@ -1798,9 +1798,9 @@ public class FormationType {
         ft.otherCriteria.add(new PercentConstraint(0.5,
                 ms -> ms.getWalkMp() <= 4,
                 "Walk/Cruise <= 4"));
-        allFormationTypes.put(ft.name, ft);        
+        allFormationTypes.put(ft.name, ft);
     }
-    
+
     private static void createAerospaceSuperioritySquadron() {
         FormationType ft = new FormationType("Aerospace Superiority Squadron");
         ft.allowedUnitTypes = FLAG_FIGHTER;
@@ -1819,7 +1819,7 @@ public class FormationType {
         ft.allowedUnitTypes = FLAG_FIGHTER;
         ft.otherCriteria.add(new PercentConstraint(0.51,
                 ms -> ms.getEquipmentNames().stream().map(EquipmentType::get)
-                .anyMatch(et -> et instanceof TAGWeapon ||  
+                .anyMatch(et -> et instanceof TAGWeapon ||
                         (et instanceof MiscType &&
                             (et.hasFlag(MiscType.F_BAP) || et.hasFlag(MiscType.F_ECM)))),
                 "Probe, ECM, TAG"));
@@ -1828,7 +1828,7 @@ public class FormationType {
                 (ms0, ms1) -> ms0.getChassis().equals(ms1.getChassis()),
                 "Same chassis");
         ft.reportMetrics.put("Probe/ECM/TAG", ms -> ft.otherCriteria.get(0).criterion.test(ms));
-        allFormationTypes.put(ft.name, ft);                
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createFireSupportSquadron() {
@@ -1843,7 +1843,7 @@ public class FormationType {
                 ms -> true,
                 (ms0, ms1) -> ms0.getChassis().equals(ms1.getChassis()),
                 "Same chassis");
-        allFormationTypes.put(ft.name, ft);                
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createInterceptorSquadron() {
@@ -1854,7 +1854,7 @@ public class FormationType {
                 ms -> true,
                 (ms0, ms1) -> ms0.getChassis().equals(ms1.getChassis()),
                 "Same chassis");
-        allFormationTypes.put(ft.name, ft);                
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createStrikeSquadron() {
@@ -1866,7 +1866,7 @@ public class FormationType {
                 ms -> true,
                 (ms0, ms1) -> ms0.getChassis().equals(ms1.getChassis()),
                 "Same chassis");
-        allFormationTypes.put(ft.name, ft);                
+        allFormationTypes.put(ft.name, ft);
     }
 
     private static void createTransportSquadron() {
@@ -1878,14 +1878,14 @@ public class FormationType {
                 ms -> true,
                 (ms0, ms1) -> ms0.getChassis().equals(ms1.getChassis()),
                 "Same chassis");
-        allFormationTypes.put(ft.name, ft);                
+        allFormationTypes.put(ft.name, ft);
     }
 
     /**
      * Helper function used by some grouping constraints to compare units. Units are considered to match
      * if they are the same model, but omnis can match with different configurations. This is used primarily
      * for ground units; aerospace units match based on chassis.
-     * 
+     *
      * @param ms0
      * @param ms1
      * @return    Whether the two units are considered the same for grouping considerations.
@@ -1898,23 +1898,23 @@ public class FormationType {
             return ms0.getName().equals(ms1.getName());
         }
     }
-    
+
     /**
-     * base class for limitations on formation type 
+     * base class for limitations on formation type
      */
     public static abstract class Constraint {
         Predicate<MechSummary> criterion;
         String description;
         boolean pairedWithNext;
         boolean pairedWithPrevious;
-        
+
         protected Constraint(Predicate<MechSummary> criterion, String description) {
             this.criterion = criterion;
             this.description = description;
         }
-        
+
         public abstract int getMinimum(int unitSize);
-        
+
         public String getDescription() {
             return description;
         }
@@ -1922,7 +1922,7 @@ public class FormationType {
         public boolean matches(MechSummary ms) {
             return criterion.test(ms);
         }
-        
+
         /* In cases where a constraint has multiple possible fulfillments requiring different
          * numbers of units (e.g. Assault requires one juggernaut or two snipers), they must
          * be assigned to separate Constraints consecutively in the list and marked with the
@@ -1931,7 +1931,7 @@ public class FormationType {
         public boolean isPairedWithPrevious() {
             return pairedWithPrevious;
         }
-        
+
         public void setPairedWithPrevious(boolean paired) {
             pairedWithPrevious = paired;
         }
@@ -1939,52 +1939,52 @@ public class FormationType {
         public boolean isPairedWithNext() {
             return pairedWithNext;
         }
-        
+
         public void setPairedWithNext(boolean paired) {
             pairedWithNext = paired;
         }
     }
-    
+
     public static class CountConstraint extends Constraint {
         int count;
-        
+
         public CountConstraint(int min, Predicate<MechSummary> criterion, String description) {
             super(criterion, description);
             count = min;
         }
-        
+
         @Override
         public int getMinimum(int unitSize) {
             return count;
         }
     }
-    
+
     private static class MaxCountConstraint extends CountConstraint {
-        
+
         public MaxCountConstraint(int max, Predicate<MechSummary> criterion, String description) {
             super(max, criterion.negate(), description);
         }
-        
+
         @Override
         public int getMinimum(int unitSize) {
             return unitSize - count;
         }
     }
-    
+
     private static class PercentConstraint extends Constraint {
         double pct;
-        
+
         public PercentConstraint(double min, Predicate<MechSummary> criterion, String description) {
             super(criterion, description);
             pct = min;
         }
-        
+
         @Override
         public int getMinimum(int unitSize) {
             return (int) Math.ceil(pct * unitSize);
         }
     }
-    
+
     /*
      * Permits additional constraints applied to a specific subset of the units.
      * Used to force pairs (or larger groups) of units that are identical or have the same base
@@ -1996,14 +1996,14 @@ public class FormationType {
         int numGroups = 1;
         BiFunction<MechSummary,MechSummary,Boolean> groupConstraint;
         String description;
-        
+
         public GroupingConstraint(Predicate<MechSummary> generalConstraint,
                 BiFunction<MechSummary,MechSummary,Boolean> groupConstraint,
                 String description) {
             super(generalConstraint, description);
             this.groupConstraint = groupConstraint;
         }
-        
+
         public GroupingConstraint(int unitTypes,
                 Predicate<MechSummary> generalConstraint,
                 BiFunction<MechSummary,MechSummary,Boolean> groupConstraint,
@@ -2011,7 +2011,7 @@ public class FormationType {
             this(generalConstraint, groupConstraint, description);
             this.unitTypes = unitTypes;
         }
-        
+
         public GroupingConstraint(int unitTypes, int groupSize, int numGroups,
                 Predicate<MechSummary> generalConstraint,
                 BiFunction<MechSummary,MechSummary,Boolean> groupConstraint,
@@ -2021,7 +2021,7 @@ public class FormationType {
             this.groupSize = groupSize;
             this.numGroups = numGroups;
         }
-        
+
         public boolean appliesTo(int unitType) {
             return ((1 << unitType) & unitTypes) != 0;
         }
@@ -2029,16 +2029,16 @@ public class FormationType {
         public int getNumGroups() {
             return numGroups;
         }
-        
+
         public int getGroupSize() {
             return groupSize;
         }
-        
+
         @Override
         public boolean matches(MechSummary ms) {
             return criterion == null || criterion.test(ms);
         }
-        
+
         public boolean matches(MechSummary ms1, MechSummary ms2) {
             return groupConstraint.apply(ms1,  ms2);
         }
@@ -2052,11 +2052,11 @@ public class FormationType {
             }
             return gs * ng;
         }
-        
+
         public boolean hasGeneralCriteria() {
             return criterion != null;
         }
-        
+
         public GroupingConstraint copy() {
             return new GroupingConstraint(this.unitTypes, this.groupSize, this.numGroups,
                 this.criterion, this.groupConstraint, this.description);

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -20,7 +20,7 @@ import megamek.common.UnitType;
 
 /**
  * Used to adjust availability to conform to a particular mission role.
- * 
+ *
  * @author Neoancient
  */
 public enum MissionRole {
@@ -44,8 +44,8 @@ public enum MissionRole {
     /* Infantry roles */
     MARINE, MOUNTAINEER, XCT, PARATROOPER, ANTI_MEK, FIELD_GUN,
     /* allows artillery but does not filter out all other roles */
-    MIXED_ARTILLERY; 
-    
+    MIXED_ARTILLERY;
+
     public boolean fitsUnitType(int unitType) {
         switch (this) {
             case RECON:
@@ -89,20 +89,20 @@ public enum MissionRole {
                 return unitType < UnitType.BATTLE_ARMOR || unitType > UnitType.PROTOMEK;
 
             case EW_SUPPORT:
-                return unitType <= UnitType.TANK || unitType == UnitType.AERO;
+                return unitType <= UnitType.TANK || unitType == UnitType.AEROSPACEFIGHTER;
 
             case TRAINING:
                 return unitType < UnitType.SMALL_CRAFT;
 
             case SPOTTER:
-                return unitType <= UnitType.AERO;
+                return unitType <= UnitType.AEROSPACEFIGHTER;
 
             case BOMBER:
             case ESCORT:
             case INTERCEPTOR:
             case GROUND_SUPPORT:
             // case STRIKE:
-                return unitType == UnitType.AERO || unitType == UnitType.CONV_FIGHTER;
+                return unitType == UnitType.AEROSPACEFIGHTER || unitType == UnitType.CONV_FIGHTER;
 
             case ASSAULT:
             case VEE_CARRIER:
@@ -127,7 +127,7 @@ public enum MissionRole {
 
             case OMNI:
                 return (unitType == UnitType.MEK)
-                        || (unitType == UnitType.AERO)
+                        || (unitType == UnitType.AEROSPACEFIGHTER)
                         || (unitType == UnitType.TANK);
                 // This should apply to fixed-wing support also, but that cannot be distinguished from conventional fighters here.
 
@@ -151,7 +151,7 @@ public enum MissionRole {
                 return false;
         }
     }
-    
+
     public static Double adjustAvailabilityByRole(double avRating,
                                                   Collection<MissionRole> desiredRoles,
                                                   ModelRecord mRec, int year, int strictness) {
@@ -604,7 +604,7 @@ public enum MissionRole {
                 (mRec.getRoles().contains(ARTILLERY) && !desiredRoles.contains(ARTILLERY)
                         && !desiredRoles.contains(MIXED_ARTILLERY));
     }
-    
+
     public static MissionRole parseRole(String role) {
         switch (role.toLowerCase().replace("_", " ")) {
             case "recon":
@@ -724,7 +724,7 @@ public enum MissionRole {
                 return null;
         }
     }
-    
+
     @Override
     public String toString() {
         return name().toLowerCase();

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -43,11 +43,11 @@ import java.util.stream.Stream;
  * Generates a random assignment table (RAT) dynamically based on a variety of criteria,
  * including faction, era, unit type, weight class, equipment rating, faction subcommand, vehicle
  * movement mode, and mission role.
- * 
+ *
  * @author Neoancient
  */
 public class RATGenerator {
-    
+
     private final HashMap<String, ModelRecord> models;
     private final HashMap<String, ChassisRecord> chassis;
     private final HashMap<String, FactionRecord> factions;
@@ -64,7 +64,7 @@ public class RATGenerator {
     private boolean initializing;
 
     private ArrayList<ActionListener> listeners;
-    
+
     protected RATGenerator() {
         models = new HashMap<>();
         chassis = new HashMap<>();
@@ -72,7 +72,7 @@ public class RATGenerator {
         modelIndex = new HashMap<>();
         chassisIndex = new HashMap<>();
         eraSet = new TreeSet<>();
-        
+
         listeners = new ArrayList<>();
     }
 
@@ -203,7 +203,7 @@ public class RATGenerator {
 
     /**
      * Provides a list of availability ratings for a unit in a given era. Used in editing and reporting.
-     * 
+     *
      * @param era  The year of the record. This must be one of the years in the <code>eraSet</code>.
      * @param unit The lookup name of the unit to find records for.
      * @return     A <code>Collection</code> of all the availability ratings for the unit in the era,
@@ -218,7 +218,7 @@ public class RATGenerator {
 
     /**
      * Adds or changes an availability rating entry for a model.
-     * 
+     *
      * @param era  The year of the record to change
      * @param unitKey The model key for the unit which is having its model record updated
      * @param ar   The new <code>AvailabilityRating</code> for the unit in the era. This provides the
@@ -232,7 +232,7 @@ public class RATGenerator {
 
     /**
      * Removes the availability rating entry.
-     * 
+     *
      * @param era      The year of the record to remove.
      * @param unit     The model to remove the record for.
      * @param faction  The faction to remove the record for.
@@ -252,7 +252,7 @@ public class RATGenerator {
 
     /**
      * Provides a list of availability ratings for a chassis in a given era. Used in editing and reporting.
-     * 
+     *
      * @param era  The year of the record. This must be one of the years in the <code>eraSet</code>.
      * @param chassisKey The chassis name to find records for.
      * @return     A <code>Collection</code> of all the availability ratings for the chassis in the era,
@@ -268,7 +268,7 @@ public class RATGenerator {
 
     /**
      * Adds or changes an availability rating entry for a chassis.
-     * 
+     *
      * @param era  The year of the record to change
      * @param unit The name of the chassis for which to change the record
      * @param ar   The new <code>AvailabilityRating</code> for the unit in the era. This provides the
@@ -282,7 +282,7 @@ public class RATGenerator {
 
     /**
      * Removes the availability rating entry.
-     * 
+     *
      * @param era      The year of the record to remove.
      * @param unit     The chassis to remove the record for.
      * @param faction  The faction to remove the record for.
@@ -303,7 +303,7 @@ public class RATGenerator {
     public TreeSet<Integer> getEraSet() {
         return eraSet;
     }
-    
+
     public Collection<ModelRecord> getModelList() {
         return models.values();
     }
@@ -323,7 +323,7 @@ public class RATGenerator {
     public Collection<FactionRecord> getFactionList() {
         return factions.values();
     }
-    
+
     public FactionRecord getFaction(String key) {
         return factions.get(key);
     }
@@ -343,7 +343,7 @@ public class RATGenerator {
     public Collection<String> getFactionKeySet() {
         return factions.keySet();
     }
-    
+
     public int eraForYear(final int year) {
         if (year < getEraSet().first()) {
             return getEraSet().first();
@@ -360,7 +360,7 @@ public class RATGenerator {
     /**
      * Used for a faction with multiple parent factions (e.g. FC == FS + LA) to find the average
      * availability among the parents. Based on average weight rather than av rating.
-     * 
+     *
      * @param faction The faction code to use for the new AvailabilityRecord
      * @param list A list of ARs for the various parent factions
      * @return A new AR with the average availability code from the various factions.
@@ -376,7 +376,7 @@ public class RATGenerator {
             totalAdj += ar.ratingAdjustment;
         }
         AvailabilityRating retVal = list.get(0).makeCopy(faction);
-        
+
         retVal.availability = (int) (AvailabilityRating.calcAvRating(totalWt / list.size()));
         if (totalAdj < 0) {
             retVal.ratingAdjustment = (totalAdj - 1)/ list.size();
@@ -385,11 +385,11 @@ public class RATGenerator {
         }
         return retVal;
     }
-    
+
     /**
      * Given values for two years, interpolates or extrapolates value for another given year.
      * If one of the two values is null, it is treated as 0.
-     * 
+     *
      * @param av1 The first value.
      * @param av2 The second value.
      * @param year1 The year for the first value.
@@ -413,7 +413,7 @@ public class RATGenerator {
         return av1.doubleValue()
                 + (av2.doubleValue() - av1.doubleValue()) * (now - year1) / (year2 - year1);
     }
-    
+
     public List<UnitTable.TableEntry> generateTable(FactionRecord fRec, int unitType, int year,
             String rating, Collection<Integer> weightClasses, int networkMask,
             Collection<EntityMovementMode> movementModes,
@@ -421,13 +421,13 @@ public class RATGenerator {
             FactionRecord user) {
         HashMap<ModelRecord, Double> unitWeights = new HashMap<>();
         HashMap<FactionRecord, Double> salvageWeights = new HashMap<>();
-        
+
         loadYear(year);
-        
+
         if (fRec == null) {
             fRec = new FactionRecord();
         }
-        
+
         Integer early = eraSet.floor(year);
         if (early == null) {
             early = eraSet.first();
@@ -439,7 +439,7 @@ public class RATGenerator {
         if (late == null) {
             late = early;
         }
-        
+
         /* Adjustments for unit rating require knowing both how many ratings are available
          * to the faction and where the rating falls within the whole. If a faction does
          * not have designated rating levels, it inherits those of the parent faction;
@@ -448,7 +448,7 @@ public class RATGenerator {
          * of -1. A faction that has one rating level is a special case that always has
          * the indicated rating within the parent faction's system.
          */
-        
+
         int ratingLevel = -1;
         ArrayList<String> factionRatings = fRec.getRatingLevelSystem();
         int numRatingLevels = factionRatings.size();
@@ -459,14 +459,19 @@ public class RATGenerator {
         if (rating != null && numRatingLevels > 1) {
             ratingLevel = factionRatings.indexOf(rating);
         }
-        
+
         for (String chassisKey : chassisIndex.get(early).keySet()) {
             ChassisRecord cRec = chassis.get(chassisKey);
             if (cRec == null) {
                 LogManager.getLogger().error("Could not locate chassis " + chassisKey);
                 continue;
             }
-            
+
+            if (Arrays.asList(UnitType.AERO, UnitType.AEROSPACEFIGHTER).contains(cRec.getUnitType())) {
+                // Handle ChassisRecords saved as "AERO" units as ASFs for now
+                cRec.setUnitType(UnitType.AEROSPACEFIGHTER);
+            }
+
             if (cRec.getUnitType() != unitType &&
                     !(unitType == UnitType.TANK
                         && cRec.getUnitType() == UnitType.VTOL
@@ -514,7 +519,7 @@ public class RATGenerator {
                         }
                     }
                 }
-            }                        
+            }
         }
 
         if (unitWeights.isEmpty()) {
@@ -548,7 +553,7 @@ public class RATGenerator {
                     Function<ModelRecord, Integer> grouper = mr -> wcdIndex[mr.getWeightClass()];
                     Map<Integer, List<ModelRecord>> weightGroups = unitWeights.keySet().stream()
                             .collect(Collectors.groupingBy(grouper));
-                    
+
                     // Go through the weight class groups and adjust the table weights so the total
                     // of each group corresponds to the distribution for this faction.
                     for (int i : weightGroups.keySet()) {
@@ -563,7 +568,7 @@ public class RATGenerator {
                 }
             }
         }
-        
+
         double total = unitWeights.values().stream().mapToDouble(Double::doubleValue).sum();
 
         if (fRec.getPctSalvage(early) != null) {
@@ -582,8 +587,8 @@ public class RATGenerator {
                                 entry.getValue(), early, late, year));
                     }
                 }
-            }            
-            
+            }
+
             double salvage = fRec.getPctSalvage(early);
             if (salvage >= 100) {
                 salvage = total;
@@ -597,7 +602,7 @@ public class RATGenerator {
             for (String fKey : salvageEntries.keySet()) {
                 FactionRecord salvageFaction = factions.get(fKey);
                 if (salvageFaction == null) {
-                    LogManager.getLogger().debug("Could not locate faction " + fKey 
+                    LogManager.getLogger().debug("Could not locate faction " + fKey
                             + " for " + fRec.getKey() + " salvage");
                 } else {
                     double wt = salvage * salvageEntries.get(fKey) / totalFactionWeight;
@@ -605,11 +610,11 @@ public class RATGenerator {
                 }
             }
         }
-        
+
         if (ratingLevel >= 0) {
             adjustForRating(fRec, unitType, year, ratingLevel, unitWeights, salvageWeights, early, late);
         }
-        
+
         // Increase weights if necessary to keep smallest from rounding down to zero
         double adj = 1.0;
         DoubleSummaryStatistics stats = Stream
@@ -623,7 +628,7 @@ public class RATGenerator {
                 adj = 1000.0 / stats.getMax();
             }
         }
-        
+
         List<TableEntry> retVal = new ArrayList<>();
         for (FactionRecord faction : salvageWeights.keySet()) {
             int wt = (int) (salvageWeights.get(faction) * adj + 0.5);
@@ -672,7 +677,7 @@ public class RATGenerator {
             pctSL = interpolate(fRec.findPctTech(TechCategory.IS_ADVANCED, early, rating),
                     fRec.findPctTech(TechCategory.IS_ADVANCED, late, rating), early, late, year);
         }
-        if (unitType == UnitType.AERO) {
+        if (unitType == UnitType.AEROSPACEFIGHTER) {
             pctOmni = interpolate(fRec.findPctTech(TechCategory.OMNI_AERO, early, rating),
                     fRec.findPctTech(TechCategory.OMNI_AERO, late, rating), early, late, year);
             pctClan = interpolate(fRec.findPctTech(TechCategory.CLAN_AERO, early, rating),
@@ -716,7 +721,7 @@ public class RATGenerator {
                     } else if (pct > pctSL + techMargin) {
                         pctSL += techMargin;
                     }
-                }                    
+                }
             }
 
             Double upgradeMargin = interpolate(fRec.getUpgradeMargin(early),
@@ -730,9 +735,9 @@ public class RATGenerator {
                 }
                 /* If clan, sl, and other are all adjusted, the values probably
                  * don't add up to 100, which is fine unless the upgradeMargin is
-                 * <= techMargin. Then pctOther is more certain, and we adjust 
+                 * <= techMargin. Then pctOther is more certain, and we adjust
                  * the values of clan and sl to keep the value of "other" equal to
-                 * a percentage. 
+                 * a percentage.
                  */
                 if (techMargin != null) {
                     if (upgradeMargin <= techMargin) {
@@ -760,8 +765,8 @@ public class RATGenerator {
                 }
             }
             pctNonOmni = 100.0 - pctOmni;
-        }            
-                
+        }
+
         // For non-Clan factions, the amount of salvage from Clan factions is part of the overall
         // Clan percentage.
         if (!fRec.isClan() && (pctClan != null) && (totalClan > 0)) {
@@ -782,7 +787,7 @@ public class RATGenerator {
                 unitWeights.put(mRec, unitWeights.get(mRec) * (pctOmni / 100.0) * (total / totalOmni));
             }
             if (pctNonOmni != null && !mRec.isOmni() && totalOmni > 0) {
-                unitWeights.put(mRec, unitWeights.get(mRec) * (pctNonOmni / 100.0) * (total / (total - totalOmni)));                        
+                unitWeights.put(mRec, unitWeights.get(mRec) * (pctNonOmni / 100.0) * (total / (total - totalOmni)));
             }
             if (pctSL != null && mRec.isSL()
                     && totalSL > 0) {
@@ -901,7 +906,7 @@ public class RATGenerator {
                 } else {
                     LogManager.getLogger().warn("Faction key not found in " + file.getPath());
                 }
-            }            
+            }
         }
     }
 
@@ -913,7 +918,7 @@ public class RATGenerator {
             loadEra(era, Configuration.forceGeneratorDir());
         }
     }
-    
+
     private synchronized void loadEra(int era, File dir) {
         if (eraIsLoaded(era)) {
             return;
@@ -981,11 +986,11 @@ public class RATGenerator {
         }
         notifyListenersEraLoaded();
     }
-    
+
     /**
      * Creates model and chassis records for all units that don't already have entries. This should
      * only be called after all availability records are loaded, otherwise they will be overwritten.
-     * 
+     *
      * Used for editing.
      */
     public void initRemainingUnits() {
@@ -1052,7 +1057,7 @@ public class RATGenerator {
             }
         }
     }
-    
+
     private void parseModelNode(int era, ChassisRecord cr, Node wn) {
         String modelKey = (cr.getChassis() + ' ' + wn.getAttributes().getNamedItem("name").getTextContent()).trim();
         boolean newEntry = false;
@@ -1076,13 +1081,13 @@ public class RATGenerator {
         if (wn.getAttributes().getNamedItem("mechanized") != null) {
             mr.setMechanizedBA(Boolean.parseBoolean(wn.getAttributes().getNamedItem("mechanized").getTextContent()));
         }
-        
+
         for (int k = 0; k < wn.getChildNodes().getLength(); k++) {
             Node wn2 = wn.getChildNodes().item(k);
             if (wn2.getNodeName().equalsIgnoreCase("roles") && newEntry) {
                 mr.addRoles(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("deployedWith") && newEntry) {
-                mr.setRequiredUnits(wn2.getTextContent().trim());                                        
+                mr.setRequiredUnits(wn2.getTextContent().trim());
             } else if (wn2.getNodeName().equalsIgnoreCase("availability")) {
                 modelIndex.get(era).put(mr.getKey(), new HashMap<>());
                 String[] codes = wn2.getTextContent().trim().split(",");
@@ -1091,8 +1096,8 @@ public class RATGenerator {
                     mr.getIncludedFactions().add(code.split(":")[0]);
                     modelIndex.get(era).get(mr.getKey()).put(ar.getFactionCode(), ar);
                 }
-            } 
-        }        
+            }
+        }
     }
 
     public synchronized void registerListener(ActionListener l) {
@@ -1125,10 +1130,10 @@ public class RATGenerator {
             }
         }
     }
-    
+
     public void exportRATGen(File dir) {
         PrintWriter pw;
-        
+
         FactionRecord[] factionRecs = factions.values().toArray(new FactionRecord[0]);
         Arrays.sort(factionRecs, (arg0, arg1) -> {
             if ((arg0.getParentFactions() == null) && (arg1.getParentFactions() != null)) {
@@ -1162,7 +1167,7 @@ public class RATGenerator {
         ChassisRecord[] chassisRecs = chassis.values().toArray(new ChassisRecord[0]);
         Arrays.sort(chassisRecs, Comparator.comparing(AbstractUnitRecord::getKey));
         ArrayList<String> avFields = new ArrayList<>();
-        
+
         final List<Integer> ERAS = new ArrayList<>(eraSet);
 
         for (int i = 0; i < ERAS.size(); i++) {
@@ -1252,7 +1257,7 @@ public class RATGenerator {
                                             }
                                         }
                                         pw.println("</availability>");
-                                        pw.println("\t\t</model>");                         
+                                        pw.println("\t\t</model>");
                                     }
                                 }
                             }

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -480,7 +480,7 @@ public class RATGenerator {
             }
 
             AvailabilityRating ar = findChassisAvailabilityRecord(early,
-                        cRec.getChassisKey(), fRec, year);
+                        chassisKey, fRec, year);
             if (ar == null) {
                 continue;
             }

--- a/megamek/src/megamek/client/ratgenerator/TransportCalculator.java
+++ b/megamek/src/megamek/client/ratgenerator/TransportCalculator.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package megamek.client.ratgenerator;
 
@@ -28,7 +28,7 @@ import megamek.common.loaders.EntityLoadingException;
 
 /**
  * Generates dropships and jumpships to fulfill transport requirements for a unit.
- * 
+ *
  * @author Neoancient
  *
  */
@@ -55,7 +55,7 @@ public class TransportCalculator {
 
     /**
      * Determines number of each type of unit based on transport requirements.
-     * 
+     *
      * @return The number of units of each type mapped to its UnitType.
      *         UnitType.VTOL is used for light vehicle bays and UnitType.NAVAL for superheavy vehicles.
      */
@@ -87,7 +87,7 @@ public class TransportCalculator {
             } else if (en.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
                 unitCounts.merge(UnitType.SMALL_CRAFT, 1, Integer::sum);
             } else if (en.isFighter()) {
-                unitCounts.merge(UnitType.AERO, 1, Integer::sum);
+                unitCounts.merge(UnitType.AEROSPACEFIGHTER, 1, Integer::sum);
             }
         }
         return unitCounts;
@@ -95,7 +95,7 @@ public class TransportCalculator {
 
     /**
      * Generates dropships to provide enough capacity to transport the given ratio of the formation.
-     * 
+     *
      * @param ratio            The ratio of dropships to generate to the total needs of the unit
      * @return                 A list of generated dropships
      */
@@ -118,7 +118,7 @@ public class TransportCalculator {
                     break; // Could not find any transport for the unit type; skip
                 }
                 bayTypeCache.get(dropship).forEach((k, v) -> {
-                    currentCapacity.merge(k, v, Integer::sum); 
+                    currentCapacity.merge(k, v, Integer::sum);
                 });
                 retVal.add(dropship);
             }
@@ -128,7 +128,7 @@ public class TransportCalculator {
 
     /**
      * Generates jumpships to provide enough docking collars to transport the given ratio of dropships.
-     * 
+     *
      * @param ratio            The ratio of jumpships to generate to the total needs of the unit
      * @param transportCollars The number of dropships generated for transport
      * @return                 A list of generated jumpships
@@ -157,7 +157,7 @@ public class TransportCalculator {
 
     /**
      * Determines whether a potential transport has capacity for the type of unit.
-     * 
+     *
      * @param ms        A potential tranporting unit
      * @param unitType  The unit to be carried
      * @return          True if the unit can be carried by the transporting unit.
@@ -184,7 +184,7 @@ public class TransportCalculator {
 
     /**
      * Loads the entity, counts the unit type transport capacity, and adds to the cache.
-     * 
+     *
      * @param ms  The unit to load
      * @return    true if the Entity can be loaded and counted, false if there was an EntityLoadingException
      */
@@ -200,7 +200,7 @@ public class TransportCalculator {
 
     /**
      * Counts the unit type transport capacity, and adds to the cache.
-     * 
+     *
      * @param entity  The transporting unit
      * @return        true if the Entity can be loaded and counted, false if there was an EntityLoadingException
      */
@@ -222,7 +222,7 @@ public class TransportCalculator {
             } else if (bay instanceof InfantryBay) {
                 bayCount.merge(UnitType.BATTLE_ARMOR, (int) bay.getCapacity(), Integer::sum);
             } else if (bay instanceof ASFBay) {
-                bayCount.merge(UnitType.AERO, (int) bay.getCapacity(), Integer::sum);
+                bayCount.merge(UnitType.AEROSPACEFIGHTER, (int) bay.getCapacity(), Integer::sum);
             } else if (bay instanceof SmallCraftBay) {
                 bayCount.merge(UnitType.SMALL_CRAFT, (int) bay.getCapacity(), Integer::sum);
             }
@@ -232,7 +232,7 @@ public class TransportCalculator {
 
     /**
      * Loads the Entity and counts the number of docking hardpoints.
-     * 
+     *
      * @param ms The unit to load
      * @return   The number of docking hardpoints on the unit.
      */

--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
 import megamek.common.Compute;
@@ -81,7 +82,7 @@ public class UnitTable {
                 movementModes, roles, roleStrictness, deployingFaction);
         return findTable(params);
     }
-    
+
     /**
      * deployingFaction not specified, uses main faction.
      *
@@ -98,7 +99,7 @@ public class UnitTable {
     /**
      * Checks cache for a unit table with the given parameters. If none is found, generates
      * one and adds to the cache using a copy of the Parameters object as a key.
-     * 
+     *
      * @param params - the parameters to use in generating the table.
      * @return a generated table matching the parameters
      */
@@ -171,10 +172,15 @@ public class UnitTable {
      * @return - the entry at the indicated index
      */
     private TableEntry getEntry(int index) {
-        if (index < salvageTable.size()) {
-            return salvageTable.get(index);
+        try {
+            if (index < salvageTable.size()) {
+                return salvageTable.get(index);
+            }
+            return unitTable.get(index - salvageTable.size());
+        } catch (IndexOutOfBoundsException e) {
+            // Can't log from a static context
         }
-        return unitTable.get(index - salvageTable.size());
+        return null;
     }
 
     /**
@@ -182,7 +188,8 @@ public class UnitTable {
      * @return - the weight value for the entry at the indicated index
      */
     public int getEntryWeight(int index) {
-        return getEntry(index).weight;
+        TableEntry te = getEntry(index);
+        return  (te != null) ? te.weight : 0;
     }
 
     /**
@@ -190,15 +197,18 @@ public class UnitTable {
      * @return - a string representing the entry at the indicated index for use in the table
      */
     public String getEntryText(int index) {
-        if (index >= salvageTable.size()) {
-            return unitTable.get(index - salvageTable.size()).getUnitEntry().getName();
-        } else {
-            if (key.getFaction().isClan()) {
-                return "Isorla: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
+        if (unitTable.size() > 0 && salvageTable.size() >= 0) {
+            if ( index >= salvageTable.size()){
+                return unitTable.get(index - salvageTable.size()).getUnitEntry().getName();
             } else {
-                return "Salvage: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
+                if (key.getFaction().isClan()) {
+                    return "Isorla: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
+                } else {
+                    return "Salvage: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
+                }
             }
         }
+        return "";
     }
 
     /**
@@ -206,7 +216,7 @@ public class UnitTable {
      * @return - a string representing the entry at the indicated index for use in the table
      */
     public String getTechBase(int index) {
-        if (index >= salvageTable.size()) {
+        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry().isClan() ? "Clan" : "IS";
         } else {
             return key.getFaction().isClan() ? "Clan" : "IS";
@@ -218,7 +228,7 @@ public class UnitTable {
      * @return - a string representing the entry at the indicated index for use in the table
      */
     public String getUnitRole(int index) {
-        if (index >= salvageTable.size()) {
+        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry().getRole().toString();
         } else {
             return "";
@@ -230,7 +240,7 @@ public class UnitTable {
      * @return - the MechSummary entry for the indicated index, or null if this is a salvage entry
      */
     public MechSummary getMechSummary(int index) {
-        if (index >= salvageTable.size()) {
+        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry();
         }
         return null;
@@ -241,7 +251,7 @@ public class UnitTable {
      * @return - the BV of the unit at the indicated index, or 0 if this is a salvage entry
      */
     public int getBV(int index) {
-        if (index >= salvageTable.size()) {
+        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry().getBV();
         } else {
             return 0;
@@ -620,6 +630,6 @@ public class UnitTable {
                 rating, weightClasses, networkMask, movementModes,
                 roles, roleStrictness, deployingFaction);
         }
-        
+
     }
 }

--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -197,18 +197,15 @@ public class UnitTable {
      * @return - a string representing the entry at the indicated index for use in the table
      */
     public String getEntryText(int index) {
-        if (unitTable.size() > 0 && salvageTable.size() >= 0) {
-            if ( index >= salvageTable.size()){
-                return unitTable.get(index - salvageTable.size()).getUnitEntry().getName();
+        if (!unitTable.isEmpty() && index >= salvageTable.size()){
+            return unitTable.get(index - salvageTable.size()).getUnitEntry().getName();
+        } else {
+            if (key.getFaction().isClan()) {
+                return "Isorla: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
             } else {
-                if (key.getFaction().isClan()) {
-                    return "Isorla: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
-                } else {
-                    return "Salvage: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
-                }
+                return "Salvage: " + salvageTable.get(index).getSalvageFaction().getName(key.getYear() - 5);
             }
         }
-        return "";
     }
 
     /**
@@ -216,7 +213,7 @@ public class UnitTable {
      * @return - a string representing the entry at the indicated index for use in the table
      */
     public String getTechBase(int index) {
-        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
+        if (!unitTable.isEmpty() && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry().isClan() ? "Clan" : "IS";
         } else {
             return key.getFaction().isClan() ? "Clan" : "IS";
@@ -228,7 +225,7 @@ public class UnitTable {
      * @return - a string representing the entry at the indicated index for use in the table
      */
     public String getUnitRole(int index) {
-        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
+        if (!unitTable.isEmpty() && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry().getRole().toString();
         } else {
             return "";
@@ -240,7 +237,7 @@ public class UnitTable {
      * @return - the MechSummary entry for the indicated index, or null if this is a salvage entry
      */
     public MechSummary getMechSummary(int index) {
-        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
+        if (!unitTable.isEmpty() && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry();
         }
         return null;
@@ -251,7 +248,7 @@ public class UnitTable {
      * @return - the BV of the unit at the indicated index, or 0 if this is a salvage entry
      */
     public int getBV(int index) {
-        if ((unitTable.size() > 0 && salvageTable.size() >= 0) && index >= salvageTable.size()) {
+        if (!unitTable.isEmpty() && index >= salvageTable.size()) {
             return unitTable.get(index - salvageTable.size()).getUnitEntry().getBV();
         } else {
             return 0;

--- a/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
+++ b/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
@@ -266,7 +266,6 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
         unitTypeModel.addElement(UnitType.getTypeDisplayableName(UnitType.INFANTRY));
         unitTypeModel.addElement(UnitType.getTypeDisplayableName(UnitType.PROTOMEK));
         unitTypeModel.addElement(UnitType.getTypeDisplayableName(UnitType.AEROSPACEFIGHTER));
-        unitTypeModel.addElement(UnitType.getTypeDisplayableName(UnitType.AERO));
         unitTypeModel.setSelectedItem(Messages.getString("MechSelectorDialog.All"));
 
         cboUnitType.setModel(unitTypeModel);

--- a/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
@@ -81,7 +81,7 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
 
     private static final int[] UNIT_TYPES = {
         UnitType.MEK, UnitType.TANK, UnitType.BATTLE_ARMOR, UnitType.INFANTRY, UnitType.PROTOMEK,
-        UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER, UnitType.AEROSPACEFIGHTER, UnitType.AERO, UnitType.SMALL_CRAFT,
+        UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER, UnitType.AEROSPACEFIGHTER, UnitType.SMALL_CRAFT,
         UnitType.DROPSHIP, UnitType.JUMPSHIP, UnitType.WARSHIP, UnitType.SPACE_STATION
     };
     private static final int EARLIEST_YEAR = 2398;
@@ -632,7 +632,6 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
                             EntityWeightClass.WEIGHT_ASSAULT, true);
                     break;
                 case UnitType.AEROSPACEFIGHTER:
-                case UnitType.AERO:
                     addWeightClasses(panWeightClass, EntityWeightClass.WEIGHT_LIGHT,
                             EntityWeightClass.WEIGHT_HEAVY, false);
                     break;
@@ -692,7 +691,6 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
                 case UnitType.NAVAL:
                 case UnitType.CONV_FIGHTER:
                 case UnitType.AEROSPACEFIGHTER:
-                case UnitType.AERO:
                     addNetworkButton(panNetwork, c, networkButtons, Messages.getString("RandomArmyDialog.NoNetwork"),
                             ModelRecord.NETWORK_NONE);
                     addNetworkButton(panNetwork, c, networkButtons, Messages.getString("RandomArmyDialog.C3S"),

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorOptionsView.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 /**
  * Controls to set options for force generator.
- * 
+ *
  * @author Neoancient
  */
 public class ForceGeneratorOptionsView extends JPanel implements FocusListener, ActionListener {
@@ -509,6 +509,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
                     }
                     break;
                 case UnitType.AERO:
+                case UnitType.AEROSPACEFIGHTER:
                     if (chkRoleAirRecon.isSelected()) {
                         fd.getRoles().add(MissionRole.RECON);
                     }
@@ -661,7 +662,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
                 panGroundRole.setVisible(unitType == UnitType.MEK || unitType == UnitType.TANK);
                 panInfRole.setVisible(unitType == UnitType.INFANTRY
                         || unitType == UnitType.BATTLE_ARMOR);
-                panAirRole.setVisible(unitType == UnitType.AERO
+                panAirRole.setVisible(unitType == UnitType.AEROSPACEFIGHTER
                         || unitType == UnitType.CONV_FIGHTER);
             }
         }
@@ -904,7 +905,7 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
 
     /**
      * Searches recursively for nodes that are flagged with C3 networks and configures them.
-     * 
+     *
      * @param fd
      */
     private void configureNetworks(ForceDescriptor fd) {

--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -1359,7 +1359,7 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
 
         @Override
         public Object getValueAt(int row, int col) {
-            if (generatedRAT != null) {
+            if (generatedRAT != null && generatedRAT.getNumEntries() > 0) {
                 switch (col) {
                     case COL_WEIGHT:
                         return generatedRAT.getEntryWeight(row);
@@ -1380,7 +1380,10 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
         }
 
         public MechSummary getUnitAt(int row) {
-            return generatedRAT.getMechSummary(row);
+            if (generatedRAT != null && generatedRAT.getNumEntries() > 0) {
+                return generatedRAT.getMechSummary(row);
+            }
+            return null;
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -809,7 +809,7 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                                 }
                                 unitList.addAll(ba);
                             } else if (m_pFormationOptions.getBooleanOption("airLance")) {
-                                UnitTable t = UnitTable.findTable(fRec, UnitType.AERO,
+                                UnitTable t = UnitTable.findTable(fRec, UnitType.AEROSPACEFIGHTER,
                                         m_pFormationOptions.getYear(), m_pFormationOptions.getRating(), null,
                                         ModelRecord.NETWORK_NONE,
                                         EnumSet.noneOf(EntityMovementMode.class),


### PR DESCRIPTION
This patch fixes a couple of issues by continuing the replacement of "AERO" values with "AEROSPACEFIGHTER":

1. ASFs being counted as non-ASF units when TOE is read to create StratCon scenario "protect" requirements,
2. Air support Scenario Modifiers not generating any friendly units even when applied,
3. RAT Generator tag in Random Unit Generator dialog finding zero ASF unit types for any faction or subfaction (regardless of era),
4. RAT Generator throwing an IndexOutOfBounds exception whenever zero-unit ASF RATs are generated.

These fixes mainly involve removing UnitType.AERO values in favor of UnitType.AEROSPACEFIGHTER.

Testing:
1. Ran all three projects' unit tests,
2. Verified functionality of RAT Generator with specific known-existing era:faction:class:weight requirements.
3. Verifed function of Air Support scenario modifier in MHQ.

Note: this fix is independent of MegaMek/mekhq#3882 and can be applied before or after the PR for that issue.