### PR TITLE
Validate that all armor is allocated

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -519,6 +519,12 @@ public class TestAero extends TestEntity {
             correct = false;
         }
 
+        if (!getEntity().hasPatchworkArmor()
+                && getEntity().getTotalOArmor() < aero.getLabTotalArmorPoints()) {
+            buff.append("Not all armor points allocated\n");
+            correct = false;
+        }
+
         return correct ;
     }
 

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -648,9 +648,15 @@ public class TestMech extends TestEntity {
         }
 
         if (!getEntity().hasPatchworkArmor()
+                && getEntity().getTotalOArmor() < mech.getLabTotalArmorPoints()) {
+            buff.append("Not all armor points allocated\n");
+            correct = false;
+        }
+
+        if (!getEntity().hasPatchworkArmor()
                 && (getEntity().getLabTotalArmorPoints() < getEntity().getTotalOArmor())) {
             correct = false;
-            buff.append("Too many armor points allocated");
+            buff.append("Too many armor points allocated\n");
         }
 
         return correct;

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -970,6 +970,11 @@ public class TestSupportVehicle extends TestEntity {
             buff.append(".\n\n");
             correct = false;
         }
+        if (!getEntity().hasPatchworkArmor()
+                && getEntity().getTotalOArmor() < supportVee.getLabTotalArmorPoints()) {
+            buff.append("Not all armor points allocated\n");
+            correct = false;
+        }
         if (supportVee.hasBARArmor(supportVee.firstArmorIndex())) {
             int bar = supportVee.getBARRating(supportVee.firstArmorIndex());
             if ((bar < 2) || (bar > 10)) {

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -321,6 +321,12 @@ public class TestTank extends TestEntity {
             buff.append(".\n\n");
             correct = false;
         }
+        if (!getEntity().hasPatchworkArmor()
+                && getEntity().getTotalOArmor() < tank.getLabTotalArmorPoints()) {
+            buff.append("Not all armor points allocated\n");
+            correct = false;
+        }
+
         if (tank instanceof VTOL) {
             long mastMountCount = tank.countEquipment(EquipmentTypeLookup.MAST_MOUNT);
             if (mastMountCount > 1) {


### PR DESCRIPTION
Since having equipment that's unallocated causes a unit to be invalid, this does the same for armor points. 

Implemented for Meks, Tanks, Suppot Vees, and AeroFighters.

Not implemented for ProtoMechs and Small Craft because the method here doesn't work and sometimes reports a unit as valid when not all points have been allocated, and I have no idea why.

Not implemented for Advanced Aerospace because I have no idea what's going in with advanced aerospace.