### PR TITLE
RATGen/force generator role handling updates

### DIFF
--- a/megamek/docs/RAT Stuff/rat-generator.txt
+++ b/megamek/docs/RAT Stuff/rat-generator.txt
@@ -161,12 +161,14 @@ ProtoMek
 VTOL
 Naval
 ConventionalFighter
-Aero
+AeroSpaceFighter
 Small Craft
 Dropship
 Jumpship
 Warship
- Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL, Naval, ConventionalFighter, Aero, Small Craft, Dropship, Jumpship, Warship. Needed to distinguish between different unit types that have the same name, such as Centurion or Eagle (both of which can apply to either a Mek or an ASF).
+Space Station
+
+This is required to distinguish between different unit types that have the same name, such as Centurion or Eagle (both of which can apply to either a Mek or an ASF).
 
 'omni' attribute: can be either 'Clan' or 'IS'. For non-omnis it is absent. Needed to distinguish between omni and fixed-configuration variants, since omnis taken as salvage/isorla use the operating faction to determine which configuration is used. Clan and IS must be stated to distinguish between the Clan Battle Cobra and the ComStar copy.
 
@@ -174,63 +176,282 @@ Warship
 
 'model' node: There is one model node for each variant in use during the year range.
 
-    'name' attribute: the name of the variant. The full unit name is chassis name + model name,separated by a space.
+    'name' attribute: the name of the variant/model. The full unit name is chassis name + model name, separated by a space.
 
-    'role' element: comma-separated list of roles the variant was designed for.
-        comma-separated list of roles the variant was designed for. Supported values are:
-        fire_support - focus on long range firepower
-        sr_fire_support - focus on short range firepower
-        infantry_support or inf_support - commonly found supporting infantry formations
-        ew_support - carries additional electronics for ECM, scanning, or command functions
+    'role' element: comma-separated list of roles the variant was designed for, or nothing for general use. Supported values are:
+
+        fire_support
+        Use: combat unit with long range weapons
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL, Naval
+        Notes: may also be applied to units with quirks such as Improved Targeting (Long)
+
+        sr_fire_support
+        Use: combat unit with short range weapons
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL, Naval
+        Notes: may also be applied to units with quirks such as Improved Targeting (Short)
+
+        ew_support
+        Use: combat unit with ECM, active probe, or other electronic warfare equipment
+        Unit types: Mek, Tank, ProtoMek, VTOL, Naval, Small Craft
+
         spotter - carries TAG or equivalent, such as C3 master
