### PR TITLE
Fix null pointer when turning with shortcut keys in movement phase.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -281,11 +281,13 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
 
                     @Override
                     public boolean shouldPerformAction() {
+                        // can get called outside of the firing phase, need to check 'isVisible' first in expression.
                         if (!clientgui.getClient().isMyTurn()
-                                || ce().getAlreadyTwisted()
-                                || clientgui.getBoardView().getChatterBoxActive()
                                 || !display.isVisible()
-                                || display.isIgnoringEvents()) {
+                                || display.isIgnoringEvents()
+                                || ce() == null
+                                || ce().getAlreadyTwisted()
+                                || clientgui.getBoardView().getChatterBoxActive()) {
                             return false;
                         } else {
                             return true;
@@ -305,11 +307,13 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
 
                     @Override
                     public boolean shouldPerformAction() {
+                        // can get called outside of the firing phase, need to check 'isVisible' first in expression.
                         if (!clientgui.getClient().isMyTurn()
-                                || ce().getAlreadyTwisted()
-                                || clientgui.getBoardView().getChatterBoxActive()
                                 || !display.isVisible()
-                                || display.isIgnoringEvents()) {
+                                || display.isIgnoringEvents()
+                                || ce() == null
+                                || ce().getAlreadyTwisted()
+                                || clientgui.getBoardView().getChatterBoxActive()) {
                             return false;
                         } else {
                             return true;


### PR DESCRIPTION
Fixes #5350 

During the movement phase that follows a previous firing phase - when using the short cut keys "Shift-A" or "Shift-D to turn left or right results in a null pointer exception in the `FiringDisplay` class when it is checking for torso twist left or right.

The expression was updated to promote the check for firing display visibility and ignore event status BEFORE checking the selected entity which can be null in the `FiringDisplay` during the movement phase.

This bug could also cause a null pointer when trying to turn other units - not just aerospace fighters like the bug report suggests.