### PR TITLE
Fix 5483: Make various calls safer from NPE and ensure searchlight target on board

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1941,11 +1941,13 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
     }
 
     protected void updateSearchlight() {
-        setSearchlightEnabled((ce() != null)
+        setSearchlightEnabled(
+                (ce() != null)
                 && (target != null)
-                && ce().isUsingSearchlight()
-                && ce().getCrew().isActive()
+                && (clientgui.getClient().getGame().getBoard().contains(target.getPosition()))
                 && !ce().isHidden()
+                && ce().getCrew().isActive()
+                && ce().isUsingSearchlight()
                 && SearchlightAttackAction.isPossible(clientgui.getClient().getGame(), cen, target, null)
                 && !((ce() instanceof Tank) && (((Tank) ce()).getStunnedTurns() > 0)));
     }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4028,10 +4028,20 @@ public class Compute {
         Vector<Coords> tPosV = new Vector<>();
         tPosV.add(target.getPosition());
         // check for secondary positions
-        if ((target instanceof Entity)
-            && (null != ((Entity) target).getSecondaryPositions())) {
-            for (int key : ((Entity) target).getSecondaryPositions().keySet()) {
-                tPosV.add(((Entity) target).getSecondaryPositions().get(key));
+        if (target instanceof Entity) {
+            Map<Integer, Coords> secondaryPositions = ((Entity) target).getSecondaryPositions();
+            if (null != secondaryPositions && !secondaryPositions.isEmpty()) {
+                // Some units fill additional hexes
+                for (Coords hex : secondaryPositions.values()) {
+                    // Some hexes may not be configured, or be invalid
+                    if (null != hex) {
+                        tPosV.add(hex);
+                    } else {
+                        LogManager.getLogger().warn(
+                                "Entity " + ((Entity) target).getDisplayName() + " has null secondary location!"
+                        );
+                    }
+                }
             }
         }
 
@@ -4068,6 +4078,11 @@ public class Compute {
         // if any of the destination coords are in the right place, then return
         // true
         for (Coords dest : destV) {
+            // Sometimes we get non-null destV containing null Coord entries.
+            if (null == dest) {
+                return true;
+            }
+
             // calculate firing angle
             int fa = src.degree(dest) - (facing * 60);
             if (fa < 0) {


### PR DESCRIPTION
Fixes an issue where the firing phase would throw an NPE if:
1. Planetary Conditions are lower light level than daylight,
2. Searchlights are on,
3. A unit that has yet to deploy, or has fled the board this turn, is at the top of the entities list

Root cause is twofold:
A) automatically selecting an off-board unit while checking to see if the selected friendly unit _could_ use its Searchlight;
B) trying to get the hex location of units that don't have coords, in order to calculate if they are in the selected unit's arc.

This fix adds safety checks around these calls / tests to avoid this in the future, but per our Discord conversation, we
should _definitely_ consider a non-null Coord value to represent "not on any board", especially if we will be adding more
simultaneous maps in the future.

Testing:
- Tested fix in 0.49.19.1 MM to verify handling
- Tested fix applied to 0.49.20 code via MHQ
- Ran all three projects' unit tests

Close #5483 