### PR TITLE
Turret Alpha V0.1.4.5 Factions 3145

### DIFF
--- a/megamek/data/mechfiles/newturrets/Medium Sniper Turret 3075.blk
+++ b/megamek/data/mechfiles/newturrets/Medium Sniper Turret 3075.blk
@@ -13,7 +13,7 @@ GunEmplacement
 Medium Sniper Turret
 </Name>
 <model>
-(3075))
+(3075)
 </model>
 <Year>
 3075

--- a/megamek/data/rat/Turret RATs/2300/2300 A.txt
+++ b/megamek/data/rat/Turret RATs/2300/2300 A.txt
@@ -1,5 +1,4 @@
 Turrets 2300 A
-
 @DirectFire Turrets 2300, 20
 @InDirectFire Turrets 2300, 40
 @AntiAir Turrets 2300, 20

--- a/megamek/data/rat/Turret RATs/2300/2300 B.txt
+++ b/megamek/data/rat/Turret RATs/2300/2300 B.txt
@@ -1,5 +1,4 @@
 Turrets 2300 B
-
 @DirectFire Turrets 2300, 20
 @InDirectFire Turrets 2300, 40
 @AntiAir Turrets 2300, 20

--- a/megamek/data/rat/Turret RATs/2300/2300 C.txt
+++ b/megamek/data/rat/Turret RATs/2300/2300 C.txt
@@ -1,5 +1,4 @@
 Turrets 2300 C
-
 @DirectFire Turrets 2300, 25
 @InDirectFire Turrets 2300, 35
 @AntiAir Turrets 2300, 25

--- a/megamek/data/rat/Turret RATs/2300/2300 D.txt
+++ b/megamek/data/rat/Turret RATs/2300/2300 D.txt
@@ -1,5 +1,4 @@
 Turrets 2300 D
-
 @DirectFire Turrets 2300, 30
 @InDirectFire Turrets 2300, 30
 @AntiAir Turrets 2300, 30

--- a/megamek/data/rat/Turret RATs/2300/2300 F.txt
+++ b/megamek/data/rat/Turret RATs/2300/2300 F.txt
@@ -1,5 +1,4 @@
 Turrets 2300 F
-
 @DirectFire Turrets 2300, 50
 @InDirectFire Turrets 2300, 20
 @AntiAir Turrets 2300, 30

--- a/megamek/data/rat/Turret RATs/2750/2750 A.txt
+++ b/megamek/data/rat/Turret RATs/2750/2750 A.txt
@@ -1,5 +1,4 @@
 Turrets 2750 A
-
 @DirectFire Turrets 2300, 20
 @InDirectFire Turrets 2300, 40
 @AntiAir Turrets 2300, 20

--- a/megamek/data/rat/Turret RATs/2750/2750 B.txt
+++ b/megamek/data/rat/Turret RATs/2750/2750 B.txt
@@ -1,5 +1,4 @@
 Turrets 2750 B
-
 @DirectFire Turrets 2300, 20
 @InDirectFire Turrets 2300, 40
 @AntiAir Turrets 2300, 20

--- a/megamek/data/rat/Turret RATs/2750/2750 C.txt
+++ b/megamek/data/rat/Turret RATs/2750/2750 C.txt
@@ -1,5 +1,4 @@
 Turrets 2750 C
-
 @DirectFire Turrets 2300, 25
 @InDirectFire Turrets 2300, 35
 @AntiAir Turrets 2300, 25

--- a/megamek/data/rat/Turret RATs/2750/2750 D.txt
+++ b/megamek/data/rat/Turret RATs/2750/2750 D.txt
@@ -1,5 +1,4 @@
 Turrets 2750 D
-
 @DirectFire Turrets 2300, 30
 @InDirectFire Turrets 2300, 30
 @AntiAir Turrets 2300, 30

--- a/megamek/data/rat/Turret RATs/3025/3025 A.txt
+++ b/megamek/data/rat/Turret RATs/3025/3025 A.txt
@@ -1,5 +1,4 @@
 Turrets 3025 A
