### PR TITLE
DS loading, issue 5495

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -3687,14 +3687,6 @@ public class GameManager extends AbstractGameManager {
         // set deployment round of the loadee to equal that of the loader
         unit.setDeployRound(loader.getDeployRound());
 
-        // Update the loading unit's passenger count, if it's a large craft
-        if ((loader instanceof SmallCraft) || (loader instanceof Jumpship)) {
-            // Don't add DropShip crew to a JumpShip or station's passenger list
-            if (!unit.isLargeCraft()) {
-                loader.setNPassenger(loader.getNPassenger() + unit.getCrew().getSize());
-            }
-        }
-
         // Update the loaded unit.
         entityUpdate(unit.getId());
         entityUpdate(loader.getId());
@@ -3956,14 +3948,6 @@ public class GameManager extends AbstractGameManager {
         if (duringDeployment) {
             unit.setUnloaded(false);
             unit.setDone(false);
-        }
-
-        //Update the transport unit's passenger count, if it's a large craft
-        if (unloader instanceof SmallCraft || unloader instanceof Jumpship) {
-            //Don't add dropship crew to a jumpship or station's passenger list
-            if (!unit.isLargeCraft()) {
-                unloader.setNPassenger(Math.max(0, unloader.getNPassenger() - unit.getCrew().getSize()));
-            }
         }
 
         // Update the unloaded unit.

--- a/megamek/unittests/megamek/common/DropShipMekLoadTest.java
+++ b/megamek/unittests/megamek/common/DropShipMekLoadTest.java
@@ -1,0 +1,60 @@
+package megamek.common;
+
+import megamek.common.enums.GamePhase;
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import megamek.common.verifier.TestEntity;
+import megamek.server.GameManager;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class DropShipMekLoadTest {
+
+    @Test
+    public void test() throws Exception {
+        MechSummaryCache instance = MechSummaryCache.getInstance(true);
+        Mech atlas = (Mech) instance.getMech("Atlas AS7-D").loadEntity();
+        atlas.setId(2);
+        Dropship leopard = (Dropship) instance.getMech("Leopard (2537)").loadEntity();
+        leopard.setId(1);
+
+        Game game = new Game();
+        game.setPhase(GamePhase.LOUNGE);
+        game.addPlayer(0, new Player(0, "TestPlayer"));
+        game.addEntity(atlas);
+        game.addEntity(leopard);
+
+        GameManager gm = mock(GameManager.class);
+        doNothing().when(gm).entityUpdate(anyInt());
+        when(gm.getGame()).thenReturn(game);
+        doCallRealMethod().when(gm).setGame(any(Game.class));
+        doCallRealMethod().when(gm).handlePacket(anyInt(), any(Packet.class));
+        gm.setGame(game);
+
+        Packet packet = new Packet(PacketCommand.ENTITY_LOAD, atlas.getId(), leopard.getId(), -1);
+        gm.handlePacket(0, packet);
+
+        doAssertions(leopard, atlas);
+
+        leopard.setAltitude(0);
+
+        doAssertions(leopard, atlas);
+    }
+
+    private void doAssertions(Entity leopard, Entity atlas) {
+        StringBuffer errors = new StringBuffer();
+        assertTrue(isValid(leopard, errors), "Leopard is not valid after loading Atlas, errors: " + errors);
+        assertTrue(isValid(atlas, errors), "Atlas is not valid after loading onto Leopard, errors: " + errors);
+        assertEquals(atlas.getTransportId(), leopard.getId(),
+                "Carrier ID " + atlas.getTransportId() + " wrong, should be " + leopard.getId());
+        assertEquals(1, leopard.getLoadedUnits().size(),
+                "Loaded unit list size" + leopard.getLoadedUnits().size() + " wrong, should be 1");
+        assertNull(atlas.getPosition(), "Loaded Atlas position is " + atlas.getPosition() + ", should be null");
+    }
+
+    private boolean isValid(Entity entity, StringBuffer errors) {
+        return TestEntity.getEntityVerifier(entity).correctEntity(errors);
+    }
+}


### PR DESCRIPTION
This removes code from GameManager that added small unit (mek) crew to an aero craft's passenger list when loading the small unit. This has been present for > 6 years but seems wrong as such crew doesn't require passenger quarters, as the bay has accomodations for such crew. Real passengers on the other hand do require accomodation, so the crew quarters validation code should indeed count them.

Also adds a test that has the GameManager load an Atlas onto a Leopard. Fails with the code previous to this PR.

Fix #5495 