### PR TITLE
Infantry attacks with secondary weapons

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4563,6 +4563,23 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
+     * Returns the CriticalSlots in the given location as a list. The returned list can be empty
+     * depending on the unit and the chosen slot but not null. The entries are not filtered in
+     * any way (could be null although that is probably an error in the internal representation
+     * of the unit.)
+     *
+     * @param location The location, e.g. Mech.LOC_HEAD
+     * @return A list of CriticalSlots in that location, possibly empty
+     */
+    public List<CriticalSlot> getCriticalSlots(int location) {
+        List<CriticalSlot> result = new ArrayList<>();
+        for (int slot = 0; slot < getNumberOfCriticals(location); slot++) {
+            result.add(getCritical(location, slot));
+        }
+        return result;
+    }
+
+    /**
      * Check if the entity has an arbitrary type of weapon
      *
      * @param flag A WeaponType.F_XXX

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3790,7 +3790,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             miscList.add((MiscMounted) mounted);
         }
         if (!(mounted instanceof AmmoMounted) && !(mounted instanceof MiscMounted)
-                && !(mounted instanceof WeaponMounted) && !(mounted instanceof InfantryWeaponMounted)) {
+                && !(mounted instanceof WeaponMounted)) {
             LogManager.getLogger().error("Trying to add plain Mounted class {} on {}!", mounted, this);
         }
     }

--- a/megamek/src/megamek/common/InfantryWeaponMounted.java
+++ b/megamek/src/megamek/common/InfantryWeaponMounted.java
@@ -14,6 +14,7 @@
 
 package megamek.common;
 
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.weapons.Weapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -27,7 +28,7 @@ import java.util.List;
  * This handles special features of both weapons. Infantry units that only have
  * a single weapon should use {@link Mounted}.
  */
-public class InfantryWeaponMounted extends Mounted<InfantryWeapon> {
+public class InfantryWeaponMounted extends WeaponMounted {
 
     transient private InfantryWeapon otherWeapon;
     private final String typeName;

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -490,7 +490,6 @@ public class TestInfantry extends TestEntity {
         }
     }
 
-
     // The following methods are a condensed version of MML's UnitUtil.removeMounted
     // and can be replaced if the latter is ever moved into MM
     public static void removeAntiMekAttacks(Infantry unit) {
@@ -500,14 +499,9 @@ public class TestInfantry extends TestEntity {
         unit.recalculateTechAdvancement();
     }
 
-    public static void removeAntiMekAttack(Infantry unit, EquipmentType et) {
-        for (int pos = unit.getEquipment().size() - 1; pos >= 0; pos--) {
-            Mounted mount = unit.getEquipment().get(pos);
-            if (mount.getType().equals(et)) {
-                unit.getEquipment().remove(mount);
-                unit.getWeaponList().remove(mount);
-                unit.getTotalWeaponList().remove(mount);
-            }
-        }
+    public static void removeAntiMekAttack(Infantry unit, EquipmentType antiMekType) {
+        unit.getEquipment().removeIf(m -> m.getType() == antiMekType);
+        unit.getWeaponList().removeIf(m -> m.getType() == antiMekType);
+        unit.getTotalWeaponList().removeIf(m -> m.getType() == antiMekType);
     }
 }

--- a/megamek/src/megamek/utilities/DebugEntity.java
+++ b/megamek/src/megamek/utilities/DebugEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2023, 2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -19,6 +19,7 @@
 package megamek.utilities;
 
 import megamek.common.*;
+import megamek.common.equipment.WeaponMounted;
 
 import java.util.List;
 import java.awt.*;
@@ -28,8 +29,8 @@ import java.awt.datatransfer.StringSelection;
 /**
  * This class is for debugging Entity with respect to the internal state of equipment.
  */
-@SuppressWarnings("unused")
-public class DebugEntity {
+@SuppressWarnings("unused") // to be used as a debugging tool, e.g. in breakpoints
+public final class DebugEntity {
 
     /**
      * Gets a full listing of the internal representation of the unit's equipment and crit slots with most
@@ -70,12 +71,32 @@ public class DebugEntity {
             }
             result.append("\n");
 
-            result.append("Transports:\n");
-            List<Transporter> transports = entity.getTransports();
-            for (int i = 0; i < transports.size(); i++) {
-                result.append("[" + i + "] ").append(transports.get(i)).append("\n");
+            if (entity.isConventionalInfantry()) {
+                result.append("Weapons:\n");
+                for (WeaponMounted weapon : entity.getTotalWeaponList()) {
+                    result.append(weapon).append("\n");
+                }
+                result.append("\n");
+
+                Infantry infantry = (Infantry) entity;
+                result.append("Infantry weapons:\n");
+                if (infantry.getPrimaryWeapon() != null) {
+                    result.append("Primary: ").append(infantry.getPrimaryWeapon()).append("\n");
+                }
+                if (infantry.getSecondaryWeapon() != null) {
+                    result.append("Secondary: ").append(infantry.getSecondaryWeapon()).append("\n");
+                }
+                result.append("\n");
             }
-            result.append("\n");
+
+            if (!entity.getTransports().isEmpty()) {
+                result.append("Transports:\n");
+                List<Transporter> transports = entity.getTransports();
+                for (int i = 0; i < transports.size(); i++) {
+                    result.append("[" + i + "] ").append(transports.get(i)).append("\n");
+                }
+                result.append("\n");
+            }
 
             result.append("Locations:\n");
             for (int location = 0; location < entity.locations(); location++) {
@@ -98,7 +119,7 @@ public class DebugEntity {
                 }
             }
         } catch (Exception e) {
-            result.append("\nAn exception was encountered here. " + e.getMessage());
+            result.append("\nAn exception was encountered here. ").append(e.getMessage());
         }
 
         return result.toString();


### PR DESCRIPTION
InfantryWeaponMounted was not a subclass of WeaponMounted but of Mounted<something> instead. I assume this was done to keep the IWM class simple and not influenced by WeaponMounted stuff that it would never need. Unfortunately this meant that infantry with secondary weapons got no weapon attacks, as IWMs were not entered into a unit's weapon list (and could not without bigger changes - List<WeaponMounted>). So, I made IWM a subclass of WeaponMounted and in nothing short of a miracle, it immediately compiled without any error and I could not find any errors when I set up a game where I shot at a target mek with two infantry units. We may of course find some error somewhere later because of this but I feel that mangling Entity's weaponList would not be the right way to go.

Fixes #5506 