### PR TITLE
Accessibility window cleanup and safety

### DIFF
--- a/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
+++ b/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
@@ -247,7 +247,7 @@ public class AccessibilityWindow extends JDialog implements KeyListener {
                     String name = (ent.getOwner() != null) ? ent.getOwner().getName() : "[Unknown]";
                     try {
                         String actionText = ent.getDisplayName() + " from player " + name + " is doing " +
-                                e.getAction().toDisplayableString(client) + ".";
+                                e.getAction().toAccessibilityDescription(client) + ".";
                         systemEvent(actionText);
                     } catch (Exception ex) {
                         LogManager.getLogger().warn("Couldn't obtain action accessibility description", ex);

--- a/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
+++ b/megamek/src/megamek/client/ui/swing/AccessibilityWindow.java
@@ -24,6 +24,7 @@ import megamek.client.ui.Messages;
 import megamek.common.Coords;
 import megamek.common.Entity;
 import megamek.common.event.*;
+import org.apache.logging.log4j.LogManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -32,151 +33,51 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.util.LinkedList;
+import java.util.Objects;
 
 public class AccessibilityWindow extends JDialog implements KeyListener {
     private static final String cleanHtmlRegex = "<[^>]*>";
     public static final int MAX_HISTORY = 10;
     public static final String ACCESSIBLE_GUI_SHORTCUT = ".";
 
-    Client client;
-    ClientGUI gui;
-    JTextArea chatArea;
+    private final Client client;
+    private final ClientGUI gui;
+    private final JTextArea chatArea = new JTextArea(" \n", 5, 40);
+    private final JTextField inputField = new JTextField();
+    private final LinkedList<String> history = new LinkedList<>();
 
     private Coords selectedTarget;
-    private JTextField inputField;
-    private LinkedList<String> history;
     private int historyBookmark = -1;
 
     public AccessibilityWindow(ClientGUI clientGUI) {
         super(clientGUI.getFrame(), Messages.getString("ClientGUI.ChatWindow"));
-        client = clientGUI.getClient();
+        client = Objects.requireNonNull(clientGUI.getClient());
         gui = clientGUI;
-        client.getGame().addGameListener(new GameListenerAdapter() {
-            @Override
-            public void gamePlayerConnected(GamePlayerConnectedEvent e) {
-                String name = (e != null) && (e.getPlayer() != null)
-                            ? e.getPlayer().getName()
-                            : "UNNAMED";
-                systemEvent("New player has connected. Their name is " + name + ".");
-            }
-
-            @Override
-            public void gamePlayerDisconnected(GamePlayerDisconnectedEvent e) {
-                String name = (e != null) && (e.getPlayer() != null)
-                            ? e.getPlayer().getName()
-                            : "UNNAMED";
-                systemEvent("The player " + name + " has disconnected.");
-            }
-
-            @Override
-            public void gamePhaseChange(GamePhaseChangeEvent e) {
-                systemEvent("Phase changed it is now " + e.getNewPhase() + ".");
-                if (client.phaseReport != null) {
-                    systemEvent(cleanHtml(client.phaseReport));
-                }
-            }
-
-            @Override
-            public void gameTurnChange(GameTurnChangeEvent e) {
-                if (e.getPlayer() != null) {
-                    systemEvent("Turn changed, it is now " + e.getPlayer().getName() + "'s turn.");
-                }
-            }
-
-            @Override
-            public void gameReport(GameReportEvent e) {
-                systemEvent(e.getReport());
-            }
-
-            @Override
-            public void gameEnd(GameEndEvent e) {
-                systemEvent("The game ended. Goodbye.");
-            }
-
-            @Override
-            public void gameBoardChanged(GameBoardChangeEvent e) {
-            }
-
-            @Override
-            public void gameEntityNew(GameEntityNewEvent e) {
-                if (e != null) {
-                    systemEvent("Added " + e.getNumberOfEntities() +  " new entities;" );
-                    for (Entity ent : e.GetEntities()) {
-                        String name = ent.getOwner() != null ? ent.getOwner().getName() : "UNNAMED";
-                        systemEvent(name + " adds " + ent.getDisplayName());
-                    }
-                }
-            }
-
-            @Override
-            public void gameEntityNewOffboard(GameEntityNewOffboardEvent e) {
-                //systemEvent("Out of game event. (unneeded)" );
-            }
-
-            @Override
-            public void gameEntityRemove(GameEntityRemoveEvent e) {
-                if ((e != null) && (e.getEntity() != null)) {
-                    final Entity ent = e.getEntity();
-                    String name = ent.getOwner() != null ? ent.getOwner().getName() : "UNNAMED";
-                    systemEvent("Removed " + ent.getDisplayName() + " from player " + name + ".");
-                }
-            }
-
-            @Override
-            public void gameEntityChange(GameEntityChangeEvent e) {
-                if ((e != null) && (e.getEntity() != null)) {
-                    systemEvent(e.toString() );
-                }
-            }
-
-            @Override
-            public void gameNewAction(GameNewActionEvent e) {
-                if ((e != null) && (e.getAction() != null)) {
-                    final Entity ent = client.getEntity(e.getAction().getEntityId());
-                    if (ent != null) {
-                        String name = ent.getOwner() != null 
-                                    ? ent.getOwner().getName() 
-                                    : "UNNAMED";
-                        systemEvent(ent.getDisplayName() + " from player " + name + " is doing " + e.getAction().toDisplayableString(client) + ".");
-                    }
-                }
-            }
-
-            @Override
-            public void gameClientFeedbackRequest(GameCFREvent e) {
-                systemEvent("New feedback event.");
-            }
-
-            @Override
-            public void gameVictory(GameVictoryEvent e) {
-                systemEvent("Game Victory! (unneeded.)");
-            }
-        });
-
-        history = new LinkedList<>();
-
+        client.getGame().addGameListener(gameListener);
         setLayout(new BorderLayout());
 
-        chatArea = new JTextArea(
-                " \n", GUIPreferences.getInstance().getInt("AdvancedChatboxSize"), 40);
         chatArea.setEditable(false);
         chatArea.setLineWrap(true);
         chatArea.setWrapStyleWord(true);
         chatArea.setFont(new Font(MMConstants.FONT_SANS_SERIF, Font.PLAIN, 12));
-        add(new JScrollPane(chatArea, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
-                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER), BorderLayout.CENTER);
+        var scrollPane = new JScrollPane(chatArea, JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED,
+                JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        add(scrollPane, BorderLayout.CENTER);
 
-        inputField = new JTextField();
         inputField.addKeyListener(this);
         add(inputField, BorderLayout.SOUTH);
     }
 
-    // Stolen in principle from the MapMenu.
     private void processAccessibleGUI() {
         final String[] args = inputField.getText().split(" ");
         if (args.length == 3) {
-            selectedTarget = new Coords(Integer.parseInt(args[1]) - 1,
-                    Integer.parseInt(args[2]) - 1);
+            try {
+                selectedTarget = new Coords(Integer.parseInt(args[1]) - 1,
+                        Integer.parseInt(args[2]) - 1);
+            } catch (NumberFormatException e) {
+                systemEvent("Couldn't parse coordinates.");
+                return;
+            }
             // Why don't constants work here?
             // Cursor over the hex.
             gui.getBoardView().mouseAction(selectedTarget, 3, InputEvent.BUTTON1_DOWN_MASK, MouseEvent.BUTTON1);
@@ -192,13 +93,9 @@ public class AccessibilityWindow extends JDialog implements KeyListener {
     }
 
     private String cleanHtml(String str) {
-        str = str.replaceAll(cleanHtmlRegex, "");
-        //replace &nbsp; with space
-        str = str.replace("&nbsp;", " ");
-        //replace &amp; with &
-        str = str.replace("&amp;", "&");
-
-        return str;
+        return str.replaceAll(cleanHtmlRegex, "")
+                .replace("&nbsp;", " ")
+                .replace("&amp;", "&");
     }
 
     /**
@@ -265,4 +162,109 @@ public class AccessibilityWindow extends JDialog implements KeyListener {
         //ignored
     }
     //endregion Key Listener
+
+    GameListener gameListener = new GameListenerAdapter() {
+
+        @Override
+        public void gamePlayerConnected(GamePlayerConnectedEvent e) {
+            String name = (e != null) && (e.getPlayer() != null)
+                    ? e.getPlayer().getName()
+                    : "[Unknown]";
+            systemEvent("New player has connected. Their name is " + name + ".");
+        }
+
+        @Override
+        public void gamePlayerDisconnected(GamePlayerDisconnectedEvent e) {
+            String name = (e != null) && (e.getPlayer() != null)
+                    ? e.getPlayer().getName()
+                    : "[Unknown]";
+            systemEvent("The player " + name + " has disconnected.");
+        }
+
+        @Override
+        public void gamePhaseChange(GamePhaseChangeEvent e) {
+            systemEvent("Phase changed; it is now " + e.getNewPhase() + ".");
+            if (client.phaseReport != null) {
+                systemEvent(cleanHtml(client.phaseReport));
+            }
+        }
+
+        @Override
+        public void gameTurnChange(GameTurnChangeEvent e) {
+            if ((e != null) && (e.getPlayer() != null)) {
+                systemEvent("Turn changed; it is now " + e.getPlayer().getName() + "'s turn.");
+            }
+        }
+
+        @Override
+        public void gameReport(GameReportEvent e) {
+            if (e != null) {
+                systemEvent(e.getReport());
+            }
+        }
+
+        @Override
+        public void gameEnd(GameEndEvent e) {
+            systemEvent("The game ended. Goodbye.");
+        }
+
+        @Override
+        public void gameEntityNew(GameEntityNewEvent e) {
+            if (e != null) {
+                systemEvent("Added " + e.getNumberOfEntities() + " new entities;");
+                try {
+                    for (Entity ent : e.GetEntities()) {
+                        String name = ent.getOwner() != null ? ent.getOwner().getName() : "UNNAMED";
+                        systemEvent(name + " adds " + ent.getDisplayName());
+                    }
+                } catch (Exception ignored) {
+                    // shouldn't happen but keep it from crashing the game
+                }
+            }
+        }
+
+        @Override
+        public void gameEntityRemove(GameEntityRemoveEvent e) {
+            if ((e != null) && (e.getEntity() != null)) {
+                final Entity ent = e.getEntity();
+                String name = (ent.getOwner() != null) ? ent.getOwner().getName() : "UNNAMED";
+                systemEvent("Removed " + ent.getDisplayName() + " from player " + name + ".");
+            }
+        }
+
+        @Override
+        public void gameEntityChange(GameEntityChangeEvent e) {
+            if ((e != null) && (e.getEntity() != null)) {
+                systemEvent(e.toString());
+            }
+        }
+
+        @Override
+        public void gameNewAction(GameNewActionEvent e) {
+            if ((e != null) && (e.getAction() != null)) {
+                final Entity ent = client.getEntity(e.getAction().getEntityId());
+                if (ent != null) {
+                    String name = (ent.getOwner() != null) ? ent.getOwner().getName() : "[Unknown]";
+                    try {
+                        String actionText = ent.getDisplayName() + " from player " + name + " is doing " +
+                                e.getAction().toDisplayableString(client) + ".";
+                        systemEvent(actionText);
+                    } catch (Exception ex) {
+                        LogManager.getLogger().warn("Couldn't obtain action accessibility description", ex);
+                        systemEvent("An unknown action happened");
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void gameClientFeedbackRequest(GameCFREvent e) {
+            systemEvent("New feedback event.");
+        }
+
+        @Override
+        public void gameVictory(GameVictoryEvent e) {
+            systemEvent("Game Victory! (unneeded.)");
+        }
+    };
 }

--- a/megamek/src/megamek/common/actions/AbstractAttackAction.java
+++ b/megamek/src/megamek/common/actions/AbstractAttackAction.java
@@ -215,7 +215,7 @@ public abstract class AbstractAttackAction extends AbstractEntityAction implemen
     }
 
     @Override
-    public String toDisplayableString(final Client client) {
+    public String toAccessibilityDescription(final Client client) {
         final Targetable target = getTarget(client.getGame());
         return (target == null) ? "Attacking Null Target with id " + getTargetId()
                 : "Attacking " + target.getDisplayName();

--- a/megamek/src/megamek/common/actions/AbstractEntityAction.java
+++ b/megamek/src/megamek/common/actions/AbstractEntityAction.java
@@ -1,34 +1,33 @@
-/**
- * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+/*
+ * MegaMek - Copyright (c) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
  *
- *  This program is free software; you can redistribute it and/or modify it
- *  under the terms of the GNU General Public License as published by the Free
- *  Software Foundation; either version 2 of the License, or (at your option)
- *  any later version.
+ * This file is part of MegaMek.
  *
- *  This program is distributed in the hope that it will be useful, but
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- *  for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
-
 package megamek.common.actions;
-
-import megamek.client.Client;
-import megamek.common.Game;
 
 import java.io.Serializable;
 
 /**
- * Abstract superclass for any action that an entity takes.
+ * This is a base implementation for {@link EntityAction}.
  */
-public abstract class AbstractEntityAction implements Serializable,
-        EntityAction {
-    /**
-     *
-     */
+public abstract class AbstractEntityAction implements Serializable, EntityAction {
+
     private static final long serialVersionUID = -758003433608975464L;
-    private int entityId;
+    private final int entityId;
 
     public AbstractEntityAction(int entityId) {
         this.entityId = entityId;
@@ -37,21 +36,5 @@ public abstract class AbstractEntityAction implements Serializable,
     @Override
     public int getEntityId() {
         return entityId;
-    }
-
-    @Override
-    public void setEntityId(int entityId) {
-        this.entityId = entityId;
-    }
-
-    @Override
-    public String toDisplayableString(Client client) {
-        return this.toString();
-    }
-
-    @Override
-    public String toSummaryString(final Game game) {
-        String typeName = this.getClass().getTypeName();
-        return typeName.substring(typeName.lastIndexOf('.') + 1);
     }
 }

--- a/megamek/src/megamek/common/actions/EntityAction.java
+++ b/megamek/src/megamek/common/actions/EntityAction.java
@@ -1,27 +1,77 @@
 /*
- * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * MegaMek - Copyright (c) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 package megamek.common.actions;
 
 import megamek.client.Client;
-import megamek.common.Game;
+import megamek.common.*;
+import megamek.client.ui.swing.AccessibilityWindow;
+import megamek.client.ui.swing.tooltip.EntityActionLog;
+import megamek.client.ui.swing.boardview.TurnDetailsOverlay;
+import megamek.common.alphaStrike.AlphaStrikeElement;
+import megamek.common.strategicBattleSystems.SBFFormation;
 
+/**
+ * This interface is implemented by all actions that game units - not restricted to Entity! - can
+ * perform, such as attacks, charges or spotting. Basic movement is currently not represented by this
+ * interface.
+ * @see Entity
+ * @see AlphaStrikeElement
+ * @see SBFFormation
+ */
 public interface EntityAction {
+
+    /**
+     * @return The ID of the acting game unit. Note that when an entity is destroyed, it may no longer be
+     * available from {@link Game#getEntity(int)} but rather only from {@link Game#getOutOfGameEntity(int)}
+     * or {@link Game#getEntityFromAllSources(int)}.
+     * As this can happen in the middle of resolving complicated situations in the GameManager, this
+     * is a potential cause for bugs.
+     * <BR>Note that this is not restricted to {@link Entity}; it can be used for all {@link InGameObject}s
+     * that are handled in the game.
+     */
     int getEntityId();
 
-    void setEntityId(int entityId);
+    /**
+     * Returns a full description of the action that is (only) to be used in the
+     * {@link AccessibilityWindow} as a textual representation of the action.
+     * By default, this method returns the value of toString().
+     *
+     * @param client The local client to obtain any necessary information for the description
+     * @return A string describing the action
+     * @see AccessibilityWindow
+     */
+    default String toAccessibilityDescription(Client client) {
+        return toString();
+    }
 
-    String toDisplayableString(Client client);
-
-    String toSummaryString(Game game);
+    /**
+     * Returns a short one-line description of the action that is used in the UI, e.g. on attack arrows
+     * in the BoardView and in the action summary in {@link TurnDetailsOverlay}.
+     *
+     * @param game The game object to get information from
+     * @return A short String describing the action
+     * @see EntityActionLog
+     * @see TurnDetailsOverlay
+     */
+    default String toSummaryString(Game game) {
+        String typeName = this.getClass().getTypeName();
+        return typeName.substring(typeName.lastIndexOf('.') + 1);
+    }
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5354,12 +5354,13 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
     }
 
     @Override
-    public String toDisplayableString(Client client) {
+    public String toAccessibilityDescription(Client client) {
         if (null == client || null == getTarget(client.getGame())) {
             LogManager.getLogger().warn("Unable to construct WAA displayable string due to null reference");
             return "Attacking Null Target with id " + getTargetId() + " using Weapon with id " + weaponId;
         }
-        return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " + getEntity(client.getGame()).getEquipment(weaponId).getName();
+        return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " +
+                getEntity(client.getGame()).getEquipment(weaponId).getName();
     }
 
     @Override


### PR DESCRIPTION
As the title says. Seeing that we got reports of exceptions in AccessibilityWindow (even though it possibly wasnt even used) I tried to make it as safe as possible. The main point is, probably, to surround creating the description of an (attack) action with a try-catch. 
@Sleet01 I remember you making changes and I believe I talked you out of the try catch. I disgree with myself now and retroactively agree fully to having a try catch to *really* prevent any exceptions from creating a text line. I placed it in AccessibilityWindow itself so the burden isnt on the code in the Actions and it cant be forgotten. An argument can probably be made to do the same in EntityActionLog for that other description method in EntityAction. Another argument might be made for creating the AccessibilityWindow only when the player calls it up, to not have a game listener in place when no one needs it. Another time.

Also updates the code in EntityAction and AbstractEntityAction with defaults and comments.