### PR TITLE
Fix #3306: Vehicle Lance Movement prevents full deployment of turrets

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3165,7 +3165,7 @@ public class GameManager implements IGameManager {
                             player.incrementOtherTurns();
                         }
                     }
-                } else if ((entity instanceof Tank) && tankMoveByLance) {
+                } else if ((entity instanceof Tank) && !(entity instanceof GunEmplacement) && tankMoveByLance) {
                     player.incrementMultiTurns(GameTurn.CLASS_TANK);
                 } else if ((entity instanceof Mech) && mekMoveByLance) {
                     player.incrementMultiTurns(GameTurn.CLASS_MECH);


### PR DESCRIPTION
This should fix the problem with vehicle lance movement preventing full turret deployment. We just needed a check when counting turns so that gun emplacements don't get counted as tanks. 

Closes #3306 
Closes #5316 
Closes #4453 