### PR TITLE
Fix seemingly incorrect round counter handling

### DIFF
--- a/megamek/src/megamek/common/AbstractGame.java
+++ b/megamek/src/megamek/common/AbstractGame.java
@@ -71,7 +71,10 @@ public abstract class AbstractGame implements IGame {
      */
     private final Map<Integer, List<Deployable>> deploymentTable = new HashMap<>();
 
-    protected int currentRound = 0;
+    /**
+     * The round counter. It gets incremented before initiative; round 0 is initial deployment only.
+     */
+    protected int currentRound = -1;
 
     @Override
     public Forces getForces() {

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1319,7 +1319,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
     public synchronized void reset() {
         uuid = UUID.randomUUID();
 
-        currentRound = 0;
+        currentRound = -1;
 
         inGameObjects.clear();
         entityPosLookup.clear();

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -1864,10 +1864,8 @@ public class GameManager extends AbstractGameManager {
                 // commander initiative bonus. Now that initiative is rolled, clear the flag.
                 game.getEntities().forEachRemaining(e -> e.getCrew().resetActedFlag());
 
-                if (!game.shouldDeployThisRound()) {
-                    incrementAndSendGameRound();
-                    asService.performRollingAutosave(this);
-                }
+                incrementAndSendGameRound();
+                asService.performRollingAutosave(this);
 
                 // setIneligible(phase);
                 determineTurnOrder(phase);

--- a/megamek/src/megamek/server/SBFGameManager.java
+++ b/megamek/src/megamek/server/SBFGameManager.java
@@ -478,10 +478,8 @@ public final class SBFGameManager extends AbstractGameManager {
                 // commander initiative bonus. Now that initiative is rolled, clear the flag.
 //                game.getEntities().forEachRemaining(e -> e.getCrew().resetActedFlag());
 
-                if (!game.shouldDeployThisRound()) {
 //                    incrementAndSendGameRound();
 //                    asService.performRollingAutosave(this);
-                }
 
                 // setIneligible(phase);
 //                determineTurnOrder(phase);


### PR DESCRIPTION
This corrects the round counter. From looking at it I believe the code has for a long time not been doing what it looked like it was doing. Specifically, the if (!game.shouldDeployThisRound()) check only ever returned true for start-of-game deployment, not reinforcements. 

My recent changes restored the function to what it *looked to be doing* (and which I did not entirely understand) which meant that round counting now no longer progressed when reinforcements were due. This PR fixes it by removing the check entirely. Line 1867 of GameManager is the only place where the round count is ever increased so it has to do it without exception. To get initial deployment at round 0, it has to start at -1.

Hopefully
Fixes #5542 