### PR TITLE
Fix 5489: NPE from BA AP Mount due to weapon linking to AP Mount equipment

### DIFF
--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1756,7 +1756,8 @@ public class WeaponHandler implements AttackHandler, Serializable {
         ae = game.getEntity(waa.getEntityId());
         weapon = (WeaponMounted) ae.getEquipment(waa.getWeaponId());
         wtype = (WeaponType) weapon.getType();
-        atype = (weapon.getLinked() != null) ? (AmmoType) weapon.getLinked().getType() : null;
+        atype = (weapon.getLinked() != null && weapon.getLinked().getType() instanceof AmmoType)
+                ? (AmmoType) weapon.getLinked().getType() : null;
         typeName = wtype.getInternalName();
         target = game.getTarget(waa.getTargetType(), waa.getTargetId());
         gameManager = m;


### PR DESCRIPTION
Problem in title.

Fix is only set atype if the linked equipment is not null _and_ is an AmmoType.
This shouldn't negatively impact anything as other uses of atype include null check.

Testing:
- Recreated and ran OP's save game in .20 code with and without fix.
- Ran all three projects' unit tests

Close #5489 
