### PR TITLE
MM's symbol font for some map indicators

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1166,6 +1166,7 @@ CommonSettingsDialog.colors.MoveMASCColor=Move MASC Color
 CommonSettingsDialog.colors.MoveRunColor=Move Run Color
 CommonSettingsDialog.colors.MoveSprintColor=Move Sprint Color
 CommonSettingsDialog.colors.PrecautionColor=Precaution Color
+CommonSettingsDialog.colors.OkColor="OK" Color
 CommonSettingsDialog.colors.PlanetaryConditionsBackgroundTransparency=Planetary Conditions / Keybinds Background Transparency
 CommonSettingsDialog.colors.PlanetaryConditionsBackgroundTransparency.tooltip=0-256
 CommonSettingsDialog.colors.PlanetaryConditionsColorBackground=Planetary Conditions / Keybinds Background Color

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -167,6 +167,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private ColourSelectorButton csbWarningColor;
     private ColourSelectorButton csbCautionColor;
     private ColourSelectorButton csbPrecautionColor;
+    private ColourSelectorButton csbOkColor;
     private ColourSelectorButton csbMyUnitColor;
     private ColourSelectorButton csbAllyUnitColor;
     private ColourSelectorButton csbEnemyColor;
@@ -1583,6 +1584,9 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         csbPrecautionColor = new ColourSelectorButton(Messages.getString("CommonSettingsDialog.colors.PrecautionColor"));
         csbPrecautionColor.setColour(GUIP.getPrecautionColor());
         row.add(csbPrecautionColor);
+        csbOkColor = new ColourSelectorButton(Messages.getString("CommonSettingsDialog.colors.OkColor"));
+        csbOkColor.setColour(GUIP.getOkColor());
+        row.add(csbOkColor);
         comps.add(row);
 
         addLineSpacer(comps);
@@ -1929,6 +1933,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         csbWarningColor.setColour(GUIP.getWarningColor());
         csbCautionColor.setColour(GUIP.getCautionColor());
         csbPrecautionColor.setColour(GUIP.getPrecautionColor());
+        csbOkColor.setColour(GUIP.getOkColor());
 
         csbMyUnitColor.setColour(GUIP.getMyUnitColor());
         csbAllyUnitColor.setColour(GUIP.getAllyUnitColor());
@@ -2112,6 +2117,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setWarningColor(csbWarningColor.getColour());
         GUIP.setCautionColor(csbCautionColor.getColour());
         GUIP.setPrecautionColor(csbPrecautionColor.getColour());
+        GUIP.setOkColor(csbOkColor.getColour());
 
         GUIP.setMyUnitColor(csbMyUnitColor.getColour());
         GUIP.setAllyUnitColor(csbAllyUnitColor.getColour());

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -125,6 +125,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String WARNING_COLOR = "WarningColor";
     public static final String CAUTION_COLOR = "CautionColor";
     public static final String PRECAUTION_COLOR = "PrecautionColor";
+    public static final String OK_COLOR = "OkColor";
 
     public static final String CUSTOM_UNIT_HEIGHT = "CustomUnitDialogSizeHeight";
     public static final String CUSTOM_UNIT_WIDTH = "CustomUnitDialogSizeWidth";
@@ -454,6 +455,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(WARNING_COLOR, DEFAULT_RED);
         setDefault(CAUTION_COLOR, Color.yellow);
         setDefault(PRECAUTION_COLOR, Color.orange);
+        setDefault(OK_COLOR, DEFAULT_GREEN);
 
         setDefault(PlayerColour.PLAYERCOLOUR_BLUE, new Color(0x8686BF));
         setDefault(PlayerColour.PLAYERCOLOUR_RED, new Color(0xCC6666));
@@ -481,7 +483,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(PlayerColour.PLAYERCOLOUR_YELLOW, new Color(0xF2F261));
 
         setDefault(BOARD_MOVE_DEFAULT_CLIMB_MODE, true);
