### PR TITLE
Fix bay weapon lookup

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1480,7 +1480,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             return;
         }
 
-        WeaponMounted mounted = (WeaponMounted) ((WeaponListModel) weaponList.getModel())
+        WeaponMounted mounted = ((WeaponListModel) weaponList.getModel())
                 .getWeaponAt(weaponList.getSelectedIndex());
         WeaponType wtype = mounted.getType();
         // The rules are a bit sparse on airborne (dropping) ground units, but it seems they should

--- a/megamek/src/megamek/common/equipment/WeaponMounted.java
+++ b/megamek/src/megamek/common/equipment/WeaponMounted.java
@@ -223,7 +223,7 @@ public class WeaponMounted extends Mounted<WeaponType> {
      */
     public WeaponMounted getBayWeapon(int index) {
         if ((index >= 0) && (index < bayWeapons.size())) {
-            return getEntity().getWeapon(index);
+            return getEntity().getWeapon(bayWeapons.get(index));
         } else {
             return null;
         }


### PR DESCRIPTION
Fixes weaponMounted::getBayWeapon, which is supposed to return a weapon in the bay by index, but instead returns a weapon in the overall weapon list by index.

Fixes #5423