### PR TITLE
Expose map settings methods for use in MekHQ

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
@@ -160,7 +160,7 @@ public class LobbyUtility {
      * Draws the given text (the board name or special text) as a label on the
      * lower edge of the image for which the graphics g is given.
      */
-    static void drawMinimapLabel(String text, int w, int h, Graphics g, boolean invalid) {
+    public static void drawMinimapLabel(String text, int w, int h, Graphics g, boolean invalid) {
         if (text.isBlank()) {
             return;
         }

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -28814,7 +28814,7 @@ public class GameManager extends AbstractGameManager {
      *                  in base path).
      * @param sizes     Where to store the discovered board sizes
      */
-    private void getBoardSizesInDir(final File searchDir, TreeSet<BoardDimensions> sizes) {
+    private static void getBoardSizesInDir(final File searchDir, TreeSet<BoardDimensions> sizes) {
         if (searchDir == null) {
             throw new IllegalArgumentException("must provide searchDir");
         }
@@ -28853,7 +28853,7 @@ public class GameManager extends AbstractGameManager {
      *
      * @return A Set containing all the available board sizes.
      */
-    private Set<BoardDimensions> getBoardSizes() {
+    public static Set<BoardDimensions> getBoardSizes() {
         TreeSet<BoardDimensions> board_sizes = new TreeSet<>();
 
         File boards_dir = Configuration.boardsDir();

--- a/megamek/src/megamek/server/ServerBoardHelper.java
+++ b/megamek/src/megamek/server/ServerBoardHelper.java
@@ -29,14 +29,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-class ServerBoardHelper {
+public class ServerBoardHelper {
 
     /**
      * Returns a list of path names of available boards of the size set in the given
      * mapSettings. The path names are minus the '.board' extension and relative to
      * the boards data directory.
      */
-    static List<String> scanForBoards(MapSettings mapSettings) {
+    public static List<String> scanForBoards(MapSettings mapSettings) {
         BoardDimensions boardSize = mapSettings.getBoardSize();
         List<String> result = new ArrayList<>();
         


### PR DESCRIPTION
This PR is needed by MegaMek/mekhq#3931 which is creating a customizable scenario dialog. One of the options in that dialog is setting up maps. This requires the ability to get all available map sizes and scan for maps based on map size. Those functions already exist in MegaMek and are usable but some are currently set to private usage. So, this PR just makes a few of those methods public. It also switches two methods in `GameManager` to static methods that don't actually depend on anything in GameManager. 