### PR TITLE
Fix #3978 [MekHQ]: NPE When Attempting to Save (Manual or Auto)

### DIFF
--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -746,7 +746,7 @@ public class EntityListFile {
                 output.write("\" " + MULParser.ATTR_QUIRKS + "=\"");
                 output.write(String.valueOf(entity.getQuirkList("::")));
             }
-            if ((entity.getC3Master() != null) && (entity.getGame() != null)) {
+            if ((entity.getGame() != null) && (entity.getC3Master() != null)) {
                 output.write("\" " + MULParser.ATTR_C3MASTERIS + "=\"");
                 output.write(entity.getGame()
                         .getEntity(entity.getC3Master().getId())

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -746,7 +746,7 @@ public class EntityListFile {
                 output.write("\" " + MULParser.ATTR_QUIRKS + "=\"");
                 output.write(String.valueOf(entity.getQuirkList("::")));
             }
-            if (entity.getC3Master() != null) {
+            if ((entity.getC3Master() != null) && (entity.getGame() != null)) {
                 output.write("\" " + MULParser.ATTR_C3MASTERIS + "=\"");
                 output.write(entity.getGame()
                         .getEntity(entity.getC3Master().getId())
@@ -1236,7 +1236,8 @@ public class EntityListFile {
             } else {
                 output.write("\" " + MULParser.ATTR_AUTOEJECT + "=\"false");
             }
-            if (entity.game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)) {
+            if ((null != entity.getGame())
+                    && (entity.getGame().getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION))) {
                 if (((Mech) entity).isCondEjectAmmo()) {
                     output.write("\" " + MULParser.ATTR_CONDEJECTAMMO + "=\"true");
                 } else {


### PR DESCRIPTION
This PR will fix issue MegaMek/mekhq#3978, which was causing an NPE when BotForce tried to write entities to XML. The immediate reason is that EntityListFile was calling `entity.getGame` in a couple of places without checking for it being null, although it was checking in a variety of places. This PR fixes the problem by adding in checks for null in every place where game is being used.

The more long term solution would be to make EntityListFile more robust to this, but I didn't want to get into bigger coding changes with the goal to release 49.19 shortly, so I will make a separate issue for that.