### PR TITLE
Update name change for LTV-4 hover tank and NameChangesValidator

### DIFF
--- a/megamek/data/mechfiles/name_changes.txt
+++ b/megamek/data/mechfiles/name_changes.txt
@@ -745,7 +745,8 @@ Desert Scorpion|Desert Scorpion Light Tank
 Donovan-Miter Magellan Series Four|Magellan Series Four
 Falcon Hover Tank (Standard)|Falcon Hover Tank
 Federated-Boeing Longhaul FB-335|Longhaul Cargo Aircraft FB-335
-Hover Tank (Standard)|LTV-4 Hover Tank
+Hover Tank (Standard)|Hawk Hover Tank (LTV-4)
+LTV-4 Hover Tank|Hawk Hover Tank (LTV-4)
 Iveco Burro Heavy Support Truck|Burro Heavy Support Truck
 Iveco Burro II Super Heavy Cargo Truck|Burro II Super Heavy Cargo Truck
 Kressly Dillinger Police Vehicle|Dillinger Police Vehicle

--- a/megamek/src/megamek/utilities/NameChangesValidator.java
+++ b/megamek/src/megamek/utilities/NameChangesValidator.java
@@ -20,7 +20,6 @@ package megamek.utilities;
 
 import megamek.common.Configuration;
 import megamek.common.MechSummaryCache;
-import megamek.common.util.fileUtils.MegaMekFile;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -32,23 +31,65 @@ import java.nio.charset.StandardCharsets;
  * This tool goes through the name_changes.txt file and finds all lines where the right-side entry (the
  * real and existing unit name) does not actually exist and prints those.
  */
-public class NameChangesValidator implements MechSummaryCache.Listener {
+public class NameChangesValidator {
 
     private static MechSummaryCache mechSummaryCache = null;
     private int errors;
+    private final File lookupNames = new File(Configuration.unitsDir(), MechSummaryCache.FILENAME_LOOKUP);
+    private final File lookupNamesHidden = new File(Configuration.unitsDir(), MechSummaryCache.FILENAME_LOOKUP + ".xxx");
 
     public static void main(String... args) {
         NameChangesValidator validator = new NameChangesValidator();
-        System.out.println("Loading Unit Cache...");
-        mechSummaryCache = MechSummaryCache.getInstance(true);
-        mechSummaryCache.addListener(validator);
+        validator.testLeftSide();
+        validator.testRightSide();
     }
 
-    @Override
-    public void doneLoading() {
-        System.out.println("Comparing name changes...");
-        File lookupNames = new MegaMekFile(Configuration.unitsDir(), MechSummaryCache.FILENAME_LOOKUP).getFile();
+    public void testLeftSide() {
+        System.out.println("Testing name changes...");
+
+        System.out.println("Trying to rename " + lookupNames + " to " + lookupNamesHidden);
+        if (lookupNames.renameTo(lookupNamesHidden) && lookupNamesHidden.exists()) {
+            System.out.println("Loading Unit Cache...");
+            mechSummaryCache = MechSummaryCache.getInstance(true);
+            mechSummaryCache.getAllMechs();
+            System.out.println("Rename successful. Testing lookup names...");
+            try (FileInputStream fis = new FileInputStream(lookupNamesHidden);
+                 InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+                 BufferedReader br = new BufferedReader(isr)) {
+                String line;
+                while (null != (line = br.readLine())) {
+                    if (line.startsWith("#")) {
+                        continue;
+                    }
+                    int index = line.indexOf('|');
+                    if (index > 0) {
+                        String lookupName = line.substring(0, index);
+                        if (mechSummaryCache.getMech(lookupName) != null) {
+                            System.out.println("Lookup name (left side) is an existing unit in line: " + line);
+                            errors++;
+                        }
+                    }
+                }
+            } catch (Exception ex) {
+                System.out.println("Exception " + ex.getMessage());
+                System.exit(64);
+            }
+        }
+
+        System.out.println("Trying to rename " + lookupNamesHidden + " back to " + lookupNames);
+        if (!lookupNamesHidden.renameTo(lookupNames)) {
+            System.out.println("ERROR: Could not rename! Check the files!");
+            System.exit(64);
+        }
+        System.out.println("Rename successful.");
+    }
+
+    private void testRightSide() {
         if (lookupNames.exists()) {
+            System.out.println("Testing actual names...");
+            System.out.println("Reloading Unit Cache...");
+            mechSummaryCache.loadMechData(true);
+            mechSummaryCache.getAllMechs();
             try (FileInputStream fis = new FileInputStream(lookupNames);
                  InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
                  BufferedReader br = new BufferedReader(isr)) {


### PR DESCRIPTION
from RAT errors in the log
Edit: I added an update to the NameChangesValidator that now checks both sides of the name_changes.txt entries.