### PR TITLE
Fix MekHQ #3986: MHQ wont save, sometimes

### DIFF
--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -753,8 +753,10 @@ public class EntityListFile {
                         .getC3UUIDAsString());
             }
             if (entity.hasC3() || entity.hasC3i() || entity.hasNavalC3()) {
-                output.write("\" " + MULParser.ATTR_C3UUID + "=\"");
-                output.write(entity.getC3UUIDAsString());
+                if(entity.getC3UUIDAsString() != null) {
+                    output.write("\" " + MULParser.ATTR_C3UUID + "=\"");
+                    output.write(entity.getC3UUIDAsString());
+                }
             }
             if (!entity.getCamouflage().hasDefaultCategory()) {
                 output.write("\" " + MULParser.ATTR_CAMO_CATEGORY + "=\"");

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -753,7 +753,7 @@ public class EntityListFile {
                         .getC3UUIDAsString());
             }
             if (entity.hasC3() || entity.hasC3i() || entity.hasNavalC3()) {
-                if(entity.getC3UUIDAsString() != null) {
+                if (entity.getC3UUIDAsString() != null) {
                     output.write("\" " + MULParser.ATTR_C3UUID + "=\"");
                     output.write(entity.getC3UUIDAsString());
                 }


### PR DESCRIPTION
This should fix Megamek/mekhq#3986. The issue is that Entity.c3UUID can be null in BotForces, but that is never checked in EntityListFile. The original XML writer in MHQ for BotForces avoided this problem by ... not checking C3 at all. Ultimately, we need to correct all of this by consolidating XML writers, but that is a bigger project. 

I fixed it simply by checking for null status before writing. I looked for other cases where we might be writing a null object in the same method and I could not find any. I tested it on the campaign file by generating random opponents when advancing day and saving. I was able to do it in 20 cases without problem including many cases where I know I had a C3 entity.