### PR TITLE
Fix 5476: Update SV armor slots to 2 or 1 for Rating E or F respectively

### DIFF
--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -235,12 +235,12 @@ public class ArmorType extends MiscType {
 
     @Override
     public int getSupportVeeSlots(Entity entity) {
-        // Support vehicle armor takes slots like ferro-fibrous at BAR 10/TL E/F
+        // Support vehicle armor takes slots like CV ferro-fibrous at BAR 10/TL E/F
         if (getArmorType() == T_ARMOR_SV_BAR_10) {
             if (entity.getArmorTechRating() == ITechnology.RATING_E) {
-                return ArmorType.of(T_ARMOR_FERRO_FIBROUS, false).criticals;
+                return ArmorType.of(T_ARMOR_FERRO_FIBROUS, false).svslots;
             } else if (entity.getArmorTechRating() == ITechnology.RATING_F) {
-                return ArmorType.of(T_ARMOR_FERRO_FIBROUS, true).criticals;
+                return ArmorType.of(T_ARMOR_FERRO_FIBROUS, true).svslots;
             }
         }
         return svslots;
@@ -371,7 +371,7 @@ public class ArmorType extends MiscType {
         armor.cost = 20000.0;
         armor.criticals = 7;
         armor.tankslots = 1;
-        armor.svslots = 3;
+        armor.svslots = 1;
         armor.patchworkSlotsMechSV = 1;
         armor.patchworkSlotsCVFtr = 1;
         armor.flags = armor.flags.or(F_FERRO_FIBROUS).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_VTOL_EQUIPMENT);

--- a/megamek/unittests/megamek/common/verifier/TestSupportVehicleTest.java
+++ b/megamek/unittests/megamek/common/verifier/TestSupportVehicleTest.java
@@ -1,13 +1,20 @@
 package megamek.common.verifier;
 
-import megamek.common.MiscType;
+import megamek.common.*;
+import megamek.common.equipment.ArmorType;
 import megamek.common.verifier.TestSupportVehicle.ChassisModification;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static megamek.common.EquipmentType.T_ARMOR_FERRO_FIBROUS;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestSupportVehicleTest {
+
+    @BeforeAll
+    public static void initialize() {
+        EquipmentType.initializeTypes();
+    }
 
     @Test
     public void testChassisModLookup() {
@@ -16,5 +23,24 @@ public class TestSupportVehicleTest {
             assertTrue(mod.equipment.hasFlag(MiscType.F_SUPPORT_TANK_EQUIPMENT));
             assertTrue(mod.equipment.hasFlag(MiscType.F_CHASSIS_MODIFICATION));
         }
+    }
+
+    @Test
+    public void testBAR10ArmorCorrectSlots() {
+        SupportTank st = new SupportTank();
+        st.setArmorType(EquipmentType.T_ARMOR_SV_BAR_10);
+        // Rating E should return CV slots for IS FF
+        st.setArmorTechRating(ITechnology.RATING_E);
+        assertEquals(
+                2,
+                ArmorType.of(T_ARMOR_FERRO_FIBROUS, false).getSupportVeeSlots(st)
+        );
+
+        // Rating F should return CV slots for Clan FF
+        st.setArmorTechRating(ITechnology.RATING_F);
+        assertEquals(
+                1,
+                ArmorType.of(T_ARMOR_FERRO_FIBROUS, true).getSupportVeeSlots(st)
+        );
     }
 }


### PR DESCRIPTION
Implements this errata: https://bg.battletech.com/forums/index.php?topic=84165.msg1993603#msg1993603

- Tech Level E BAR10 armor on Support Vehicles will take as many slots as IS FF armor for CVs (2, currently)
- Tech Level F BAR10 armor on SVs will take as many slots as Clan FF armor for CVs (1, currently)

Testing:
- Loaded numerous BAR10 SVs in MegaMek / MegaMekLab and confirmed armor slot count for each tech level
- Ran existing unit tests for all 3 projects
- Add unit test for SV BAR10 armor

NOTE: the errata requested specific values for Patchwork BAR10 armor, but we do not support Patchwork armor for SVs at this time.  If that functionality is ever added, the above linked errata should be referenced for values.

Media:
Tech Level E:
<img width="371" alt="Screenshot_20240519_173629" src="https://github.com/MegaMek/megamek/assets/22018319/67d3a132-fc76-4c69-b7dc-481fc22c91da">
<img width="199" alt="Screenshot_20240519_173729" src="https://github.com/MegaMek/megamek/assets/22018319/eb7c92e6-ed6c-486b-a3ba-b926078b2bde">
<img width="506" alt="Screenshot_20240519_173836" src="https://github.com/MegaMek/megamek/assets/22018319/25b3ea2f-0b7f-4ced-8228-e095e01ad08d">

Tech Level F:
<img width="356" alt="Screenshot_20240519_173805" src="https://github.com/MegaMek/megamek/assets/22018319/0a1809f1-860f-4895-98f4-7957884ffaea">
<img width="178" alt="Screenshot_20240519_173818" src="https://github.com/MegaMek/megamek/assets/22018319/f5c543d3-b6fd-4c9b-a4f6-0ead44b14a22">
<img width="554" alt="Screenshot_20240519_173853" src="https://github.com/MegaMek/megamek/assets/22018319/2f1adf38-00ee-4129-a0eb-3c48de29d08c">


Close #5476 