-
 @DirectFire Turrets 2300, 20
 @InDirectFire Turrets 2300, 40
 @AntiAir Turrets 3025, 20

--- a/megamek/data/rat/Turret RATs/3025/3025 B.txt
+++ b/megamek/data/rat/Turret RATs/3025/3025 B.txt
@@ -1,5 +1,4 @@
 Turrets 3025 B
-
 @DirectFire Turrets 2300, 20
 @InDirectFire Turrets 2300, 40
 @AntiAir Turrets 3025, 20

--- a/megamek/data/rat/Turret RATs/3025/3025 C.txt
+++ b/megamek/data/rat/Turret RATs/3025/3025 C.txt
@@ -1,5 +1,4 @@
 Turrets 3025 C
-
 @DirectFire Turrets 2300, 25
 @InDirectFire Turrets 2300, 35
 @AntiAir Turrets 3025, 25

--- a/megamek/data/rat/Turret RATs/3075/3075 A.txt
+++ b/megamek/data/rat/Turret RATs/3075/3075 A.txt
@@ -1,5 +1,4 @@
 Turrets 3075 A
-
 @DirectFire Turrets 3075, 20
 @InDirectFire Turrets 3050, 35
 @AntiAir Turrets 3075, 20

--- a/megamek/data/rat/Turret RATs/3075/3075 B.txt
+++ b/megamek/data/rat/Turret RATs/3075/3075 B.txt
@@ -1,5 +1,4 @@
 Turrets 3075 B
-
 @DirectFire Turrets 3075, 20
 @InDirectFire Turrets 3050, 40
 @AntiAir Turrets 3075, 20

--- a/megamek/data/rat/Turret RATs/3075/3075 C.txt
+++ b/megamek/data/rat/Turret RATs/3075/3075 C.txt
@@ -1,5 +1,4 @@
 Turrets 3075 C
-
 @DirectFire Turrets 3075, 25
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 25

--- a/megamek/data/rat/Turret RATs/3075/3075 D.txt
+++ b/megamek/data/rat/Turret RATs/3075/3075 D.txt
@@ -1,5 +1,4 @@
 Turrets 3075 D
-
 @DirectFire Turrets 3075, 30
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 30

--- a/megamek/data/rat/Turret RATs/3075/3075 F.txt
+++ b/megamek/data/rat/Turret RATs/3075/3075 F.txt
@@ -1,5 +1,4 @@
 Turrets 3075 F
-
 @DirectFire Turrets 30675, 40
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 30

--- a/megamek/data/rat/Turret RATs/3085/3085 A.txt
+++ b/megamek/data/rat/Turret RATs/3085/3085 A.txt
@@ -1,5 +1,4 @@
 Turrets 3085 A
-
 @DirectFire Turrets 3075, 20
 @InDirectFire Turrets 3050, 35
 @AntiAir Turrets 3075, 20

--- a/megamek/data/rat/Turret RATs/3085/3085 B.txt
+++ b/megamek/data/rat/Turret RATs/3085/3085 B.txt
@@ -1,5 +1,4 @@
 Turrets 3085 B
-
 @DirectFire Turrets 3075, 20
 @InDirectFire Turrets 3050, 40
 @AntiAir Turrets 3075, 20

--- a/megamek/data/rat/Turret RATs/3085/3085 C.txt
+++ b/megamek/data/rat/Turret RATs/3085/3085 C.txt
@@ -1,5 +1,4 @@
 Turrets 3085 C
-
 @DirectFire Turrets 3075, 25
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 25

--- a/megamek/data/rat/Turret RATs/3085/3085 D.txt
+++ b/megamek/data/rat/Turret RATs/3085/3085 D.txt
@@ -1,5 +1,4 @@
 Turrets 3085 D
-
 @DirectFire Turrets 3075, 30
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 30

