### PR TITLE
Flight path indicator

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -572,6 +572,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     public void performAction() {
                         clear();
                         computeMovementEnvelope(ce());
+                        updateMove();
                     }
                 });
 
@@ -4654,6 +4655,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         } else if (actionCmd.equals(MoveCommand.MOVE_CANCEL.getCmd())) {
             clear();
             computeMovementEnvelope(ce);
+            updateMove();
         } else if (ev.getSource().equals(getBtn(MoveCommand.MOVE_MORE))) {
             currentButtonGroup++;
             currentButtonGroup %= numButtonGroups;

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -806,6 +806,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
         clientgui.getBoardView().clearFieldOfFire();
         computeMovementEnvelope(ce);
+        updateMove();
         computeCFWarningHexes(ce);
     }
 
@@ -4572,6 +4573,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         // Refresh the new velocity envelope on the map.
         try {
             computeMovementEnvelope(ae);
+            updateMove();
         } catch (Exception e) {
             LogManager.getLogger().error("An error occured trying to compute the move envelope for an Aero.");
         } finally {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -3873,9 +3873,49 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
 
             pathSprites.add(new StepSprite(this, step, md.isEndStep(step)));
+
+            // On the last step - process possible aerospace flight path indicators.
+            if (md.isEndStep(step)) {
+                displayFlightPathIndicator(md);
+            }
+
             previousStep = step;
         }
+
         repaint(100);
