### PR TITLE
Minor commit to force Maven repo refresh

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,9 +1,9 @@
 MEGAMEK VERSION HISTORY:
 ----------------
-0.49.19.1 (2024-05-06 1744 UTC)
+0.49.19.1 (2024-05-09 0526 UTC)
 + Fix #5415: Implement RFE #5408: update Princess ammo conservation values
 + Fix #5426: add null checks for getC3UUIDAsString()
-+ Fix #5433: Handle one-shot ammo weapons like RLs appropriately 
++ Fix #5433: Handle one-shot ammo weapons like RLs appropriately
 + Fix #5440: MM fix for MML issue where Partial Wing not accounted for
 + Fix #5442: add null check for turn timer when stopping
 
@@ -32,14 +32,14 @@ MEGAMEK VERSION HISTORY:
 + Fix #5214: Exception when loading saved game
 + Fix #5224: Infantry Firing issue
 + PR #5241: Add test to ensure every unit can load
-+ PR #5244: Fixing MML #1452 Allows you to pod mount null signature system. 
++ PR #5244: Fixing MML #1452 Allows you to pod mount null signature system.
 + Fix #5228: The TAG phase will no longer inadvertently reveal hidden units
 + Fix #5206: Prevent an error with the map preview in the lobby
-+ PR #5240: Fix MML 1365: Sponson Turrets not being included in TechLevel calcs 
-+ PR #5218: add additional zoom levels and font adjustment levels 
++ PR #5240: Fix MML 1365: Sponson Turrets not being included in TechLevel calcs
++ PR #5218: add additional zoom levels and font adjustment levels
 + Data: Fixing #5194, #4979, #4525, #4906, #5141, #5253, #4258, #4555, #5017, #4837
 + PR #5259: Refactor code to add new units to a C3 network
-+ PR #5257: Flat Darcula skin 
++ PR #5257: Flat Darcula skin
 + PR #5256: Bind escape to the close action on various dialogs
 + Fix #5219: Show CF Warning over isometric bridges and turrets.
 + PR #5266: Added a story arcs directory with support for loading units, camo and portraits
@@ -51,7 +51,7 @@ MEGAMEK VERSION HISTORY:
 + PR #5203: Improvements for the internal representation of planetary conditions
 + PR #5270: The weapon panel is now split to prevent info being obscured depending on screen resolution and other factors
 + PR #5274: Update Aerospace SI damage calculation to round naturally with a minimum of 1
-+ Fix #5285: MML #1461 Consider pintle weapons in the same location as in the same pintle 
++ Fix #5285: MML #1461 Consider pintle weapons in the same location as in the same pintle
 + PR #5278: correct issue when using multiple boards and restricting deployment
 + Data: Sprite Swap Project. All shaded sprites that can be (Deadborder mostly) replaced have been.
 + Fix #5298: Illegal Cast Exception when lowering elevation with a VTOL
@@ -60,18 +60,18 @@ MEGAMEK VERSION HISTORY:
 + PR #5305: Princess Behaviour Update
 + Fix #3882 (MM part): ASFs not tracked correctly in MHQ
 + Fix #5205: Handle ConcurrentModification and NPE from opening dialogs
-+ PR #5306: MM portion of fix for MHQ #3803: WOB.pm/.PM mismatch and missing parent faction check 
++ PR #5306: MM portion of fix for MHQ #3803: WOB.pm/.PM mismatch and missing parent faction check
 + PR #5311: Unblock build by removing extraneous Java logging import in UnitTable.java
 + PR #5289: Improved MissionRole Switch Cases & Role List
-+ Fix #5291: Fix for MML #135  Industrial tripod cockpit 
++ Fix #5291: Fix for MML #135  Industrial tripod cockpit
 + Fix #3306: Vehicle Lance Movement prevents full deployment of turrets
 + PR #5303: add client settings for report colors (Allows custom colors)
-+ PR #5322: Fix reading player names from savegames 
++ PR #5322: Fix reading player names from savegames
 + Fix #5280: Fix Null Pointer Error when updating Convert Mode Button status
