### PR TITLE
Fix 5205: Handle ConcurrentModification and NPE from opening dialogs while Roun…

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -30,6 +30,7 @@ import megamek.common.enums.GamePhase;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -398,11 +399,13 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
 
         // Pass the action on to each of our listeners.
         // This is a source of ConcurrentModificationException errors if dialogs are open during events
-        // but closed after handling them;
+        // but closed after handling them; catching the CME does not lead to later issues.
         try {
             actionListeners.forEach(l -> l.actionPerformed(event));
         } catch (ConcurrentModificationException e) {
-            LogManager.getLogger().error("Probable dialog open during Round Report handling", e);
+            Logger l = LogManager.getLogger();
+            l.warn("Probable dialog open during Round Report handling", e);
+            l.info("Event causing this issue: " + event.getActionCommand());
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -29,15 +29,13 @@ import megamek.common.KeyBindParser;
 import megamek.common.enums.GamePhase;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.awt.event.KeyEvent.*;
 import static megamek.client.ui.Messages.getString;
@@ -399,7 +397,13 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         }
 
         // Pass the action on to each of our listeners.
-        actionListeners.forEach(l -> l.actionPerformed(event));
+        // This is a source of ConcurrentModificationException errors if dialogs are open during events
+        // but closed after handling them;
+        try {
+            actionListeners.forEach(l -> l.actionPerformed(event));
+        } catch (ConcurrentModificationException e) {
+            LogManager.getLogger().error("Probable dialog open during Round Report handling", e);
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5358,7 +5358,12 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
     @Override
     public String toDisplayableString(Client client) {
-        return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " + getEntity(client.getGame()).getEquipment(weaponId).getName();
+        try {
+            return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " + getEntity(client.getGame()).getEquipment(weaponId).getName();
+        } catch (NullPointerException e) {
+            LogManager.getLogger().error("Unable to construct WAA displayable string due to null reference", e);
+        }
+        return "attacking target with weapon";
     }
 
     @Override

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5358,12 +5358,11 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
     @Override
     public String toDisplayableString(Client client) {
-        try {
-            return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " + getEntity(client.getGame()).getEquipment(weaponId).getName();
-        } catch (NullPointerException e) {
-            LogManager.getLogger().error("Unable to construct WAA displayable string due to null reference", e);
+        if (null == client || null == getTarget(client.getGame())) {
+            LogManager.getLogger().warn("Unable to construct WAA displayable string due to null reference");
+            return "Attacking Null Target with id " + getTargetId() + " using Weapon with id " + weaponId;
         }
-        return "attacking target with weapon";
+        return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " + getEntity(client.getGame()).getEquipment(weaponId).getName();
     }
 
     @Override


### PR DESCRIPTION
…d Report being handled

This should clear up some of the Exceptions reported by CasualJoker, and avoid those Exceptions breaking the game and/or sidelining Princess.

Root cause is that we are doing some weird manual tracking of open dialogs within the ClientGUI, which exposes us to ConcurrentModificationExceptions in the UI itself.  These, if not handled, will propagate and break the game.
If caught, they don't cause any harm because we're removing unneeded dialogs from our list of elements, and then trying to notify the deleted dialog of the event signaling the completion of its work (usually, reinforcing from a MUL).

This fix also puts a try/catch around the contents of WAA.toDisplayableString() to avoid the case where it throws an NPE because the client instance can't dereference some information about the current target, likely due to the above bug (or because the main thread is in the context of another dialog while also trying to update the chat box or Round Report).  Either way, this shouldn't break the game.

Testing:
- Ran all 3 projects' unit tests.
- Followed same steps observed in CasualJoker's game when the reported Exceptions occurred.
- Observed Princess-vs-Princess fight for many turns following reinforcing from MUL or RAT generator, which previously would throw one of the above Exceptions and then have one or another Princess instance hang.

Close #5205 
Close MegaMek/mekhq#3879