### PR TITLE
FIX: NPE when attacking a unit on a building when Blood Stalking another unit.

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5173,7 +5173,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
 
         // blood stalker SPA
         if (ae.getBloodStalkerTarget() > Entity.NONE) {
-            if (ae.getBloodStalkerTarget() == target.getId()) {
+            // Issue #5275 - Attacker with bloodstalker SPA, `target` can be null if a building etc.
+            if ((target != null) && (ae.getBloodStalkerTarget() == target.getId())) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BloodStalkerTarget"));
             } else {
                 toHit.addModifier(+2, Messages.getString("WeaponAttackAction.BloodStalkerNonTarget"));


### PR DESCRIPTION
This fixes #5275 

When targeting a mech on a building, a choice dialog is created that calculates some to-hit metrics for each of the targets in the selected hex for the user to choose.   However, when the attacker has the Blood Stalker SPA with a declared target, this ends up trying to compare the building to see if it's the chosen target in which case the `target` value passed to the to-hit calculation logic is passed as null.

This fix checks to see if `target` is null before calling `target.getID()`.