### PR TITLE
AS advanced search and rear weapon conversion

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitSelector/ASAdvancedSearchPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitSelector/ASAdvancedSearchPanel.java
@@ -32,7 +32,6 @@ import megamek.common.alphaStrike.BattleForceSUA;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -159,7 +158,7 @@ public class ASAdvancedSearchPanel extends JPanel {
     JToggleButton unitRoleTransport = new JToggleButton(UnitRole.TRANSPORT.toString());
     JToggleButton unitRoleNone = new JToggleButton(UnitRole.NONE.toString());
 
-    private JButton btnClear = new JButton(Messages.getString("MechSelectorDialog.ClearTab"));
+    private final JButton btnClear = new JButton(Messages.getString("MechSelectorDialog.ClearTab"));
 
     public ASAdvancedSearchPanel() {
         setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
@@ -251,10 +250,18 @@ public class ASAdvancedSearchPanel extends JPanel {
                 && (mechSummary.getMovement().get(moveMode) <= mvTo.getIntVal(Integer.MAX_VALUE)))) {
             return false;
         } else if (useAbility1.isSelected() &&
-                !mechSummary.getSpecialAbilities().hasSUA(ability1.getSelectedItem())) {
+                !(mechSummary.getSpecialAbilities().hasSUA(ability1.getSelectedItem())
+                        || (mechSummary.usesArcs() && (mechSummary.getLeftArc().hasSUA(ability1.getSelectedItem())
+                        || mechSummary.getRightArc().hasSUA(ability1.getSelectedItem())
+                        || mechSummary.getFrontArc().hasSUA(ability1.getSelectedItem())
+                        || mechSummary.getRearArc().hasSUA(ability1.getSelectedItem()))))) {
             return false;
         } else if (useAbility2.isSelected() &&
-                !mechSummary.getSpecialAbilities().hasSUA(ability2.getSelectedItem())) {
+                !(mechSummary.getSpecialAbilities().hasSUA(ability2.getSelectedItem())
+                        || (mechSummary.usesArcs() && (mechSummary.getLeftArc().hasSUA(ability2.getSelectedItem())
+                        || mechSummary.getRightArc().hasSUA(ability2.getSelectedItem())
+                        || mechSummary.getFrontArc().hasSUA(ability2.getSelectedItem())
+                        || mechSummary.getRearArc().hasSUA(ability2.getSelectedItem()))))) {
             return false;
         } else {
             return true;

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASDamageConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASDamageConverter.java
@@ -120,10 +120,7 @@ public class ASDamageConverter {
     protected void processSpecialAbilities() {
         report.addEmptyLine();
         report.addSubHeader("Weapon-based Special Abilities:");
-        for (Mounted weapon : weaponsList) {
-            WeaponType weaponType = (WeaponType) weapon.getType();
-            assignSpecialAbilities(weapon, weaponType);
-        }
+        weaponsList.forEach(weapon -> assignSpecialAbilities(weapon, weapon.getType()));
         if (foundNoSpecialAbility()) {
             report.addLine("None", "", "");
         }
@@ -486,7 +483,7 @@ public class ASDamageConverter {
      */
     protected void assignToLocations(Mounted weapon, BattleForceSUA sua) {
         for (int loc = 0; loc < locations.length; loc++) {
-            if ((ASLocationMapper.damageLocationMultiplier(entity, loc, weapon) != 0)
+            if ((ASLocationMapper.damageLocationMultiplierForSpecials(entity, loc, weapon) != 0)
                     && !locations[loc].hasSUA(sua)) {
                 locations[loc].setSUA(sua);
                 reportAssignToLocations(weapon, sua, "", loc);
@@ -505,29 +502,9 @@ public class ASDamageConverter {
      */
     protected void assignToLocations(Mounted weapon, BattleForceSUA sua, int abilityValue) {
         for (int loc = 0; loc < locations.length; loc++) {
-            if (ASLocationMapper.damageLocationMultiplier(entity, loc, weapon) != 0) {
+            if (ASLocationMapper.damageLocationMultiplierForSpecials(entity, loc, weapon) != 0) {
                 locations[loc].mergeSUA(sua, abilityValue);
                 reportAssignToLocations(weapon, sua, abilityValue + "", loc);
-            }
-        }
-    }
-
-    /**
-     * Checks the location multiplier for all locations and assigns the given SUA with the given ability
-     * value to any location where the multiplier is not zero, i.e. to any location that the weapon is
-     * counted towards. If the SUA is already present, the ability value is added.
-     *
-     * @param weapon The weapon to check
-     * @param sua The special unit ability to add
-     * @param abilityValue The ability value to add
-     */
-    protected void assignToLocations(Mounted weapon, BattleForceSUA sua, double abilityValue) {
-        for (int loc = 0; loc < locations.length; loc++) {
-            if (ASLocationMapper.damageLocationMultiplier(entity, loc, weapon) != 0) {
-                // The location multiplier is always 1 except for some of the large aerospace units, where it affects only PNT
-                abilityValue *= ASLocationMapper.damageLocationMultiplier(entity, loc, weapon);
-                locations[loc].mergeSUA(sua, abilityValue);
-                reportAssignToLocations(weapon, sua, formatForReport(abilityValue), loc);
             }
         }
     }

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASLocationMapper.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASLocationMapper.java
@@ -91,6 +91,31 @@ public class ASLocationMapper {
         }
     }
 
+    /**
+     * Returns the value multiplier for the given Mounted of the given entity in the AS conversion location loc.
+     * The AS conversion location is an {@link megamek.common.alphaStrike.ASSpecialAbilityCollection} assembling
+     * the specials for the unit, a TUR ability, REAR and the arcs of large units, not the
+     * mounted's location on the entity. This multiplier is only correct for weapon-based special abilities
+     * like MHQ, C3M, NARC or ART-x abilities.
+     *
+     * @param en The entity
+     * @param loc The conversion location index, see locations[] in ASDamageConverter
+     * @param mount the weapon
+     * @return The value multiplier, 1 meaning "counts for this location", 0 meaning "doesnt count"
+     */
+    public static double damageLocationMultiplierForSpecials(Entity en, int loc, Mounted mount) {
+        if (en.isFighter() || en.isProtoMek() || en.isMek()) {
+            if ((loc == 0) && (mount.isRearMounted() || (en.isFighter() && mount.getLocation() == Aero.LOC_AFT))) {
+                // Special abilities like MHQ or ART must count for loc 0 (standard specials) even if in rear locations
+                return 1;
+            } else if (locationName(en, loc).equals("REAR")) {
+                return 0;
+            }
+        }
+        return damageLocationMultiplier(en, loc, mount);
+
+    }
+
     public static String locationName(Entity en, int index) {
         if ((en instanceof Warship) || (en instanceof SmallCraft)) {
             return en.getLocationAbbrs()[index];


### PR DESCRIPTION
Fixes #5447 
This changes conversion to count specials from rear-facing weapons such as the Arrow IV on the Planetlifter Tactical Support for the standard specials list (instead of trying to place them in the non-existent REAR specials). Also affects NARC, C3M and other weapon-based specials.
Also the AS advanced search now also searches for specials in the arcs of large aero units, so a search for ARTLT finds the Fortress Dropship.