### PR TITLE
MM fix for MML issue where Partial Wing not accounted for

### DIFF
--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -528,6 +528,10 @@ public class BattleArmor extends Infantry {
                     && ignoreGameLessThanThin) {
                 mp++;
             }
+        } else {
+            if ((mp > 0) && hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
+                mp++;
+            }
         }
 
         if ((mp > 0)

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -519,6 +519,7 @@ public class BattleArmor extends Infantry {
             mp++;
         }
 
+        // MM is concerned with in-game conditions that impact Partial Wing mp
         if ((game != null)) {
             PlanetaryConditions conditions = game.getPlanetaryConditions();
             boolean ignoreGameLessThanThin = mpCalculationSetting.ignoreWeather
@@ -529,6 +530,7 @@ public class BattleArmor extends Infantry {
                 mp++;
             }
         } else {
+            // MML just cares that the Partial Wing exists and is installed
             if ((mp > 0) && hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
                 mp++;
             }


### PR DESCRIPTION
Adds PW Jump MP accounting outside of games so MML stats are correct.

Testing:
- Ran MM and MML unit tests (MHQ currently broken)
- Tested with Kage suits in MML and verified correct Jump MP with and without Partial Wing
- Tested with Kage suits in MM and verified correct Jump MP with atmosphere and without.

Close #5439 