### PR TITLE
Fix Targeting Comp loading (.20!)

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3790,6 +3790,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if (mounted instanceof MiscMounted) {
             miscList.add((MiscMounted) mounted);
         }
+        if (!(mounted instanceof AmmoMounted) && !(mounted instanceof BombMounted) && !(mounted instanceof MiscMounted)
+                && !(mounted instanceof WeaponMounted) && !(mounted instanceof InfantryWeaponMounted)) {
+            LogManager.getLogger().error("Trying to add plain Mounted class {} on {}!", mounted, this);
+        }
     }
 
     private void addOneshotAmmo(Mounted<?> mounted) throws LocationFullException {

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -2756,8 +2756,8 @@ public abstract class Mech extends Entity {
      * Adds equipment without adding slots for it.
      * Specifically for targeting computers, which when loaded from a file don't have a correct size and get loaded slot by slot
      */
-    public Mounted addTargCompWithoutSlots(EquipmentType etype, int loc, boolean omniPod, boolean armored) throws LocationFullException {
-        Mounted mounted = new Mounted(this, etype);
+    public MiscMounted addTargCompWithoutSlots(MiscType etype, int loc, boolean omniPod, boolean armored) throws LocationFullException {
+        MiscMounted mounted = (MiscMounted) MiscMounted.createMounted(this, etype);
         mounted.setOmniPodMounted(omniPod);
         mounted.setArmored(armored);
         super.addEquipment(mounted, loc, false);

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -789,7 +789,7 @@ public class MtfFile implements IMechLoader {
                 if (etype != null) {
                     if (etype.isSpreadable()) {
                         // do we already have one of these? Key on Type
-                        Mounted m = hSharedEquip.get(etype);
+                        Mounted<?> m = hSharedEquip.get(etype);
                         if (m != null) {
                             // use the existing one
                             mech.addCritical(loc, new CriticalSlot(m));
@@ -800,11 +800,11 @@ public class MtfFile implements IMechLoader {
                                               isTurreted);
                         m.setOmniPodMounted(isOmniPod);
                         hSharedEquip.put(etype, m);
-                    } else if (etype instanceof  MiscType && etype.hasFlag(MiscType.F_TARGCOMP)) {
+                    } else if (etype instanceof MiscType && etype.hasFlag(MiscType.F_TARGCOMP)) {
                         // Targeting computers are special, they need to be loaded like spreadable equipment, but they aren't spreadable
-                        Mounted m = hSharedEquip.get(etype);
+                        Mounted<?> m = hSharedEquip.get(etype);
                         if (m == null) {
-                            m = mech.addTargCompWithoutSlots(etype, loc, isOmniPod, isArmored);
+                            m = mech.addTargCompWithoutSlots((MiscType) etype, loc, isOmniPod, isArmored);
                             hSharedEquip.put(etype, m);
                         }
                         mech.addCritical(loc, new CriticalSlot(m));


### PR DESCRIPTION
Targeting Comps were created as Mounted instead of MiscMounted and therefore added to the equipment list but not the misc list which made them quantum mechanical (there and at the same time not there)
Fixes it and adds a log error when a plain Mounted.class equipment is being added. By clicking around I could not find another unit with an error but there's sure to be one somewhere.