### PR TITLE
Add actionlistener for combobox in DialogOptionComponent

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMechDialog.java
@@ -397,6 +397,11 @@ public class CustomMechDialog extends AbstractButtonDialog implements ActionList
     @Override
     public void optionClicked(DialogOptionComponent comp, IOption option, boolean state) { }
 
+    @Override
+    public void optionSwitched(DialogOptionComponent clickedComp, IOption option, int i) {
+        // nothing implemented yet
+    }
+
     public boolean isOkay() {
         return okay;
     }

--- a/megamek/src/megamek/client/ui/swing/DialogOptionComponent.java
+++ b/megamek/src/megamek/client/ui/swing/DialogOptionComponent.java
@@ -29,7 +29,7 @@ import megamek.client.ui.swing.util.UIUtil.FixedYPanel;
 import megamek.common.options.*;
 
 /** @author Cord Awtry */
-public class DialogOptionComponent extends FixedYPanel implements ItemListener, Comparable<DialogOptionComponent> {
+public class DialogOptionComponent extends FixedYPanel implements ItemListener, ActionListener, Comparable<DialogOptionComponent> {
 
     private static final long serialVersionUID = -4190538980884459746L;
 
@@ -85,6 +85,7 @@ public class DialogOptionComponent extends FixedYPanel implements ItemListener, 
                 label.setLabelFor(choice);
                 label.setToolTipText(convertToHtml(option.getDescription()));
                 choice.setEnabled(editable);
+                choice.addActionListener(this);
                 if (choiceLabelFirst) {
                     add(choice);
                     add(label);
@@ -92,6 +93,7 @@ public class DialogOptionComponent extends FixedYPanel implements ItemListener, 
                     add(label);
                     add(choice);
                 }
+
                 break;
             default:
                 textField = new JTextField(option.stringValue(), option.getTextFieldLength());
@@ -217,7 +219,10 @@ public class DialogOptionComponent extends FixedYPanel implements ItemListener, 
     }
 
     public void addValue(String value) {
+        //turn off listener when adding the item
+        choice.removeActionListener(this);
         choice.addItem(value);
+        choice.addActionListener(this);
     }
 
     public boolean isDefaultValue() {
@@ -257,6 +262,11 @@ public class DialogOptionComponent extends FixedYPanel implements ItemListener, 
     }
 
     @Override
+    public void actionPerformed(ActionEvent actionEvent) {
+        dialogOptionListener.optionSwitched(this, option, choice.getSelectedIndex());
+    }
+
+    @Override
     public int compareTo(DialogOptionComponent doc) {
         return option.getDisplayableName().compareTo(doc.option.getDisplayableName());
     }
@@ -265,4 +275,5 @@ public class DialogOptionComponent extends FixedYPanel implements ItemListener, 
     public String toString() {
         return option.getDisplayableName();
     }
+
 }

--- a/megamek/src/megamek/client/ui/swing/DialogOptionListener.java
+++ b/megamek/src/megamek/client/ui/swing/DialogOptionListener.java
@@ -25,4 +25,6 @@ import megamek.common.options.IOption;
 public interface DialogOptionListener {
 
     void optionClicked(DialogOptionComponent comp, IOption option, boolean state);
+
+    void optionSwitched(DialogOptionComponent comp, IOption option, int i);
 }

--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -768,6 +768,11 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
     }
 
     @Override
+    public void optionSwitched(DialogOptionComponent clickedComp, IOption option, int i) {
+        // tracks changes to a combobox option - nothing implemented yet
+    }
+
+    @Override
     protected void okAction() {
         if (clientGui != null) {
             send();


### PR DESCRIPTION
This is needed for story arcs. The CreateCharacterDialog tracks how much XP has been used on skills and abilities as players make choices, but currently doesn't have any ability to track changes when they are made to JComboBoxes because there is no listener for those kinds of options. So, this PR adds a listener for those cases. I temporarily disable the listener when the `addValue` method is called so that the listener is not triggered during initialization. 

This PR needs to be done at the same time as PRs in megameklab and MekHQ because they use the DialogOptionListener. Specifically:

* MegaMek/mekhq#4005
* MegaMek/megameklab#1486

For now, it should come after .19 is out.