### PR TITLE
Add test for invalid canon units

### DIFF
--- a/megamek/unittests/megamek/common/loaders/CacheRebuildTest.java
+++ b/megamek/unittests/megamek/common/loaders/CacheRebuildTest.java
@@ -1,30 +1,69 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
 package megamek.common.loaders;
 
+import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
-import megamek.common.util.fileUtils.MegaMekFile;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.File;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class CacheRebuildTest {
+
     /**
-     * Tests that every single unit can load successfully
+     * Tests that every single unit can load successfully.
      */
     @Test
+    @Order(1)
     public void testCacheRebuild() {
-        File file = new MegaMekFile(MechSummaryCache.getUnitCacheDir(),
-            MechSummaryCache.FILENAME_UNITS_CACHE).getFile();
-        if (file.exists()) {
-            // Ensure the cache really is cleared
-            assertTrue(file.delete());
+        File cacheFile = new File(MechSummaryCache.getUnitCacheDir(), MechSummaryCache.FILENAME_UNITS_CACHE);
+        if (cacheFile.exists()) {
+            assertTrue(cacheFile.delete(), "Couldn't delete cache");
         }
-        MechSummaryCache instance = MechSummaryCache.getInstance(true);
+
+        MechSummaryCache cache = MechSummaryCache.getInstance(true);
+
         // Make sure no units failed loading
-        assertTrue(instance.getFailedFiles().isEmpty());
+        assertTrue(cache.getFailedFiles().isEmpty());
         // Sanity check to make sure the loader thread didn't fail outright
-        assertTrue(instance.getAllMechs().length > 100);
+        assertTrue(cache.getAllMechs().length > 9000);
+    }
+
+    /**
+     * Tests that all canon units are valid.
+     */
+    @Test
+    @Order(2)
+    public void testInvalidCanonUnits() {
+        MechSummaryCache cache = MechSummaryCache.getInstance(true);
+
+        boolean hasInvalidUnits = false;
+        for (MechSummary ms : cache.getAllMechs()) {
+            if (ms.isCanon() && ms.getInvalid()) {
+                hasInvalidUnits = true;
+                System.out.println("Invalid canon unit: " + ms);
+            }
+        }
+        assertFalse(hasInvalidUnits);
     }
 }


### PR DESCRIPTION
Updates the Cache test to also test for invalid canon units. Currently fails pretty hard.