### PR TITLE
#5348 stop adding jump start step when deleting movement

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1360,13 +1360,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
         clientgui.getBoardView().setSensorRange(ce, cmd.getFinalCoords());
 
         // set to "walk," or the equivalent
-        if (gear != MovementDisplay.GEAR_JUMP) {
-            gear = MovementDisplay.GEAR_LAND;
-            Color walkColor = GUIP.getMoveDefaultColor();
-            clientgui.getBoardView().setHighlightColor(walkColor);
-        } else if (!cmd.isJumping()) {
-            addStepToMovePath(MoveStepType.START_JUMP);
-        }
+
+        gear = MovementDisplay.GEAR_LAND;
+        Color walkColor = GUIP.getMoveDefaultColor();
+        clientgui.getBoardView().setHighlightColor(walkColor);
 
         // update some GUI elements
         clientgui.getBoardView().clearMovementData();
@@ -1430,10 +1427,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void removeLastStep() {
-       if(cmd.getLastStep() != null && cmd.getLastStep().getType() == MoveStepType.START_JUMP) {
-            gear = MovementDisplay.GEAR_LAND;
-        }
-
         cmd.removeLastStep();
         final Entity entity = ce();
         if (entity == null) {

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1360,7 +1360,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
         clientgui.getBoardView().setSensorRange(ce, cmd.getFinalCoords());
 
         // set to "walk," or the equivalent
-
         gear = MovementDisplay.GEAR_LAND;
         Color walkColor = GUIP.getMoveDefaultColor();
         clientgui.getBoardView().setHighlightColor(walkColor);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1430,6 +1430,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void removeLastStep() {
+       if(cmd.getLastStep() != null && cmd.getLastStep().getType() == MoveStepType.START_JUMP) {
+            gear = MovementDisplay.GEAR_LAND;
+        }
+
         cmd.removeLastStep();
         final Entity entity = ce();
         if (entity == null) {


### PR DESCRIPTION
Fixes #5348
This pr removes some checks in the movement control class that was stopping the movement control system leaving jump mode when you delete the last movement node, this was causing an infinte loop where the system constantly tried to add an illegal jump start node to the start of the move path only to have it subsquently removed and then re-added again this was locking up the app.