--- a/megamek/data/rat/Turret RATs/3085/3085 F.txt
+++ b/megamek/data/rat/Turret RATs/3085/3085 F.txt
@@ -1,5 +1,4 @@
 Turrets 3085 F
-
 @DirectFire Turrets 30675, 40
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 30

--- a/megamek/data/rat/Turret RATs/3145/3145 A.txt
+++ b/megamek/data/rat/Turret RATs/3145/3145 A.txt
@@ -1,5 +1,4 @@
 Turrets 3145 A
-
 @DirectFire Turrets 3075, 20
 @InDirectFire Turrets 3050, 35
 @AntiAir Turrets 3075, 20

--- a/megamek/data/rat/Turret RATs/3145/3145 B.txt
+++ b/megamek/data/rat/Turret RATs/3145/3145 B.txt
@@ -1,5 +1,4 @@
 Turrets 3145 B
-
 @DirectFire Turrets 3075, 20
 @InDirectFire Turrets 3050, 40
 @AntiAir Turrets 3075, 20

--- a/megamek/data/rat/Turret RATs/3145/3145 C.txt
+++ b/megamek/data/rat/Turret RATs/3145/3145 C.txt
@@ -1,5 +1,4 @@
 Turrets 3145 C
-
 @DirectFire Turrets 3075, 25
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 25

--- a/megamek/data/rat/Turret RATs/3145/3145 D.txt
+++ b/megamek/data/rat/Turret RATs/3145/3145 D.txt
@@ -1,5 +1,4 @@
 Turrets 3145 D
-
 @DirectFire Turrets 3075, 30
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 30

--- a/megamek/data/rat/Turret RATs/3145/3145 F.txt
+++ b/megamek/data/rat/Turret RATs/3145/3145 F.txt
@@ -1,5 +1,4 @@
 Turrets 3145 F
-
 @DirectFire Turrets 30675, 40
 @InDirectFire Turrets 3050, 30
 @AntiAir Turrets 3075, 30

--- a/megamek/data/rat/Turret RATs/Actual Turrets/AntiAir Turrets 3075.txt
+++ b/megamek/data/rat/Turret RATs/Actual Turrets/AntiAir Turrets 3075.txt
@@ -7,5 +7,5 @@ Heavy Flak Turret (3050), 8
 Assault Flak Turret (3025), 4
 
 #Air Defense Emplacements
-Medium Air Defense Emplacement (3075), 12
-Assault Air Defense Emplacement (3075), 4
+Medium Air Defense Missile Emplacement (3075), 12
+Assault Air Defense Missile Emplacement (3075), 4

--- a/megamek/data/rat/Turret RATs/Actual Turrets/Special Turrets 3025.txt
+++ b/megamek/data/rat/Turret RATs/Actual Turrets/Special Turrets 3025.txt
@@ -1,7 +1,7 @@
 Special Turrets 3025
 
 #Command Towers
-Blaze Medium Turret (3025), 40
-Blaze Heavy Turret (3025), 10
+Medium Blaze Turret (3025), 40
+Heavy Blaze Turret (3025), 10
 Medium Command Tower (2300), 20
 Calliope Turret (2800), 30

--- a/megamek/data/rat/Turret RATs/Actual Turrets/Special Turrets 3039.txt
+++ b/megamek/data/rat/Turret RATs/Actual Turrets/Special Turrets 3039.txt
@@ -1,7 +1,7 @@
 Special Turrets 3039
 
 #Command Towers
-Blaze Medium Turret (3025), 40
-Blaze Heavy Turret (3025), 10
+Medium Blaze Turret (3025), 40
+Heavy Blaze Turret (3025), 10
 Medium Command Tower (3039), 20
 Calliope Turret (2800), 30


### PR DESCRIPTION
Fixed Typo in Medium Sniper Turret 3075 [Extra ) at end of Model]
Fixed Typo in Special Turret 3025/3039 RATs [Blaze and Size were backwards]
Removed initial space in all basic RATs in order to reduce log spam