### PR TITLE
Fixes #5280 NPE updating 'convert mode button'

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2782,9 +2782,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateConvertModeButton() {
-        if (cmd.length() > 0 && cmd.getLastStep().getType() != MoveStepType.CONVERT_MODE) {
-            setModeConvertEnabled(false);
-            return;
+        // Issue #5280 NPE - make sure the move path is valid and the last step isn't null.
+        // MovePath::getLastStep() can return null.
+        if ((cmd != null) && (cmd.getLastStep() != null)) {
+            if (cmd.length() > 0 && cmd.getLastStep().getType() != MoveStepType.CONVERT_MODE) {
+                setModeConvertEnabled(false);
+                return;
+            }
         }
 
         final Entity ce = ce();


### PR DESCRIPTION
Fixes #5280 

Added some null guard checks around code that could produce null pointer errors when checking to see if the Convert Mode button should be enabled.  The code currently checks the last step in the movement path which can return null.  

This guard is around the line of code in version 0.49.18 that produced the NPE in issue #5280.  

This can happen if the `MovePath` object is not initialized or if the call to get the last step in the move path is null; as this code was calling methods of a returned @nullable object.  