### PR TITLE
Fix: #2659 - Mek Quad turret firing arc reflects turret rotation changes.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TurretFacingDialog.java
+++ b/megamek/src/megamek/client/ui/swing/TurretFacingDialog.java
@@ -226,11 +226,33 @@ public class TurretFacingDialog extends JDialog implements ActionListener {
                 } else {
                     locToChange = turret.getLocation();
                 }
+
+                Mounted firstMountedWeapon = null;  // Take note of the first weapon mounted on this turret.
+                Mounted currentSelectedWeapon = null; // Take note of current selected weapon.
+                if (clientgui.getUnitDisplay() != null) {
+                    currentSelectedWeapon = clientgui.getUnitDisplay().wPan.getSelectedWeapon();
+                }
+
                 for (Mounted weapon : mech.getWeaponList()) {
                     if ((weapon.getLocation() == locToChange) && weapon.isMechTurretMounted()) {
                         weapon.setFacing(facing);
                         clientgui.getClient().sendMountFacingChange(mech.getId(), mech.getEquipmentNum(weapon), facing);
+
+                        // Tag the first mounted weapon as a backup option to refresh after the turret rotation.
+                        if (firstMountedWeapon == null) {
+                            firstMountedWeapon = weapon;
+                        }
+
+                        // If the currently selected weapon is in the turret, refresh it by default.
+                        if (mech.getEquipmentNum(currentSelectedWeapon) == mech.getEquipmentNum(weapon)) {
+                            firstMountedWeapon = currentSelectedWeapon;
+                        }
                     }
+                }
+
+                // Select the mounted weapon in the unit display to refresh the firing arch.
+                if (clientgui.getUnitDisplay() != null) {
+                    clientgui.getUnitDisplay().wPan.selectWeapon(mech.getEquipmentNum(firstMountedWeapon));
                 }
             } else if (tank != null) {
                 tank.setDualTurretOffset(((6 - tank.getFacing()) + facing) % 6);

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2191,6 +2191,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             if (entity.isSecondaryArcWeapon(entity.getEquipmentNum(mounted))) {
                 facing = entity.getSecondaryFacing();
             }
+            // If this is mech with turrets, check to see if the weapon is on a turret.
+            if ((entity instanceof Mech) && (entity.getEquipment(weaponId).isMechTurretMounted())) {
+                facing = mounted.getFacing();
+            }
             // If this is a tank with dual turrets, check to see if the weapon is a second turret.
             if ((entity instanceof Tank) &&
                     (entity.getEquipment(weaponId).getLocation() == ((Tank) entity).getLocTurret2())) {


### PR DESCRIPTION
Fixes #2659 - This PR fixes firing arcs updates for mek mounted turrets such as that on a QUAD mek.  This is similar to the fix for vehicle turret firing arcs.  When changing the turret direction, the selected turret weapon will be updated if selected, or the first weapon on the turret if a non-turret weapon is the current selected weapon.

![image](https://github.com/MegaMek/megamek/assets/83041327/8123f22a-1c56-4996-946e-33a0f759f33e)