+    }
+
+    /**
+     * Add Aerospace ground map flight path indicators on the last step based on how much
+     * aerodyne movement is left.  This will add sprites along the forward path for the
+     * remaining velocity and indicate what point along it's forward path the unit can turn.
+     *
+     * @param md - Current MovePath that represents the current units movement state
+     */
+    private void displayFlightPathIndicator(MovePath md) {
+        // If the unit has remaining aerodyne velocity display the flight path indicators for remaining velocity.
+        if ((md.getFinalVelocityLeft() > 0) && !md.nextForwardStepOffBoard()) {
+            List<MoveStep> fpiSteps = new Vector<MoveStep>();
+
+            // Cloning the current movement path because we don't want to change it's state.
+            MovePath fpiPath = md.clone();
+
+            // While velocity remains, add a forward step to the cloned movement path.
+            while (fpiPath.getFinalVelocityLeft() > 0) {
+                fpiPath.addStep(MoveStepType.FORWARDS);
+                fpiSteps.add(fpiPath.getLastStep());
+
+                // short circuit the flight path indicator if we are off the board.
+                if (fpiPath.nextForwardStepOffBoard()) {
+                    break;
+                }
+            }
+
+            // As a test, lets add some sprites for the rest of the path just to see what this looks like.
+            for (MoveStep ms : fpiSteps) {
+                pathSprites.add(new StepSprite(this, ms, fpiPath.isEndStep(ms)));
+            }
+        }
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -3900,6 +3900,11 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
      * @param md - Current MovePath that represents the current units movement state
      */
     private void displayFlightPathIndicator(MovePath md) {
+        // Don't calculate any kind of flight path indicators if the move is not legal.
+        if (md.getLastStepMovementType() == EntityMovementType.MOVE_ILLEGAL) {
+            return;
+        }
+
         // If the unit has remaining aerodyne velocity display the flight path indicators for remaining velocity.
         if ((md.getFinalVelocityLeft() > 0) && !md.nextForwardStepOffBoard()) {
             List<MoveStep> fpiSteps = new Vector<MoveStep>();

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -195,6 +195,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     // sprite for current movement
     ArrayList<StepSprite> pathSprites = new ArrayList<>();
+    ArrayList<FlightPathIndicatorSprite> fpiSprites = new ArrayList<FlightPathIndicatorSprite>();
 
     private ArrayList<Coords> strafingCoords = new ArrayList<>(5);
 
@@ -1195,6 +1196,9 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         // draw movement, if valid
         drawSprites(g, pathSprites);
+
+        // draw flight path indicators
+        drawSprites(g, fpiSprites);
 
         // draw firing solution sprites, but only during the firing phase
         if (game.getPhase().isFiring() || game.getPhase().isOffboard()) {
@@ -2288,6 +2292,9 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
             // draw movement, if valid
             drawSprites(boardGraph, pathSprites);
+
+            // draw flight path indicators
+            drawSprites(boardGraph, fpiSprites);
 
             // draw firing solution sprites, but only during the firing phase
             if (game.getPhase().isFiring() || game.getPhase().isOffboard()) {
@@ -3913,7 +3920,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
             // As a test, lets add some sprites for the rest of the path just to see what this looks like.
             for (MoveStep ms : fpiSteps) {
-                pathSprites.add(new StepSprite(this, ms, fpiPath.isEndStep(ms)));
+                fpiSprites.add(new FlightPathIndicatorSprite(this, ms.getPosition(), ms, fpiPath.isEndStep(ms)));
             }
         }
     }
@@ -3923,6 +3930,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
      */
     public void clearMovementData() {
         pathSprites = new ArrayList<>();
+        fpiSprites = new ArrayList<>();
         movementTarget = null;
         checkFoVHexImageCacheClear();
         repaint();
@@ -5211,6 +5219,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
     void clearSprites() {
         pathSprites.clear();
+        fpiSprites.clear();
         firingSprites.clear();
         attackSprites.clear();
         c3Sprites.clear();
@@ -6129,8 +6138,13 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
         updateFontSizes();
         updateBoard();
+
         for (StepSprite sprite : pathSprites) {
             sprite.refreshZoomLevel();
+        }
+
+        for (FlightPathIndicatorSprite sprite : fpiSprites) {
+            sprite.prepare();
         }
 
         for (FiringSolutionSprite sprite : firingSprites) {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -3880,7 +3880,6 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
             }
 
             pathSprites.add(new StepSprite(this, step, md.isEndStep(step)));
-
             previousStep = step;
         }
 
@@ -3896,6 +3895,11 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
      * @param md - Current MovePath that represents the current units movement state
      */
     private void displayFlightPathIndicator(MovePath md) {
+        // Don't attempt displaying Flight Path Indicators if using advanced aero movement.
+        if (this.game.useVectorMove()) {
+            return;
+        }
+
         // Don't calculate any kind of flight path indicators if the move is not legal.
         if (md.getLastStepMovementType() == EntityMovementType.MOVE_ILLEGAL) {
             return;
@@ -3919,7 +3923,7 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
                 }
             }
 
-            // As a test, lets add some sprites for the rest of the path just to see what this looks like.
+            // For each hex in the entities forward trajectory, add a flight turn indicator sprite.
             for (MoveStep ms : fpiSteps) {
                 fpiSprites.add(new FlightPathIndicatorSprite(this, ms.getPosition(), ms, fpiPath.isEndStep(ms)));
             }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -3881,14 +3881,10 @@ public class BoardView extends JPanel implements Scrollable, BoardListener, Mous
 
             pathSprites.add(new StepSprite(this, step, md.isEndStep(step)));
 
-            // On the last step - process possible aerospace flight path indicators.
-            if (md.isEndStep(step)) {
-                displayFlightPathIndicator(md);
-            }
-
             previousStep = step;
         }
 
+        displayFlightPathIndicator(md);
         repaint(100);
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -56,64 +56,63 @@ public class FlightPathIndicatorSprite extends HexSprite {
     private MoveStep step = null;
     private boolean isLast = false;
 
-    //U+26AA  MEDIUM WHITE CIRCLE
-    //U+26AB  MEDIUM BLACK CIRCLE
-    //U+2690  WHITE FLAG
-    //U+2691  BLACK FLAG
-    //U+26E2  ASTRONOMICAL SYMBOL FOR URANUS
-    //U+26D6  BLACK TWO-WAY LEFT WAY TRAFFIC
-    //U+26D7  WHITE TWO-WAY LEFT WAY TRAFFIC
+    private static final String EMPTY_CIRCLE = "\u26AA";
+    private static final String SOLID_CIRCLE = "\u26AB";
+    private static final String EMPTY_FLAG = "\u2690";
+    private static final String SOLID_FLAG = "\u2691";
+    //private static final String EMPTY_TWO_WAY = "\u26D7";
+    private static final String SOLID_TWO_WAY = "\u26D6";
 
-    //Draw a special character 'circle'.
-    private final StringDrawer mustFlyIcon = new StringDrawer("\u26AA")
+    // Setup 'StringDrawers' to write special characters as icons.
+    private final StringDrawer mustFlyIcon = new StringDrawer(EMPTY_CIRCLE)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_RED)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer greenFlagIcon = new StringDrawer("\u2691")
+    private final StringDrawer greenFlagIcon = new StringDrawer(SOLID_FLAG)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_GREEN)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer redFlagIcon = new StringDrawer("\u2690")
+    private final StringDrawer redFlagIcon = new StringDrawer(EMPTY_FLAG)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_RED)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer yellowFlagIcon = new StringDrawer("\u2691")
+    private final StringDrawer yellowFlagIcon = new StringDrawer(SOLID_FLAG)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_YELLOW)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer yellowEmptyFlagIcon = new StringDrawer("\u2690")
+    private final StringDrawer yellowEmptyFlagIcon = new StringDrawer(EMPTY_FLAG)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_YELLOW)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer flyOffIcon = new StringDrawer("\u26D6")
+    private final StringDrawer flyOffIcon = new StringDrawer(SOLID_TWO_WAY)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_YELLOW)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 2.0f);
 
