### PR TITLE
Candidate fix for #5417 NPE Freeze bot moves invalid or nonsense.

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -674,11 +674,11 @@ public class Game extends AbstractGame implements Serializable, PlanetaryConditi
     public void receivePhase(GamePhase phase) {
         final GamePhase oldPhase = this.phase;
         setPhase(phase);
-        processGameEvent(new GamePhaseChangeEvent(this, oldPhase, phase));
     }
 
     @Override
     public void setPhase(GamePhase phase) {
+        final GamePhase oldPhase = this.phase;
         this.phase = phase;
         // Handle phase-specific items.
         switch (phase) {
@@ -707,6 +707,8 @@ public class Game extends AbstractGame implements Serializable, PlanetaryConditi
                 break;
             default:
         }
+
+        processGameEvent(new GamePhaseChangeEvent(this, oldPhase, phase));
     }
 
     public void processGameEvent(GameEvent event) {

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -672,7 +672,6 @@ public class Game extends AbstractGame implements Serializable, PlanetaryConditi
 
     @Override
     public void receivePhase(GamePhase phase) {
-        final GamePhase oldPhase = this.phase;
         setPhase(phase);
     }
 


### PR DESCRIPTION
Fixes #5417 

Moved `processGameEvent()` back into `setPhase()` where it was.  `setPhase()` gets called from places currently that `receivePhase()` doesn't get called from.  It looks like this was pulled out as a refactor but has un-intended side effects for the bots processing.

![image](https://github.com/MegaMek/megamek/assets/83041327/32ea1f5b-05c5-40cd-ab1f-d5ac75a8d747)


Before making this tweak, I was able to easily reproduce the NPE by running a bot vs bot as described in #5417.   After this change, the bot games end naturally after 15 to 25 rounds.   Before this tweak, the same bot games would either end in a NPE or infinite mindless bot moves that would go into over 100 rounds.