### PR TITLE
MegaMek 0.49.19.1 dot release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
 
 subprojects {
     group = 'org.megamek'
-    version = '0.49.19'
+    version = '0.49.19.1'
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ ext {
     mmGitRoot = 'https://github.com/MegaMek/megamek.git'
     // Work on MML or MHQ sometimes requires changes in MM as well. The maven publishing tasks use
     // these properties to append the branch name to the artifact id if the repo is not in the master
-    // branch, making it available separately to the child project. 
+    // branch, making it available separately to the child project.
     mmBranch = grgit.branch.current().name
     mmBranchTag = mmBranch.equals('master') ? '' : '-' + mmBranch
 }

--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -350,7 +350,7 @@ task javadocJar(type: Jar) {
 publishing {
     publications {
         publishMMLibrary(MavenPublication) {
-            artifactId = "megamek${mmBranchTag}"
+            artifactId = "megamek"
             from components.java
             artifact sourcesJar
 //            artifact javadocJar

--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,5 +1,12 @@
 MEGAMEK VERSION HISTORY:
 ----------------
+0.49.19.1 (2024-05-06 1744 UTC)
++ Fix #5415: Implement RFE #5408: update Princess ammo conservation values
++ Fix #5426: add null checks for getC3UUIDAsString()
++ Fix #5433: Handle one-shot ammo weapons like RLs appropriately 
++ Fix #5440: MM fix for MML issue where Partial Wing not accounted for
++ Fix #5442: add null check for turn timer when stopping
+
 0.49.19 (2024-04-19 2030 UTC)
 + Fix #5182: Fixes aerospace fighters getting a zero engine rating in TestAero
 + Fix #5168: Indirect Arty Fire under 17 hexes now correctly uses a +4 instead of +7 modifier

--- a/megamek/src/megamek/SuiteConstants.java
+++ b/megamek/src/megamek/SuiteConstants.java
@@ -24,7 +24,7 @@ package megamek;
 public abstract class SuiteConstants {
     //region General Constants
     public static final String PROJECT_NAME = "MegaMek Suite";
-    public static final Version VERSION = new Version("0.49.19");
+    public static final Version VERSION = new Version("0.49.19.1");
     public static final int MAXIMUM_D6_VALUE = 6;
 
     // This is used in creating the name of save files, e.g. the MekHQ campaign file

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -292,7 +292,7 @@ public final class Version implements Comparable<Version>, Serializable {
 
     @Override
     public String toString() {
-        return (getRevision() != -1) ?
+        return (getRevision() == -1) ?
             String.format("%d.%d.%d%s", getRelease(), getMajor(), getMinor(), (isSnapshot() ? "-SNAPSHOT" : "")) :
             String.format("%d.%d.%d.%d%s", getRelease(), getMajor(), getMinor(), getRevision(), (isSnapshot() ? "-SNAPSHOT" : ""));
     }

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -38,6 +38,10 @@ public final class Version implements Comparable<Version>, Serializable {
     private int release;
     private int major;
     private int minor;
+
+    // Optional
+    private int revision;
+
     private boolean snapshot;
     //endregion Variable Declarations
 
@@ -49,6 +53,7 @@ public final class Version implements Comparable<Version>, Serializable {
         setRelease(0);
         setMajor(0);
         setMinor(0);
+        setRevision(-1);
         setSnapshot(false);
     }
 
@@ -88,8 +93,16 @@ public final class Version implements Comparable<Version>, Serializable {
         return minor;
     }
 
+    public int getRevision() {
+        return revision;
+    }
+
     public void setMinor(final int minor) {
         this.minor = minor;
+    }
+
+    public void setRevision(final int revision) {
+        this.revision = revision;
     }
 
     public boolean isSnapshot() {
@@ -223,7 +236,7 @@ public final class Version implements Comparable<Version>, Serializable {
 
         if ((snapshotSplit.length > 2) || (versionSplit.length < 3)) {
             final String message = String.format(
-                    "Version text %s is in an illegal version format. Versions should be in the format 'release.major.minor-SNAPSHOT', with the snapshot being an optional inclusion. This may lead to severe issues that cannot be otherwise explained.",
+                    "Version text %s is in an illegal version format. Versions should be in the format 'release.major.minor[.revision]-SNAPSHOT', with the snapshot being an optional inclusion. This may lead to severe issues that cannot be otherwise explained.",
                     text);
             LogManager.getLogger().fatal(message);
             JOptionPane.showMessageDialog(null, message, "Version Parsing Failure",
@@ -267,13 +280,20 @@ public final class Version implements Comparable<Version>, Serializable {
             return;
         }
 
+        try {
+            setRevision(Integer.parseInt(versionSplit[3]));
+        } catch (Exception e) {
+            // We don't care if the revision is not found.
+        }
+
         setSnapshot(snapshotSplit.length == 2);
     }
     //endregion File I/O
 
     @Override
     public String toString() {
-        return String.format("%d.%d.%d%s", getRelease(), getMajor(), getMinor(),
-                (isSnapshot() ? "-SNAPSHOT" : ""));
+        return (getRevision() != -1) ?
+            String.format("%d.%d.%d%s", getRelease(), getMajor(), getMinor(), (isSnapshot() ? "-SNAPSHOT" : "")) :
+            String.format("%d.%d.%d.%d%s", getRelease(), getMajor(), getMinor(), getRevision(), (isSnapshot() ? "-SNAPSHOT" : ""));
     }
 }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -770,7 +770,7 @@ public class Princess extends BotClient {
                     continue;
                 } else if (weaponType.hasFlag(WeaponType.F_ONESHOT)) {
                     // Shoot OS weapons on a 10 / 9 / 8 for Aggro 10 / 5 / 0
-                    ammoConservation.put(weapon, (40-aggroFactor)/100.0);
+                    ammoConservation.put(weapon, (35 - 2.0 * aggroFactor) / 100.0);
                     msg.append(" One Shot weapon.");
                     continue;
                 }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -735,7 +735,7 @@ public class Princess extends BotClient {
         sendDone(true);
     }
 
-    private Map<Mounted, Double> calcAmmoConservation(final Entity shooter) {
+    protected Map<Mounted, Double> calcAmmoConservation(final Entity shooter) {
         final double aggroFactor = getBehaviorSettings().getHyperAggressionIndex();
         final StringBuilder msg = new StringBuilder("\nCalculating ammo conservation for ")
                 .append(shooter.getDisplayName());

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -764,8 +764,14 @@ public class Princess extends BotClient {
                 final WeaponType weaponType = (WeaponType) weapon.getType();
                 msg.append("\n\t").append(weaponType);
                 if (!(weaponType instanceof AmmoWeapon)) {
-                    ammoConservation.put(weapon, 0.0);
+                    // Just require a 12 or lower TN
+                    ammoConservation.put(weapon, 0.01);
                     msg.append(" doesn't use ammo.");
+                    continue;
+                } else if (weaponType.hasFlag(WeaponType.F_ONESHOT)) {
+                    // Shoot OS weapons on a 10 / 9 / 8 for Aggro 10 / 5 / 0
+                    ammoConservation.put(weapon, (40-aggroFactor)/100.0);
+                    msg.append(" One Shot weapon.");
                     continue;
                 }
 
@@ -777,13 +783,14 @@ public class Princess extends BotClient {
                     ammoCount += ammoCounts.get(ammoType);
                 }
                 msg.append(" has ").append(ammoCount).append(" shots left");
-                // Desired behavior:
-                // At min aggro (0 of 10), require ~50% chance to hit with > 3 shots left
-                // At normal aggro (5 of 10), require at least 10% to-hit chance with > 3 shots left
-                // At max aggro (10 of 10) require just over 0% chance to hit until at 1 round left.
+                // Desired behavior, with 7 / 3 / 1 rounds left:
+                // At min aggro (0 of 10), fire on TN 10, 9, 7
+                // At normal aggro (5 of 10), fire on 12, 11, 10
+                // At max aggro (10 of 10), fire on 12, 12, 10
                 final double toHitThreshold =
-                        Math.max(0.0,
-                                (0.8/((aggroFactor) + 2) + 1.0 / ((ammoCount*ammoCount)+1)));
+                        Math.max(0.01,
+                                (0.6/((8*aggroFactor) + 4)
+                                + 4.0 / (4 * (ammoCount*ammoCount) * (aggroFactor + 2) + (4 / (aggroFactor + 1)))));
                 msg.append("; To Hit Threshold = ").append(new DecimalFormat("0.000").format(toHitThreshold));
                 ammoConservation.put(weapon, toHitThreshold);
             }

--- a/megamek/src/megamek/client/ui/swing/util/TurnTimer.java
+++ b/megamek/src/megamek/client/ui/swing/util/TurnTimer.java
@@ -120,7 +120,9 @@ public class TurnTimer {
             phaseDisplay.getClientgui().getMenuBar().remove(display);
         }
 
-        timer.stop();
+        if (timer != null) {
+            timer.stop();
+        }
     }
 
     public void setExtendTimer() {

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -14330,6 +14330,8 @@ public class AmmoType extends EquipmentType {
             return false;
         } else if (!(ammo.getType() instanceof AmmoType)) {
             return false;
+        } else if (weaponType.hasFlag(WeaponType.F_ONESHOT)) {
+            return ammo.getUsableShotsLeft() > 0 && isAmmoValid((AmmoType) ammo.getType(), weaponType);
         } else {
             return ammo.isAmmoUsable() && isAmmoValid((AmmoType) ammo.getType(), weaponType);
         }

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -525,6 +525,10 @@ public class BattleArmor extends Infantry {
                     && ignoreGameLessThanThin) {
                 mp++;
             }
+        } else {
+            if ((mp > 0) && hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
+                mp++;
+            }
         }
 
         if ((mp > 0)

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -516,6 +516,7 @@ public class BattleArmor extends Infantry {
             mp++;
         }
 
+        // MM is concerned with in-game conditions that impact Partial Wing mp
         if ((game != null)) {
             PlanetaryConditions conditions = game.getPlanetaryConditions();
             boolean ignoreGameLessThanThin = mpCalculationSetting.ignoreWeather
@@ -526,6 +527,7 @@ public class BattleArmor extends Infantry {
                 mp++;
             }
         } else {
+            // MML just cares that the Partial Wing exists and is installed
             if ((mp > 0) && hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
                 mp++;
             }

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -747,10 +747,11 @@ public class EntityListFile {
                 output.write(String.valueOf(entity.getQuirkList("::")));
             }
             if ((entity.getGame() != null) && (entity.getC3Master() != null)) {
-                output.write("\" " + MULParser.ATTR_C3MASTERIS + "=\"");
-                output.write(entity.getGame()
-                        .getEntity(entity.getC3Master().getId())
-                        .getC3UUIDAsString());
+                Entity entityC3MAster = entity.getGame().getEntity(entity.getC3Master().getId());
+                if (entityC3MAster.getC3UUIDAsString() != null) {
+                    output.write("\" " + MULParser.ATTR_C3MASTERIS + "=\"");
+                    output.write(entityC3MAster.getC3UUIDAsString());
+                }
             }
             if (entity.hasC3() || entity.hasC3i() || entity.hasNavalC3()) {
                 if (entity.getC3UUIDAsString() != null) {
@@ -997,7 +998,8 @@ public class EntityListFile {
                 while (c3iList.hasNext()) {
                     final Entity C3iEntity = c3iList.next();
 
-                    if (C3iEntity.onSameC3NetworkAs(entity, true)) {
+                    if ((C3iEntity.getC3UUIDAsString() != null) &&
+                            C3iEntity.onSameC3NetworkAs(entity, true)) {
                         output.write(indentStr(indentLvl + 1) + "<" + MULParser.ELE_C3ILINK + " " + MULParser.ATTR_LINK + "=\"");
                         output.write(C3iEntity.getC3UUIDAsString());
                         output.write("\"/>\n");
@@ -1013,7 +1015,8 @@ public class EntityListFile {
                 while (NC3List.hasNext()) {
                     final Entity NC3Entity = NC3List.next();
 
-                    if (NC3Entity.onSameC3NetworkAs(entity, true)) {
+                    if ((NC3Entity.getC3UUIDAsString() != null) &&
+                            NC3Entity.onSameC3NetworkAs(entity, true)) {
                         output.write(indentStr(indentLvl + 1) + "<" + MULParser.ELE_NC3LINK + " " + MULParser.ATTR_LINK + "=\"");
                         output.write(NC3Entity.getC3UUIDAsString());
                         output.write("\"/>\n");

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -22,6 +22,7 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,10 +31,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -45,6 +45,9 @@ import static org.mockito.Mockito.when;
  */
 public class PrincessTest {
 
+    static WeaponType mockAC5 = (WeaponType) EquipmentType.get("ISAC5");
+    static AmmoType mockAC5AmmoType = (AmmoType) EquipmentType.get("ISAC5 Ammo");
+    static WeaponType mockRL20 = (WeaponType) EquipmentType.get("RL20");
     private Princess mockPrincess;
     private BasicPathRanker mockPathRanker;
 
@@ -63,6 +66,7 @@ public class PrincessTest {
         when(mockPrincess.getPathRanker(PathRankerType.Basic)).thenReturn(mockPathRanker);
         when(mockPrincess.getPathRanker(any(Entity.class))).thenReturn(mockPathRanker);
         when(mockPrincess.getMoraleUtil()).thenReturn(mockMoralUtil);
+        when(mockPrincess.calcAmmoConservation(any(Entity.class))).thenCallRealMethod();
     }
 
     @Test
@@ -359,19 +363,19 @@ public class PrincessTest {
 
         when(mockPrincess.wantsToFallBack(any(Entity.class))).thenReturn(false);
         when(mockPrincess.isFallingBack(any(Entity.class))).thenCallRealMethod();
-       
+
         BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
         when(mockBehavior.getDestinationEdge()).thenReturn(CardinalEdge.NONE);
         when(mockBehavior.isForcedWithdrawal()).thenReturn(true);
         when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
-        
+
         // A normal undamaged mech.
         assertFalse(mockPrincess.isFallingBack(mockMech));
 
         // A mobile mech that wants to fall back (for any reason).
         when(mockMech.isCrippled(anyBoolean())).thenReturn(true);
         assertTrue(mockPrincess.isFallingBack(mockMech));
-        
+
         // A mech whose bot is set for a destination edge
         when(mockBehavior.getDestinationEdge()).thenReturn(CardinalEdge.NEAREST);
         assertTrue(mockPrincess.isFallingBack(mockMech));
@@ -536,5 +540,139 @@ public class PrincessTest {
         when(mockMech.isProne()).thenReturn(false);
         when(mockMech.isStuck()).thenReturn(true);
         assertTrue(mockPrincess.isImmobilized(mockMech));
+    }
+
+    @Test
+    public void testCalcAmmoForDefaultAggressionLevel() throws megamek.common.LocationFullException {
+        // Expected toHitThresholds should equate to a TN of 12, 11, and 10 for ammo values
+        // of 7+, 3+, 1.
+
+        // Set aggression to default level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(5);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted bin1 = mech1.addEquipment(mockAC5AmmoType, Mech.LOC_LT);
+        Mounted wpn1 = mech1.addEquipment(mockAC5, Mech.LOC_RT);
+
+        // Check default toHitThresholds
+        // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
+        Double target = Compute.oddsAbove(12);
+        bin1.setShotsLeft(7);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
+        target = Compute.oddsAbove(11);
+        bin1.setShotsLeft(3);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
+        target = Compute.oddsAbove(10);
+        bin1.setShotsLeft(1);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+    }
+
+    @Test
+    public void testCalcAmmoForMaxAggressionLevel() throws megamek.common.LocationFullException {
+        // Expected toHitThresholds should equate to a TN of 12, 12, and 10 for ammo values
+        // of 7+, 3+, 1.
+
+        // Set aggression to default level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(10);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted bin1 = mech1.addEquipment(mockAC5AmmoType, Mech.LOC_LT);
+        Mounted wpn1 = mech1.addEquipment(mockAC5, Mech.LOC_RT);
+
+        // Check default toHitThresholds
+        // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
+        Double target = Compute.oddsAbove(12);
+        bin1.setShotsLeft(7);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 3+ rounds for this level should allow firing on 12s
+        bin1.setShotsLeft(3);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
+        target = Compute.oddsAbove(10);
+        bin1.setShotsLeft(1);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+    }
+
+    @Test
+    public void testCalcAmmoForZeroAggressionLevel() throws megamek.common.LocationFullException {
+        // Expected toHitThresholds should equate to a TN of 10, 9, and 7 for ammo values
+        // of 7+, 3+, 1.
+
+        // Set aggression to default level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(0);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted bin1 = mech1.addEquipment(mockAC5AmmoType, Mech.LOC_LT);
+        Mounted wpn1 = mech1.addEquipment(mockAC5, Mech.LOC_RT);
+
+        // Check default toHitThresholds
+        // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
+        Double target = Compute.oddsAbove(10);
+        bin1.setShotsLeft(7);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
+        target = Compute.oddsAbove(9);
+        bin1.setShotsLeft(3);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
+        target = Compute.oddsAbove(7);
+        bin1.setShotsLeft(1);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+    }
+
+    @Test
+    public void testCalcAmmoForOneShotWeapons() throws megamek.common.LocationFullException {
+        // Set aggression to lowest level
+        BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(0);
+        when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);
+
+        // Set up unit
+        Mech mech1 = new BipedMech();
+        Mounted wpn1 = mech1.addEquipment(mockRL20, Mech.LOC_LT);
+
+        // Check default toHitThresholds
+        // For max aggro, shoot OS weapons at TN 10 or better
+        Double target = Compute.oddsAbove(10);
+        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // For default aggro, shoot OS weapons at TN 9 or better
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(5);
+        target = Compute.oddsAbove(9);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
+
+        // For lowest aggro, shoot OS weapons at TN 8 or better
+        when(mockBehavior.getHyperAggressionIndex()).thenReturn(10);
+        target = Compute.oddsAbove(8);
+        conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        assertTrue(conserveMap.get(wpn1) <= target);
     }
 }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -559,19 +559,19 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12) / 100.0;
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
-        target = Compute.oddsAbove(11);
+        target = Compute.oddsAbove(11) / 100.0;
         bin1.setShotsLeft(3);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
-        target = Compute.oddsAbove(10);
+        target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(1);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -594,7 +594,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12) / 100.0;
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -605,7 +605,7 @@ public class PrincessTest {
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
-        target = Compute.oddsAbove(10);
+        target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(1);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -628,19 +628,19 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
-        target = Compute.oddsAbove(9);
+        target = Compute.oddsAbove(9) / 100.0;
         bin1.setShotsLeft(3);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 1 rounds for this level should allow firing on 10s
-        target = Compute.oddsAbove(7);
+        target = Compute.oddsAbove(7) / 100.0;
         bin1.setShotsLeft(1);
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -659,19 +659,19 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // For max aggro, shoot OS weapons at TN 10 or better
-        double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(8) / 100.0;
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // For default aggro, shoot OS weapons at TN 9 or better
         when(mockBehavior.getHyperAggressionIndex()).thenReturn(5);
-        target = Compute.oddsAbove(9);
+        target = Compute.oddsAbove(9) / 100.0;
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // For lowest aggro, shoot OS weapons at TN 8 or better
         when(mockBehavior.getHyperAggressionIndex()).thenReturn(10);
-        target = Compute.oddsAbove(8);
+        target = Compute.oddsAbove(10) / 100.0;
         conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
     }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -648,7 +648,7 @@ public class PrincessTest {
 
     @Test
     public void testCalcAmmoForOneShotWeapons() throws megamek.common.LocationFullException {
-        // Set aggression to lowest level
+        // Set aggression to the lowest level first
         BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
         when(mockBehavior.getHyperAggressionIndex()).thenReturn(0);
         when(mockPrincess.getBehaviorSettings()).thenReturn(mockBehavior);

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -559,7 +559,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        Double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12);
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -594,7 +594,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        Double target = Compute.oddsAbove(12);
+        double target = Compute.oddsAbove(12);
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -628,7 +628,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
-        Double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(10);
         bin1.setShotsLeft(7);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
@@ -659,7 +659,7 @@ public class PrincessTest {
 
         // Check default toHitThresholds
         // For max aggro, shoot OS weapons at TN 10 or better
-        Double target = Compute.oddsAbove(10);
+        double target = Compute.oddsAbove(10);
         Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -22,7 +22,6 @@ package megamek.client.bot.princess;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
-import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import org.junit.jupiter.api.BeforeAll;
@@ -561,7 +560,7 @@ public class PrincessTest {
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
         double target = Compute.oddsAbove(12) / 100.0;
         bin1.setShotsLeft(7);
-        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        Map<Mounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
@@ -596,7 +595,7 @@ public class PrincessTest {
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
         double target = Compute.oddsAbove(12) / 100.0;
         bin1.setShotsLeft(7);
-        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        Map<Mounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 12s
@@ -630,7 +629,7 @@ public class PrincessTest {
         // Default toHitThreshold for 7+ rounds for this level should allow firing on 12s
         double target = Compute.oddsAbove(10) / 100.0;
         bin1.setShotsLeft(7);
-        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        Map<Mounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // Default toHitThreshold for 3+ rounds for this level should allow firing on 11s
@@ -660,7 +659,7 @@ public class PrincessTest {
         // Check default toHitThresholds
         // For max aggro, shoot OS weapons at TN 10 or better
         double target = Compute.oddsAbove(8) / 100.0;
-        Map<WeaponMounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
+        Map<Mounted, Double> conserveMap = mockPrincess.calcAmmoConservation(mech1);
         assertTrue(conserveMap.get(wpn1) <= target);
 
         // For default aggro, shoot OS weapons at TN 9 or better


### PR DESCRIPTION
Includes the following fixes back-ported from 0.49.20:

#5426
#5415
#5433
#5440
#5442

Plus an update to Version to support a 4th field in the version number (without this, bug reports would be quite difficult to keep track of).

Version is reported as 0.49.19.1, but will load 0.49.19 MM save games because we don't compare revisions anywhere, only Release, Major, Minor, and -SNAPSHOT (or not).  This is probably for the best, though; none of the included changes should invalidate current .19 saves.

Testing:
- Ran all unit tests
- Verified Partial Wing handling in MML (built from this version)
- Verified #5426 fix working in MML (built from this version)