### PR TITLE
Fix #5375: quirks and SPAs applying twice to ADA missiles only

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4937,10 +4937,19 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             // Return without SRT set so that regular to-hit mods get applied.
             return toHit;
         }
+
+        // ADA has its to-hit mods calculated separately; handle other direct artillery quirk and SPA mods here:
+        // Quirks
+        processAttackerQuirks(toHit, ae, te, weapon);
+
+        // SPAs
+        processAttackerSPAs(toHit, ae, te, weapon, game);
+        processDefenderSPAs(toHit, ae, te, weapon, game);
+
         //If an airborne unit occupies the target hex, standard artillery ammo makes a flak attack against it
         //TN is a flat 3 + the altitude mod + the attacker's weapon skill - 2 for Flak
         //Grounded/destroyed/landed/wrecked ASF/VTOL/WiGE should be treated as normal.
-        else if ((isArtilleryFLAK || (atype.countsAsFlak())) && te != null) {
+        if ((isArtilleryFLAK || (atype.countsAsFlak())) && te != null) {
             if (te.isAirborne() || te.isAirborneVTOLorWIGE()) {
                 toHit.addModifier(3, Messages.getString("WeaponAttackAction.ArtyFlak"));
                 toHit.addModifier(-2, Messages.getString("WeaponAttackAction.Flak"));
@@ -5077,18 +5086,6 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             te = (Entity) target;
         }
 
-        if (toHit == null) {
-            // Without valid toHit data, the rest of this will fail
-            toHit = new ToHitData();
-        }
-
-        // Quirks
-        processAttackerQuirks(toHit, ae, te, weapon);
-
-        // SPAs
-        processAttackerSPAs(toHit, ae, te, weapon, game);
-        processDefenderSPAs(toHit, ae, te, weapon, game);
-
         //Homing warheads just need a flat 4 to seek out a successful TAG, but Princess needs help
         //judging what a good homing target is.
         if (isHoming) {
@@ -5120,16 +5117,29 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
             return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS, Messages.getString("WeaponAttackAction.ArtyDesTarget"));
         }
 
+        // If we're not skipping To-Hit calculations, ensure that we have a toHit instance
+        if (toHit == null) {
+            // Without valid toHit data, the rest of this will fail
+            toHit = new ToHitData();
+        }
+
         // Handle direct artillery attacks.
         if (isArtilleryDirect) {
             return artilleryDirectToHit(game, ae, target, ttype, losMods, toHit, wtype,
                     weapon, atype, isArtilleryFLAK, usesAmmo, srt
             );
-        }
-        //And now for indirect artillery fire
-        if (isArtilleryIndirect) {
+        } else if (isArtilleryIndirect) {
+            //And now for indirect artillery fire; process quirks and SPAs here or they'll be missed
+            // Quirks
+            processAttackerQuirks(toHit, ae, te, weapon);
+
+            // SPAs
+            processAttackerSPAs(toHit, ae, te, weapon, game);
+            processDefenderSPAs(toHit, ae, te, weapon, game);
+
             return artilleryIndirectToHit(ae, target, toHit, wtype, weapon, srt);
         }
+
         //If we get here, this isn't an artillery attack
         return toHit;
     }


### PR DESCRIPTION
This was caused by changing ADA (and only ADA) to-hit calculations to continue in the standard To-Hit mod path after calculating ADA's unusual range mod; all other artillery direct and indirect fire to-hit mods were unaffected.  Since the main-line mod calculation path calcs Quirks and SPAs last, but the Artillery path calcs them first, ADA was double-dipping.

Fix is to move the Artillery-specific quirk and SPA calculations to after the ADA mod path returns to the main path, so ADA only gets these calculated once (but other artillery still gets theirs calculated separately from the main-line path).

Testing:
- Ran a variety of attack calculations using Anti-Air quirk units and every kind of weapon system versus various airborne units
- Ran all projects' unit tests.