### PR TITLE
Cargo loading on SV

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -320,11 +320,6 @@ public class BLKFile {
                                 * ((InfantryWeapon) mount.getType()).getShots());
                             mount.getLinked().setShotsLeft(mount.getLinked().getOriginalShots());
                         }
-                        if (etype.hasFlag(MiscType.F_CARGO)) {
-                            // Treat F_CARGO equipment as cargo bays with 1 door, e.g. for ASF with IBB.
-                            int idx = t.getTransportBays().size();
-                            t.addTransporter(new CargoBay(mount.getSize(), 1, idx), isOmniMounted);
-                        }
                     } catch (LocationFullException ex) {
                         throw new EntityLoadingException(ex.getMessage());
                     }

--- a/megamek/src/megamek/utilities/DebugEntity.java
+++ b/megamek/src/megamek/utilities/DebugEntity.java
@@ -18,11 +18,9 @@
  */
 package megamek.utilities;
 
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.Mech;
-import megamek.common.Protomech;
+import megamek.common.*;
 
+import java.util.List;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
@@ -69,6 +67,13 @@ public class DebugEntity {
                 if (entity != entity.getEquipment(i).getEntity()) {
                     result.append("Different Entity!");
                 }
+            }
+            result.append("\n");
+
+            result.append("Transports:\n");
+            List<Transporter> transports = entity.getTransports();
+            for (int i = 0; i < transports.size(); i++) {
+                result.append("[" + i + "] ").append(transports.get(i)).append("\n");
             }
             result.append("\n");
 


### PR DESCRIPTION
Fixes #5515 

This removes code that tried to add cargo bays for F_CARGO equipment. I assume this was added to facilitate the internal bomb bay quirk. Cargo bays count towards weight and cannot be added in this way. I played around with this quite a bit and found that it was somewhat ineffective on units that can possibly have IBB (DS, SC, FWS, AF and CF). DS and SC do not use the that part of the code. F_CARGO is only on Cargo Containers (10t) and variable size cargo bays. For cargo bays, adding more cargo bays seems redundant (and didnt even work for a reason I couldn't see). For cargo containers, they seem not accessible to IBB with or without this code. I suppose we have to find another way to allow IBB in containers.

This makes a handful of SV canon units valid again, see #5509

Also (helpfully) adds transports to the output of DebugEntity.