### PR TITLE
Implement RFE #5408: update Princess ammo conservation values to make…

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -769,7 +769,7 @@ public class Princess extends BotClient {
                     continue;
                 } else if (weaponType.hasFlag(WeaponType.F_ONESHOT)) {
                     // Shoot OS weapons on a 10 / 9 / 8 for Aggro 10 / 5 / 0
-                    ammoConservation.put(weapon, (40-aggroFactor)/100.0);
+                    ammoConservation.put(weapon, (35 - 2.0 * aggroFactor) / 100.0);
                     msg.append(" One Shot weapon.");
                     continue;
                 }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -22,6 +22,7 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,10 +31,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -45,6 +45,9 @@ import static org.mockito.Mockito.when;
  */
 public class PrincessTest {
 
+    static WeaponType mockAC5 = (WeaponType) EquipmentType.get("ISAC5");
+    static AmmoType mockAC5AmmoType = (AmmoType) EquipmentType.get("ISAC5 Ammo");
+    static WeaponType mockRL20 = (WeaponType) EquipmentType.get("RL20");
     private Princess mockPrincess;
     private BasicPathRanker mockPathRanker;
 
@@ -63,6 +66,7 @@ public class PrincessTest {
         when(mockPrincess.getPathRanker(PathRankerType.Basic)).thenReturn(mockPathRanker);
         when(mockPrincess.getPathRanker(any(Entity.class))).thenReturn(mockPathRanker);
         when(mockPrincess.getMoraleUtil()).thenReturn(mockMoralUtil);
+        when(mockPrincess.calcAmmoConservation(any(Entity.class))).thenCallRealMethod();
     }
 
     @Test
@@ -359,19 +363,19 @@ public class PrincessTest {
 
         when(mockPrincess.wantsToFallBack(any(Entity.class))).thenReturn(false);
         when(mockPrincess.isFallingBack(any(Entity.class))).thenCallRealMethod();
-       
+
         BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
         when(mockBehavior.getDestinationEdge()).thenReturn(CardinalEdge.NONE);
         when(mockBehavior.isForcedWithdrawal()).thenReturn(true);
         when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
-        
+
         // A normal undamaged mech.
         assertFalse(mockPrincess.isFallingBack(mockMech));
 
         // A mobile mech that wants to fall back (for any reason).
         when(mockMech.isCrippled(anyBoolean())).thenReturn(true);
         assertTrue(mockPrincess.isFallingBack(mockMech));
-        
+
         // A mech whose bot is set for a destination edge
         when(mockBehavior.getDestinationEdge()).thenReturn(CardinalEdge.NEAREST);
         assertTrue(mockPrincess.isFallingBack(mockMech));
@@ -536,5 +540,139 @@ public class PrincessTest {
         when(mockMech.isProne()).thenReturn(false);
         when(mockMech.isStuck()).thenReturn(true);
         assertTrue(mockPrincess.isImmobilized(mockMech));
+    }
+
+    @Test
+    public void testCalcAmmoForDefaultAggressionLevel() throws megamek.common.LocationFullException {
+        // Expected toHitThresholds should equate to a TN of 12, 11, and 10 for ammo values
+        // of 7+, 3+, 1.
+
+        // Set aggression to default level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(5);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted bin1 = mech1.addEquipment(mockAC5AmmoType, Mech.LOC_LT);
+        Mounted wpn1 = mech1.addEquipment(mockAC5, Mech.LOC_RT);
+
+        // Check default toHitThresholds
+        // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
+        Double target = Compute.oddsAbove(12);
+        bin1.setShotsLeft(7);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
+        target = Compute.oddsAbove(11);
+        bin1.setShotsLeft(3);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
+        target = Compute.oddsAbove(10);
+        bin1.setShotsLeft(1);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+    }
+
+    @Test
+    public void testCalcAmmoForMaxAggressionLevel() throws megamek.common.LocationFullException {
+        // Expected toHitThresholds should equate to a TN of 12, 12, and 10 for ammo values
+        // of 7+, 3+, 1.
+
+        // Set aggression to default level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(10);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted bin1 = mech1.addEquipment(mockAC5AmmoType, Mech.LOC_LT);
+        Mounted wpn1 = mech1.addEquipment(mockAC5, Mech.LOC_RT);
+
+        // Check default toHitThresholds
+        // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
+        Double target = Compute.oddsAbove(12);
+        bin1.setShotsLeft(7);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 3+ rounds for this level should allow firing on 12s
+        bin1.setShotsLeft(3);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
+        target = Compute.oddsAbove(10);
+        bin1.setShotsLeft(1);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+    }
+
+    @Test
+    public void testCalcAmmoForZeroAggressionLevel() throws megamek.common.LocationFullException {
+        // Expected toHitThresholds should equate to a TN of 10, 9, and 7 for ammo values
+        // of 7+, 3+, 1.
+
+        // Set aggression to default level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(0);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted bin1 = mech1.addEquipment(mockAC5AmmoType, Mech.LOC_LT);
+        Mounted wpn1 = mech1.addEquipment(mockAC5, Mech.LOC_RT);
+
+        // Check default toHitThresholds
+        // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
+        Double target = Compute.oddsAbove(10);
+        bin1.setShotsLeft(7);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
+        target = Compute.oddsAbove(9);
+        bin1.setShotsLeft(3);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
+        target = Compute.oddsAbove(7);
+        bin1.setShotsLeft(1);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+    }
+
+    @Test
+    public void testCalcAmmoForOneShotWeapons() throws megamek.common.LocationFullException {
+        // Set aggression to lowest level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(0);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted wpn1 = mech1.addEquipment(mockRL20, Mech.LOC_LT);
+
+        // Check default toHitThresholds
+        // For max aggro, shoot OS weapons at TN 10 or better
+        Double target = Compute.oddsAbove(10);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // For default aggro, shoot OS weapons at TN 9 or better
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(5);
+        target = Compute.oddsAbove(9);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // For lowest aggro, shoot OS weapons at TN 8 or better
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(10);
+        target = Compute.oddsAbove(8);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
     }
 }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -559,19 +559,19 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12) / 100.0;
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
-        target = Compute.oddsAbove(11);
+        target = Compute.oddsAbove(11) / 100.0;
         bin1.setShotsLeft(3);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
