### PR TITLE
Fix #5343: damage display not showing damage color when multiples used

### DIFF
--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -683,7 +683,7 @@ public final class UnitToolTip {
                 String msg_x = Messages.getString("BoardView1.Tooltip.X");
                 String sDamage = dChar + msg_x + tensDmgd * 10;
                 sDamage += repeat(dChar, numDmgd - 10 * tensDmgd);
-                result +=  guiScaledFontHTML(colorIntact, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";
+                result +=  guiScaledFontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";
             } else {
                 String sDamage  = repeat(dChar, numDmgd);
                 result += guiScaledFontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";


### PR DESCRIPTION
Damage display was using the undamaged color for damaged blocks, but _only_ when the total of 
```(undamaged + damage) / <client settings damage block factor>``` is greater than 30.

Issue was that the less-common code path was using the undamaged block color for the damaged blocks.

Testing:

- Used save from #5343 to repro issue, and validate fix
- Ran all three projects' unit tests

Close #5343 