-+ Fix MekHQ #3986: MHQ wont save, sometimes 
-+ Fix #5348: Stop adding jump start step when deleting movement 
-+ PR #5353: Utility update and small icon error correction 
-+ Fix #5351: Null pointer when turning with shortcut keys in movement phase. 
++ Fix MekHQ #3986: MHQ wont save, sometimes
++ Fix #5348: Stop adding jump start step when deleting movement
++ PR #5353: Utility update and small icon error correction
++ Fix #5351: Null pointer when turning with shortcut keys in movement phase.
 + Fix #5367: correct issue when using multiple boards and restricting deployment
 + PR #5366: Added Faction Logos from UCC (With Permission)
 + Fix #5215 - Secondary turret firing arc display to reflect tanks turret rotation.
@@ -110,7 +110,7 @@ MEGAMEK VERSION HISTORY:
 + PR #5059: Unit tooltip pilot updates
 + PR #5057: Lobby force updates
 + PR #5041: Princess Ice & Infantry On Ice Fix
-+ PR #5069: Reset forces when resetting game 
++ PR #5069: Reset forces when resetting game
 + Fix #5064, Fix #5065: Aero movement cenvelope and acc/dec next optimizations.
 + PR #5071: MUL parser updates
 + PR #5075: Laser-guided bombs now receive a -2 bonus on tagged units
@@ -129,20 +129,20 @@ MEGAMEK VERSION HISTORY:
 + Fix #5103: Check for not dusk dawn for searchlight penalty reduction
 + PR #5121: Bot command updates
 + Fix #4878: Princess non-combat PSR reduction
-+ Fix #5103, #5030, #5072: Correct issues with BAP targeting to hit bonus 
++ Fix #5103, #5030, #5072: Correct issues with BAP targeting to hit bonus
 + Fix #5073: Brings Quirks in line with Campaign Ops 4th printing table.
 + PR #5126: turn timer updates
 + PR #5132: Fix Long Tom Cannon not dealing damage to flying dropship
 + Fix #5104: To-hit calculation bug when shooting at VTOLs
-+ PR #5146: planetary conditions weather updates 
++ PR #5146: planetary conditions weather updates
 + PR #5140: BA tech advancement for Exoskeltons.
-+ PR #5147: Fix weather restrictions around wind 
++ PR #5147: Fix weather restrictions around wind
 + Data: Implement Shrapnel #9 Laser Weapons.
 + PR #5159: Light and Heavy Machine Gun Ammo is mislabeled
 + Fix #5149, #5151: fix NPE in getHexTip(), fix NPE in doEntityDisplacement()
-+ PR #5173 Add bot command for dishonored players 
++ PR #5173 Add bot command for dishonored players
 + Fix #4670: Hide entity statblocks from the hex tooltip when entity is hidden
-+ PR #5170: Use IGame in TurnOrdered 
++ PR #5170: Use IGame in TurnOrdered
 + PR #5169: Code cleanup #5169
 + Fix #5155: Add checkbox to turn off showing player deployment on map preview
 + Fix #4952: Princess does not select alt ammo
@@ -150,7 +150,7 @@ MEGAMEK VERSION HISTORY:
 
 0.49.17 (2023-12-31 1900 UTC)
 + Fix #1031: Show structure collapse warning when deploying and moving.
-+ PR #4990: FixedWingSupport: automatically set SI when walk MPs are set 
++ PR #4990: FixedWingSupport: automatically set SI when walk MPs are set
 
 0.49.16 (2023-12-30 2200 UTC)
 + Fix #4769: BA Tube Artillery should support smoke rounds
@@ -430,7 +430,7 @@ MEGAMEK VERSION HISTORY:
 + Data: Fixing #4223, #4206, #4371, #4398, #4377, #4272, #4257, #4244 ,#4312
 + PR #4430: Highlight min/max visual and sensor ranges
 + PR #4450: When tacops sensors is not on, dont show sensor rings
-+ PR #4451: When tacops sensors is not on, show visual range in tool tip 
++ PR #4451: When tacops sensors is not on, show visual range in tool tip
 
 
 0.49.12 (2023-03-04 2200 UTC)


### PR DESCRIPTION
Now that the workflows are checked in on MegaMek/0.49.19.1, we need to refresh the Maven repo for each project in order to unblock automatic building.