-        setDefault(BOARD_MOVE_DEFAULT_COLOR, DEFAULT_CYAN.CYAN);
+        setDefault(BOARD_MOVE_DEFAULT_COLOR, Color.CYAN);
         setDefault(BOARD_MOVE_ILLEGAL_COLOR, DEFAULT_DARK_GRAY);
         setDefault(BOARD_MOVE_JUMP_COLOR, DEFAULT_RED);
         setDefault(BOARD_MOVE_MASC_COLOR, DEFAULT_ORANGE);
@@ -2505,6 +2507,14 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setPrecautionColor(Color color) {
         store.setValue(PRECAUTION_COLOR, getColorString(color));
+    }
+
+    public Color getOkColor() {
+        return getColor(OK_COLOR);
+    }
+
+    public void setOkColor(Color color) {
+        store.setValue(OK_COLOR, getColorString(color));
     }
 
     public boolean getMoveDefaultClimbMode() {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -3362,7 +3362,8 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
 
             // For each hex in the entities forward trajectory, add a flight turn indicator sprite.
             for (MoveStep ms : fpiSteps) {
-                fpiSprites.add(new FlightPathIndicatorSprite(this, ms.getPosition(), ms, fpiPath.isEndStep(ms)));
+//                fpiSprites.add(new FlightPathIndicatorSprite(this, ms.getPosition(), ms, fpiPath.isEndStep(ms)));
+                fpiSprites.add(new FlightPathIndicatorSprite(this, fpiSteps, fpiSteps.indexOf(ms), fpiPath.isEndStep(ms)));
             }
         }
     }

--- a/megamek/src/megamek/client/ui/swing/boardview/ConstructionWarningSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/ConstructionWarningSprite.java
@@ -19,10 +19,9 @@
 package megamek.client.ui.swing.boardview;
 
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 
-import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.FontHandler;
 import megamek.client.ui.swing.util.StringDrawer;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
