### PR TITLE
Squadrons and ammo weapons

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/aero.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/aero.ftlh
@@ -8,56 +8,7 @@
 <#if includeFluff>
 <#include "fluff.ftlh">
 </#if>
-  	<p>
-  	<b>Mass: </b>${massDesc}<br/>
-<#if frameDesc??>  	
-  	<b>Frame:</b> ${frameDesc}<br/>
-<#else>
-  	<b>Frame:</b> Unknown<br/>
-</#if>
-  	<b>Power Plant: </b>${engineDesc}<br/>
-  	<b>Armor: </b>${armorDesc}</b><br/>
-  	<b>Armament:</b><br/>
-  		<#list armamentList as armament>
-  			&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;${armament}<br/>
-  		</#list>
-	<#if manufacturerDesc??><b>Manufacturer:</b> ${manufacturerDesc}<br/></#if>
-  	<#if factoryDesc??><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Primary Factory: </b>${factoryDesc}</b></#if>
-  	<#if communicationDesc??><b>Communication System: </b>${communicationDesc}<br/></#if>
-  	<#if targetingDesc??><b>Targeting & Tracking System: </b>${targetingDesc}<br/></#if>
-  	<b>Introduction Year:</b> ${year}<br/>
-  	<b>Tech Rating/Availability:</b> ${techRating}<br/>
-  	<b>Cost:</b> ${cost} C-bills<br/>
-  	</p>
-	
-	<#if fluffOverview??>
-	<p>
-	<b>Overview</b><br/>
-	${fluffOverview}
-	</p>
-	</#if>
 
-	<#if fluffCapabilities??>
-	<p>
-	<b>Capabilities</b><br/>
-	${fluffCapabilities}
-	</p>
-	</#if>
-
-	<#if fluffDeployment??>
-	<p>
-	<b>Deployment</b><br/>
-	${fluffDeployment}
-	</p>
-	</#if>
-
-	<#if fluffHistory??>
-	<p>
-	<b>History</b><br/>
-	${fluffHistory}
-	</p>
-	</#if>
-  
 	<p>
 	<b>Type:</b> ${chassis}<br/>
 	<b>Technology Base:</b> ${techBase}<br/> 
@@ -67,14 +18,18 @@
 	
 	<table>
 	<tr><th>Equipment</th><th/><th>Mass</th></tr>
-	<tr><td>Engine</td><td align="center">${engineName}</td><td align="center">${engineMass}</td></tr>
+	<#if !isFighterSquadron>
+	<tr><td>Engine</td><td align="center">${engineName!'(None)'}</td><td align="center">${engineMass!''}</td></tr>
+	</#if>
 	<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Safe Thrust:</td><td align="center">${safeThrust}</td><td></td></tr>
 	<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Max Thrust:</td><td align="center">${maxThrust}</td><td></td></tr>
 	<tr><td>Structural Integrity:</td><td align="center">${si}</td><td></td></tr>
 	<#if isVSTOL && isConventional && !isSupportVehicle>
 	<tr><td>VSTOL Equipment:</td><td align="center"></td><td align="center">${vstolMass}</td></tr>
 	</#if>
+	<#if !isFighterSquadron>
 	<tr><td>Heat Sinks:</td><td align="center">${hsCount}</td><td align="center">${hsMass}</td></tr>
+	</#if>
 	<tr><td>Fuel:</td><td align="center">${fuelPoints}</td><td align="center">${fuelMass}</td></tr>
 	<tr><td>${cockpitType}:</td><td></td><td align="center">${cockpitMass}</td></tr>
 	<tr><td>Armor Factor${armorType}:</td><td align="center">${armorFactor}</td><td align="center">${armorMass}</td></tr>