-    private final StringDrawer freeTurnIcon = new StringDrawer("\u26AB")
+    private final StringDrawer freeTurnIcon = new StringDrawer(SOLID_CIRCLE)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_GREEN)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer costTurnIcon = new StringDrawer("\u26AB")
+    private final StringDrawer costTurnIcon = new StringDrawer(SOLID_CIRCLE)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_YELLOW)
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer noThrustIcon = new StringDrawer("\u26AA")
+    private final StringDrawer noThrustIcon = new StringDrawer(EMPTY_CIRCLE)
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_YELLOW)
             .fontSize(TEXT_SIZE)

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -1,0 +1,98 @@
+/**
+ *
+ */
+package megamek.client.ui.swing.boardview;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.StringDrawer;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.Coords;
+import megamek.common.MoveStep;
+
+/**
+ * The Flight Path Indicator Sprite represents the status of a hex in the trajectory of an
+ * aerospace unit going in a straight line until it expends its velocity.
+ *
+ * A green solid circle represents required trajectory.
+ * A green non-filled circle represents a point on the path where a turn is allowed.
+ */
+public class FlightPathIndicatorSprite extends HexSprite {
+
+    private static final GUIPreferences GUIP = GUIPreferences.getInstance();
+    private static final int TEXT_SIZE = 30;
+    //private static final Color TEXT_COLOR = new Color(255, 255, 40, 128);
+    private static final Color TEXT_COLOR = Color.GREEN;
+    private static final Color OUTLINE_COLOR = new Color(40, 40,40,200);
+
+    private static final int HEX_CENTER_X = BoardView.HEX_W / 2;
+    private static final int HEX_CENTER_Y = BoardView.HEX_H / 2;
+
+    private MoveStep step = null;
+    private boolean isLast = false;
+
+    //U+26AA  MEDIUM WHITE CIRCLE
+    //U+26AB  MEDIUM BLACK CIRCLE
+
+    //Draw a special character 'circle'.
+    private final StringDrawer xWriter = new StringDrawer("\u26AB")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(TEXT_COLOR)
+            .fontSize(TEXT_SIZE)
+            .center().outline(OUTLINE_COLOR, 1.5f);
+
+    /**
+     * @param boardView - BoardView associated with the sprite.
+     * @param loc - hex coordinate to place the sprite.
+     * @param step - the MoveStep object that backs the flight indicator state at that hex.
+     * @param last - true if the sprite represents the last indicator on the board.
+     */
+    public FlightPathIndicatorSprite(BoardView boardView, Coords loc, final MoveStep step, boolean last) {
+        super(boardView, loc);
+        this.step = step;
+        this.isLast = last;
+    }
+
+    @Override
+    public void prepare() {
+        Graphics2D graph = spriteSetup();
+        xWriter.draw(graph);
+        graph.dispose();
+    }
+
+    /*
+     * Standard Hex Sprite 2D Graphics setup.  Creates the context, base hex image
+     * settings, scale, and fonts.
+     */
+    private Graphics2D spriteSetup() {
+        updateBounds();
+        image = createNewHexImage();
+        Graphics2D graph = (Graphics2D) image.getGraphics();
+        UIUtil.setHighQualityRendering(graph);
+        graph.scale(bv.scale, bv.scale);
+
+        fontSetup(graph);
+
+        return graph;
+    }
+
+    /*
+     * Sets the font name, style, and size from configured default parameters.
+     */
+    private void fontSetup(Graphics2D graph) {
+        String fontName = GUIP.getMoveFontType();
+        int fontStyle = GUIP.getMoveFontStyle();
+        graph.setFont(new Font(fontName, fontStyle, TEXT_SIZE));
+    }
+
+    /*
+     * Return true if this sprite/step is the last of the flight path indicators in the
+     * flight path.
+     */
+    private boolean isLastIndicator() {
+        return isLast;
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -71,7 +71,7 @@ public class FlightPathIndicatorSprite extends HexSprite {
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
-    private final StringDrawer finalIcon = new StringDrawer("\u2691")
+    private final StringDrawer greenFlagIcon = new StringDrawer("\u2691")
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_GREEN)
             .fontSize(TEXT_SIZE)
@@ -128,26 +128,26 @@ public class FlightPathIndicatorSprite extends HexSprite {
      */
     private void drawSprite(Graphics2D graph) {
         Entity entity = step.getEntity();
-        int safeThrust = Integer.MAX_VALUE;
+        int maxMP = Integer.MAX_VALUE;
         int turnCost = Integer.MIN_VALUE;
 
         if (null != entity) {
-            safeThrust = entity.getRunMP();
+            maxMP = entity.getRunMP();
             turnCost = step.asfTurnCost(step.getGame(), MoveStepType.TURN_LEFT, entity);
         }
 
-        if (this.isLastIndicator()) {
-            if (this.step.getVelocityLeft() > 0) {
+        if (isLastIndicator()) {
+            if (step.getVelocityLeft() > 0) {
                 flyOffIcon.draw(graph);
             } else {
-                finalIcon.draw(graph);
+                greenFlagIcon.draw(graph);
             }
         } else {
-            if (this.step.dueFreeTurn()) {
+            if (step.dueFreeTurn()) {
                 freeTurnIcon.draw(graph);
-            } else if (this.step.canAeroTurn(bv.game)) {
+            } else if (step.canAeroTurn(bv.game)) {
                 // instead of blindly trusting theoretical canTurn(), see if bird can actually turn.
-                if ((this.step.getMpUsed() + turnCost) > safeThrust) {
+                if ((step.getMpUsed() + turnCost) > maxMP) {
                     noThrustIcon.draw(graph);
                 } else {
                     costTurnIcon.draw(graph);

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -22,6 +22,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
 
+import megamek.MMConstants;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.StringDrawer;
 import megamek.client.ui.swing.util.UIUtil;
@@ -52,6 +53,7 @@ public class FlightPathIndicatorSprite extends HexSprite {
 
     private static final int HEX_CENTER_X = BoardView.HEX_W / 2;
     private static final int HEX_CENTER_Y = BoardView.HEX_H / 2;
+    private static final int TEXT_Y_OFFSET = 17;
 
     private MoveStep step = null;
     private boolean isLast = false;
@@ -147,6 +149,7 @@ public class FlightPathIndicatorSprite extends HexSprite {
         if (isLastIndicator()) {
             if (step.getVelocityLeft() > 0) {
                 flyOffIcon.draw(graph);
+                drawRemainingDistance(graph, this.step);
             } else {
                 if (canTurnForFree()) {
                     greenFlagIcon.draw(graph);
@@ -241,5 +244,35 @@ public class FlightPathIndicatorSprite extends HexSprite {
      */
     private boolean isLastIndicator() {
         return isLast;
+    }
+
+    /*
+     * Render a number on the lower center of the hex that represents the distance remaining to
+     * travel for the given step.
+     */
+    private void drawRemainingDistance(Graphics2D graph, MoveStep moveStep) {
+        int velocity = moveStep.getVelocity();
+        if (bv.game.getBoard().onGround()) {
+            velocity *= 16;
+        }
+
+        // calculate the remaining number of hexes off the end of the map.
+        int remainingDistance = velocity - moveStep.getDistance();
+
+        // string and font setup for text.
+        String remString = Integer.toString(remainingDistance);
+        graph.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 12));
+
+        // center the remaining distance and put it just above the fly-off icon indicator.
+        int x_offset = HEX_CENTER_X - (graph.getFontMetrics(graph.getFont()).stringWidth(remString) / 2);
+        int y_offset = HEX_CENTER_Y - TEXT_Y_OFFSET;
+
+        // draw a dark gray shadow string and then a red string on top.
+        graph.setColor(Color.darkGray);
+        graph.drawString(remString, x_offset, y_offset);
+        graph.setColor(Color.red);
+        graph.drawString(remString, x_offset - 1, y_offset - 1);
+
+        return;
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -24,9 +24,10 @@ public class FlightPathIndicatorSprite extends HexSprite {
 
     private static final GUIPreferences GUIP = GUIPreferences.getInstance();
     private static final int TEXT_SIZE = 30;
-    //private static final Color TEXT_COLOR = new Color(255, 255, 40, 128);
-    private static final Color TEXT_COLOR = Color.GREEN;
-    private static final Color OUTLINE_COLOR = new Color(40, 40,40,200);
+    private static final Color COLOR_YELLOW = new Color(255, 255, 0, 128);
+    private static final Color COLOR_GREEN = new Color(0, 255, 0, 128);
+    private static final Color COLOR_RED = new Color(255, 0, 0, 128);
+    private static final Color COLOR_OUTLINE = new Color(40, 40,40,200);
 
     private static final int HEX_CENTER_X = BoardView.HEX_W / 2;
     private static final int HEX_CENTER_Y = BoardView.HEX_H / 2;
@@ -36,13 +37,42 @@ public class FlightPathIndicatorSprite extends HexSprite {
 
     //U+26AA  MEDIUM WHITE CIRCLE
     //U+26AB  MEDIUM BLACK CIRCLE
+    //U+2690  WHITE FLAG
+    //U+2691  BLACK FLAG
+    //U+26E2  ASTRONOMICAL SYMBOL FOR URANUS
+    //U+26D6  BLACK TWO-WAY LEFT WAY TRAFFIC
+    //U+26D7  WHITE TWO-WAY LEFT WAY TRAFFIC
 
     //Draw a special character 'circle'.
-    private final StringDrawer xWriter = new StringDrawer("\u26AB")
+    private final StringDrawer mustFlyIcon = new StringDrawer("\u26AA")
             .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(TEXT_COLOR)
+            .color(COLOR_RED)
             .fontSize(TEXT_SIZE)
-            .center().outline(OUTLINE_COLOR, 1.5f);
+            .center().outline(COLOR_OUTLINE, 1.5f);
+
+    private final StringDrawer finalIcon = new StringDrawer("\u2691")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_GREEN)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 1.5f);
+
+    private final StringDrawer flyOffIcon = new StringDrawer("\u26D6")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_YELLOW)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 2.0f);
+
+    private final StringDrawer freeTurnIcon = new StringDrawer("\u26AB")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_GREEN)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 1.5f);
+
+    private final StringDrawer costTurnIcon = new StringDrawer("\u26AB")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_YELLOW)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 1.5f);
 
     /**
      * @param boardView - BoardView associated with the sprite.
@@ -59,8 +89,28 @@ public class FlightPathIndicatorSprite extends HexSprite {
     @Override
     public void prepare() {
         Graphics2D graph = spriteSetup();
-        xWriter.draw(graph);
+        drawSprite(graph);
         graph.dispose();
+    }
+
+    private void drawSprite(Graphics2D graph) {
+        if (this.isLastIndicator()) {
+            if (this.step.getVelocityLeft() > 0) {
+                flyOffIcon.draw(graph);
+            } else {
+                finalIcon.draw(graph);
+            }
+        } else {
+            if (this.step.dueFreeTurn()) {
+                freeTurnIcon.draw(graph);
+            } else if (this.step.canAeroTurn(bv.game)) {
+                costTurnIcon.draw(graph);
+            } else {
+                mustFlyIcon.draw(graph);
+            }
+        }
+
+        return;
     }
 
     /*

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -77,6 +77,24 @@ public class FlightPathIndicatorSprite extends HexSprite {
             .fontSize(TEXT_SIZE)
             .center().outline(COLOR_OUTLINE, 1.5f);
 
+    private final StringDrawer redFlagIcon = new StringDrawer("\u2690")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_RED)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 1.5f);
+
+    private final StringDrawer yellowFlagIcon = new StringDrawer("\u2691")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_YELLOW)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 1.5f);
+
+    private final StringDrawer yellowEmptyFlagIcon = new StringDrawer("\u2690")
+            .at(HEX_CENTER_X, HEX_CENTER_Y)
+            .color(COLOR_YELLOW)
+            .fontSize(TEXT_SIZE)
+            .center().outline(COLOR_OUTLINE, 1.5f);
+
     private final StringDrawer flyOffIcon = new StringDrawer("\u26D6")
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(COLOR_YELLOW)
@@ -140,7 +158,23 @@ public class FlightPathIndicatorSprite extends HexSprite {
             if (step.getVelocityLeft() > 0) {
                 flyOffIcon.draw(graph);
             } else {
-                greenFlagIcon.draw(graph);
+                // Its the last hex the bird can fly on the map - draw a flag - but what kind?
+                if (step.dueFreeTurn()) {
+                    // use a green flag to indicate ability to free turn on last hex.
+                    greenFlagIcon.draw(graph);
+                } else if (step.canAeroTurn(bv.game)) {
+                    // use a yellow flag to indicate ability to turn with a cost.
+                    if ((step.getMpUsed() + turnCost) > maxMP) {
+                        // use an empty yellow flag to indicate turn with cost, but no remaining thrust
+                        yellowEmptyFlagIcon.draw(graph);
+                    } else {
+                        // use a solid yellow flag to indicate player can turn on the last hex for a cost.
+                        yellowFlagIcon.draw(graph);
+                    }
+                } else {
+                    // use an empty red flag to indicate no turn on the last hex.
+                    redFlagIcon.draw(graph);
+                }
             }
         } else {
             if (step.dueFreeTurn()) {

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -1,5 +1,20 @@
-/**
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
  *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 package megamek.client.ui.swing.boardview;
 
@@ -14,11 +29,15 @@ import megamek.common.Coords;
 import megamek.common.MoveStep;
 
 /**
- * The Flight Path Indicator Sprite represents the status of a hex in the trajectory of an
- * aerospace unit going in a straight line until it expends its velocity.
+ * The Flight Path Indicator Sprite paints a path in front of an aerospace movement path
+ * and indicates the turn status and remaining velocity by showing the length of path
+ * the flight must follow and when the unit can turn.
  *
- * A green solid circle represents required trajectory.
- * A green non-filled circle represents a point on the path where a turn is allowed.
+ * A green solid circle indicates the craft can make a free turn on that hex.
+ * A yellow solid circle indicates the craft can make a turn with cost to thrust.
+ * A red empty circle indicates the craft cannot turn on that hex.
+ * A green flag indicates the craft has used all its remaining velocity on that hex.
+ * A yellow two-way diamond indicates the craft will fly off the map with remaining velocity.
  */
 public class FlightPathIndicatorSprite extends HexSprite {
 
@@ -93,6 +112,12 @@ public class FlightPathIndicatorSprite extends HexSprite {
         graph.dispose();
     }
 
+    /*
+     * Based on the condition of the MoveStep associated with this sprite, draw a
+     * green, yellow, or red flight path indicator to indicate turn status on that
+     * hex.  Draw a flag for final hex and a yellow diamond to indicate flying
+     * off the map.
+     */
     private void drawSprite(Graphics2D graph) {
         if (this.isLastIndicator()) {
             if (this.step.getVelocityLeft() > 0) {

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -144,43 +144,27 @@ public class FlightPathIndicatorSprite extends HexSprite {
      * off the map.
      */
     private void drawSprite(Graphics2D graph) {
-        Entity entity = step.getEntity();
-        int maxMP = Integer.MAX_VALUE;
-        int turnCost = Integer.MIN_VALUE;
-
-        if (null != entity) {
-            maxMP = entity.getRunMP();
-            turnCost = step.asfTurnCost(step.getGame(), MoveStepType.TURN_LEFT, entity);
-        }
-
         if (isLastIndicator()) {
             if (step.getVelocityLeft() > 0) {
                 flyOffIcon.draw(graph);
             } else {
-                // Its the last hex the bird can fly on the map - draw a flag - but what kind?
-                if (step.dueFreeTurn()) {
-                    // use a green flag to indicate ability to free turn on last hex.
+                if (canTurnForFree()) {
                     greenFlagIcon.draw(graph);
-                } else if (step.canAeroTurn(bv.game)) {
-                    // use a yellow flag to indicate ability to turn with a cost.
-                    if ((step.getMpUsed() + turnCost) > maxMP) {
-                        // use an empty yellow flag to indicate turn with cost, but no remaining thrust
+                } else if (canTurnWithThrustCost()) {
+                    if (costsTooMuchToTurn()) {
                         yellowEmptyFlagIcon.draw(graph);
                     } else {
-                        // use a solid yellow flag to indicate player can turn on the last hex for a cost.
                         yellowFlagIcon.draw(graph);
                     }
                 } else {
-                    // use an empty red flag to indicate no turn on the last hex.
                     redFlagIcon.draw(graph);
                 }
             }
         } else {
-            if (step.dueFreeTurn()) {
+            if (canTurnForFree()) {
                 freeTurnIcon.draw(graph);
-            } else if (step.canAeroTurn(bv.game)) {
-                // instead of blindly trusting theoretical canTurn(), see if bird can actually turn.
-                if ((step.getMpUsed() + turnCost) > maxMP) {
+            } else if (canTurnWithThrustCost()) {
+                if (costsTooMuchToTurn()) {
                     noThrustIcon.draw(graph);
                 } else {
                     costTurnIcon.draw(graph);
@@ -191,6 +175,39 @@ public class FlightPathIndicatorSprite extends HexSprite {
         }
 
         return;
+    }
+
+    /*
+     * Return true if the fighter would be able to turn at this step but doesn't have enough
+     * movement points left to actually make the turn.
+     */
+    private boolean costsTooMuchToTurn() {
+        Entity entity = step.getEntity();
+        int maxMP = Integer.MAX_VALUE;
+        int turnCost = Integer.MIN_VALUE;
+
+
+        if (null != entity) {
+            maxMP = entity.getRunMP();
+            turnCost = step.asfTurnCost(step.getGame(), MoveStepType.TURN_LEFT, entity);
+        }
+
+        return ((step.getMpUsed() + turnCost) > maxMP);
+    }
+
+    /*
+     * Returns true if the fighter can make a turn at this step given it's current velocity
+     * and turn restrictions.
+     */
+    private boolean canTurnWithThrustCost() {
+        return (step.canAeroTurn(bv.game));
+    }
+
+    /*
+     * Returns true if the fighter can make a free turn at this given step.
+     */
+    private boolean canTurnForFree() {
+        return (step.dueFreeTurn());
     }
 
     /*

--- a/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
@@ -141,7 +141,6 @@ class StepSprite extends Sprite {
                 // forward movement arrow
                 drawArrowShape(g2D, moveArrow, col);
                 drawMovementCost(step, isLastStep, new Point(0, 0), graph, col, true);
-                drawRemainingVelocity(step, graph, true);
                 break;
             case GO_PRONE:
             case HULL_DOWN:
@@ -153,7 +152,6 @@ class StepSprite extends Sprite {
                 currentArrow = upDownOffset.createTransformedShape(bv.downArrow);
                 drawArrowShape(g2D, currentArrow, col);
                 drawMovementCost(step, isLastStep, new Point(1, 15), graph, col, false);
-                drawRemainingVelocity(step, graph, true);
                 break;
             case GET_UP:
             case UP:
@@ -162,7 +160,6 @@ class StepSprite extends Sprite {
                 currentArrow = upDownOffset.createTransformedShape(bv.upArrow);
                 drawArrowShape(g2D, currentArrow, col);
                 drawMovementCost(step, isLastStep, new Point(0, 15), graph, col, false);
-                drawRemainingVelocity(step, graph, true);
                 break;
             case CLIMB_MODE_ON:
                 String climb;
@@ -381,64 +378,6 @@ class StepSprite extends Sprite {
         int fontStyle = GUIP.getMoveFontStyle();
         int fontSize = GUIP.getMoveFontSize();
         return new Font(fontName, fontStyle, fontSize);
-    }
-
-    private void drawRemainingVelocity(MoveStep step, Graphics graph, boolean shiftFlag) {
-        StringBuilder velStringBuf = new StringBuilder();
-
-        if (bv.game.useVectorMove()) {
-            return;
-        }
-
-        if (!step.getEntity().isAirborne() || !step.getEntity().isAero()) {
-            return;
-        }
-
-        if (((IAero) step.getEntity()).isSpheroid()) {
-            return;
-        }
-
-        int distTraveled = step.getDistance();
-        int velocity = step.getVelocity();
-        if (bv.game.getBoard().onGround()) {
-            velocity *= 16;
-        }
-
-        velStringBuf.append("(").append(distTraveled).append("/")
-                .append(velocity).append(")");
-
-        Color col = (step.getVelocityLeft() > 0) ? Color.RED : Color.GREEN;
-
-        // Convert the buffer to a String and draw it.
-        String velString = velStringBuf.toString();
-        graph.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 12));
-        int costX = 42;
-        if (shiftFlag) {
-            costX -= (graph.getFontMetrics(graph.getFont()).stringWidth(velString) / 2);
-        }
-        graph.setColor(Color.darkGray);
-        graph.drawString(velString, costX, 28);
-        graph.setColor(col);
-        graph.drawString(velString, costX - 1, 27);
-
-        // if we are in atmosphere, then report the free turn status as well
-        if (!bv.game.getBoard().inSpace()) {
-            if (step.dueFreeTurn()) {
-                col = Color.GREEN;
-            } else if (step.canAeroTurn(bv.game)) {
-                col = Color.YELLOW;
-            } else {
-                col = Color.RED;
-            }
-
-            String turnString = "<" + step.getNStraight() + ">";
-            graph.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 10));
-            costX = 50;
-            graph.setColor(Color.darkGray);
-            graph.drawString(turnString, costX, 15);
-            graph.setColor(col);
-            graph.drawString(turnString, costX - 1, 14);
-        }
     }
 
     private void drawMovementCost(MoveStep step, boolean isLastStep,


### PR DESCRIPTION
### Description
This PR introduces a graphic enhancement called Flight Path Indicator to help visualize flight path planning with fighters on ground maps.  When units have remaining velocity in the move phase, the Flight Path Indicator will project the remaining path in front of the flying unit to show the path trajectory the unit will take for the remaining velocity.  The color (and shape) of the indicator tells the pilot where the fighter can turn along its path, where the path ends, and that a fighter will fly off the map.

![image](https://github.com/MegaMek/megamek/assets/83041327/2ece7060-1cbc-4845-93fb-50d9287f599b)

![image](https://github.com/MegaMek/megamek/assets/83041327/471e21ee-1cea-4303-8a96-2d6dbc2acec8) ![image](https://github.com/MegaMek/megamek/assets/83041327/fe0fb532-e085-42d7-9f9d-f4560bc62b50)
Empty red circles or flags indicate the fighter cannot turn on that hex along its flight path.

![image](https://github.com/MegaMek/megamek/assets/83041327/3c33aba4-4968-4ecc-8ff8-cedeb6c88250) ![image](https://github.com/MegaMek/megamek/assets/83041327/fa0c3421-bffb-4b76-88e7-dc1845021cf9)
A yellow solid circle or flag indicates the fighter can make a turn for a cost.

![image](https://github.com/MegaMek/megamek/assets/83041327/1323ab09-cbb0-4c35-8e17-b2f3b4581ce1) ![image](https://github.com/MegaMek/megamek/assets/83041327/2a5bfb58-1c3c-4166-9b21-80ca60a1c1d8)
A yellow empty circle or flag indicates the fighter could make a turn for a cost but doesn't have enough movement to do so.

![image](https://github.com/MegaMek/megamek/assets/83041327/3ed97223-a428-4764-9604-24985135238a) ![image](https://github.com/MegaMek/megamek/assets/83041327/4757d13a-6ca0-46fe-9b72-be38ab36d94d)
A green solid circle or flag indicates the fighter can make a free turn at that location along its flight path.

![image](https://github.com/MegaMek/megamek/assets/83041327/f7bf13ec-fcea-474b-83f3-723ff2d37a6b)
A yellow diamond indicates the fighter has remaining velocity at the edge of the map and will fly off the map.

![image](https://github.com/MegaMek/megamek/assets/83041327/4757d13a-6ca0-46fe-9b72-be38ab36d94d)
A flag indicates the hex that will end the flight path on this trajectory at the current velocity.

![image](https://github.com/MegaMek/megamek/assets/83041327/5fff6786-8f3d-4147-8e11-1e63e8a43907)
When the fighter turns, the Flight Path Indicator adjusts to the new trajectory and turn restrictions.

![image](https://github.com/MegaMek/megamek/assets/83041327/d316fe33-c9ce-4332-9e63-7f945cd84858)
Fighter used up its MP turning.  If it had enough thrust points, it could turn on the empty yellow.  Therefore, solid indicators are 'can turn' while empty indicators are 'no turn'.