### PR TITLE
Fix #5413: Fix improper drop-through in packet handling switch/case

### DIFF
--- a/megamek/src/megamek/client/AbstractClient.java
+++ b/megamek/src/megamek/client/AbstractClient.java
@@ -409,6 +409,7 @@ public abstract class AbstractClient implements IClient {
             case SERVER_GREETING:
                 connected = true;
                 send(new Packet(PacketCommand.CLIENT_NAME, name, isBot()));
+                break;
             case SERVER_CORRECT_NAME:
                 correctName(packet);
                 break;


### PR DESCRIPTION
It looks like the `break;` line went missing in the `SERVER_GREETING` case.  Adding a `break;` fixes the issue.

Testing:
- Ran all three projects' unit tests.
- Confirmed that the proposed fix returns Princess's ability to join games.

Close #5413 