### PR TITLE
add null check for turn timer when stopping

### DIFF
--- a/megamek/src/megamek/client/ui/swing/util/TurnTimer.java
+++ b/megamek/src/megamek/client/ui/swing/util/TurnTimer.java
@@ -120,7 +120,9 @@ public class TurnTimer {
             phaseDisplay.getClientgui().getMenuBar().remove(display);
         }
 
-        timer.stop();
+        if (timer != null) {
+            timer.stop();
+        }
     }
 
     public void setExtendTimer() {


### PR DESCRIPTION
- add null check for turn timer when stopping
- got this when testing and clicking through phase rapidly

19:55:31,109 ERROR [megamek.MegaMek] {AWT-EventQueue-0}
megamek.MegaMek.lambda$main$0(MegaMek.java:63) - Uncaught Exception Detected
java.lang.NullPointerException: Cannot invoke "javax.swing.Timer.stop()" because "this.timer" is null
	at megamek.client.ui.swing.util.TurnTimer.stopTimer(TurnTimer.java:123)
	at megamek.client.ui.swing.StatusBarPhaseDisplay.stopTimer(StatusBarPhaseDisplay.java:330)
	at megamek.client.ui.swing.MovementDisplay.endMyTurn(MovementDisplay.java:1095)
	at megamek.client.ui.swing.MovementDisplay.ready(MovementDisplay.java:1674)
	at megamek.client.ui.swing.ActionPhaseDisplay.performDoneNoAction(ActionPhaseDisplay.java:85)
	at megamek.client.ui.swing.ActionPhaseDisplay$1.actionPerformed(ActionPhaseDisplay.java:67)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2313)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6626)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3389)
	at megamek.client.ui.swing.widget.MegamekButton.processMouseEvent(MegamekButton.java:242)
	at java.desktop/java.awt.Component.processEvent(Component.java:6391)
	at java.desktop/java.awt.Container.processEvent(Container.java:2266)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5001)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4833)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4575)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4833)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:722)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:716)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:97)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:746)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:744)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:743)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)