### PR TITLE
Allow plain lookandfeel border for MegamekButton

### DIFF
--- a/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
+++ b/megamek/src/megamek/client/ui/swing/widget/MegamekButton.java
@@ -167,7 +167,9 @@ public class MegamekButton extends JButton implements MouseListener {
      */
     private void initialize(String component, boolean defaultToPlain) {
         SkinSpecification skinSpec = SkinXMLHandler.getSkin(component, defaultToPlain, true);
-        setBorder(new MegamekBorder(skinSpec));
+        if (!skinSpec.noBorder) {
+            setBorder(new MegamekBorder(skinSpec));
+        }
         loadIcon(skinSpec);
         isBGTiled = skinSpec.tileBackground;
 


### PR DESCRIPTION
This changes the skinned MegamekButton to allow the look and feel border if no border is set by the skin (in other words, it allows a skinned button to actually be a normal look and feel button - formerly, the LaF border was always overwritten)