### PR TITLE
Add ammo null check to prevent NPEs for firing artillery bays

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -107,7 +107,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;
-                r.add(wtype.getName() + " (" + atype.getShortName() + ")");
+                r.add(wtype.getName() + (atype != null ? " (" + atype.getShortName() + ")" : ""));
                 r.add(aaa.getTurnsTilHit());
                 vPhaseReport.addElement(r);
                 Report.addNewline(vPhaseReport);


### PR DESCRIPTION
Fixes #5503 

I think there must be more going on here. Bay shots don't quite seem to care about ammo, at least before the shot is actually taken. But this PR will at least fix the NPE from the report and allow the game to continue. Firing with the Arrow IV bay with the from the issue will correctly redice the ammo count by 12 for each shot (of 12 weapons).