### PR TITLE
Fixes #5307 build warning, missing deprecation annotation.

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -262,6 +262,7 @@ public class EquipmentType implements ITechnology {
      */
     // @Deprecated This is using the new TechAdvancement class under the hood.
     // Should it really be deprecated now?
+    @Deprecated
     public Map<Integer, Integer> getTechLevels() {
         Map<Integer, Integer> techLevel = new HashMap<Integer, Integer>();
         if (isUnofficial()) {


### PR DESCRIPTION
Fixes #5307 - Missing deprecation annotation on deprecated method causing a compiler warning on CD/CD build actions.