### PR TITLE
PhaseDisplays

### DIFF
--- a/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
@@ -33,6 +33,8 @@ public abstract class AbstractPhaseDisplay extends SkinnedJPanel implements
 
     protected DistractableAdapter distracted = new DistractableAdapter();
     protected MegamekButton butDone;
+
+    /** The IClientgui that this display is a part of. Cannot be null. */
     private final IClientGUI clientgui;
 
     protected AbstractPhaseDisplay(IClientGUI cg) {

--- a/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
@@ -23,6 +23,7 @@ import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
+import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
 import megamek.common.preference.PreferenceChangeEvent;
 
@@ -34,8 +35,12 @@ import java.util.List;
 import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 
 public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
+
     protected MegamekButton butSkipTurn;
-    private boolean isDoingAction = false;
+
+    /** The currently selected unit for taking action. Not necessarily equal to the unit shown in the unit viewer. */
+    protected int currentEntity = Entity.NONE;
+
     private boolean ignoreNoActionNag = false;
 
     protected ActionPhaseDisplay(ClientGUI cg) {
@@ -315,14 +320,13 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
             return;
         }
 
-        this.isDoingAction = isDoingAction;
         if (GUIP.getNagForNoAction()) {
             butDone.setText("<html><b>" + doneButtonLabel + "</b></html>");
             butSkipTurn.setText("<html><b>" + skipButtonLabel + "</b></html>");
         } else {
             // toggle the text on the done button, butIgnoreNag is not used
             butSkipTurn.setVisible(false);
-            if (this.isDoingAction) {
+            if (isDoingAction) {
                 butDone.setText("<html><b>" + doneButtonLabel + "</b></html>");
             } else {
                 butDone.setText("<html><b>" + skipButtonLabel + "</b></html>");
@@ -331,10 +335,12 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
         butSkipTurn.setText("<html><b>" + skipButtonLabel + "</b></html>");
 
         // point blank shots don't have the "isMyTurn()" characteristic
-        if (!clientgui.getClient().isMyTurn() && !clientgui.isProcessingPointblankShot()) {
+        if ((currentEntity == Entity.NONE)
+                || getClientgui().getClient().getGame().getInGameObject(currentEntity).isEmpty()
+                || (!clientgui.getClient().isMyTurn() && !clientgui.isProcessingPointblankShot())) {
             butDone.setEnabled(false);
             butSkipTurn.setEnabled(false);
-        } else if (this.isDoingAction || ignoreNoActionNag) {
+        } else if (isDoingAction || ignoreNoActionNag) {
             butDone.setEnabled(true);
             butSkipTurn.setEnabled(false);
         } else {
@@ -351,4 +357,17 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
     private void adaptToGUIScale() {
         butSkipTurn.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
     }
+
+    /**
+     * @return The currently selected entity, if any, or null. A null check is **always** required, as displays
+     * are active when it's not the player's turn and when the setting to not auto-select a unit for the
+     * player is active, no unit may be selected even in a player's turn.
+     * Note that this is not necessarily equal to the currently *viewed* unit in the unit display.
+     *
+     * @see ClientGUI#getSelectedUnit()
+     */
+    protected final Entity ce() {
+        return clientgui.getClient().getGame().getEntity(currentEntity);
+    }
+
 }

--- a/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AttackPhaseDisplay.java
@@ -44,7 +44,6 @@ public abstract class AttackPhaseDisplay extends ActionPhaseDisplay {
      */
     abstract protected String getSkipTurnButtonLabel();
 
-
     @Override
     protected void updateDonePanel() {
         if (attacks.isEmpty() || ((attacks.size() == 1) && (attacks.firstElement() instanceof TorsoTwistAction))) {

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2931,6 +2931,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
 
     @Nullable
     @Override
+    //FIXME: rename this. it's the viewed unit, not the selected unit
     public Entity getSelectedUnit() {
         return client.getGame().getEntity(selectedEntityNum);
     }

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -162,9 +162,6 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
     // buttons
     private Map<FiringCommand, MegamekButton> buttons;
 
-    // let's keep track of what we're shooting and at what, too
-    protected int cen = Entity.NONE; // current entity number
-
     Targetable target; // target
 
     // HACK : track when we want to show the target choice dialog.
@@ -292,9 +289,9 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         controller.registerCommandAction(KeyCommandBind.PREV_WEAPON, this, this::prevWeapon);
 
         controller.registerCommandAction(KeyCommandBind.NEXT_UNIT, this,
-                () -> selectEntity(clientgui.getClient().getNextEntityNum(cen)));
+                () -> selectEntity(clientgui.getClient().getNextEntityNum(currentEntity)));
         controller.registerCommandAction(KeyCommandBind.PREV_UNIT, this,
-                () -> selectEntity(clientgui.getClient().getPrevEntityNum(cen)));
+                () -> selectEntity(clientgui.getClient().getPrevEntityNum(currentEntity)));
 
         controller.registerCommandAction(KeyCommandBind.NEXT_TARGET, this,
                 () -> jumpToTarget(true, false, false));
@@ -365,7 +362,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
      */
     public void selectEntity(int en) {
         // clear any previously considered attacks
-        if (en != cen) {
+        if (en != currentEntity) {
             target(null);
             clearAttacks();
             refreshAll();
@@ -380,7 +377,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         }
 
         if (clientgui.getClient().getGame().getEntity(en) != null) {
-            cen = en;
+            currentEntity = en;
             clientgui.setSelectedEntityNum(en);
             clientgui.getUnitDisplay().displayEntity(ce());
 
@@ -393,7 +390,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                      nextId = clientgui.getClient().getNextEntityNum(nextId)) {
 
                     if (clientgui.getClient().getGame().getEntity(nextId).getPosition() != null) {
-                        cen = nextId;
+                        currentEntity = nextId;
                         break;
                     }
                 } // Check the player's next entity.
@@ -527,7 +524,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             clientgui.maybeShowUnitDisplay();
 
         }
-        cen = Entity.NONE;
+        currentEntity = Entity.NONE;
         target(null);
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().highlight(null);
@@ -598,7 +595,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                 && (Integer.parseInt(m.curMode().getName().replace("-shot", "")) > ce().getTotalInternal())) {
             m.setMode(0);
         }
-        clientgui.getClient().sendModeChange(cen, wn, nMode);
+        clientgui.getClient().sendModeChange(currentEntity, wn, nMode);
 
         // notify the player
         if (m.canInstantSwitch(nMode)) {
@@ -632,7 +629,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
 
         // send change to the server
         m.getCalledShot().switchCalledShot();
-        clientgui.getClient().sendCalledShotChange(cen, wn);
+        clientgui.getClient().sendCalledShotChange(currentEntity, wn);
 
         updateTarget();
         clientgui.getUnitDisplay().wPan.displayMech(ce());
@@ -886,15 +883,15 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
 
         // If the user picked a hex along the flight path, server needs to know
         if ((target instanceof Entity) && Compute.isGroundToAir(ce(), target)) {
-            Coords targetPos = ((Entity) target).getPlayerPickedPassThrough(cen);
+            Coords targetPos = ((Entity) target).getPlayerPickedPassThrough(currentEntity);
             if (targetPos != null) {
                 clientgui.getClient().sendPlayerPickedPassThrough(
-                        ((Entity) target).getId(), cen, targetPos);
+                        ((Entity) target).getId(), currentEntity, targetPos);
             }
         }
 
         // send out attacks
-        clientgui.getClient().sendAttackData(cen, newAttacks);
+        clientgui.getClient().sendAttackData(currentEntity, newAttacks);
 
         // clear queue
         removeAllAttacks();
@@ -1005,12 +1002,12 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             throw new IllegalArgumentException("current searchlight parameters are invalid");
         }
 
-        if (!SearchlightAttackAction.isPossible(clientgui.getClient().getGame(), cen, target, null)) {
+        if (!SearchlightAttackAction.isPossible(clientgui.getClient().getGame(), currentEntity, target, null)) {
             return;
         }
 
         // create and queue a searchlight action
-        SearchlightAttackAction saa = new SearchlightAttackAction(cen,
+        SearchlightAttackAction saa = new SearchlightAttackAction(currentEntity,
                 target.getTargetType(), target.getId());
         addAttack(saa);
 
@@ -1050,7 +1047,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                     continue;
                 }
 
-                toHit = WeaponAttackAction.toHit(game, cen, t, weaponId,
+                toHit = WeaponAttackAction.toHit(game, currentEntity, t, weaponId,
                         Entity.LOC_NONE, AimingMode.NONE, true);
                 toHitBuff.append(t.getShortName() + ": ");
                 toHitBuff.append(toHit.getDesc());
@@ -1063,14 +1060,14 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             Building bldg = game.getBoard().getBuildingAt(c);
             if (bldg != null) {
                 Targetable t = new BuildingTarget(c, game.getBoard(), false);
-                toHit = WeaponAttackAction.toHit(game, cen, t, weaponId,
+                toHit = WeaponAttackAction.toHit(game, currentEntity, t, weaponId,
                         Entity.LOC_NONE, AimingMode.NONE, true);
                 toHitBuff.append(t.getDisplayName() + ": ");
                 toHitBuff.append(toHit.getDesc());
                 toHitBuff.append("\n");
             }
             Targetable hexTarget = new HexTarget(c, HexTarget.TYPE_HEX_CLEAR);
-            toHit = WeaponAttackAction.toHit(game, cen, hexTarget, weaponId,
+            toHit = WeaponAttackAction.toHit(game, currentEntity, hexTarget, weaponId,
                     Entity.LOC_NONE, AimingMode.NONE, true);
             if (m.getType().hasFlag(WeaponType.F_AUTO_TARGET)
                     || (toHit.getValue() == TargetRoll.IMPOSSIBLE)) {
@@ -1226,10 +1223,10 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             if (!(mounted.getType().hasFlag(WeaponType.F_ARTILLERY)
                     || (mounted.getType() instanceof CapitalMissileWeapon
                             && Compute.isGroundToGround(ce(), t)))) {
-                waa = new WeaponAttackAction(cen, t.getTargetType(),
+                waa = new WeaponAttackAction(currentEntity, t.getTargetType(),
                         t.getId(), weaponNum);
             } else {
-                waa = new ArtilleryAttackAction(cen, t.getTargetType(),
+                waa = new ArtilleryAttackAction(currentEntity, t.getTargetType(),
                         t.getId(), weaponNum, game);
             }
 
@@ -1363,7 +1360,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         }
 
         removeAllAttacks();
-        addAttack(new FindClubAction(cen));
+        addAttack(new FindClubAction(currentEntity));
 
         ready();
     }
@@ -1388,7 +1385,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         if (!clientgui.doYesNoDialog(title, body)) {
             return;
         }
-        addAttack(new SpotAction(cen, target.getId()));
+        addAttack(new SpotAction(currentEntity, target.getId()));
 
     }
 
@@ -1432,7 +1429,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
      */
     protected void removeTempAttacks() {
         // remove temporary attacks from game & board
-        clientgui.getClient().getGame().removeActionsFor(cen);
+        clientgui.getClient().getGame().removeActionsFor(currentEntity);
         clientgui.getBoardView().removeAttacksFor(ce());
     }
 
@@ -1502,7 +1499,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             }
         }
         if ((target instanceof Entity) && Compute.isGroundToAir(ce(), target)) {
-            Coords targetPos = Compute.getClosestFlightPath(cen, ce().getPosition(), (Entity) target);
+            Coords targetPos = Compute.getClosestFlightPath(currentEntity, ce().getPosition(), (Entity) target);
             clientgui.getBoardView().cursor(targetPos);
         }
         ash.setAimingMode();
@@ -1550,19 +1547,19 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                 boolean aiming = ash.isAimingAtLocation() && ash.allowAimedShotWith(weapon);
                 ash.setEnableAll(aiming);
                 if (aiming) {
-                    toHit = WeaponAttackAction.toHit(game, cen, target,
+                    toHit = WeaponAttackAction.toHit(game, currentEntity, target,
                             weaponId, ash.getAimingAt(), ash.getAimingMode(),
                             false);
                     clientgui.getUnitDisplay().wPan.setTarget(target, Messages.getFormattedString("MechDisplay.AimingAt", ash.getAimingLocation()));
                 } else {
-                    toHit = WeaponAttackAction.toHit(game, cen, target, weaponId, Entity.LOC_NONE,
+                    toHit = WeaponAttackAction.toHit(game, currentEntity, target, weaponId, Entity.LOC_NONE,
                             AimingMode.NONE, false);
                     clientgui.getUnitDisplay().wPan.setTarget(target, null);
 
                 }
                 ash.setPartialCover(toHit.getCover());
             } else {
-                toHit = WeaponAttackAction.toHit(game, cen, target, weaponId,
+                toHit = WeaponAttackAction.toHit(game, currentEntity, target, weaponId,
                         Entity.LOC_NONE, AimingMode.NONE, false);
                 clientgui.getUnitDisplay().wPan.setTarget(target, null);
             }
@@ -1663,7 +1660,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
 
         if (direction != ce().getSecondaryFacing()) {
             clearAttacks();
-            addAttack(new TorsoTwistAction(cen, direction));
+            addAttack(new TorsoTwistAction(currentEntity, direction));
             ce().setSecondaryFacing(direction);
             refreshAll();
         }
@@ -1684,23 +1681,16 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         if (twistDir == 0) {
             clearAttacks();
             direction = ce().clipSecondaryFacing((direction + 5) % 6);
-            addAttack(new TorsoTwistAction(cen, direction));
+            addAttack(new TorsoTwistAction(currentEntity, direction));
             ce().setSecondaryFacing(direction);
             refreshAll();
         } else if (twistDir == 1) {
             clearAttacks();
             direction = ce().clipSecondaryFacing((direction + 7) % 6);
-            addAttack(new TorsoTwistAction(cen, direction));
+            addAttack(new TorsoTwistAction(currentEntity, direction));
             ce().setSecondaryFacing(direction);
             refreshAll();
         }
-    }
-
-    /**
-     * Returns the current entity.
-     */
-    Entity ce() {
-        return clientgui.getClient().getGame().getEntity(cen);
     }
 
     //
@@ -1781,13 +1771,13 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                                 continue;
                             }
                             AttackAction aa = (AttackAction) action;
-                            if ((action.getEntityId() == cen)
+                            if ((action.getEntityId() == currentEntity)
                                     && (aa.getTargetId() == entTarg.getId())) {
                                 alreadyShotAt = true;
                             }
                         }
                         if (!alreadyShotAt) {
-                            entTarg.setPlayerPickedPassThrough(cen, evtCoords);
+                            entTarg.setPlayerPickedPassThrough(currentEntity, evtCoords);
                         }
                     }
                     target(targ);
@@ -1817,7 +1807,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         if (clientgui.getClient().getGame().getPhase().isFiring()) {
             String s = getRemainingPlayerWithTurns();
             if (clientgui.getClient().isMyTurn()) {
-                if (cen == Entity.NONE) {
+                if (currentEntity == Entity.NONE) {
                     beginMyTurn();
                 }
 
@@ -1879,7 +1869,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         } else if (ev.getActionCommand().equals(FiringCommand.FIRE_TWIST.getCmd())) {
             twisting = true;
         } else if (ev.getActionCommand().equals(FiringCommand.FIRE_NEXT.getCmd())) {
-            selectEntity(clientgui.getClient().getNextEntityNum(cen));
+            selectEntity(clientgui.getClient().getNextEntityNum(currentEntity));
         } else if (ev.getActionCommand().equals(FiringCommand.FIRE_MORE.getCmd())) {
             currentButtonGroup++;
             currentButtonGroup %= numButtonGroups;
@@ -1935,7 +1925,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
 
         clearAttacks();
         ce().setArmsFlipped(armsFlipped);
-        addAttack(new FlipArmsAction(cen, armsFlipped));
+        addAttack(new FlipArmsAction(currentEntity, armsFlipped));
         updateTarget();
         refreshAll();
     }
@@ -1948,7 +1938,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
                 && !ce().isHidden()
                 && ce().getCrew().isActive()
                 && ce().isUsingSearchlight()
-                && SearchlightAttackAction.isPossible(clientgui.getClient().getGame(), cen, target, null)
+                && SearchlightAttackAction.isPossible(clientgui.getClient().getGame(), currentEntity, target, null)
                 && !((ce() instanceof Tank) && (((Tank) ce()).getStunnedTurns() > 0)));
     }
 
@@ -2066,7 +2056,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             setStatusBarText(Messages.getString("FiringDisplay.its_your_turn"));
         }
         if ((target instanceof Entity) && Compute.isGroundToAir(ce(), target)) {
-            ((Entity) target).setPlayerPickedPassThrough(cen, null);
+            ((Entity) target).setPlayerPickedPassThrough(currentEntity, null);
         }
         if ((ce() != null) && !ce().isMakingVTOLGroundAttack()) {
             target(null);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -310,7 +310,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
     private Map<MoveCommand, MegamekButton> buttons;
 
     // let's keep track of what we're moving, too
-    private int cen = Entity.NONE; // current entity number
     private MovePath cmd; // considering movement data
 
     // what "gear" is our mech in?
@@ -517,9 +516,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
         controller.registerCommandAction(KeyCommandBind.UNDO_SINGLE_STEP, this, this::undoLastStep);
 
         controller.registerCommandAction(KeyCommandBind.NEXT_UNIT, this,
-                () -> selectEntity(clientgui.getClient().getNextEntityNum(cen)));
+                () -> selectEntity(clientgui.getClient().getNextEntityNum(currentEntity)));
         controller.registerCommandAction(KeyCommandBind.PREV_UNIT, this,
-                () -> selectEntity(clientgui.getClient().getPrevEntityNum(cen)));
+                () -> selectEntity(clientgui.getClient().getPrevEntityNum(currentEntity)));
 
         controller.registerCommandAction(KeyCommandBind.CANCEL, this::shouldPerformClearKeyCommand, this::cancel);
         controller.registerCommandAction(KeyCommandBind.TOGGLE_MOVEMODE, this, this::performToggleMovemode);
@@ -641,7 +640,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             clientgui.getClient().sendEntityWeaponOrderUpdate(ce);
         }
 
-        cen = en;
+        currentEntity = en;
         clientgui.setSelectedEntityNum(en);
         gear = MovementDisplay.GEAR_LAND;
 
@@ -989,7 +988,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
         MovePath possible = cmd.clone();
         possible.clipToPossible();
-        if (possible.length() == 0) {
+        if ((possible.length() == 0) || (ce() == null)) {
             updateDonePanelButtons(Messages.getString("MovementDisplay.Move"), Messages.getString("MovementDisplay.Skip"), false, null);
         } else if (!possible.isMoveLegal()) {
             updateDonePanelButtons(Messages.getString("MovementDisplay.IllegalMove"), Messages.getString("MovementDisplay.Skip"), false, null);
@@ -1109,7 +1108,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 && (next.getOwnerId() != ce.getOwnerId())) {
             clientgui.maybeShowUnitDisplay();
         }
-        cen = Entity.NONE;
+        currentEntity = Entity.NONE;
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().highlight(null);
         // Return the highlight sprite back to its original color
@@ -1671,21 +1670,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
         if (ce().hasUMU()) {
             clientgui.getClient().sendUpdateEntity(ce());
         }
-        clientgui.getClient().moveEntity(cen, cmd);
+        clientgui.getClient().moveEntity(currentEntity, cmd);
         if (ce().isWeapOrderChanged()) {
             clientgui.getClient().sendEntityWeaponOrderUpdate(ce());
         }
         endMyTurn();
-    }
-
-    /**
-     * Returns the current entity.
-     */
-    private synchronized Entity ce() {
-        if (clientgui != null) {
-            return clientgui.getClient().getGame().getEntity(cen);
-        }
-        return null;
     }
 
     /**
@@ -1915,7 +1904,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
                 addStepToMovePath(MoveStepType.RAM);
 
-                ToHitData toHit = new RamAttackAction(cen,
+                ToHitData toHit = new RamAttackAction(currentEntity,
                         target.getTargetType(), target.getId(),
                         target.getPosition()).toHit(clientgui.getClient().getGame(), cmd);
                 if (toHit.getValue() != TargetRoll.IMPOSSIBLE) {
@@ -1966,11 +1955,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 // check if it's a valid charge
                 ToHitData toHit = null;
                 if (ce.isAirborneVTOLorWIGE()) {
-                    toHit = new AirmechRamAttackAction(cen,
+                    toHit = new AirmechRamAttackAction(currentEntity,
                             target.getTargetType(), target.getId(),
                             target.getPosition()).toHit(clientgui.getClient().getGame(), cmd);
                 } else {
-                    toHit = new ChargeAttackAction(cen,
+                    toHit = new ChargeAttackAction(currentEntity,
                             target.getTargetType(), target.getId(),
                             target.getPosition()).toHit(clientgui.getClient().getGame(), cmd);
                 }
@@ -2039,7 +2028,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 }
 
                 // check if it's a valid DFA
-                ToHitData toHit = DfaAttackAction.toHit(clientgui.getClient().getGame(), cen, target, cmd);
+                ToHitData toHit = DfaAttackAction.toHit(clientgui.getClient().getGame(), currentEntity, target, cmd);
                 if (toHit.getValue() != TargetRoll.IMPOSSIBLE) {
                     // if yes, ask them if they want to DFA
                     if (clientgui.doYesNoDialog(
@@ -4304,7 +4293,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             // Can the player unload entities stranded on immobile transports?
             if (clientgui.getClient().canUnloadStranded()) {
                 unloadStranded();
-            } else if (cen == Entity.NONE) {
+            } else if (currentEntity == Entity.NONE) {
                 setStatusBarText(Messages.getString("MovementDisplay.its_your_turn") + s);
                 beginMyTurn();
             }
@@ -4510,7 +4499,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         final String actionCmd = ev.getActionCommand();
         final AbstractOptions opts = clientgui.getClient().getGame().getOptions();
         if (actionCmd.equals(MoveCommand.MOVE_NEXT.getCmd())) {
-            selectEntity(clientgui.getClient().getNextEntityNum(cen));
+            selectEntity(clientgui.getClient().getNextEntityNum(currentEntity));
         } else if (actionCmd.equals(
                 MoveCommand.MOVE_FORWARD_INI.getCmd())) {
             selectNextPlayer();
@@ -4549,7 +4538,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 // ready() was cancelled (ie, not all Velocity is spent), if it
                 // is cancelled we have to ensure the UNJAM_RAC step is removed,
                 // otherwise it can fire multiple times.
-                if (cen != Entity.NONE) {
+                if (currentEntity != Entity.NONE) {
                     cmd.removeLastStep();
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
@@ -277,7 +277,7 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
         refreshAll();
 
         if (clientgui.getClient().getGame().getEntity(en) != null) {
-            cen = en;
+            currentEntity = en;
             clientgui.setSelectedEntityNum(en);
             clientgui.getUnitDisplay().displayEntity(ce());
 
@@ -334,7 +334,7 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
                 && (next.getOwnerId() != ce().getOwnerId())) {
             clientgui.maybeShowUnitDisplay();
         }
-        cen = Entity.NONE;
+        currentEntity = Entity.NONE;
         target(null);
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().highlight(null);
@@ -492,10 +492,10 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
 
         // If the user picked a hex along the flight path, server needs to know
         if ((target instanceof Entity) && Compute.isGroundToAir(ce(), target)) {
-            Coords targetPos = ((Entity) target).getPlayerPickedPassThrough(cen);
+            Coords targetPos = ((Entity) target).getPlayerPickedPassThrough(currentEntity);
             if (targetPos != null) {
                 clientgui.getClient().sendPlayerPickedPassThrough(
-                        ((Entity) target).getId(), cen, targetPos);
+                        ((Entity) target).getId(), currentEntity, targetPos);
             }
         }
 
@@ -541,10 +541,10 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
         if (!(mounted.getType().hasFlag(WeaponType.F_ARTILLERY)
                 || (mounted.getType() instanceof CapitalMissileWeapon
                         && Compute.isGroundToGround(ce(), target)))) {
-            waa = new WeaponAttackAction(cen, target.getTargetType(),
+            waa = new WeaponAttackAction(currentEntity, target.getTargetType(),
                     target.getId(), weaponNum);
         } else {
-            waa = new ArtilleryAttackAction(cen, target.getTargetType(),
+            waa = new ArtilleryAttackAction(currentEntity, target.getTargetType(),
                     target.getId(), weaponNum, game);
         }
 
@@ -640,7 +640,7 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
             target = t;
         }
         if ((target instanceof Entity) && Compute.isGroundToAir(ce(), target)) {
-            Coords targetPos = Compute.getClosestFlightPath(cen, ce().getPosition(), (Entity) target);
+            Coords targetPos = Compute.getClosestFlightPath(currentEntity, ce().getPosition(), (Entity) target);
             clientgui.getBoardView().cursor(targetPos);
         }
         ash.setAimingMode();
@@ -666,20 +666,20 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
                 boolean aiming = ash.isAimingAtLocation() && ash.allowAimedShotWith(weapon);
                 ash.setEnableAll(aiming);
                 if (aiming) {
-                    toHit = WeaponAttackAction.toHit(game, cen, target,
+                    toHit = WeaponAttackAction.toHit(game, currentEntity, target,
                             weaponId, ash.getAimingAt(), ash.getAimingMode(),
                             false, false, null, null, false, true, -1);
                     clientgui.getUnitDisplay().wPan.setTarget(target, Messages.getFormattedString("MechDisplay.AimingAt", ash.getAimingLocation()));
 
                 } else {
-                    toHit = WeaponAttackAction.toHit(game, cen, target, weaponId, Entity.LOC_NONE,
+                    toHit = WeaponAttackAction.toHit(game, currentEntity, target, weaponId, Entity.LOC_NONE,
                             AimingMode.NONE, false, false,
                             null, null, false, true, -1);
                     clientgui.getUnitDisplay().wPan.setTarget(target, null);
                 }
                 ash.setPartialCover(toHit.getCover());
             } else {
-                toHit = WeaponAttackAction.toHit(game, cen, target, weaponId, Entity.LOC_NONE,
+                toHit = WeaponAttackAction.toHit(game, currentEntity, target, weaponId, Entity.LOC_NONE,
                         AimingMode.NONE, false, false, null,
                         null, false, true, -1);
                 clientgui.getUnitDisplay().wPan.setTarget(target, null);
@@ -878,7 +878,7 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
     @Override
     public void clear() {
         if ((target instanceof Entity) && Compute.isGroundToAir(ce(), target)) {
-            ((Entity) target).setPlayerPickedPassThrough(cen, null);
+            ((Entity) target).setPlayerPickedPassThrough(currentEntity, null);
         }
         clearAttacks();
         clientgui.getBoardView().select(null);

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -102,7 +102,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
 
     protected StatusBarPhaseDisplay(ClientGUI cg) {
         super(cg);
-        this.clientgui = cg;
+        clientgui = cg;
         getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), SBPD_KEY_CLEARBUTTON);
         getActionMap().put(SBPD_KEY_CLEARBUTTON, new AbstractAction() {
             @Override
@@ -159,7 +159,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
     protected abstract void setButtonsTooltips();
 
     protected String createToolTip(String cmd, String keyPrefix, String hotKeyDesc) {
-        String reuslt  = "";
+        String result  = "";
         String ttKey = keyPrefix + cmd + ".tooltip";
         String toolTip = hotKeyDesc;
         if (!toolTip.isEmpty()) {
@@ -173,9 +173,9 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         }
         if (!toolTip.isEmpty()) {
             String b = "<BODY>" + toolTip + "</BODY>";
-            reuslt = "<HTML>" + b + "</HTML>";
+            result = "<HTML>" + b + "</HTML>";
         }
-        return reuslt;
+        return result;
     }
 
     /**


### PR DESCRIPTION
This PR corrects the Done/Skip button behaviors when using the option of not auto-selecting a unit for the player's turns. They used to be active but had no effect when no unit was selected.
On the code side, this centralizes currentEntity (the selected unit for action) handling into ActionPhaseDisplay. The rename from cen to currentEntity makes this PR appear bigger than it is.