### PR TITLE
Build blocker: Fix ambiguous LogManager import introduced by IDE auto-import

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -21,7 +21,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
 import megamek.common.Compute;


### PR DESCRIPTION
Somehow an ambiguous import of the Java LogManager (not the log4j version we use) was added to this file, possibly by an over-zealous IDE.  Removing the Java version should fix the build.

Testing:
- Ran all 3 projects' unit tests
- Ran MegaMek
- Generated units using RATGenerator and previously-failing factions (Circinus Federation and Word of Blake Planetary Militia)