### PR TITLE
Fixes #5215 - Secondary turret firing arc display to reflect turret rotation. (tanks)

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TurretFacingDialog.java
+++ b/megamek/src/megamek/client/ui/swing/TurretFacingDialog.java
@@ -235,6 +235,19 @@ public class TurretFacingDialog extends JDialog implements ActionListener {
             } else if (tank != null) {
                 tank.setDualTurretOffset(((6 - tank.getFacing()) + facing) % 6);
                 clientgui.getClient().sendUpdateEntity(tank);
+
+                // `turret` is null here - need to find the first weapon ID of the 2nd turret.
+                for (Mounted weapon : tank.getWeaponList()) {
+                    if (weapon.getLocation() == tank.getLocTurret2()) {
+                        turret = weapon;
+                        break;
+                    }
+                }
+
+                // Select the turret in the unit display.
+                if (clientgui.getUnitDisplay() != null) {
+                    clientgui.getUnitDisplay().wPan.selectWeapon(tank.getEquipmentNum(turret));
+                }
             }
 
             dispose();

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2181,7 +2181,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         }
 
         // pass all this to the Displays
-        int arc = entity.getWeaponArc(entity.getEquipmentNum(mounted));
+        int weaponId = entity.getEquipmentNum(mounted);
+        int arc = entity.getWeaponArc(weaponId);
         int loc = mounted.getLocation();
 
         if (gui.getCurrentPanel() instanceof FiringDisplay) {
@@ -2189,6 +2190,11 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             int facing = entity.getFacing();
             if (entity.isSecondaryArcWeapon(entity.getEquipmentNum(mounted))) {
                 facing = entity.getSecondaryFacing();
+            }
+            // If this is a tank with dual turrets, check to see if the weapon is a second turret.
+            if ((entity instanceof Tank) &&
+                    (entity.getEquipment(weaponId).getLocation() == ((Tank) entity).getLocTurret2())) {
+                    facing = ((Tank) entity).getDualTurretFacing();
             }
             ((FiringDisplay) gui.getCurrentPanel()).setWeaponFieldOfFire(entity, ranges, arc, loc, facing);
         } else if (gui.getCurrentPanel() instanceof TargetingPhaseDisplay) {

--- a/megamek/src/megamek/common/SuperHeavyTank.java
+++ b/megamek/src/megamek/common/SuperHeavyTank.java
@@ -373,11 +373,10 @@ public class SuperHeavyTank extends Tank {
                     return Compute.ARC_NOSE;
                 }
             case LOC_TURRET:
+            case LOC_TURRET_2:
                 if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_VEHICLE_ARCS)) {
                     return Compute.ARC_TURRET;
                 }
-                return Compute.ARC_FORWARD;
-            case LOC_TURRET_2:
                 return Compute.ARC_FORWARD;
             case LOC_FRONTRIGHT:
             case LOC_REARRIGHT:


### PR DESCRIPTION
This PR fixes issue #5215 by checking for dual turret rotation and updating the selected weapon to be the dual turret upon rotation.  This doesn't specifically address the Mek turret rotation firing display issue as this logic is specific to tanks and super heavy vehicles.