### PR TITLE
Correct mek arc facing when mek is turned.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2193,7 +2193,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             }
             // If this is mech with turrets, check to see if the weapon is on a turret.
             if ((entity instanceof Mech) && (entity.getEquipment(weaponId).isMechTurretMounted())) {
-                facing = mounted.getFacing();
+                facing = (mounted.getFacing() + entity.getFacing()) % 6;
             }
             // If this is a tank with dual turrets, check to see if the weapon is a second turret.
             if ((entity instanceof Tank) &&


### PR DESCRIPTION
This is a correction PR #5373.  

The Fix for #2659 didn't account for mek facing.  This PR ensures the mek turret facing is correct for selected turret facing and mek facing.