@@ -38,20 +37,19 @@ import megamek.common.Coords;
  */
 public class ConstructionWarningSprite extends HexSprite {
 
-    private static final GUIPreferences GUIP = GUIPreferences.getInstance();
-    private static final int TEXT_SIZE = 30;
+    private static final int TEXT_SIZE = BoardView.HEX_H / 2;
     private static final Color TEXT_COLOR = new Color(255, 255, 40, 128);
     private static final Color OUTLINE_COLOR = new Color(40, 40,40,200);
-    
+
     private static final int HEX_CENTER_X = BoardView.HEX_W / 2;
     private static final int HEX_CENTER_Y = BoardView.HEX_H / 2;
 
-    //Draw a special character 'warning sign'.
-    private final StringDrawer xWriter = new StringDrawer("\u26A0")
+    // Draw a special character 'warning sign'.
+    private final StringDrawer xWriter = new StringDrawer("\ue160")
             .at(HEX_CENTER_X, HEX_CENTER_Y)
             .color(TEXT_COLOR)
             .fontSize(TEXT_SIZE)
-            .center().outline(OUTLINE_COLOR, 1.5f);
+            .absoluteCenter().outline(OUTLINE_COLOR, 2.5f);
 
     /**
      * @param boardView1 - parent BoardView object this sprite will be displayed on.
@@ -64,7 +62,7 @@ public class ConstructionWarningSprite extends HexSprite {
     @Override
     public void prepare() {
         Graphics2D graph = spriteSetup();
-        xWriter.draw(graph);        
+        xWriter.draw(graph);
         graph.dispose();
     }
 
@@ -78,18 +76,7 @@ public class ConstructionWarningSprite extends HexSprite {
         Graphics2D graph = (Graphics2D) image.getGraphics();
         UIUtil.setHighQualityRendering(graph);
         graph.scale(bv.scale, bv.scale);
-
-        fontSetup(graph);
-
+        graph.setFont(FontHandler.symbolFont());
         return graph;
-    }
-
-    /*
-     * Sets the font name, style, and size from configured default parameters.
-     */
-    private void fontSetup(Graphics2D graph) {
-        String fontName = GUIP.getMoveFontType();
-        int fontStyle = GUIP.getMoveFontStyle();
-        graph.setFont(new Font(fontName, fontStyle, TEXT_SIZE));		
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FlightPathIndicatorSprite.java
@@ -23,7 +23,7 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 
 import megamek.MMConstants;
-import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.util.FontHandler;
 import megamek.client.ui.swing.util.StringDrawer;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Coords;
@@ -44,7 +44,6 @@ import megamek.common.MoveStep;
  */
 public class FlightPathIndicatorSprite extends HexSprite {
 
-    private static final GUIPreferences GUIP = GUIPreferences.getInstance();
     private static final int TEXT_SIZE = 30;
     private static final Color COLOR_YELLOW = new Color(255, 255, 0, 128);
     private static final Color COLOR_GREEN = new Color(0, 255, 0, 128);
@@ -55,70 +54,54 @@ public class FlightPathIndicatorSprite extends HexSprite {
     private static final int HEX_CENTER_Y = BoardView.HEX_H / 2;
     private static final int TEXT_Y_OFFSET = 17;
 
-    private MoveStep step = null;
-    private boolean isLast = false;
+    private final MoveStep step;
+    private final boolean isLast;
 
-    private static final String EMPTY_CIRCLE = "\u26AA";
-    private static final String SOLID_CIRCLE = "\u26AB";
-    private static final String EMPTY_FLAG = "\u2690";
-    private static final String SOLID_FLAG = "\u2691";
-    //private static final String EMPTY_TWO_WAY = "\u26D7";
-    private static final String SOLID_TWO_WAY = "\u26D6";
+    private static final String EMPTY_CIRCLE = "\ue061";
+    private static final String SOLID_CIRCLE = "\ue57b";
+    private static final String EMPTY_FLAG = "\ueaf8";
+    private static final String SOLID_FLAG = "\uf06e";
+    private static final String SOLID_TWO_WAY = "\uf1ff";
+
+    private final StringDrawer.StringDrawerConfig redSymbolConfig =
+            new StringDrawer.StringDrawerConfig().absoluteCenter().fontSize(TEXT_SIZE)
+                    .outline(COLOR_OUTLINE, 1.5f).color(COLOR_RED);
+
+    private final StringDrawer.StringDrawerConfig greenSymbolConfig =
+            new StringDrawer.StringDrawerConfig().absoluteCenter().fontSize(TEXT_SIZE)
+                    .outline(COLOR_OUTLINE, 1.5f).color(COLOR_GREEN);
+
+    private final StringDrawer.StringDrawerConfig yellowSymbolConfig =
+            new StringDrawer.StringDrawerConfig().absoluteCenter().fontSize(TEXT_SIZE)
+                    .outline(COLOR_OUTLINE, 1.5f).color(COLOR_YELLOW);
 
     // Setup 'StringDrawers' to write special characters as icons.
     private final StringDrawer mustFlyIcon = new StringDrawer(EMPTY_CIRCLE)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_RED)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(redSymbolConfig);
 
     private final StringDrawer greenFlagIcon = new StringDrawer(SOLID_FLAG)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_GREEN)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(greenSymbolConfig);
 
     private final StringDrawer redFlagIcon = new StringDrawer(EMPTY_FLAG)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_RED)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(redSymbolConfig);
 
     private final StringDrawer yellowFlagIcon = new StringDrawer(SOLID_FLAG)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_YELLOW)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(yellowSymbolConfig);
 
     private final StringDrawer yellowEmptyFlagIcon = new StringDrawer(EMPTY_FLAG)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_YELLOW)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(yellowSymbolConfig);
 
     private final StringDrawer flyOffIcon = new StringDrawer(SOLID_TWO_WAY)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_YELLOW)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 2.0f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(yellowSymbolConfig);
 
     private final StringDrawer freeTurnIcon = new StringDrawer(SOLID_CIRCLE)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_GREEN)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(greenSymbolConfig);
 
     private final StringDrawer costTurnIcon = new StringDrawer(SOLID_CIRCLE)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_YELLOW)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(yellowSymbolConfig);
 
     private final StringDrawer noThrustIcon = new StringDrawer(EMPTY_CIRCLE)