-        incendiary - can easily set fires
-        mag_clamp - battle armor or ProtoMek with magnetic clamps
-        artillery - carries tube artillery or artillery cannon
-        missile_artillery - carries missile artillery, typically Arrow IV
-        minesweeper - can clear mines
-        minelayer - can lay mines
-        anti_aircraft - special anti-aircraft targeting or flak-coded weapons
-        anti_infantry - focus on fighting conventional infantry
-        apc - vehicle can carry infantry or battle armor internally
-        specops - more focus on stealth than combat
-        urban - normally used for urban combat
-        recon - speed and detection gear over firepower
-        cavalry - speed and firepower
-        command - has 'Command Mek' quirk, C3 master, or is otherwise commonly used as a commanders ride
-        raider - focus on speed and ammo independence
-        engineer - various combat support engineering roles, such as fieldworks and bridge layers
-        cargo - primarily a cargo mover, or has large cargo capacity
-        support - primary role is noncombat
-        civilian - non-military vehicles
-        training - historically used for training purposes rather than regular combat
-        bomber - focus on bomb delivery
-        interceptor - focus on attacking other aerospace units
-        ground_support - focus on ground units
-        assault - focus on heavy firepower
-        escort - small craft and fighters designed to protect others
-        mech_carrier - has Mek bays
-        asf_carrier - has aerospace bays
-        vee_carrier - has vehicle bays
-        infantry_carrier - has infantry bays
-        troop_carrier - has both infantry and vehicle bays
-        ba_carrier - has battle armor bays
-        mechanized_ba - eligible to be carried by Omni units as mechanized BA
-        tug - has tug adaptor
-        pocket_warship - pocket warship DropShip
-        corvette - WarShip class
-        destroyer - WarShip class
-        frigate - WarShip class
-        cruiser - WarShip class
-        battleship - WarShip class
-        marine - conventional infantry that can fight in vacuum
-        mountaineer - conventional infantry with mountaineer specialty
-        xct - conventional infantry that can survive hostile environments
-        paratrooper - conventional non-jump infantry that can be air dropped
-        anti_mek - conventional infantry that can perform anti-mek attacks
-        field_gun - motorized or mechanized infantry with a towed ballistic or artillery weapon
+        Use: combat unit with TAG, or suitable for spotting for indirect fire
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL, Naval, ConventionalFighter
+
+        incendiary
+        Use: combat unit with weapons that can easily start fires
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek
+
+        artillery
+        Use: combat support unit with non-missile artillery, and infantry with field artillery
+        Unit types: Mek, Tank, BattleArmor, Infantry, VTOL, Naval, ConventionalFighter, Small Craft, Dropship
+        Notes: when this is the only role, the unit is only generated when the ARTILLERY role is specifically
+                called for.
+
+        missile_artillery
+        Use: combat support unit with missile artillery, frequently loaded with homing rounds
+        Unit Types: Mek, Tank, BattleArmor, Infantry, VTOL, Naval, ConventionalFighter, Small Craft, Dropship
+        Notes: when this is the only role, the unit is only generated when the ARTILLERY or MISSILE_ARTILLERY
+                roles are specifically used.
+
+        mixed_artillery
+        Use: combat unit with either tube or missile artillery
+        Unit types: Mek, Tank, BattleArmor, Infantry, VTOL, Naval, ConventionalFighter, Small Craft, Dropship
+        Notes: use in place of artillery or missile_artillery roles for units which carry artillery but may
+                also be deployed as combat units
+
+        anti_aircraft
+        Use: combat unit with weapons suitable for shooting airborne VTOL and fixed wing targets
+        Unit types: Mek, Tank, Infantry, Naval
+        Notes: may be applied to conventional infantry equipped with field guns, and units with the
+                Anti-Aircraft Targeting quirk
+
+        apc
+        Use: combat unit with infantry bay
+        Unit types: Tank, VTOL
+        Notes: small craft and larger vessels should use the infantry_carrier role
+
+        specops
+        Use: combat unit with attributes suitable for special operations, such as stealth gear
+        Unit types: Mek, Tank, Infantry, BattleArmor, VTOL
+        Notes: typically applied to low availability stealthy units, so they have higher availability when
+                a special operations formation is specifically generated
+
+        urban
+        Use: combat unit optimized for urban combat
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek
+        Notes: typically applied to units with wheeled motive type
+
+        anti_infantry
+        Use: combat unit optimized for use against conventional infantry
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL
+        Notes: typically applied to units with multiple anti-personnel weapons
+
+        inf_support/infantry_support
+        Use: combat unit optimized for supporting conventional infantry
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL
+        Notes: typically applied to units that provide heavier fire support for infantry
+
+        recon
+        Use: combat unit optimized for speed over firepower
+        Unit types: Mek, Tank, BattleArmor, Infantry, ProtoMek, VTOL, Naval, ConventionalFighter,
+                    AeroSpaceFighter, Small Craft, Dropship
+        Notes: typically applied to units with active probe or similar detection equipment, and
+                units with faster than normal speed for their class
+
+        cavalry
+        Use: combat units with high speed and above average firepower
+        Unit types: Mek, Tank, ProtoMek
+        Notes: typically applied to heavier hovercraft and similar fast, well armed units
+
+        raider
+        Use: mobile units with ammo independence
+        Unit types: Mek, Tank, ProtoMek, VTOL
+        Notes: typically applied to units with energy weapons or otherwise suited for operating
+                without reloading for extended periods
+
+        mechanized_ba
+        Use: combat battle armor that is capable of riding on omni units using mechanized battle armor rules
+        Unit types: BattleArmor
+        Notes: not used, the 'mechanized' attribute on the model element is the preferred use
+
+        mag_clamp
+        Use: the unit can mount non-omni units using mechanized battle armor rules
+        Unit types: BattleArmor, ProtoMek
+        Notes: applied to units which carry mag clamp equipment which allows them to be carried
+                by other non-omni units
+
+        marine
+        Use: conventional infantry and battle armor suited for space combat
+        Unit types: BattleArmor, Infantry
+        Notes: applies to battle armor with the space operations adaptation gear, and infantry with
+                advanced rules combat space suits and Marine specialization
+
+        mountaineer
+        Use: conventional infantry with the Mountaineer specialization
+        Unit types: Infantry
+
+        xct
+        Use: conventional infantry suitable for combat in hostile environment and weather
+        Unit types: Infantry
+        Notes: typically applied to units with advanced rules hostile environment armor and XCT
+                specialization
+
+        paratrooper
+        Use: combat infantry suitable for air dropping
+        Unit types: Infantry
+        Notes: typically applied to foot infantry with the Paratrooper specialization, may also
+                apply to other infantry types that are considered 'airmobile' i.e. light enough
+                for easy air transport.
+
+        anti_mek
+        Use: infantry with equipment for making anti-Mech attacks
+        Unit types: Infantry
+        Notes: typically applied to foot, jump, or motorized infantry that are built with anti-Mech
+                equipment, may be applied to units which do not have the gear but are still allowed
+                to make such attacks
+
+        field_gun
+        Use: combat infantry equipped with field guns (not field artillery)
+        Unit types: Infantry
+        Notes: typically applied to infantry equipped with ballistic field guns. Field artillery
+                uses the artillery, missile_artillery, or mixed_artillery roles. instead of this one.
+
+        command
+        Use: combat or combat support command unit
+        Unit types: Mek, Tank, VTOL, Naval, ConventionalFighter, Small Craft
+        Notes: typically applied to command and control units, such as those equipped with C3 master
+                equipment, command console cockpits, communications gear, or have the Command Mek
+                quirk
+
+        training
+        Use: combat or combat support unit frequently used for cadets/trainees
+        Unit types: Mek, Tank, VTOL, Naval, ConventionalFighter
+        Notes: usually based on fluff/lore rather than equipment
+
+        engineer
+        Use: combat support unit equipped for engineering work
+        Unit types: Mek, Tank, Infantry
+        Notes: units with this role will be generated along with regular combat units unless the
+                support role is added
+
+        minesweeper
+        Use: unit is equipped to clear mines
+        Unit types: Tank, BattleArmor, Infantry
+        Notes: typically applied to infantry units with the Minesweeping Engineers specialization,
+                and battle armor equipped with mine clearance actuators
+
+        minelayer
+        Use: unit is equipped to lay mines
+        Unit types: Tank, BattleArmor, Infantry
+        Notes: typically applied to units which carry mine dispensers. Vehicles frequently loaded
+                with FASCAM ammo may also be given this role.
+
+        support
+        Use: non-combat military unit used to provide support rather than weapons
+        Unit types: Mek, Tank, BattleArmor, Infantry, VTOL, Naval, ConventionalFighter, AeroSpaceFighter,
+                    Small Craft, Dropship, Jumpship, Space Station
+        Notes: units with this role are excluded when generating general combat forces. Typically
+                used for military non-combat units rather than civilian.
+
+        cargo
+        Use: civilian or non-combat military units with more than token cargo space
+        Unit types: Tank, VTOL, Naval, ConventionalFighter, Small Craft, Dropship, Jumpship, Warship,
+                    Space Station
+        Notes: units with this role will generate along with regular combat units unless the support
+                or civilian roles are added. Units with specific unit bays should use the various
+                *_carrier roles.
+
+        civilian
+        Use: non-military vehicles
+        Unit types: Mek, Tank, BattleArmor, Infantry, VTOL, Naval, ConventionalFighter, AeroSpaceFighter,
+                    Small Craft, Dropship, Jumpship, Space Station
+        Notes: units with this role are excluded when generating general combat forces, and only generated
+                when specifically generating units with the role. Typically used for civilian/non-military
+                vehicles.
+
+        bomber
+        Use: combat units specialized in carrying bombs/external ordnance
+        Unit types: ConventionalFighter, AeroSpaceFighter
+        Notes: fixed wing aircraft with no weapons, external hardpoints, or otherwise normally used for
+                bombing rather than strike/strafing attacks
+
+        interceptor
+        Use: combat units for fighting other fixed wing aircraft
+        Unit types: ConventionalFighter, AeroSpaceFighter
+        Notes: typically applied to fixed wing aircraft that are specialized in air/space superiority
+
+        ground_support
+        Use: combat units for attacking ground targets
+        Unit types: ConventionalFighter, AeroSpaceFighter, Small Craft
+        Notes: typically applied to units that are more frequently used in ground attack rather than
+                air/space combat
+
+        escort
+        Use: combat units for protecting other air/space units
+        Unit types: ConventionalFighter, AeroSpaceFighter, Small Craft
+        Notes: typically used on small craft
+
+        infantry_carrier
+        Use: unit has bays for transporting conventional infantry
+        Unit types: Small Craft, Dropship
+        Notes: use troop_carrier role on WarShips
+
+        ba_carrier
+        Use: unit has bays for transporting battle armor
+        Unit types: Small Craft, Dropship
+        Notes: use troop_carrier role on WarShips
+
+        mech_carrier
+        Use: unit has bays for transporting Mechs
+        Unit types: Dropship
+        Notes: use troop_carrier role on WarShips
+
+        protomech_carrier
+        Use: unit has bays for transporting ProtoMechs
+        Unit types: Dropship
+        Notes: use troop_carrier role on WarShips
+
+        asf_carrier
+        Use: unit has bays for transporting fixed wing aircraft
+        Unit types: Dropship, Warship
+
+        vee_carrier
+        Use: unit has bays for transporting ground vehicles
+        Unit types: Dropship
+
+        troop_carrier
+        Use: unit has bays for transporting multiple types of ground units
+        Unit types: Dropship, Warship
+        Notes: DropShips may also use multiple roles with the specific bay types
+
+        assault
+        Use: attack ships
+        Unit types: Small Craft, Dropship
+        Notes: typically applied to assault DropShips
+
+        pocket_warship
+        Use: Pocket WarShip and assault DropShips intended to stand against larger targets
+        Unit types: Dropship
+
+        tug
+        Use: DropShips with a tug adaptor for moving disabled ships
+        Unit types: Dropship
+        Notes: units with this role generate along with combat units unless the support or civilian
+                roles are also added
+
+        corvette
+        destroyer
+        frigate
+        cruiser
+        battleship
+        Use: rough hull classes for WarShips
+        Unit types: Warship
+        Notes: WarShip hull classes are not strictly defined so these are based more on lore/source
+                material than displacement
 
     'deployedWith' element: not used by RAT Generator, but provided for utilities that might want to use RAT Generator as a back end to build larger forces. Lists other units this one is frequently deployed with. Prefixing the other unit name with "req:" indicates that it is required (e.g. LongTom and its trailers). Units that are deployed independently can indicate this by using "solo" instead of another unit name.
 
     'availability' element: same as in the chassis element
 
