### PR TITLE
Handle one-shot ammo weapons like RLs appropriately

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -14340,6 +14340,8 @@ public class AmmoType extends EquipmentType {
             return false;
         } else if (!(ammo.getType() instanceof AmmoType)) {
             return false;
+        } else if (weaponType.hasFlag(WeaponType.F_ONESHOT)) {
+            return ammo.getUsableShotsLeft() > 0 && isAmmoValid((AmmoType) ammo.getType(), weaponType);
         } else {
             return ammo.isAmmoUsable() && isAmmoValid((AmmoType) ammo.getType(), weaponType);
         }


### PR DESCRIPTION
After ammo selection was added for Princess, she no longer fires Rocket Launchers, for two reasons:
1. The to-hit threshold for weapons with only one remaining shot of ammo was far too low, near 50% / 6+ TN.
2. OS weapons, although using linked ammo bins like regular weapons, use a fake location that causes checks of ammo validity to fail.

Since Princess verifies if prospective ammo for a weapon can be loaded into it when planning attacks, and OS ammo (like RL's single shot) the end result is that Princess skips OS weapons when actually creating her firing plans.

The first issue has already been fixed by adding specific thresholds for OS weapons based on Princess's aggression setting, which I've confirmed are generating the appropriate thresholds.

The final fix is to only check if a OS weapon's ammo still has a shot left and that it is of the appropriate type, rather than running the full gamut of checks used for regular ammo (shots left, validity, whether it is missing, damaged, or dumping, as well as valid location) since most of those states don't apply.

Testing:
- Ran existing unit tests for all three projects (MHQ tests currently broken by other changes)
- Ran Princess vs. Princess matches using RLs on a variety of unit types and confirmed firing