-        target = Compute.oddsAbove(10);
+        target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(1);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -594,7 +594,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12) / 100.0;
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -605,7 +605,7 @@ public class PrincessTest {
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
-        target = Compute.oddsAbove(10);
+        target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(1);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -628,19 +628,19 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
-        target = Compute.oddsAbove(9);
+        target = Compute.oddsAbove(9) / 100.0;
         bin1.setShotsLeft(3);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
-        target = Compute.oddsAbove(7);
+        target = Compute.oddsAbove(7) / 100.0;
         bin1.setShotsLeft(1);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -659,19 +659,19 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // For max aggro, shoot OS weapons at TN 10 or better
-        double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(8) / 100.0;
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // For default aggro, shoot OS weapons at TN 9 or better
         when(mockBehavior.getHyperAggressionIndex()).thenReturn(5);
-        target = Compute.oddsAbove(9);
+        target = Compute.oddsAbove(9) / 100.0;
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // For lowest aggro, shoot OS weapons at TN 8 or better
         when(mockBehavior.getHyperAggressionIndex()).thenReturn(10);
-        target = Compute.oddsAbove(8);
+        target = Compute.oddsAbove(10) / 100.0;
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
     }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -648,7 +648,7 @@ public class PrincessTest {
 
     @Test
     public void testCalcAmmoForOneShotWeapons() throws megamek.common.LocationFullException {
-        // Set aggression to lowest level
+        // Set aggression to the lowest level first
         BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
         when(mockBehavior.getHyperAggressionIndex()).thenReturn(0);
         when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -559,7 +559,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        Double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12);
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -594,7 +594,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        Double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12);
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -628,7 +628,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        Double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(10);
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -659,7 +659,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // For max aggro, shoot OS weapons at TN 10 or better
-        Double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(10);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 


### PR DESCRIPTION
… Princess more aggressive

After a few reports that Princess was being too withholding of her ammo-based love, we did some analysis and determined that the current ammo conservation thresholds should be bumped up significantly.

Edit: also adds separate, simpler calculations for one-shot weapons, which previously were handled like normal weapons having only a single round of ammo remaining.  We want to incentivize firing these weapons slightly earlier so the new code pushes allowed to-hit % down slightly for each level of Aggression.

Testing:
- Ran all 3 projects' unit tests
- Added new unit tests for the calcAmmoConservation() method on Princess
- Ran bot vs bot matches using ammo-heavy units and default and maxed Aggression settings.

Close #5408 