### PR TITLE
Fix 5419: iATM ranges incorrect

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1661,7 +1661,7 @@ public class FireControl {
             } else {
                 // For certain weapon types, look over all their loaded ammos
                 List<AmmoMounted> ammos;
-                if (wtype.getAmmoType() == AmmoType.T_ATM || wtype.getAmmoType() == AmmoType.T_MML) {
+                if (List.of(AmmoType.T_ATM, AmmoType.T_IATM, AmmoType.T_MML).contains(wtype.getAmmoType())) {
                     ammos = shooter.getAmmo(weapon);
                 } else {
                     // Otherwise assume the current loaded ammo is suitable representative

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1213,7 +1213,7 @@ public class FireControl {
                 } else {
                     // For certain weapon types, look over all their loaded ammos
                     List<AmmoMounted> ammos;
-                    if (wtype.getAmmoType() == AmmoType.T_ATM || wtype.getAmmoType() == AmmoType.T_MML) {
+                    if (List.of(AmmoType.T_ATM, AmmoType.T_IATM, AmmoType.T_MML).contains(wtype.getAmmoType())) {
                         ammos = shooter.getAmmo(weapon);
                     } else {
                         // Otherwise assume the current loaded ammo is suitable representative
@@ -1810,7 +1810,7 @@ public class FireControl {
             } else {
                 // For certain weapon types, look over all their loaded ammos
                 List<AmmoMounted> ammos;
-                if (wtype.getAmmoType() == AmmoType.T_ATM || wtype.getAmmoType() == AmmoType.T_MML) {
+                if (List.of(AmmoType.T_ATM, AmmoType.T_IATM, AmmoType.T_MML).contains(wtype.getAmmoType())) {
                     ammos = shooter.getAmmo(weapon);
                 } else {
                     // Otherwise assume the current loaded ammo is suitable representative
@@ -2649,7 +2649,7 @@ public class FireControl {
 
                 // For certain weapon types, look over all their loaded ammos
                 List<AmmoMounted> ammos;
-                if (weaponType.getAmmoType() == AmmoType.T_ATM || weaponType.getAmmoType() == AmmoType.T_MML) {
+                if (List.of(AmmoType.T_ATM, AmmoType.T_IATM, AmmoType.T_MML).contains(weaponType.getAmmoType())) {
                     ammos = shooter.getAmmo(weapon);
                 } else {
                     // Otherwise assume the current loaded ammo is suitable representative
@@ -2728,7 +2728,7 @@ public class FireControl {
             }
 
             final AmmoMounted suggestedAmmo = info.getAmmo();
-            final AmmoMounted mountedAmmo = getPreferredAmmo(shooter, info.getTarget(), currentWeapon);
+            final AmmoMounted mountedAmmo = getPreferredAmmo(shooter, info.getTarget(), currentWeapon, suggestedAmmo);
             // if we found preferred ammo but can't apply it to the weapon, log it and continue.
             if ((null != mountedAmmo) && !shooter.loadWeapon(currentWeapon, mountedAmmo)) {
                 LogManager.getLogger().warn(shooter.getDisplayName() + " tried to load "

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -421,9 +421,11 @@ public class WeaponFireInfo {
         // but we'll roll an "average" cluster for the given weapon size to estimate damage.
         if ((weaponType.getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE) ||
            (weaponType.getDamage() == WeaponType.DAMAGE_ARTILLERY)) {
-            // Assume average cluster size for this weapon
-            int rs = weaponType.getRackSize();
-            return Compute.calculateClusterHitTableAmount(7, rs);
+            // Assume average cluster size for this weapon, unless it has Streak capabilities
+            if (!List.of(AmmoType.T_SRM_STREAK, AmmoType.T_LRM_STREAK, AmmoType.T_IATM).contains(weaponType.getAmmoType())) {
+                int rs = weaponType.getRackSize();
+                return Compute.calculateClusterHitTableAmount(7, rs);
+            }
         }
 
         // infantry weapons use number of troopers multiplied by weapon damage,

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2130,8 +2130,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         // Aero
         if (entity.isAirborne()) {
 
-            // prepare fresh ranges, no underwater
-            ranges[0] = new int[] { 0, 0, 0, 0, 0 };
+            // keep original ranges ranges, no underwater
             ranges[1] = new int[] { 0, 0, 0, 0, 0 };
             int maxr = WeaponType.RANGE_SHORT;
 
@@ -2145,20 +2144,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                     && ((mounted.getLinked() == null)
                             || (mounted.getLinked().getUsableShotsLeft() > 0))) {
                 maxr = wtype.getMaxRange(mounted);
-
-                if (atype != null) {
-                    if (atype.getAmmoType() == AmmoType.T_ATM) {
-                        if (atype.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE)) {
-                            maxr = WeaponType.RANGE_EXT;
-                        } else if (atype.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE)) {
-                            maxr = WeaponType.RANGE_SHORT;
-                        }
-                    } else if (atype.getAmmoType() == AmmoType.T_MML) {
-                        if (!atype.hasFlag(AmmoType.F_MML_LRM)) {
-                            maxr = WeaponType.RANGE_SHORT;
-                        }
-                    }
-                }
 
                 // set the standard ranges, depending on capital or no
                 // boolean isCap = wtype.isCapital();

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2086,42 +2086,25 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             ranges[1] = new int[] { 0, 0, 0, 0, 0 };
         }
 
-        // Override for the various ATM and MML ammos
+        // Override for the MML ammos
         if (atype != null) {
-            if (atype.getAmmoType() == AmmoType.T_ATM) {
-                if (atype.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE)) {
-                    ranges[0] = new int[] { 4, 9, 18, 27, 36 };
-                } else if (atype.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE)) {
-                    ranges[0] = new int[] { 0, 3, 6, 9, 12 };
-                } else {
-                    ranges[0] = new int[] { 4, 5, 10, 15, 20 };
-                }
-            } else if (atype.getAmmoType() == AmmoType.T_MML) {
+            if (atype.getAmmoType() == AmmoType.T_MML) {
                 if (atype.hasFlag(AmmoType.F_MML_LRM)) {
                     if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
-                        ranges[0] = new int[] { 4, 5, 10, 15, 20 };
+                        ranges[0] = new int[]{4, 5, 10, 15, 20};
                     } else {
-                        ranges[0] = new int[] { 6, 7, 14, 21, 28 };
+                        ranges[0] = new int[]{6, 7, 14, 21, 28};
                     }
                 } else {
                     if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
-                        ranges[0] = new int[] { 0, 2, 4, 6, 8 };
+                        ranges[0] = new int[]{0, 2, 4, 6, 8};
                     } else {
-                        ranges[0] = new int[] { 0, 3, 6, 9, 12 };
+                        ranges[0] = new int[]{0, 3, 6, 9, 12};
                     }
-                }
-            } else if (atype.getAmmoType() == AmmoType.T_IATM) {
-                if (atype.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE)) {
-                    ranges[0] = new int[] { 4, 9, 18, 27, 36 };
-                } else if (atype.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE)) {
-                    ranges[0] = new int[] { 0, 3, 6, 9, 12 };
-                } else if (atype.getMunitionType().contains(AmmoType.Munitions.M_IATM_IMP)) {
-                    ranges[0] = new int[] { 0, 3, 6, 9, 12 };
-                } else {
-                    ranges[0] = new int[] { 4, 5, 10, 15, 20 };
                 }
             }
         }
+
         // No minimum range for hotload
         if ((mounted.getLinked() != null) && mounted.getLinked().isHotLoaded()) {
             ranges[0][0] = 0;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1335,7 +1335,7 @@ public class Compute {
         }
         int maxRange = wtype.getMaxRange(weapon, ammo);
 
-        // if aero and greater than max range then swith to range_out
+        // if aero and greater than max range then switch to range_out
         if ((ae.isAirborne() || (ae.usesWeaponBays() && game.getBoard()
                 .onGround())) && (range > maxRange)) {
             range = RangeType.RANGE_OUT;
@@ -3211,18 +3211,22 @@ public class Compute {
             }
         }
 
-        if (use_table == true) {
+        if (use_table) {
             if (!(attacker instanceof BattleArmor)) {
                 if (weapon.getLinked() == null) {
                     return 0.0f;
                 }
             }
+
             AmmoType at = null;
-            if ((weapon.getLinked() != null)
+            if (waa.getAmmoId() != -1) {
+                // If a preferred ammo has been set for this WAA, use that
+                at = waa.getEntity(g).getAmmo(waa.getAmmoId()).getType();
+            } else if ((weapon.getLinked() != null)
                     && (weapon.getLinked().getType() instanceof AmmoType)) {
                 at = (AmmoType) weapon.getLinked().getType();
-                fDamage = at.getDamagePerShot();
             }
+            fDamage = (at != null) ? at.getDamagePerShot() : fDamage;
 
             float fHits = 0.0f;
             if ((wt.getRackSize() != 40) && (wt.getRackSize() != 30)) {
@@ -3230,8 +3234,10 @@ public class Compute {
             } else {
                 fHits = 2.0f * expectedHitsByRackSize[wt.getRackSize() / 2];
             }
+            // Streaks / iATMs will _all_ hit, if they hit at all.
             if (((wt.getAmmoType() == AmmoType.T_SRM_STREAK)
                     || (wt.getAmmoType() == AmmoType.T_LRM_STREAK))
+                    || (wt.getAmmoType() == AmmoType.T_IATM)
                     && !ComputeECM.isAffectedByAngelECM(attacker, attacker
                             .getPosition(), waa.getTarget(g).getPosition(),
                             allECMInfo)) {

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -3219,7 +3219,7 @@ public class Compute {
             }
 
             AmmoType at = null;
-            if (waa.getAmmoId() != -1) {
+            if (waa.getAmmoId() != WeaponAttackAction.UNASSIGNED) {
                 // If a preferred ammo has been set for this WAA, use that
                 at = waa.getEntity(g).getAmmo(waa.getAmmoId()).getType();
             } else if ((weapon.getLinked() != null)

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -15,6 +15,8 @@
 package megamek.common;
 
 import java.math.BigInteger;
+import java.util.List;
+import java.util.Set;
 
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.equipment.AmmoMounted;
@@ -614,14 +616,14 @@ public class WeaponType extends EquipmentType {
     }
 
     public int getMaxRange(WeaponMounted weapon, AmmoMounted ammo) {
-        if (getAmmoType() == AmmoType.T_ATM) {
+        if (weapon.getType().getAtClass() == CLASS_ATM) {
             AmmoType ammoType = ammo.getType();
-            if ((ammoType.getAmmoType() == AmmoType.T_ATM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
-                return RANGE_EXT;
-            } else if ((ammoType.getAmmoType() == AmmoType.T_ATM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE))) {
-                return RANGE_SHORT;
+            if (List.of(AmmoType.T_ATM, AmmoType.T_IATM).contains(ammoType.getAmmoType())) {
+                if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE)) {
+                    return RANGE_EXT;
+                } else if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE)) {
+                    return RANGE_SHORT;
+                }
             }
         }
         if (getAmmoType() == AmmoType.T_MML) {
@@ -634,6 +636,7 @@ public class WeaponType extends EquipmentType {
         }
         return maxRange;
     }
+
     public int getInfantryDamageClass() {
         return infDamageClass;
     }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -47,16 +47,17 @@ import java.util.*;
 public class WeaponAttackAction extends AbstractAttackAction implements Serializable {
     public static int DEFAULT_VELOCITY = 50;
     private static final long serialVersionUID = -9096603813317359351L;
+    public static int UNASSIGNED = -1;
 
     public static final int STRATOPS_SENSOR_SHADOW_WEIGHT_DIFF = 100000;
 
     private int weaponId;
-    private int ammoId = -1;
+    private int ammoId = UNASSIGNED;
     private EnumSet<AmmoType.Munitions> ammoMunitionType = EnumSet.noneOf(AmmoType.Munitions.class);
-    private int ammoCarrier = -1;
+    private int ammoCarrier = UNASSIGNED;
     private int aimedLocation = Entity.LOC_NONE;
     private AimingMode aimMode = AimingMode.NONE;
-    private int otherAttackInfo = -1;
+    private int otherAttackInfo = UNASSIGNED;
     private boolean nemesisConfused;
     private boolean swarmingMissiles;
     protected int launchVelocity = DEFAULT_VELOCITY;
@@ -64,8 +65,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
      * Keeps track of the ID of the current primary target for a swarm missile
      * attack.
      */
-    private int oldTargetId = -1;
-
+    private int oldTargetId = UNASSIGNED;
     /**
      * Keeps track of the Targetable type for the current primary target for a
      * swarm missile attack.
@@ -273,14 +273,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId, boolean isStrafing) {
         // Use -1 as ammoId because this method should always use the currently linked ammo for display calcs
         return toHit(game, attackerId, target, weaponId, Entity.LOC_NONE, AimingMode.NONE,
-                false, false, null, null, isStrafing, false, -1);
+                false, false, null, null, isStrafing, false, UNASSIGNED);
     }
 
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
                                   int aimingAt, AimingMode aimingMode, boolean isStrafing) {
         // Use -1 as ammoId because this method should always use the currently linked ammo for display calcs
         return toHit(game, attackerId, target, weaponId, aimingAt, aimingMode, false,
-                false, null, null, isStrafing, false, -1);
+                false, null, null, isStrafing, false, UNASSIGNED);
     }
 
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
@@ -312,7 +312,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                                    int ammoId) {
         final Entity ae = game.getEntity(attackerId);
         final WeaponMounted weapon = (WeaponMounted) ae.getEquipment(weaponId);
-        final AmmoMounted linkedAmmo = (ammoId == -1) ? weapon.getLinkedAmmo() : (AmmoMounted) ae.getEquipment(ammoId);
+        final AmmoMounted linkedAmmo = (ammoId == UNASSIGNED) ? weapon.getLinkedAmmo() : (AmmoMounted) ae.getEquipment(ammoId);
 
         final EquipmentType type = weapon.getType();
 
@@ -1847,7 +1847,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     }
                 }
                 if (isHoming) {
-                    if ((te == null) || (te.getTaggedBy() == -1)) {
+                    if ((te == null) || (te.getTaggedBy() == UNASSIGNED)) {
                         // Homing missiles must target a tagged entity
                         return Messages.getString("WeaponAttackAction.MustTargetTagged");
                     }
@@ -4159,7 +4159,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                     || (atype.getAmmoType() == AmmoType.T_MML)
                     || (atype.getAmmoType() == AmmoType.T_NLRM)
                     || (atype.getAmmoType() == AmmoType.T_MEK_MORTAR))
-                    && (munition.contains(AmmoType.Munitions.M_SEMIGUIDED)) && (te.getTaggedBy() != -1)) {
+                    && (munition.contains(AmmoType.Munitions.M_SEMIGUIDED)) && (te.getTaggedBy() != UNASSIGNED)) {
                 int nAdjust = thTemp.getValue();
                 if (nAdjust > 0) {
                     toHit.append(new ToHitData(-nAdjust, Messages.getString("WeaponAttackAction.SemiGuidedTag")));

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -43,6 +43,7 @@ import megamek.common.util.*;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.*;
 import megamek.common.weapons.*;
+import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.server.commands.*;
 import megamek.server.victory.VictoryResult;
@@ -25358,20 +25359,22 @@ public class GameManager extends AbstractGameManager {
                         }
                     }
                     // if this is a weapons bay then also hit all the other weapons
-                    for (WeaponMounted bayWeap : ((WeaponMounted) equipmentHit).getBayWeapons()) {
-                        bayWeap.setHit(true);
-                        // Taharqa : We should also damage the critical slot, or MM and MHQ
-                        // won't remember that this weapon is damaged on the MUL file
-                        for (int i = 0; i < aero.getNumberOfCriticals(loc); i++) {
-                            CriticalSlot slot1 = aero.getCritical(loc, i);
-                            if ((slot1 == null)
-                                    || (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
-                                continue;
-                            }
-                            Mounted mounted = slot1.getMount();
-                            if (mounted.equals(bayWeap)) {
-                                aero.hitAllCriticals(loc, i);
-                                break;
+                    if (equipmentHit instanceof WeaponMounted) {
+                        for (WeaponMounted bayWeap : ((WeaponMounted) equipmentHit).getBayWeapons()) {
+                            bayWeap.setHit(true);
+                            // Taharqa : We should also damage the critical slot, or MM and MHQ
+                            // won't remember that this weapon is damaged on the MUL file
+                            for (int i = 0; i < aero.getNumberOfCriticals(loc); i++) {
+                                CriticalSlot slot1 = aero.getCritical(loc, i);
+                                if ((slot1 == null)
+                                        || (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
+                                    continue;
+                                }
+                                Mounted mounted = slot1.getMount();
+                                if (mounted.equals(bayWeap)) {
+                                    aero.hitAllCriticals(loc, i);
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Initial issue was that iATM weapon bays did not accurately reflect their selected ammo.
In the process of investigating this I discovered a number of issues:

1. iATMs are not covered by most code that handles ATMs
2. iATMs are not considered Streak weapons for Princess planning purposes
3. iATM ammo types are not considered by Princess when guessing at expected damage from prospective attacks
4. ATM and iATM weapon ranges are retrieved, re-calculated, overwritten, and recreated from magic numbers _multiple_ times every turn for each launcher due to redundant code throughout WeaponType, WeaponFireInfo, WeaponAttackAction, and the WeaponPanel GUI elements.
5. The merge of PR #5406 reverted at least some of the Princess ammo selection code; any other code merged after 02/08/2024 is also suspect.

This PR fixes 1-4 and part of 5.

Testing:
- Re-ran all projects' unit tests (note: MHQ unit tests were already failing for other reasons)
- Tested extensively with player-controlled and bot-controlled Aerospace units mounting iATMs
- Built custom Dropships to confirm iATM bays functioning as expected.

Note: appears to be blocked by #5423 

Close #5419 