-            .at(HEX_CENTER_X, HEX_CENTER_Y)
-            .color(COLOR_YELLOW)
-            .fontSize(TEXT_SIZE)
-            .center().outline(COLOR_OUTLINE, 1.5f);
+            .at(HEX_CENTER_X, HEX_CENTER_Y).useConfig(yellowSymbolConfig);
 
     /**
      * @param boardView - BoardView associated with the sprite.
@@ -129,7 +112,7 @@ public class FlightPathIndicatorSprite extends HexSprite {
     public FlightPathIndicatorSprite(BoardView boardView, Coords loc, final MoveStep step, boolean last) {
         super(boardView, loc);
         this.step = step;
-        this.isLast = last;
+        isLast = last;
     }
 
     @Override
@@ -149,7 +132,7 @@ public class FlightPathIndicatorSprite extends HexSprite {
         if (isLastIndicator()) {
             if (step.getVelocityLeft() > 0) {
                 flyOffIcon.draw(graph);
-                drawRemainingDistance(graph, this.step);
+                drawRemainingDistance(graph, step);
             } else {
                 if (canTurnForFree()) {
                     greenFlagIcon.draw(graph);
@@ -176,8 +159,6 @@ public class FlightPathIndicatorSprite extends HexSprite {
                 mustFlyIcon.draw(graph);
             }
         }
-
-        return;
     }
 
     /*
@@ -223,19 +204,8 @@ public class FlightPathIndicatorSprite extends HexSprite {
         Graphics2D graph = (Graphics2D) image.getGraphics();
         UIUtil.setHighQualityRendering(graph);
         graph.scale(bv.scale, bv.scale);
-
-        fontSetup(graph);
-
+        graph.setFont(FontHandler.symbolFont());
         return graph;
-    }
-
-    /*
-     * Sets the font name, style, and size from configured default parameters.
-     */
-    private void fontSetup(Graphics2D graph) {
-        String fontName = GUIP.getMoveFontType();
-        int fontStyle = GUIP.getMoveFontStyle();
-        graph.setFont(new Font(fontName, fontStyle, TEXT_SIZE));
     }
 
     /*
@@ -272,7 +242,5 @@ public class FlightPathIndicatorSprite extends HexSprite {
         graph.drawString(remString, x_offset, y_offset);
         graph.setColor(Color.red);
         graph.drawString(remString, x_offset - 1, y_offset - 1);
-
-        return;
     }
 }

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3994,6 +3994,9 @@ public class MoveStep implements Serializable {
 
     public boolean dueFreeTurn() {
         Entity en = getEntity();
+        if (en.isSpaceborne()) {
+            return false;
+        }
         int straight = getNStraight();
         int vel = getVelocity();
         int thresh = 99;


### PR DESCRIPTION
I noticed that on my selected move font the symbols for CF warning and flight path indicators were tofu and I couldnt find any font they worked with except the java logical serif. So this PR changes the symbols to some of the symbol font that is part of MM. This way they'll work for everyone and are independent from the move font. Additionally StringDrawer is upgraded to allow absolute Y centering without regard for ascent/descent which performs better for this use case (single symbols).
For the flight path symbols I thought I'd use arrows that are slightly more self-explanatory. Also the symbols are larger and less transparent so they show up well over complicated terrain or when zoomed out.

![image](https://github.com/MegaMek/megamek/assets/17069663/c55a8961-e51c-4648-b575-f30ccd9c8612)

![image](https://github.com/MegaMek/megamek/assets/17069663/f5d5336c-a748-40a6-b3b7-45d31bf314b3)