-    'mechanized' element: 'true' for BattleArmor that qualifies for the mechanized BattleArmor rules
+    'mechanized' attribute: 'true' for BattleArmor that qualifies for the mechanized BattleArmor rules

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -33,7 +33,7 @@ public enum MissionRole {
     /* Specialized ground support roles */
     SPECOPS, ENGINEER, MINESWEEPER, MINELAYER,
     /* ASF roles */
-    BOMBER, ESCORT, INTERCEPTOR, GROUND_SUPPORT, //unused: STRIKE,
+    BOMBER, ESCORT, INTERCEPTOR, GROUND_SUPPORT,
     /* DropShip roles */
     ASSAULT, MECH_CARRIER, ASF_CARRIER, VEE_CARRIER, INFANTRY_CARRIER, BA_CARRIER, TROOP_CARRIER,
     TUG, POCKET_WARSHIP, PROTOMECH_CARRIER,
@@ -101,7 +101,6 @@ public enum MissionRole {
             case ESCORT:
             case INTERCEPTOR:
             case GROUND_SUPPORT:
-            // case STRIKE:
                 return unitType == UnitType.AEROSPACEFIGHTER || unitType == UnitType.CONV_FIGHTER;
 
             case ASSAULT:
@@ -655,8 +654,6 @@ public enum MissionRole {
                 return INTERCEPTOR;
             case "ground support":
                 return GROUND_SUPPORT;
-            // case "strike":
-                //return STRIKE;
             case "training":
                 return TRAINING;
             case "assault":

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -386,6 +386,10 @@ public enum MissionRole {
                     // equipment take priority, while others without the role or equipment are
                     // reduced in priority.
                     case COMMAND:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(COMMAND)) {
                             avRating += medium_adjust;
                         }
@@ -440,6 +444,10 @@ public enum MissionRole {
                     // Calling for ARTILLERY includes all units with artillery, including missile
                     // artillery. Units without artillery are excluded.
                     case ARTILLERY:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(ARTILLERY) &&
                                 !mRec.getRoles().contains(MISSILE_ARTILLERY) &&
                                 !mRec.getRoles().contains(MIXED_ARTILLERY)) {
@@ -447,10 +455,14 @@ public enum MissionRole {
                         }
                         break;
 
-                    // Calling for MIXED_ARTILLERY only includes units which ave the role. Other
+                    // Calling for MIXED_ARTILLERY only includes units which have the role. Other
                     // units with artillery are considered specific-purpose, while these are
                     // 'mixed use' i.e. both combat and artillery.
                     case MIXED_ARTILLERY:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(MIXED_ARTILLERY)) {
                             return null;
                         }
@@ -536,6 +548,14 @@ public enum MissionRole {
                     // Calling for armored personnel carriers should only return units which have
                     // that role
                     case APC:
+                        if (mRec.getRoles().contains(SUPPORT) &&
+                                !desiredRoles.contains(SUPPORT)) {
+                            return null;
+                        }
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(APC)) {
                             return null;
                         }
@@ -544,6 +564,14 @@ public enum MissionRole {
                     // Calling for MECHANIZED_BA should only return units which can either ride on
                     // omni-based transport or use mag-clamps
                     case MECHANIZED_BA:
+                        if (mRec.getRoles().contains(SUPPORT) &&
+                                !desiredRoles.contains(SUPPORT)) {
+                            return null;
+                        }
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.canDoMechanizedBA() &&
                                 !mRec.getRoles().contains(MAG_CLAMP)) {
                             return null;
@@ -553,6 +581,10 @@ public enum MissionRole {
                     // Calling for MAG_CLAMP should only return units equipped with
                     // mag-clamp equipment, which includes ProtoMechs
                     case MAG_CLAMP:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.hasMagClamp() && !mRec.getRoles().contains(MAG_CLAMP)) {
                             return null;
                         }
@@ -561,6 +593,9 @@ public enum MissionRole {
                     // Calling for MARINE only returns infantry or battle armor which is equipped
                     // for space combat. All other units are excluded.
                     case MARINE:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(MARINE)) {
                             return null;
                         }
@@ -569,6 +604,9 @@ public enum MissionRole {
                     // Calling for MOUNTAINEER only returns units which are equipped as such. All
                     // other units are excluded.
                     case MOUNTAINEER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(MOUNTAINEER)) {
                             return null;
                         }
@@ -626,6 +664,9 @@ public enum MissionRole {
                     // and weather conditions. Marines are included at a lower priority. All other
                     // units are excluded.
                     case XCT:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(XCT)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(MARINE)) {
@@ -770,14 +811,28 @@ public enum MissionRole {
                     // Calling for OMNI will only return units with that characteristic. Unlike
                     // other roles, this is pulled from the unit data rather than a role tag.
                     case OMNI:
+                        if (mRec.getRoles().contains(SUPPORT) &&
+                                !desiredRoles.contains(SUPPORT)) {
+                            return null;
+                        }
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (isSpecialized(desiredRoles, mRec) || !mRec.isOmni()) {
                             return null;
                         }
                         break;
 
-                    // Calling for TRAINING will return other units without the role at a lower priority
+                    // Calling for TRAINING will return other units without the role at a lower
+                    // priority
                     case TRAINING:
-                        if (isSpecialized(desiredRoles, mRec)) {
+                        if (mRec.getRoles().contains(SUPPORT) &&
+                                !desiredRoles.contains(SUPPORT)) {
+                            return null;
+                        }
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
                             return null;
                         }
                         if (mRec.getRoles().contains(TRAINING)) {
@@ -789,6 +844,9 @@ public enum MissionRole {
 
                     // Calling for GROUND_SUPPORT includes other units at a lower priority
                     case GROUND_SUPPORT:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(GROUND_SUPPORT)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(BOMBER)) {
@@ -800,6 +858,9 @@ public enum MissionRole {
 
                     // Calling for INTERCEPTOR includes other units at a lower priority
                     case INTERCEPTOR:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(INTERCEPTOR)) {
                             avRating += medium_adjust;
                         } else {
@@ -809,6 +870,9 @@ public enum MissionRole {
 
                     // Calling for BOMBER includes other units at a lower priority
                     case BOMBER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(BOMBER)) {
                             avRating += medium_adjust;
                         } else {
@@ -818,6 +882,9 @@ public enum MissionRole {
 
                     // Calling for ESCORT includes other units at a lower priority
                     case ESCORT:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(ESCORT)) {
                             avRating += medium_adjust;
                         } else {
@@ -828,6 +895,9 @@ public enum MissionRole {
                     // Calling for ASSAULT (assault DropShip) may include pocket warships at a
                     // lower priority. Other units are excluded.
                     case ASSAULT:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(ASSAULT)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(POCKET_WARSHIP)) {
@@ -840,6 +910,9 @@ public enum MissionRole {
                     // Calling for VEE_CARRIER (vehicle transport) may include troop (multi-type)
                     // transports at a lower priority. Other units are excluded.
                     case VEE_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(VEE_CARRIER)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(TROOP_CARRIER)) {
@@ -852,6 +925,9 @@ public enum MissionRole {
                     // Calling for INFANTRY_CARRIER may include troop (multi-type) transports at a
                     // lower priority. Other units are excluded.
                     case INFANTRY_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(INFANTRY_CARRIER)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(TROOP_CARRIER)) {
@@ -863,6 +939,9 @@ public enum MissionRole {
 
                     // Calling for BA_CARRIER will only return units with this role
                     case BA_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(BA_CARRIER)) {
                             return null;
                         }
@@ -871,6 +950,9 @@ public enum MissionRole {
                     // Calling for MECH_CARRIER may include troop (multi-type) transports at a
                     // lower priority. Other units are excluded.
                     case MECH_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(MECH_CARRIER)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(TROOP_CARRIER)) {
@@ -882,6 +964,9 @@ public enum MissionRole {
 
                     // Calling for PROTOMECH_CARRIER will only return units with this role
                     case PROTOMECH_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(PROTOMECH_CARRIER)) {
                             return null;
                         }
@@ -889,6 +974,9 @@ public enum MissionRole {
 
                     // Calling for TUG will only return units with this role
                     case TUG:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(TUG)) {
                             return null;
                         }
@@ -897,6 +985,9 @@ public enum MissionRole {
                     // Calling for POCKET_WARSHIP may include assault DropShips at a
                     // lower priority. Other units are excluded.
                     case POCKET_WARSHIP:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (mRec.getRoles().contains(POCKET_WARSHIP)) {
                             avRating += medium_adjust;
                         } else if (mRec.getRoles().contains(ASSAULT)) {
@@ -909,6 +1000,9 @@ public enum MissionRole {
                     // Calling for ASF_CARRIER (fighter carrier) will only return units with this
                     // role
                     case ASF_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(ASF_CARRIER)) {
                             return null;
                         }
@@ -917,6 +1011,9 @@ public enum MissionRole {
                     // Calling for TROOP_CARRIER (multi-unit transport) will only return units with
                     // this role
                     case TROOP_CARRIER:
+                        if (isSpecialized(desiredRoles, mRec)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(TROOP_CARRIER)) {
                             return null;
                         }
@@ -995,6 +1092,10 @@ public enum MissionRole {
 
                     // Calling for MINESWEEPER only returns units with that role
                     case MINESWEEPER:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(MINESWEEPER)) {
                             return null;
                         }
@@ -1002,6 +1103,10 @@ public enum MissionRole {
 
                     // Calling for MINELAYER only returns units with that role
                     case MINELAYER:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(MINELAYER)) {
                             return null;
                         }
@@ -1043,6 +1148,10 @@ public enum MissionRole {
                     // additional SUPPORT, CIVILIAN, or ENGINEER roles are handled with those
                     // specific roles.
                     case CARGO:
+                        if (mRec.getRoles().contains(CIVILIAN) &&
+                                !desiredRoles.contains(CIVILIAN)) {
+                            return null;
+                        }
                         if (!mRec.getRoles().contains(CARGO)) {
                             return null;
                         }

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -553,7 +553,7 @@ public enum MissionRole {
                     // Calling for MAG_CLAMP should only return units equipped with
                     // mag-clamp equipment, which includes ProtoMechs
                     case MAG_CLAMP:
-                        if (!mRec.hasMagClamp()) {
+                        if (!mRec.hasMagClamp() && !mRec.getRoles().contains(MAG_CLAMP)) {
                             return null;
                         }
                         break;

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -1276,6 +1276,8 @@ public enum MissionRole {
                 return ARTILLERY;
             case "missile artillery":
                 return MISSILE_ARTILLERY;
+            case "mixed artillery":
+                return  MIXED_ARTILLERY;
             case "anti aircraft":
                 return ANTI_AIRCRAFT;
             case "anti infantry":

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -197,8 +197,13 @@ public enum MissionRole {
             // Roles for conventional and aerospace fighters
             case BOMBER:
             case INTERCEPTOR:
+                return unitType == UnitType.CONV_FIGHTER ||
+                        unitType == UnitType.AEROSPACEFIGHTER;
+
             case GROUND_SUPPORT:
-                return unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER;
+                return unitType == UnitType.CONV_FIGHTER ||
+                        unitType == UnitType.AEROSPACEFIGHTER ||
+                        unitType == UnitType.SMALL_CRAFT;
 
             case ESCORT:
                 return  unitType == UnitType.CONV_FIGHTER ||
@@ -207,9 +212,12 @@ public enum MissionRole {
 
             // Roles for DropShips
             case ASSAULT:
-            case VEE_CARRIER:
             case INFANTRY_CARRIER:
             case BA_CARRIER:
+                return unitType == UnitType.DROPSHIP ||
+                        unitType == UnitType.SMALL_CRAFT;
+
+            case VEE_CARRIER:
             case MECH_CARRIER:
             case TUG:
             case POCKET_WARSHIP:

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -177,13 +177,14 @@ public enum MissionRole {
             case INCENDIARY:
                 return unitType <= UnitType.PROTOMEK;
 
-            // SPECOPS role applies to Mechs, ground vehicles, conventional infantry, and
+            // SPECOPS role applies to Mechs, ground vehicles, VTOLs, conventional infantry, and
             // battle armor.
             case SPECOPS:
                 return unitType == UnitType.MEK ||
                         unitType == UnitType.TANK ||
                         unitType == UnitType.INFANTRY ||
-                        unitType == UnitType.BATTLE_ARMOR;
+                        unitType == UnitType.BATTLE_ARMOR ||
+                        unitType == UnitType.VTOL;
 
             // OMNI applies to all units which are capable of being built to make use of pod-mounted
             // equipment.  This is primarily used to determine suitability for mechanized battle

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -48,61 +48,157 @@ public enum MissionRole {
 
     public boolean fitsUnitType(int unitType) {
         switch (this) {
+
+            // RECON applies to all unit types except gun emplacements, JumpShips,
+            // space stations, and some specialized aerospace
             case RECON:
-            case SUPPORT:
-                return true;
+                return unitType != UnitType.GUN_EMPLACEMENT &&
+                        unitType != UnitType.JUMPSHIP &&
+                        unitType != UnitType.SPACE_STATION &&
+                        unitType != UnitType.AERO;
 
-            case CIVILIAN:
-                return unitType >= UnitType.SMALL_CRAFT && unitType != UnitType.WARSHIP;
-
-            case COMMAND:
-                return unitType <= UnitType.GUN_EMPLACEMENT;
-
-            case SPECOPS:
-                return unitType < UnitType.JUMPSHIP;
-
-            case URBAN:
-            case ANTI_INFANTRY:
-            case INF_SUPPORT:
-                return unitType <= UnitType.TANK;
-
-            case FIRE_SUPPORT:
-            case CAVALRY:
-            case RAIDER:
-            case APC:
-                return unitType <= UnitType.TANK || unitType == UnitType.VTOL;
-
-            case ARTILLERY:
-            case MISSILE_ARTILLERY:
-                return unitType < UnitType.CONV_FIGHTER || unitType == UnitType.SMALL_CRAFT || unitType == UnitType.DROPSHIP;
-
-            case INCENDIARY:
-            case ANTI_AIRCRAFT:
-                return unitType <= UnitType.PROTOMEK; // all ground units
-
-            case ENGINEER:
-            case MINESWEEPER:
-            case MINELAYER:
-                return unitType < UnitType.TANK || unitType == UnitType.INFANTRY;
-
-            case CARGO:
-                return unitType < UnitType.BATTLE_ARMOR || unitType > UnitType.PROTOMEK;
-
+            // EW_SUPPORT role applies to all ground units, VTOL, blue water naval, gun emplacement,
+            // and small craft. Infantry and large spacecraft are excluded.
             case EW_SUPPORT:
-                return unitType <= UnitType.TANK || unitType == UnitType.AEROSPACEFIGHTER;
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.PROTOMEK ||
+                        unitType == UnitType.VTOL ||
+                        unitType == UnitType.NAVAL ||
+                        unitType == UnitType.GUN_EMPLACEMENT ||
+                        unitType == UnitType.SMALL_CRAFT;
 
-            case TRAINING:
-                return unitType < UnitType.SMALL_CRAFT;
-
+            // SPOTTER role applies to all ground units plus VTOL, blue water naval, gun
+            // emplacements, and fixed wing aircraft.
             case SPOTTER:
                 return unitType <= UnitType.AEROSPACEFIGHTER;
 
+            // COMMAND role applies to all ground units, VTOLs, blue water naval, conventional
+            // fixed wing aircraft, and small craft. Conventional infantry, battle armor,
+            // ProtoMechs, gun emplacements, and large space vessels are excluded.
+            case COMMAND:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.VTOL ||
+                        unitType == UnitType.NAVAL ||
+                        unitType == UnitType.CONV_FIGHTER ||
+                        unitType == UnitType.SMALL_CRAFT;
+
+            // Fire support roles apply to most types except fixed wing aircraft and spacecraft
+            case FIRE_SUPPORT:
+            case SR_FIRE_SUPPORT:
+                return unitType <= UnitType.GUN_EMPLACEMENT;
+
+            // Artillery roles apply to all ground units, VTOL, blue water naval, gun emplacements,
+            // and conventional fighters. Small craft and DropShips, which are capable of mounting
+            // artillery type weapons, are included.  ProtoMechs cannot carry any existing artillery
+            // weapons so are excluded.
+            case ARTILLERY:
+            case MISSILE_ARTILLERY:
+            case MIXED_ARTILLERY:
+                return unitType <= UnitType.INFANTRY ||
+                        unitType == UnitType.VTOL ||
+                        unitType == UnitType.NAVAL ||
+                        unitType == UnitType.GUN_EMPLACEMENT ||
+                        unitType == UnitType.CONV_FIGHTER ||
+                        unitType == UnitType.SMALL_CRAFT ||
+                        unitType == UnitType.DROPSHIP;
+
+            // URBAN role applies to all ground units. Although infantry are inherently
+            // urban-oriented this role should be reserved for mechanized (wheeled) and others which
+            // are not optimized for non-urban terrain.
+            case URBAN:
+                return unitType <= UnitType.PROTOMEK;
+
+            // Infantry support roles are limited to ground units and VTOLs. This includes infantry
+            // and battle armor that are armed primarily with anti-infantry weapons.
+            case ANTI_INFANTRY:
+            case INF_SUPPORT:
+                return unitType <= UnitType.PROTOMEK ||
+                        unitType == UnitType.VTOL;
+
+            // APC role is limited to units which can carry conventional infantry. Although blue
+            // water naval units can carry infantry they have limited use so are excluded.
+            case APC:
+                return unitType == UnitType.TANK ||
+                        unitType == UnitType.VTOL;
+
+            // Naturally limited to battle armor
+            case MECHANIZED_BA:
+                return unitType == UnitType.BATTLE_ARMOR;
+
+            // Both battle armor and ProtoMechs can make use of mag clamps
+            case MAG_CLAMP:
+                return unitType == UnitType.BATTLE_ARMOR ||
+                        unitType == UnitType.PROTOMEK;
+
+            // MARINE role applies to select battle armor and conventional infantry units equipped
+            // for space combat
+            case MARINE:
+                return unitType == UnitType.BATTLE_ARMOR ||
+                        unitType == UnitType.INFANTRY;
+
+            // Conventional infantry roles:
+            //    PARATROOPER may be added on non-foot infantry to designate 'airmobile'
+            case MOUNTAINEER:
+            case PARATROOPER:
+            case ANTI_MEK:
+            case FIELD_GUN:
+            case XCT:
+                return unitType == UnitType.INFANTRY;
+
+            // CAVALRY applies to Mechs, ground vehicles, and ProtoMechs
+            case CAVALRY:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.PROTOMEK;
+
+            // RAIDER can be applied to Mechs, ground vehicles, ProtoMechs, and VTOLs
+            case RAIDER:
+                return  unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.PROTOMEK ||
+                        unitType == UnitType.VTOL;
+
+            // ANTI_AIRCRAFT role applies to all ground units, plus blue water naval and
+            // gun emplacements. Conventional infantry are included (field guns/artillery) but
+            // not battle armor or ProtoMechs.
+            case ANTI_AIRCRAFT:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.INFANTRY ||
+                        unitType == UnitType.NAVAL ||
+                        unitType == UnitType.GUN_EMPLACEMENT;
+
+            // INCENDIARY applies to all ground units. This excludes VTOL, blue water naval,
+            // and gun emplacements.
+            case INCENDIARY:
+                return unitType <= UnitType.PROTOMEK;
+
+            // SPECOPS role applies to Mechs, ground vehicles, conventional infantry, and
+            // battle armor.
+            case SPECOPS:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.INFANTRY ||
+                        unitType == UnitType.BATTLE_ARMOR;
+
+            // OMNI applies to all units which are capable of being built to make use of pod-mounted
+            // equipment.  This is primarily used to determine suitability for mechanized battle
+            // armor but other uses may be added later.
+            case OMNI:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.AEROSPACEFIGHTER;
+
+            // Roles for conventional and aerospace fighters
             case BOMBER:
             case ESCORT:
             case INTERCEPTOR:
             case GROUND_SUPPORT:
-                return unitType == UnitType.AEROSPACEFIGHTER || unitType == UnitType.CONV_FIGHTER;
+                return unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER;
 
+            // Roles for DropShips
             case ASSAULT:
             case VEE_CARRIER:
             case INFANTRY_CARRIER:
@@ -113,10 +209,13 @@ public enum MissionRole {
             case PROTOMECH_CARRIER:
                 return unitType == UnitType.DROPSHIP;
 
+            // Mixed units carrier and aerospace carrier roles apply to DropShips and
+            // WarShips
             case TROOP_CARRIER:
             case ASF_CARRIER:
                 return unitType == UnitType.DROPSHIP || unitType == UnitType.WARSHIP;
 
+            // Roles for WarShips are primarily 'class' designations.
             case CORVETTE:
             case DESTROYER:
             case FRIGATE:
@@ -124,28 +223,57 @@ public enum MissionRole {
             case BATTLESHIP:
                 return unitType == UnitType.WARSHIP;
 
-            case OMNI:
-                return (unitType == UnitType.MEK)
-                        || (unitType == UnitType.AEROSPACEFIGHTER)
-                        || (unitType == UnitType.TANK);
-                // This should apply to fixed-wing support also, but that cannot be distinguished from conventional fighters here.
+            // TRAINING applies to Mechs, ground vehicles, VTOLs, blue water naval, and conventional
+            // fighters. Infantry, battle armor, ProtoMechs, and gun emplacements are excluded.
+            case TRAINING:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.VTOL ||
+                        unitType == UnitType.NAVAL ||
+                        unitType == UnitType.CONV_FIGHTER;
 
-            case MECHANIZED_BA:
-            case MAG_CLAMP:
-                return unitType == UnitType.BATTLE_ARMOR;
+            // ENGINEER applies to Mechs, ground vehicles, and conventional infantry
+            case ENGINEER:
+                return unitType == UnitType.MEK ||
+                        unitType == UnitType.TANK ||
+                        unitType == UnitType.INFANTRY;
 
-            case MARINE:
-            case XCT:
-                return unitType == UnitType.INFANTRY || unitType == UnitType.BATTLE_ARMOR;
+            // MINESWEEPER and MINELAYER roles apply to ground vehicles, battle armor, and
+            // conventional infantry
+            case MINESWEEPER:
+            case MINELAYER:
+                return unitType == UnitType.TANK ||
+                        unitType == UnitType.BATTLE_ARMOR ||
+                        unitType == UnitType.INFANTRY;
 
-            case MOUNTAINEER:
-            case PARATROOPER:
-            case ANTI_MEK:
-            case FIELD_GUN:
-                return unitType == UnitType.INFANTRY;
+            // SUPPORT applies to all non-combat ground units, VTOLs, blue water naval, conventional
+            // fighters, small craft, and some specialized aerospace. ProtoMechs, gun
+            // emplacements, and WarShips are excluded as these are strictly combat units.
+            case SUPPORT:
+                return unitType != UnitType.PROTOMEK &&
+                        unitType != UnitType.GUN_EMPLACEMENT &&
+                        unitType != UnitType.WARSHIP;
 
-            case MIXED_ARTILLERY:
-                /* TODO: allow inclusion of artillery without binary either/or */
+            // CIVILIAN applies to all non-combat vehicles in civilian service, which includes
+            // all ground units, VTOLs, blue water naval, conventional fighters, small craft,
+            // DropShips, JumpShips, space stations, and some specialized aerospace. ProtoMechs,
+            // gun emplacements, aerospace fighters, and WarShips are excluded as they are strictly
+            // combat units.
+            case CIVILIAN:
+                return unitType != UnitType.PROTOMEK &&
+                        unitType != UnitType.GUN_EMPLACEMENT &&
+                        unitType != UnitType.AEROSPACEFIGHTER &&
+                        unitType != UnitType.WARSHIP;
+
+            // CARGO applies to ground vehicles, VTOLs, blue water naval, conventional fighters,
+            // small craft, and all large space vessels.
+            case CARGO:
+                return unitType == UnitType.TANK ||
+                        unitType == UnitType.VTOL ||
+                        unitType == UnitType.NAVAL ||
+                        unitType == UnitType.CONV_FIGHTER ||
+                        (unitType >= UnitType.SMALL_CRAFT && unitType <= UnitType.SPACE_STATION);
+
             default:
                 return false;
         }

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -469,15 +469,19 @@ public enum MissionRole {
                             return null;
                         }
                         if (mRec.getRoles().contains(URBAN)) {
-                            avRating += medium_adjust;
+                            avRating += strong_adjust;
                         } else if (mRec.getRoles().contains(ANTI_INFANTRY) ||
-                                mRec.getRoles().contains(SR_FIRE_SUPPORT)) {
+                                mRec.getRoles().contains(SR_FIRE_SUPPORT) ||
+                                mRec.getLongRange() <= 0.2) {
                             avRating += light_adjust;
                         } else if (mRec.getRoles().contains(INF_SUPPORT)) {
                             avRating += min_adjust;
                         } else {
-                            if (mRec.getRoles().contains(FIRE_SUPPORT)) {
+                            if (mRec.getRoles().contains(FIRE_SUPPORT) ||
+                                    mRec.getLongRange() >= 0.5) {
                                 avRating -= min_adjust;
+                            } else {
+                                avRating -= medium_adjust;
                             }
                         }
                         if (mRec.getMovementMode() == EntityMovementMode.WHEELED) {

--- a/megamek/src/megamek/client/ratgenerator/MissionRole.java
+++ b/megamek/src/megamek/client/ratgenerator/MissionRole.java
@@ -196,10 +196,14 @@ public enum MissionRole {
 
             // Roles for conventional and aerospace fighters
             case BOMBER:
-            case ESCORT:
             case INTERCEPTOR:
             case GROUND_SUPPORT:
                 return unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER;
+
+            case ESCORT:
+                return  unitType == UnitType.CONV_FIGHTER ||
+                        unitType == UnitType.AEROSPACEFIGHTER ||
+                        unitType == UnitType.SMALL_CRAFT;
 
             // Roles for DropShips
             case ASSAULT:


### PR DESCRIPTION
The role handling for converting the force generator XMLs to RAT tables/generating random forces has a few holes that need patching, mostly around infantry roles and non-combat units.  There were also a few errors, such as limiting MINELAYER/MINESWEEPER to Mechs (rather than ground vehicles) and infantry.

closes #5286 

Role/unit type validation:
- adds missing SR_FIRE_SUPPORT and MIXED_ARTILLERY roles to unit type validations
- updates role/unit type validations to properly account for all unit type/role combinations
- organize and comment for readability (enum integer-equivalent less/greater than comparisons are pretty hard to follow at a glance unless you know all the values by heart)

Availability value modifications by role:
- adds missing roles for when specific roles are requested, mostly infantry but a few standard ones as well
- more extensive handling of non-combat roles (not needed now, but will be useful later)
- replace array index calls with named variables for readability
- relax application of role modifiers when no roles are called for, while still filtering out non-combat units
- organize and comment for readability

Non-combat/support unit identification:
- simplifies identification of non-combat support and civilian units

Role parser:
- adds missing MIXED_ARTILLERY role to string parser

Help file is updated to list the full set of roles, along with valid unit types and typical uses.