--- a/megamek/src/megamek/common/CriticalSlot.java
+++ b/megamek/src/megamek/common/CriticalSlot.java
@@ -231,8 +231,10 @@ public class CriticalSlot implements Serializable {
         String typeString = type == 0 ? "System Slot" : "Equipment Slot";
         List<String> state = new ArrayList<>();
         if (type == 0) state.add("System No: " + index);
-        if (mount != null) state.add("[" + mount.equipmentIndex() + "] " + mount.getType().getInternalName());
-        if (mount2 != null) state.add("Mount 2: [" + mount2.equipmentIndex() + "] " + mount2.getType().getInternalName());
+        if (mount != null) state.add("[" + mount.equipmentIndex() + "] " + mount.getType().getInternalName()
+                + (mount.isWeaponGroup() ? " -Group-" : ""));
+        if (mount2 != null) state.add("Mount 2: [" + mount2.equipmentIndex() + "] " + mount2.getType().getInternalName()
+                + (mount.isWeaponGroup() ? " -Group-" : ""));
         if (destroyed) state.add("Destroyed");
         if (hit) state.add("Hit");
         if (!hittable) state.add("Not hittable");

--- a/megamek/src/megamek/common/CriticalSlot.java
+++ b/megamek/src/megamek/common/CriticalSlot.java
@@ -234,7 +234,7 @@ public class CriticalSlot implements Serializable {
         if (mount != null) state.add("[" + mount.equipmentIndex() + "] " + mount.getType().getInternalName()
                 + (mount.isWeaponGroup() ? " -Group-" : ""));
         if (mount2 != null) state.add("Mount 2: [" + mount2.equipmentIndex() + "] " + mount2.getType().getInternalName()
-                + (mount.isWeaponGroup() ? " -Group-" : ""));
+                + (mount2.isWeaponGroup() ? " -Group-" : ""));
         if (destroyed) state.add("Destroyed");
         if (hit) state.add("Hit");
         if (!hittable) state.add("Not hittable");

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -9386,7 +9386,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     @Override
     public String toString() {
-        return "Entity [" + getDisplayName() + ", " + getId() + "]";
+        return "Entity [" + getDisplayName() + ", ID: " + getId() + "]";
     }
 
     /**

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -23,6 +23,7 @@ import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.cost.CostCalculator;
 import megamek.common.enums.AimingMode;
 import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryconditions.PlanetaryConditions;
 import org.apache.logging.log4j.LogManager;
@@ -378,7 +379,7 @@ public class FighterSquadron extends AeroSpaceFighter {
                 String name = key.split(":")[0];
                 int loc = Integer.parseInt(key.split(":")[1]);
                 EquipmentType etype = EquipmentType.get(name);
-                Mounted newmount;
+                WeaponMounted newmount;
                 if (etype != null) {
                     try {
                         newmount = addWeaponGroup(etype, loc);
@@ -779,7 +780,6 @@ public class FighterSquadron extends AeroSpaceFighter {
         for (int fid: fighters) {
             AeroSpaceFighter fighter = (AeroSpaceFighter) game.getEntity(fid);
             fighter.damageLocation(loc);
-
         }
     }
 

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1672,9 +1672,27 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
                 + ")";
 
         List<String> state = new ArrayList<>();
-        if (linked != null) state.add("Linked: [" + entity.getEquipment().indexOf(linked) + "]");
-        if (linkedBy != null) state.add("LinkedBy: [" + entity.getEquipment().indexOf(linkedBy) + "]");
-        if (crossLinkedBy != null) state.add("CrossLinkedBy: [" + entity.getEquipment().indexOf(crossLinkedBy) + "]");
+        if (linked != null) {
+            if (linked.getEntity().getId() != entity.getId()) {
+                state.add("Linked: [" + linked.getEntity() + ":" + linked.getEntity().getEquipment().indexOf(linked) + "]");
+            } else {
+                state.add("Linked: [" + entity.getEquipment().indexOf(linked) + "]");
+            }
+        }
+        if (linkedBy != null) {
+            if (linkedBy.getEntity().getId() != entity.getId()) {
+                state.add("LinkedBy: [" + linkedBy.getEntity() + ":" + linkedBy.getEntity().getEquipment().indexOf(linkedBy) + "]");
+            } else {
+                state.add("LinkedBy: [" + entity.getEquipment().indexOf(linkedBy) + "]");
+            }
+        }
+        if (crossLinkedBy != null) {
+            if (crossLinkedBy.getEntity().getId() != entity.getId()) {
+                state.add("CrossLinkedBy: [" + crossLinkedBy.getEntity() + ":" + crossLinkedBy.getEntity().getEquipment().indexOf(crossLinkedBy) + "]");
+            } else {
+                state.add("CrossLinkedBy: [" + entity.getEquipment().indexOf(crossLinkedBy) + "]");
+            }
+        }
         if (linkedBayId != -1) state.add("LinkedBay: [" + linkedBayId + "]");
         state.addAll(bayComponentsToString());
         if (type instanceof AmmoType) {
@@ -1691,7 +1709,7 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
         if (facing != -1) state.add("Facing: " + facing);
         if (!quirks.activeQuirks().isEmpty()) state.add("Quirks: " + quirks.getOptionList("/"));
         if (weaponGroup) state.add("Group");
-        if (nweapons != 1) state.add("#Weapons: " + nweapons);
+        if (nweapons != 1 || weaponGroup) state.add("#Weapons: " + nweapons);
         if (size != 1) state.add("Size: " + size);
         return intro + " { " + String.join(", ", state) + " }";
     }

--- a/megamek/src/megamek/common/actions/AbstractAttackAction.java
+++ b/megamek/src/megamek/common/actions/AbstractAttackAction.java
@@ -220,4 +220,9 @@ public abstract class AbstractAttackAction extends AbstractEntityAction implemen
         return (target == null) ? "Attacking Null Target with id " + getTargetId()
                 : "Attacking " + target.getDisplayName();
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + "; Target type/ID: " + targetType + "/" + targetId;
+    }
 }

--- a/megamek/src/megamek/common/actions/AbstractEntityAction.java
+++ b/megamek/src/megamek/common/actions/AbstractEntityAction.java
@@ -19,6 +19,8 @@
  */
 package megamek.common.actions;
 
+import megamek.common.Game;
+
 import java.io.Serializable;
 
 /**
@@ -36,5 +38,10 @@ public abstract class AbstractEntityAction implements Serializable, EntityAction
     @Override
     public int getEntityId() {
         return entityId;
+    }
+
+    @Override
+    public String toString() {
+        return "[" + getClass().getSimpleName() + "]: Unit ID " + entityId;
     }
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -246,7 +246,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 getWeaponId(), getAimedLocation(), getAimingMode(), nemesisConfused, swarmingMissiles,
                 game.getTarget(getOldTargetType(), getOldTargetId()),
                 game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(),
-                this.ammoId);
+                UNASSIGNED);
     }
 
     /**
@@ -259,7 +259,8 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         return toHit(game, getEntityId(), game.getTarget(getTargetType(), getTargetId()),
                 getWeaponId(), getAimedLocation(), getAimingMode(), nemesisConfused, swarmingMissiles,
                 game.getTarget(getOldTargetType(), getOldTargetId()),
-                game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(), evenIfAlreadyFired, this.ammoId);
+                game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(),
+                evenIfAlreadyFired, ammoId);
     }
 
     public ToHitData toHit(Game game, List<ECMInfo> allECMInfo) {
@@ -267,13 +268,14 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                 getWeaponId(), getAimedLocation(), getAimingMode(), nemesisConfused, swarmingMissiles,
                 game.getTarget(getOldTargetType(), getOldTargetId()),
                 game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(),
-                allECMInfo, false, this.ammoId);
+                allECMInfo, false, ammoId);
     }
 
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId, boolean isStrafing) {
         // Use -1 as ammoId because this method should always use the currently linked ammo for display calcs
         return toHit(game, attackerId, target, weaponId, Entity.LOC_NONE, AimingMode.NONE,
-                false, false, null, null, isStrafing, false, UNASSIGNED);
+                false, false, null, null, isStrafing,
+                false, UNASSIGNED);
     }
 
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
@@ -289,16 +291,18 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
                                   Targetable originalTarget, boolean isStrafing, boolean isPointblankShot,
                                   int ammoId) {
         return toHitCalc(game, attackerId, target, weaponId, aimingAt, aimingMode, isNemesisConfused,
-                exchangeSwarmTarget, oldTarget, originalTarget, isStrafing, isPointblankShot, null, false, ammoId);
+                exchangeSwarmTarget, oldTarget, originalTarget, isStrafing, isPointblankShot, null,
+                false, ammoId);
     }
 
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
                                   int aimingAt, AimingMode aimingMode, boolean isNemesisConfused,
                                   boolean exchangeSwarmTarget, Targetable oldTarget,
-                                  Targetable originalTarget, boolean isStrafing, boolean isPointblankShot, boolean evenIfAlreadyFired,
-                                  int ammoId) {
+                                  Targetable originalTarget, boolean isStrafing, boolean isPointblankShot,
+                                  boolean evenIfAlreadyFired, int ammoId) {
         return toHitCalc(game, attackerId, target, weaponId, aimingAt, aimingMode, isNemesisConfused,
-                exchangeSwarmTarget, oldTarget, originalTarget, isStrafing, isPointblankShot, null, evenIfAlreadyFired, ammoId);
+                exchangeSwarmTarget, oldTarget, originalTarget, isStrafing, isPointblankShot, null,
+                evenIfAlreadyFired, ammoId);
     }
 
     /**

--- a/megamek/src/megamek/common/templates/AeroTROView.java
+++ b/megamek/src/megamek/common/templates/AeroTROView.java
@@ -65,6 +65,7 @@ public class AeroTROView extends TROView {
         setModelData("isConventional", aero.hasETypeFlag(Entity.ETYPE_CONV_FIGHTER));
         setModelData("isSupportVehicle", aero.isSupportVehicle());
         setModelData("isVSTOL", aero.isVSTOL());
+        setModelData("isFighterSquadron", aero instanceof FighterSquadron);
         final TestAero testAero = new TestAero(aero, verifier.aeroOption, null);
         if (aero.hasEngine()) {
             setModelData("engineName", stripNotes(aero.getEngine().getEngineName()));

--- a/megamek/src/megamek/utilities/DebugEntity.java
+++ b/megamek/src/megamek/utilities/DebugEntity.java
@@ -60,6 +60,7 @@ public class DebugEntity {
         try {
             result.append("Chassis: >").append(entity.getChassis()).append("<\n");
             result.append("Model: >").append(entity.getModel()).append("<\n");
+            result.append("Game ID: ").append(entity.getId()).append("\n");
 
             result.append("Equipment:\n");
             for (int i = 0; i < entity.getEquipment().size(); i++) {


### PR DESCRIPTION
This PR 
- corrects the TRO text template to not show the fluff info twice on aero units
- adds some toString() overrides and adds to DebugEntity to give better debugging info (took me a bit of debugging to get to the right place)
- makes FighterSquadrons actually do fire ammo weapons again. This is done by the single change in line 249 in WeaponAttackAction of replacing ammoId with UNASSIGNED, reverting this method essentially to the way it was before the recent ammo-related changes. Calls of this specific toHit method are all old code that should work by just looking up the ammo from the weapon. The problem is that while a FSq has weapons, it uses the ammo on its fighters, meaning that an equipment ID alone is not enough to identify it.


Fixes #5523 