### PR TITLE
ModelRecord updates

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -481,6 +481,8 @@ public class ModelRecord extends AbstractUnitRecord {
                     ((megamek.common.weapons.Weapon) check_weapon).getAmmoType() == AmmoType.T_HAG ||
                     ((megamek.common.weapons.Weapon) check_weapon).getAmmoType() == AmmoType.T_SBGAUSS) {
                 return very_effective;
+            } else if (((WeaponType) check_weapon).getMedAV() >= 10) {
+                return somewhat_effective;
             } else {
                 return ineffective;
             }

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -341,7 +341,11 @@ public class ModelRecord extends AbstractUnitRecord {
         weightClass = unitData.getWeightClass();
 
         // Adjust weight class for support vehicles
-        if (weightClass >= EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if ((unitType == UnitType.TANK ||
+                unitType == UnitType.VTOL ||
+                unitType == UnitType.NAVAL ||
+                unitType == UnitType.CONV_FIGHTER) &&
+                weightClass >= EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
             if (unitData.getTons() <= 39) {
                 weightClass = EntityWeightClass.WEIGHT_LIGHT;
             } else if (unitData.getTons() <= 59) {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -570,7 +570,9 @@ public class ModelRecord extends AbstractUnitRecord {
         boolean isIndirect = ((WeaponType) check_weapon).hasIndirectFire();
 
         if (((WeaponType) check_weapon).getLongRange() >= 20 ||
-                check_weapon instanceof megamek.common.weapons.artillery.ArtilleryWeapon) {
+                check_weapon instanceof megamek.common.weapons.artillery.ArtilleryWeapon ||
+                check_weapon instanceof megamek.common.weapons.missiles.MMLWeapon ||
+                check_weapon instanceof megamek.common.weapons.missiles.ATMWeapon) {
             return fullRange;
         } else if (((WeaponType) check_weapon).getMediumRange() >= 14) {
             if (isIndirect) {
@@ -621,7 +623,9 @@ public class ModelRecord extends AbstractUnitRecord {
                     return mediumRange;
                 }
             }
-            if (((WeaponType) check_weapon).getLongRange() <= 15) {
+            if (((WeaponType) check_weapon).getLongRange() <= 15 ||
+                    check_weapon instanceof megamek.common.weapons.missiles.MMLWeapon ||
+                    check_weapon instanceof megamek.common.weapons.missiles.ATMWeapon) {
                 return shortRange;
             }
         } else if (((WeaponType) check_weapon).getMinimumRange() <= 3) {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -1047,7 +1047,7 @@ public class ModelRecord extends AbstractUnitRecord {
      * @param checkWeapon   Weapon to check
      * @return   between zero (not a short ranged weapon) and 1
      */
-    private  double getShortRangeModifier (EquipmentType checkWeapon) {
+    private double getShortRangeModifier (EquipmentType checkWeapon) {
 
         double shortRange = 1.0;
         double mediumRange = 0.6;
@@ -1068,7 +1068,7 @@ public class ModelRecord extends AbstractUnitRecord {
         if (((WeaponType) checkWeapon).getMinimumRange() <= 0)
         {
             if (checkWeapon instanceof InfantryWeapon) {
-                if (((WeaponType) checkWeapon).getLongRange() <= 6){
+                if (((WeaponType) checkWeapon).getLongRange() <= 6) {
                     return shortRange;
                 } else if (((WeaponType) checkWeapon).getLongRange() <= 12) {
                     return mediumRange;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -125,12 +125,13 @@ public class ModelRecord extends AbstractUnitRecord {
                     flakBV += getFlakBVModifier(eq) * eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
 
-                // Only add an artillery role if this model does not already have MIXED_ARTILLERY
-                if (eq.hasFlag(WeaponType.F_ARTILLERY)) {
-                    if (!roles.contains(MissionRole.MIXED_ARTILLERY)) {
-                        roles.add(((WeaponType) eq).getAmmoType() == AmmoType.T_ARROW_IV ?
-                                MissionRole.MISSILE_ARTILLERY : MissionRole.ARTILLERY);
-                    }
+                // If the unit has an artillery weapon but does not have an artillery role
+                // assume it is tactical support, and give it the MIXED_ARTILLERY role
+                if (eq.hasFlag(WeaponType.F_ARTILLERY) &&
+                        !roles.contains(MissionRole.ARTILLERY) &&
+                        !roles.contains(MissionRole.MISSILE_ARTILLERY) &&
+                        !roles.contains(MissionRole.MIXED_ARTILLERY)) {
+                    roles.add(MissionRole.MIXED_ARTILLERY);
                 }
 
                 // Don't check incendiary weapons for conventional infantry, fixed wing aircraft,

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -42,6 +42,7 @@ public class ModelRecord extends AbstractUnitRecord {
     private MechSummary mechSummary;
 
     private boolean primitive;
+    private boolean retrotech;
     private boolean starLeague;
     private int weightClass;
     private EntityMovementMode movementMode;
@@ -111,6 +112,15 @@ public class ModelRecord extends AbstractUnitRecord {
      */
     public boolean isPrimitive() {
         return primitive;
+    }
+
+    /**
+     * Unit consists of at least some primitive technology and some advanced/Star League/Clan
+     * technology. Testing is not extensive, there may be units that are not properly flagged.
+     * @return   true, if unit contains both primitive and advanced tech
+     */
+    public boolean isRetrotech () {
+        return retrotech;
     }
 
     public boolean isSL() {
@@ -462,12 +472,11 @@ public class ModelRecord extends AbstractUnitRecord {
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
                     magClamp = true;
+                } else if (eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
+                    losTech = true;
                 } else if (eq.hasFlag(MiscType.F_UMU)) {
                     movementMode = EntityMovementMode.BIPED_SWIM;
                 }
-
-
-
 
             }
         }
@@ -499,7 +508,10 @@ public class ModelRecord extends AbstractUnitRecord {
             }
         }
 
+        // Categorize by technology type
         starLeague = losTech && !clan;
+        primitive = base_primitive && !losTech && !clan;
+        retrotech = base_primitive && (losTech || clan);
 
         speed = ms.getWalkMp();
         if (ms.getJumpMp() > 0) {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -170,11 +170,29 @@ public class ModelRecord extends AbstractUnitRecord {
                             eq instanceof megamek.common.weapons.SwarmAttack);
                 }
 
+                // Total up BV for weapons that require ammo. Streak-type missile systems get a
+                // discount. Ignore small craft, DropShips, and large space craft. Ignore infantry
+                // weapons except for field guns.
+                if (unitType < UnitType.SMALL_CRAFT) {
+                    double ammoFactor = 1.0;
 
-                if (((WeaponType) eq).getAmmoType() > megamek.common.AmmoType.T_NA) {
-                    ammoBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
+                    if (eq instanceof megamek.common.weapons.srms.StreakSRMWeapon ||
+                            eq instanceof megamek.common.weapons.lrms.StreakLRMWeapon ||
+                            ((WeaponType) eq).getAmmoType() == AmmoType.T_IATM) {
+                        ammoFactor = 0.4;
+                    }
+
+                    if (unitType == UnitType.INFANTRY || unitType == UnitType.BATTLE_ARMOR) {
+                        if (eq instanceof megamek.common.weapons.infantry.InfantryWeapon) {
+                            ammoFactor = 0.0;
+                        }
+                    }
+
+                    if  (ammoFactor > 0.0 && ((WeaponType) eq).getAmmoType() > megamek.common.AmmoType.T_NA) {
+                        ammoBV += eq.getBV(null) * ammoFactor * ms.getEquipmentQuantities().get(i);
+                    }
+
                 }
-
 
                 if (((WeaponType) eq).getLongRange() >= 20) {
                     lrBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -420,23 +420,15 @@ public class ModelRecord extends AbstractUnitRecord {
             }
         }
 
-        if (totalBV > 0 &&
-                (ms.getUnitType().equals("Mek") ||
-                        ms.getUnitType().equals("Tank") ||
-                        ms.getUnitType().equals("BattleArmor") ||
-                        ms.getUnitType().equals("Infantry") ||
-                        ms.getUnitType().equals("ProtoMek") ||
-                        ms.getUnitType().equals("Naval") ||
-                        ms.getUnitType().equals("Gun Emplacement"))) {
+        // Calculate BV proportions for all ground units, VTOL, blue water naval, and
+        // fixed wing aircraft. Exclude Small craft, DropShips, and large space craft.
+        if (totalBV > 0 && unitType <= UnitType.AEROSPACEFIGHTER) {
             flak = flakBV / totalBV;
             artilleryBVProportion = artilleryBV/totalBV;
             longRange = lrBV / totalBV;
             srBVProportion = srBV / totalBV;
             ammoRequirement = ammoBV / totalBV;
-        }
 
-        // Characterize unit as anti-personnel based on total equipment levels
-        if (totalBV > 0) {
             apWeapons = apRating >= apThreshold;
         }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -16,12 +16,27 @@ package megamek.client.ratgenerator;
 import megamek.common.*;
 import megamek.common.weapons.*;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
+import megamek.common.weapons.battlearmor.BAFlamerWeapon;
+import megamek.common.weapons.battlearmor.BAMGWeapon;
+import megamek.common.weapons.battlearmor.CLBAMGBearhunterSuperheavy;
+import megamek.common.weapons.defensivepods.BPodWeapon;
 import megamek.common.weapons.flamers.FlamerWeapon;
+import megamek.common.weapons.gaussrifles.CLAPGaussRifle;
+import megamek.common.weapons.gaussrifles.GaussWeapon;
+import megamek.common.weapons.infantry.InfantrySupportMk2PortableAAWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
+import megamek.common.weapons.lasers.CLPulseLaserSmall;
+import megamek.common.weapons.lasers.ISPulseLaserSmall;
+import megamek.common.weapons.lrms.StreakLRMWeapon;
 import megamek.common.weapons.mgs.MGWeapon;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
+import megamek.common.weapons.missiles.RLWeapon;
+import megamek.common.weapons.mortars.MekMortarWeapon;
+import megamek.common.weapons.ppc.CLPlasmaCannon;
+import megamek.common.weapons.ppc.ISPlasmaRifle;
 import megamek.common.weapons.srms.SRMWeapon;
+import megamek.common.weapons.srms.StreakSRMWeapon;
 
 import org.apache.logging.log4j.LogManager;
 
@@ -506,9 +521,9 @@ public class ModelRecord extends AbstractUnitRecord {
                 if (!incendiary &&
                         (unitType < UnitType.CONV_FIGHTER && unitType != UnitType.INFANTRY)) {
                     if (eq instanceof FlamerWeapon ||
-                            eq instanceof megamek.common.weapons.battlearmor.BAFlamerWeapon ||
-                            eq instanceof megamek.common.weapons.ppc.ISPlasmaRifle ||
-                            eq instanceof megamek.common.weapons.ppc.CLPlasmaCannon) {
+                            eq instanceof BAFlamerWeapon ||
+                            eq instanceof ISPlasmaRifle ||
+                            eq instanceof CLPlasmaCannon) {
                         incendiary = true;
                     }
                     // Some missile types are capable of being loaded with infernos, which are
@@ -533,12 +548,12 @@ public class ModelRecord extends AbstractUnitRecord {
                 // discount. Ignore small craft, DropShips, and large space craft. Ignore infantry
                 // weapons except for field guns.
                 if (unitType < UnitType.SMALL_CRAFT &&
-                        ((WeaponType) eq).getAmmoType() > megamek.common.AmmoType.T_NA &&
+                        ((WeaponType) eq).getAmmoType() > AmmoType.T_NA &&
                         !(eq instanceof InfantryWeapon)) {
                     double ammoFactor = 1.0;
 
-                    if (eq instanceof megamek.common.weapons.srms.StreakSRMWeapon ||
-                            eq instanceof megamek.common.weapons.lrms.StreakLRMWeapon ||
+                    if (eq instanceof StreakSRMWeapon ||
+                            eq instanceof StreakLRMWeapon ||
                             ((WeaponType) eq).getAmmoType() == AmmoType.T_IATM) {
                         ammoFactor = 0.4;
                     }
@@ -928,10 +943,10 @@ public class ModelRecord extends AbstractUnitRecord {
         if (((Weapon) checkWeapon).getAmmoType() == AmmoType.T_AC_LBX ||
                 ((Weapon) checkWeapon).getAmmoType() == AmmoType.T_HAG ||
                 ((Weapon) checkWeapon).getAmmoType() == AmmoType.T_SBGAUSS ||
-                checkWeapon instanceof megamek.common.weapons.infantry.InfantrySupportMk2PortableAAWeapon) {
+                checkWeapon instanceof InfantrySupportMk2PortableAAWeapon) {
             return veryEffective;
         } else if (checkWeapon instanceof InfantryWeapon ||
-                checkWeapon instanceof megamek.common.weapons.missiles.RLWeapon) {
+                checkWeapon instanceof RLWeapon) {
             return ineffective;
         } else if (((WeaponType) checkWeapon).getLongRange() >= 16) {
             return somewhatEffective;
@@ -965,29 +980,29 @@ public class ModelRecord extends AbstractUnitRecord {
 
         if (checkWeapon instanceof InfantryWeapon) {
             return notEffective;
-        } else if (checkWeapon instanceof megamek.common.weapons.battlearmor.BAMGWeapon) {
+        } else if (checkWeapon instanceof BAMGWeapon) {
             return extremelyEffective;
-        } else if (checkWeapon instanceof megamek.common.weapons.battlearmor.BAFlamerWeapon) {
+        } else if (checkWeapon instanceof BAFlamerWeapon) {
             return extremelyEffective;
-        } else if (checkWeapon instanceof megamek.common.weapons.gaussrifles.GaussWeapon) {
-            if (checkWeapon instanceof megamek.common.weapons.gaussrifles.CLAPGaussRifle) {
+        } else if (checkWeapon instanceof GaussWeapon) {
+            if (checkWeapon instanceof CLAPGaussRifle) {
                 return veryEffective;
             } else {
                 return ineffective;
             }
-        } else if (checkWeapon instanceof megamek.common.weapons.battlearmor.CLBAMGBearhunterSuperheavy) {
+        } else if (checkWeapon instanceof CLBAMGBearhunterSuperheavy) {
             return extremelyEffective;
-        } else if (checkWeapon instanceof megamek.common.weapons.ppc.ISPlasmaRifle ||
-                checkWeapon instanceof megamek.common.weapons.ppc.CLPlasmaCannon) {
+        } else if (checkWeapon instanceof ISPlasmaRifle ||
+                checkWeapon instanceof CLPlasmaCannon) {
             return veryEffective;
-        } else if (checkWeapon instanceof megamek.common.weapons.lasers.ISPulseLaserSmall ||
-                    checkWeapon instanceof megamek.common.weapons.lasers.CLPulseLaserSmall) {
+        } else if (checkWeapon instanceof ISPulseLaserSmall ||
+                    checkWeapon instanceof CLPulseLaserSmall) {
             return veryEffective;
         }
 
-        if (checkWeapon instanceof megamek.common.weapons.defensivepods.BPodWeapon) {
+        if (checkWeapon instanceof BPodWeapon) {
             return notEffective;
-        } else if (checkWeapon instanceof megamek.common.weapons.mortars.MekMortarWeapon) {
+        } else if (checkWeapon instanceof MekMortarWeapon) {
             return notEffective;
         }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -204,7 +204,14 @@ public class ModelRecord extends AbstractUnitRecord {
     }
 
     /**
-     * Proportion of total weapons BV that is best at long range
+     * Proportion of total weapons BV that is capable of attacking targets at longer ranges.
+     * Units with values of 0.75 or higher are mostly armed with weapons that can hit targets at
+     * 15+ hexes, have a minimum range, and potentially fire indirectly in ground combat; or
+     * reach long/extreme range in air or space combat.
+     * Complementary to getSRProportion() - where one is high and the other is low, the unit is
+     * specialized for that range bracket. If both values are similar the unit is well balanced
+     * between long and short ranged capabilities.
+     * TODO: rename for consistency and clarity
      * @return   between zero (none) and 1.0 (all weapons)
      */
     public double getLongRange() {
@@ -212,8 +219,14 @@ public class ModelRecord extends AbstractUnitRecord {
     }
 
     /**
-     * Proportion of total weapons BV that is best at short range
-     * @return   between zero (none) and 1.o (all weapons)
+     * Proportion of total weapons BV that is limited to attacking targets at close range.
+     * Units with values of 0.75 or higher are mostly armed with weapons that have a long range
+     * of less than 12 hexes and do not have a minimum range in ground combat, or are limited to
+     * short range in air/space combat.
+     * Complementary to getLongRange() - where one is high and the other is low, the unit is
+     * specialized for that range bracket. If both values are similar the unit is well balanced
+     * between long and short ranged capabilities.
+     * @return   between zero (none) and 1.0 (all weapons)
      */
     public double getSRProportion() {
         return srBVProportion;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -788,7 +788,8 @@ public class ModelRecord extends AbstractUnitRecord {
 
 
     /**
-     * Get a BV modifier for a weapon for use against airborne targets
+     * Get a BV modifier for a weapon for use against airborne targets. Slightly different checks
+     * are provided for fixed wing aircraft for air-to-air combat use
      * @param check_weapon
      * @return   Relative value from zero (not useful) to 1
      */
@@ -819,7 +820,8 @@ public class ModelRecord extends AbstractUnitRecord {
                 ((megamek.common.weapons.Weapon) check_weapon).getAmmoType() == AmmoType.T_SBGAUSS ||
                 check_weapon instanceof megamek.common.weapons.infantry.InfantrySupportMk2PortableAAWeapon) {
             return very_effective;
-        } else if (check_weapon instanceof megamek.common.weapons.infantry.InfantryWeapon) {
+        } else if (check_weapon instanceof megamek.common.weapons.infantry.InfantryWeapon ||
+                check_weapon instanceof megamek.common.weapons.missiles.RLWeapon) {
             return ineffective;
         } else if (((WeaponType) check_weapon).getLongRange() >= 16) {
             return somewhat_effective;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -80,13 +80,9 @@ public class ModelRecord extends AbstractUnitRecord {
         mechSummary = ms;
         unitType = parseUnitType(ms.getUnitType());
         introYear = ms.getYear();
-        if (unitType == UnitType.MEK) {
-            //TODO: id quads and tripods
-            movementMode = EntityMovementMode.BIPED;
-            omni = ms.getUnitSubType().equals("Omni");
-        } else {
-            movementMode = EntityMovementMode.parseFromString(ms.getUnitSubType().toLowerCase());
-        }
+
+        analyzeModel(ms);
+
 
         double totalBV = 0.0;
         double flakBV = 0.0;
@@ -126,10 +122,8 @@ public class ModelRecord extends AbstractUnitRecord {
                 }
 
                 // Don't check incendiary weapons for conventional infantry, fixed wing aircraft,
-                // and space-going units. Also, don't bother checking if it's already set or has
-                // the role.
-                if (!roles.contains(MissionRole.INCENDIARY) &&
-                        !incendiary &&
+                // and space-going units
+                if (!incendiary &&
                         (unitType < UnitType.CONV_FIGHTER && unitType != UnitType.INFANTRY)) {
                     if (eq instanceof megamek.common.weapons.flamers.FlamerWeapon ||
                             eq instanceof megamek.common.weapons.battlearmor.BAFlamerWeapon ||
@@ -428,6 +422,24 @@ public class ModelRecord extends AbstractUnitRecord {
         return canAntiMek;
     }
 
+
+    /**
+     * Checks the equipment carried by this unit and summarizes it in a variety of easy to access
+     * data
+     * @param ms   Data for unit
+     */
+    private void analyzeModel (MechSummary ms) {
+
+        if (unitType == UnitType.MEK) {
+            //TODO: id quads and tripods
+            movementMode = EntityMovementMode.BIPED;
+            omni = ms.getUnitSubType().equals("Omni");
+        } else {
+            movementMode = EntityMovementMode.parseFromString(ms.getUnitSubType().toLowerCase());
+        }
+
+
+    }
 
     /**
      * Get a BV modifier for a weapon for use against airborne targets

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -430,29 +430,43 @@ public class ModelRecord extends AbstractUnitRecord {
                     if (ms.getEquipmentQuantities().get(i) > 1) {
                         networkMask |= NETWORK_COMPANY_COMMAND;
                     }
+                    losTech = true;
                 } else if (eq.hasFlag(WeaponType.F_C3MBS)) {
                     networkMask |= NETWORK_BOOSTED_MASTER;
                     if (ms.getEquipmentQuantities().get(i) > 1) {
                         networkMask |= NETWORK_COMPANY_COMMAND;
                     }
+                    losTech = true;
                 }
 
             // Various non-weapon equipment
             } else if (eq instanceof MiscType) {
 
-                if (eq.hasFlag(MiscType.F_UMU)) {
-                    movementMode = EntityMovementMode.BIPED_SWIM;
-                } else if (eq.hasFlag(MiscType.F_C3S)) {
+                if (eq.hasFlag(MiscType.F_C3S)) {
                     networkMask |= NETWORK_C3_SLAVE;
+                    losTech = true;
                 } else if (eq.hasFlag(MiscType.F_C3I)) {
                     networkMask |= NETWORK_C3I;
+                    losTech = true;
+                } else if (eq.hasFlag(MiscType.F_ECM) ||
+                        eq.hasFlag(MiscType.F_ANGEL_ECM) ||
+                        eq.hasFlag(MiscType.F_BAP) ||
+                        eq.hasFlag(MiscType.F_BLOODHOUND)) {
+                    losTech = true;
                 } else if (eq.hasFlag(MiscType.F_C3SBS)) {
                     networkMask |= NETWORK_BOOSTED_SLAVE;
+                    losTech = true;
                 } else if (eq.hasFlag(MiscType.F_NOVA)) {
                     networkMask |= NETWORK_NOVA;
+                    losTech = true;
                 } else if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
                     magClamp = true;
+                } else if (eq.hasFlag(MiscType.F_UMU)) {
+                    movementMode = EntityMovementMode.BIPED_SWIM;
                 }
+
+
+
 
             }
         }

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -80,7 +80,6 @@ public class ModelRecord extends AbstractUnitRecord {
     private boolean unarmed;
 
     private int speed;
-    private boolean canJump;
 
     private boolean mechanizedBA;
     private boolean magClamp;
@@ -210,7 +209,7 @@ public class ModelRecord extends AbstractUnitRecord {
     }
 
     public boolean getJump() {
-        return canJump;
+        return mechSummary.getJumpMp() > 0;
     }
 
     /**
@@ -368,7 +367,6 @@ public class ModelRecord extends AbstractUnitRecord {
         if (unitType <= UnitType.PROTOMEK &&
                 unitData.getJumpMp() > 0) {
             int jumpDistance = unitData.getJumpMp();
-            canJump = true;
             if (unitType == UnitType.INFANTRY || unitType == UnitType.BATTLE_ARMOR) {
                 speed = Math.max(speed, jumpDistance);
             } else {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -567,14 +567,7 @@ public class ModelRecord extends AbstractUnitRecord {
         }
 
         // Quick and dirty check for most indirect fire weapons
-        boolean isIndirect = (check_weapon instanceof megamek.common.weapons.lrms.LRMWeapon &&
-                !(check_weapon instanceof megamek.common.weapons.lrms.StreakLRMWeapon)) ||
-                check_weapon instanceof megamek.common.weapons.missiles.MMLWeapon ||
-                check_weapon instanceof megamek.common.weapons.missiles.ThunderBoltWeapon ||
-                check_weapon instanceof megamek.common.weapons.mortars.MekMortarWeapon ||
-                check_weapon instanceof megamek.common.weapons.infantry.InfantrySupportLRMWeapon ||
-                check_weapon instanceof megamek.common.weapons.infantry.InfantrySupportMortarHeavyWeapon ||
-                check_weapon instanceof megamek.common.weapons.infantry.InfantrySupportMortarLightWeapon;
+        boolean isIndirect = ((WeaponType) check_weapon).hasIndirectFire();
 
         if (((WeaponType) check_weapon).getLongRange() >= 20 ||
                 check_weapon instanceof megamek.common.weapons.artillery.ArtilleryWeapon) {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -89,8 +89,8 @@ public class ModelRecord extends AbstractUnitRecord {
         double totalBV = 0.0;
         double flakBV = 0.0;
         double lrBV = 0.0;
-        int ap_rating = 0;
-        int ap_threshold = 6;
+        int apRating = 0;
+        int apThreshold = 6;
         double ammoBV = 0.0;
         boolean losTech = false;
         for (int i = 0; i < ms.getEquipmentNames().size(); i++) {
@@ -113,12 +113,15 @@ public class ModelRecord extends AbstractUnitRecord {
 
             if (eq instanceof WeaponType) {
                 totalBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
+
+                // Check for use against airborne targets
                 switch (((megamek.common.weapons.Weapon) eq).getAmmoType()) {
                     case AmmoType.T_AC_LBX:
                     case AmmoType.T_HAG:
                     case AmmoType.T_SBGAUSS:
                         flakBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
+
                 // Only add an artillery role if this model does not already have MIXED_ARTILLERY
                 if (eq.hasFlag(WeaponType.F_ARTILLERY)) {
                     flakBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i) / 2.0;
@@ -154,22 +157,25 @@ public class ModelRecord extends AbstractUnitRecord {
                 // Don't check anti-personnel weapons for conventional infantry, fixed wing
                 // aircraft, and space-going units. Also, don't bother checking if we're
                 // already high enough.
-                if (ap_rating < ap_threshold &&
+                if (apRating < apThreshold &&
                         (unitType < UnitType.CONV_FIGHTER && unitType != UnitType.INFANTRY)) {
-                    ap_rating += getAPRating(eq);
+                    apRating += getAPRating(eq);
                 }
 
                 // Check if a conventional infantry or battle armor unit can perform anti-Mech
-                // attacks
+                // attacks. This will also pick up battle armor that must first jettison equipment.
                 if (!canAntiMek &&
                         (unitType == UnitType.INFANTRY || unitType == UnitType.BATTLE_ARMOR)) {
                     canAntiMek = (eq instanceof megamek.common.weapons.LegAttack ||
                             eq instanceof megamek.common.weapons.SwarmAttack);
                 }
 
+
                 if (((WeaponType) eq).getAmmoType() > megamek.common.AmmoType.T_NA) {
                     ammoBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
+
+
                 if (((WeaponType) eq).getLongRange() >= 20) {
                     lrBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
@@ -217,9 +223,9 @@ public class ModelRecord extends AbstractUnitRecord {
             ammoRequirement = ammoBV / totalBV;
         }
 
-        // Characterize uit as anti-personnel based on total equipment levels
+        // Characterize unit as anti-personnel based on total equipment levels
         if (totalBV > 0) {
-            apWeapons = ap_rating >= ap_threshold;
+            apWeapons = apRating >= apThreshold;
         }
 
         weightClass = ms.getWeightClass();

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -433,11 +433,17 @@ public class ModelRecord extends AbstractUnitRecord {
         if (unitType == UnitType.MEK) {
             //TODO: id quads and tripods
             movementMode = EntityMovementMode.BIPED;
-            omni = ms.getUnitSubType().equals("Omni");
         } else {
             movementMode = EntityMovementMode.parseFromString(ms.getUnitSubType().toLowerCase());
         }
 
+        if (unitType == UnitType.MEK ||
+                unitType == UnitType.TANK ||
+                unitType == UnitType.VTOL ||
+                unitType == UnitType.CONV_FIGHTER ||
+                unitType == UnitType.AEROSPACEFIGHTER) {
+            omni = ms.getOmni();
+        }
 
     }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -506,7 +506,7 @@ public class ModelRecord extends AbstractUnitRecord {
                 // Check for use against airborne targets. Ignore small craft, DropShips, and other
                 // large space craft.
                 if (unitType < UnitType.SMALL_CRAFT) {
-                    flakBV += getFlakBVModifier(eq) * eq.getBV(null) *
+                    flakBV += getFlakBVModifier((WeaponType) eq) * eq.getBV(null) *
                             unitData.getEquipmentQuantities().get(i);
                 }
 
@@ -541,7 +541,7 @@ public class ModelRecord extends AbstractUnitRecord {
                 // already high enough.
                 if (apRating < apThreshold &&
                         (unitType < UnitType.CONV_FIGHTER && unitType != UnitType.INFANTRY)) {
-                    apRating += getAPRating(eq);
+                    apRating += getAPRating((WeaponType) eq);
                 }
 
                 // Total up BV for weapons that require ammo. Streak-type missile systems get a
@@ -570,14 +570,14 @@ public class ModelRecord extends AbstractUnitRecord {
                 // Total up BV for weapons capable of attacking at the longest ranges or using
                 // indirect fire. Ignore small craft, DropShips, and other space craft.
                 if (unitType < UnitType.SMALL_CRAFT) {
-                    longRangeBV += getLongRangeModifier(eq) * eq.getBV(null) *
+                    longRangeBV += getLongRangeModifier((WeaponType) eq) * eq.getBV(null) *
                             unitData.getEquipmentQuantities().get(i);
                 }
 
                 // Total up BV of weapons suitable for attacking at close range. Ignore small craft,
                 // DropShips, and other space craft. Also skip anti-Mech attacks.
                 if (unitType < UnitType.SMALL_CRAFT) {
-                    shortRangeBV += getShortRangeModifier(eq) * eq.getBV(null) *
+                    shortRangeBV += getShortRangeModifier((WeaponType) eq) * eq.getBV(null) *
                             unitData.getEquipmentQuantities().get(i);
                 }
 
@@ -915,7 +915,7 @@ public class ModelRecord extends AbstractUnitRecord {
      * @param checkWeapon   weapon to check
      * @return              Relative value from zero (not useful) to 1
      */
-    private double getFlakBVModifier(EquipmentType checkWeapon) {
+    private double getFlakBVModifier(WeaponType checkWeapon) {
 
         double veryEffective = 1.0;
         double somewhatEffective = 0.5;
@@ -925,12 +925,12 @@ public class ModelRecord extends AbstractUnitRecord {
         // Use a limited version for checking air-to-air capability, including potential for
         // thresholding heavily armored targets
         if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
-            if (((Weapon) checkWeapon).getAmmoType() == AmmoType.T_AC_LBX ||
-                    ((Weapon) checkWeapon).getAmmoType() == AmmoType.T_HAG ||
-                    ((Weapon) checkWeapon).getAmmoType() == AmmoType.T_SBGAUSS) {
+            if (checkWeapon.getAmmoType() == AmmoType.T_AC_LBX ||
+                    checkWeapon.getAmmoType() == AmmoType.T_HAG ||
+                    checkWeapon.getAmmoType() == AmmoType.T_SBGAUSS) {
                 return veryEffective;
-            } else if (((WeaponType) checkWeapon).getMedAV() >= 10 ||
-                    ((WeaponType) checkWeapon).getShortAV() >= 15) {
+            } else if (checkWeapon.getMedAV() >= 10 ||
+                    checkWeapon.getShortAV() >= 15) {
                 return somewhatEffective;
             } else {
                 return ineffective;
@@ -940,17 +940,17 @@ public class ModelRecord extends AbstractUnitRecord {
         if (checkWeapon instanceof ArtilleryWeapon) {
             return somewhatEffective;
         }
-        if (((Weapon) checkWeapon).getAmmoType() == AmmoType.T_AC_LBX ||
-                ((Weapon) checkWeapon).getAmmoType() == AmmoType.T_HAG ||
-                ((Weapon) checkWeapon).getAmmoType() == AmmoType.T_SBGAUSS ||
+        if (checkWeapon.getAmmoType() == AmmoType.T_AC_LBX ||
+                checkWeapon.getAmmoType() == AmmoType.T_HAG ||
+                checkWeapon.getAmmoType() == AmmoType.T_SBGAUSS ||
                 checkWeapon instanceof InfantrySupportMk2PortableAAWeapon) {
             return veryEffective;
         } else if (checkWeapon instanceof InfantryWeapon ||
                 checkWeapon instanceof RLWeapon) {
             return ineffective;
-        } else if (((WeaponType) checkWeapon).getLongRange() >= 16) {
+        } else if (checkWeapon.getLongRange() >= 16) {
             return somewhatEffective;
-        } else if (((WeaponType) checkWeapon).getMediumRange() >= 8) {
+        } else if (checkWeapon.getMediumRange() >= 8) {
             return notEffective;
         }
 
@@ -962,7 +962,7 @@ public class ModelRecord extends AbstractUnitRecord {
      * @param checkWeapon  Weapon to check
      * @return             Relative value, 0 is ineffective, higher is more effective
      */
-    private int getAPRating(EquipmentType checkWeapon) {
+    private int getAPRating(WeaponType checkWeapon) {
         int extremelyEffective = 6;
         int veryEffective = 4;
         int somewhatEffective = 2;
@@ -1014,7 +1014,7 @@ public class ModelRecord extends AbstractUnitRecord {
      * @param checkWeapon   Weapon to check
      * @return   between zero (not a long ranged weapon) and 1
      */
-    private double getLongRangeModifier(EquipmentType checkWeapon) {
+    private double getLongRangeModifier(WeaponType checkWeapon) {
 
         double fullRange = 1.0;
         double partialRange = 0.8;
@@ -1022,8 +1022,8 @@ public class ModelRecord extends AbstractUnitRecord {
         double shortRange = 0.0;
 
         if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
-            if (((WeaponType) checkWeapon).getExtAV() > 0 ||
-                    ((WeaponType) checkWeapon).getLongAV() > 0 ||
+            if (checkWeapon.getExtAV() > 0 ||
+                    checkWeapon.getLongAV() > 0 ||
                     checkWeapon instanceof MMLWeapon ||
                     checkWeapon instanceof ATMWeapon) {
                 return fullRange;
@@ -1032,19 +1032,19 @@ public class ModelRecord extends AbstractUnitRecord {
             }
         }
 
-        boolean isIndirect = ((WeaponType) checkWeapon).hasIndirectFire();
-        if (((WeaponType) checkWeapon).getLongRange() >= 20 ||
+        boolean isIndirect = checkWeapon.hasIndirectFire();
+        if (checkWeapon.getLongRange() >= 20 ||
                 checkWeapon instanceof ArtilleryWeapon ||
                 checkWeapon instanceof MMLWeapon ||
                 checkWeapon instanceof ATMWeapon) {
             return fullRange;
-        } else if (((WeaponType) checkWeapon).getMediumRange() >= 14) {
+        } else if (checkWeapon.getMediumRange() >= 14) {
             if (isIndirect) {
                 return fullRange;
             } else {
                 return partialRange;
             }
-        } else if (((WeaponType) checkWeapon).getMediumRange() >= 12) {
+        } else if (checkWeapon.getMediumRange() >= 12) {
             if (isIndirect) {
                 return partialRange;
             } else {
@@ -1062,40 +1062,40 @@ public class ModelRecord extends AbstractUnitRecord {
      * @param checkWeapon   Weapon to check
      * @return   between zero (not a short ranged weapon) and 1
      */
-    private double getShortRangeModifier (EquipmentType checkWeapon) {
+    private double getShortRangeModifier (WeaponType checkWeapon) {
 
         double shortRange = 1.0;
         double mediumRange = 0.6;
         double longRange = 0.0;
 
         if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
-            if (((WeaponType) checkWeapon).getMedAV() == 0 ||
+            if (checkWeapon.getMedAV() == 0 ||
                     checkWeapon instanceof MMLWeapon ||
                     checkWeapon instanceof ATMWeapon) {
                 return shortRange;
-            } else if (((WeaponType) checkWeapon).getLongAV() == 0) {
+            } else if (checkWeapon.getLongAV() == 0) {
                 return mediumRange;
             } else {
                 return longRange;
             }
         }
 
-        if (((WeaponType) checkWeapon).getMinimumRange() <= 0)
+        if (checkWeapon.getMinimumRange() <= 0)
         {
             if (checkWeapon instanceof InfantryWeapon) {
-                if (((WeaponType) checkWeapon).getLongRange() <= 6) {
+                if (checkWeapon.getLongRange() <= 6) {
                     return shortRange;
-                } else if (((WeaponType) checkWeapon).getLongRange() <= 12) {
+                } else if (checkWeapon.getLongRange() <= 12) {
                     return mediumRange;
                 }
             }
-            if (((WeaponType) checkWeapon).getLongRange() <= 15 ||
+            if (checkWeapon.getLongRange() <= 15 ||
                     checkWeapon instanceof MMLWeapon ||
                     checkWeapon instanceof ATMWeapon) {
                 return shortRange;
             }
-        } else if (((WeaponType) checkWeapon).getMinimumRange() <= 3) {
-            if (((WeaponType) checkWeapon).getLongRange() <= 15) {
+        } else if (checkWeapon.getMinimumRange() <= 3) {
+            if (checkWeapon.getLongRange() <= 15) {
                 return mediumRange;
             }
         }

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -128,12 +128,28 @@ public class ModelRecord extends AbstractUnitRecord {
                                 MissionRole.MISSILE_ARTILLERY : MissionRole.ARTILLERY);
                     }
                 }
-                if (eq.hasFlag(WeaponType.F_FLAMER) || eq.hasFlag(WeaponType.F_INFERNO)) {
-                    incendiary = true;
+
+                // Don't check incendiary weapons for conventional infantry, fixed wing aircraft,
+                // and space-going units. Also, don't bother checking if it's already set or has
+                // the role.
+                if (!roles.contains(MissionRole.INCENDIARY) &&
+                        !incendiary &&
+                        (unitType < UnitType.CONV_FIGHTER && unitType != UnitType.INFANTRY)) {
+                    if (eq instanceof megamek.common.weapons.flamers.FlamerWeapon ||
+                            eq instanceof megamek.common.weapons.battlearmor.BAFlamerWeapon ||
+                            eq instanceof megamek.common.weapons.ppc.ISPlasmaRifle ||
+                            eq instanceof megamek.common.weapons.ppc.CLPlasmaCannon) {
+                        incendiary = true;
+                    }
+                    // Some missile types are capable of being loaded with infernos, which are
+                    // highly capable of setting fires
+                    if (((WeaponType) eq).getAmmoType() == AmmoType.T_SRM ||
+                            ((WeaponType) eq).getAmmoType() == AmmoType.T_SRM_IMP ||
+                            ((WeaponType) eq).getAmmoType() == AmmoType.T_MML ||
+                            ((WeaponType) eq).getAmmoType() == AmmoType.T_IATM) {
+                        incendiary = true;
+                    }
                 }
-                incendiary |= ((WeaponType) eq).getAmmoType() == AmmoType.T_SRM
-                        || ((WeaponType) eq).getAmmoType() == AmmoType.T_SRM_IMP
-                        || ((WeaponType) eq).getAmmoType() == AmmoType.T_MRM;
 
                 // Don't check anti-personnel weapons for conventional infantry, fixed wing
                 // aircraft, and space-going units. Also, don't bother checking if we're

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -512,7 +512,8 @@ public class ModelRecord extends AbstractUnitRecord {
                 check_weapon instanceof megamek.common.weapons.infantry.InfantrySupportMortarHeavyWeapon ||
                 check_weapon instanceof megamek.common.weapons.infantry.InfantrySupportMortarLightWeapon;
 
-        if (((WeaponType) check_weapon).getLongRange() >= 20) {
+        if (((WeaponType) check_weapon).getLongRange() >= 20 ||
+                check_weapon instanceof megamek.common.weapons.artillery.ArtilleryWeapon) {
             return fullRange;
         } else if (((WeaponType) check_weapon).getMediumRange() >= 14) {
             if (isIndirect) {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -60,6 +60,8 @@ public class ModelRecord extends AbstractUnitRecord {
     private boolean mechanizedBA;
     private boolean magClamp;
 
+    private boolean canAntiMek = false;
+
     public ModelRecord(String chassis, String model) {
         super(chassis);
         roles = EnumSet.noneOf(MissionRole.class);
@@ -139,6 +141,14 @@ public class ModelRecord extends AbstractUnitRecord {
                 if (ap_rating < ap_threshold &&
                         (unitType < UnitType.CONV_FIGHTER && unitType != UnitType.INFANTRY)) {
                     ap_rating += getAPRating(eq);
+                }
+
+                // Check if a conventional infantry or battle armor unit can perform anti-Mech
+                // attacks
+                if (!canAntiMek &&
+                        (unitType == UnitType.INFANTRY || unitType == UnitType.BATTLE_ARMOR)) {
+                    canAntiMek = (eq instanceof megamek.common.weapons.LegAttack ||
+                            eq instanceof megamek.common.weapons.SwarmAttack);
                 }
 
                 if (((WeaponType) eq).getAmmoType() > megamek.common.AmmoType.T_NA) {
@@ -360,6 +370,10 @@ public class ModelRecord extends AbstractUnitRecord {
 
     public void setMagClamp(boolean magClamp) {
         this.magClamp = magClamp;
+    }
+
+    public boolean getAntiMek(){
+        return canAntiMek;
     }
 
     /**

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -46,6 +46,8 @@ public class ModelRecord extends AbstractUnitRecord {
     private boolean starLeague;
     private int weightClass;
     private EntityMovementMode movementMode;
+    private boolean isQuad;
+    private boolean isTripod;
     private EnumSet<MissionRole> roles;
     private ArrayList<String> deployedWith;
     private ArrayList<String> requiredUnits;
@@ -68,6 +70,9 @@ public class ModelRecord extends AbstractUnitRecord {
 
     private boolean canAntiMek = false;
 
+    private boolean isRemoteDrone;
+    private boolean isRobotDrone;
+
     public ModelRecord(String chassis, String model) {
         super(chassis);
         roles = EnumSet.noneOf(MissionRole.class);
@@ -82,7 +87,6 @@ public class ModelRecord extends AbstractUnitRecord {
     public ModelRecord(MechSummary ms) {
         this(ms.getFullChassis(), ms.getModel());
         mechSummary = ms;
-        unitType = parseUnitType(ms.getUnitType());
         introYear = ms.getYear();
 
         analyzeModel(ms);
@@ -99,6 +103,14 @@ public class ModelRecord extends AbstractUnitRecord {
 
     public EntityMovementMode getMovementMode() {
         return movementMode;
+    }
+
+    public boolean getIsQuad() {
+        return isQuad;
+    }
+
+    public boolean getIsTripod () {
+        return isTripod;
     }
 
     @Override
@@ -183,6 +195,14 @@ public class ModelRecord extends AbstractUnitRecord {
 
     public boolean hasAPWeapons() {
         return apWeapons;
+    }
+
+    public boolean getIsRemoteDrone () {
+        return isRemoteDrone;
+    }
+
+    public boolean getIsRobotDrone () {
+        return isRobotDrone;
     }
 
     public MechSummary getMechSummary() {
@@ -271,9 +291,18 @@ public class ModelRecord extends AbstractUnitRecord {
     private void analyzeModel (MechSummary ms) {
 
         // Basic unit type and movement
+        unitType = parseUnitType(ms.getUnitType());
         if (unitType == UnitType.MEK) {
-            //TODO: id quads and tripods
+
             movementMode = EntityMovementMode.BIPED;
+            if (ms.isQuadMek()) {
+                isQuad = true;
+                movementMode = EntityMovementMode.QUAD;
+            } else if (ms.isTripodMek()) {
+                isTripod = true;
+                movementMode = EntityMovementMode.TRIPOD;
+            }
+
         } else {
             movementMode = EntityMovementMode.parseFromString(ms.getUnitSubType().toLowerCase());
         }
@@ -494,7 +523,8 @@ public class ModelRecord extends AbstractUnitRecord {
                         eq.hasFlag(MiscType.F_TARGCOMP) ||
                         eq.hasFlag(MiscType.F_ARTEMIS) ||
                         eq.hasFlag(MiscType.F_ARTEMIS_V) ||
-                        eq.hasFlag(MiscType.F_APOLLO)) {
+                        eq.hasFlag(MiscType.F_APOLLO) ||
+                        eq.hasFlag((MiscType.F_MASC))) {
                     losTech = true;
                 }
                 if (eq.hasFlag(MiscType.F_C3S)) {
@@ -513,6 +543,14 @@ public class ModelRecord extends AbstractUnitRecord {
                     apRating++;
                 } else if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
                     magClamp = true;
+                    losTech = true;
+                } else if (eq.hasFlag(MiscType.F_DRONE_OPERATING_SYSTEM)) {
+                    isRemoteDrone = true;
+                    losTech = true;
+                } else if (eq.hasFlag(MiscType.F_SRCS) ||
+                        eq.hasFlag(MiscType.F_SASRCS)) {
+                    isRemoteDrone = true;
+                    isRobotDrone = true;
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_UMU)) {
                     movementMode = EntityMovementMode.BIPED_SWIM;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -51,6 +51,8 @@ public class ModelRecord extends AbstractUnitRecord {
     private ArrayList<String> excludedFactions;
     private int networkMask;
     private double flak; //proportion of weapon BV that can fire flak ammo
+
+    private double artilleryBVProportion;
     private double longRange; // Proportion of weapons BV with long range and/or indirect fire
 
     private double srBVProportion; // Proportion of weapons BV with short range
@@ -129,6 +131,10 @@ public class ModelRecord extends AbstractUnitRecord {
     }
     public void setFlak(double flak) {
         this.flak = flak;
+    }
+
+    public double getArtilleryProportion () {
+        return artilleryBVProportion;
     }
 
     public double getLongRange() {
@@ -257,13 +263,16 @@ public class ModelRecord extends AbstractUnitRecord {
 
         double totalBV = 0.0;
         double flakBV = 0.0;
+        double artilleryBV = 0.0;
         double lrBV = 0.0;
         double srBV = 0.0;
         int apRating = 0;
         int apThreshold = 6;
         double ammoBV = 0.0;
         boolean losTech = false;
+
         for (int i = 0; i < ms.getEquipmentNames().size(); i++) {
+
             //EquipmentType.get is throwing an NPE intermittently, and the only possibility I can see
             //is that there is a null equipment name.
             if (null == ms.getEquipmentNames().get(i)) {
@@ -276,6 +285,7 @@ public class ModelRecord extends AbstractUnitRecord {
             if (eq == null) {
                 continue;
             }
+
             if (!eq.isAvailableIn(3000, false)) {
                 //FIXME: needs to filter out primitive
                 losTech = true;
@@ -290,6 +300,11 @@ public class ModelRecord extends AbstractUnitRecord {
                         !(eq instanceof megamek.common.weapons.LegAttack) &&
                         !(eq instanceof megamek.common.weapons.StopSwarmAttack)) {
                     flakBV += getFlakBVModifier(eq) * eq.getBV(null) * ms.getEquipmentQuantities().get(i);
+                }
+
+                // Check for artillery weapons
+                if ((eq instanceof megamek.common.weapons.artillery.ArtilleryWeapon)) {
+                    artilleryBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
 
                 // Don't check incendiary weapons for conventional infantry, fixed wing aircraft,
@@ -410,6 +425,7 @@ public class ModelRecord extends AbstractUnitRecord {
                         ms.getUnitType().equals("Naval") ||
                         ms.getUnitType().equals("Gun Emplacement"))) {
             flak = flakBV / totalBV;
+            artilleryBVProportion = artilleryBV/totalBV;
             longRange = lrBV / totalBV;
             srBVProportion = srBV / totalBV;
             ammoRequirement = ammoBV / totalBV;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -420,8 +420,9 @@ public class ModelRecord extends AbstractUnitRecord {
                 }
 
                 // Add the spotter role to all units which carry TAG
-                if (eq.hasFlag(WeaponType.F_TAG)) {
+                if (unitType <= UnitType.AEROSPACEFIGHTER && eq.hasFlag(WeaponType.F_TAG)) {
                     roles.add(MissionRole.SPOTTER);
+                    losTech = true;
                 }
 
                 // Check for C3 master units. These are bit-masked values.

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -384,21 +384,25 @@ public class ModelRecord extends AbstractUnitRecord {
                     srBV += getShortRangeModifier(eq) * eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
 
+                // Add the spotter role to all units which carry TAG
                 if (eq.hasFlag(WeaponType.F_TAG)) {
                     roles.add(MissionRole.SPOTTER);
                 }
+
+                // Check for C3 master units. These are bit-masked values.
                 if (eq.hasFlag(WeaponType.F_C3M)) {
                     networkMask |= NETWORK_C3_MASTER;
                     if (ms.getEquipmentQuantities().get(i) > 1) {
                         networkMask |= NETWORK_COMPANY_COMMAND;
                     }
-                }
-                if (eq.hasFlag(WeaponType.F_C3MBS)) {
+                } else if (eq.hasFlag(WeaponType.F_C3MBS)) {
                     networkMask |= NETWORK_BOOSTED_MASTER;
                     if (ms.getEquipmentQuantities().get(i) > 1) {
                         networkMask |= NETWORK_COMPANY_COMMAND;
                     }
                 }
+
+            // Various non-weapon equipment
             } else if (eq instanceof MiscType) {
                 if (eq.hasFlag(MiscType.F_UMU)) {
                     movementMode = EntityMovementMode.BIPED_SWIM;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -347,6 +347,23 @@ public class ModelRecord extends AbstractUnitRecord {
             if (eq instanceof WeaponType) {
                 totalBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
 
+                // Check for C3 master units. These are bit-masked values.
+                if (eq.hasFlag(WeaponType.F_C3M)) {
+                    networkMask |= NETWORK_C3_MASTER;
+                    if (ms.getEquipmentQuantities().get(i) > 1) {
+                        networkMask |= NETWORK_COMPANY_COMMAND;
+                    }
+                    losTech = true;
+                    continue;
+                } else if (eq.hasFlag(WeaponType.F_C3MBS)) {
+                    networkMask |= NETWORK_BOOSTED_MASTER;
+                    if (ms.getEquipmentQuantities().get(i) > 1) {
+                        networkMask |= NETWORK_COMPANY_COMMAND;
+                    }
+                    losTech = true;
+                    continue;
+                }
+
                 // Check for use against airborne targets. Ignore small craft, DropShips, and other
                 // large space craft.
                 if (unitType < UnitType.SMALL_CRAFT &&
@@ -444,21 +461,6 @@ public class ModelRecord extends AbstractUnitRecord {
                 // Add the spotter role to all units which carry TAG
                 if (unitType <= UnitType.AEROSPACEFIGHTER && eq.hasFlag(WeaponType.F_TAG)) {
                     roles.add(MissionRole.SPOTTER);
-                    losTech = true;
-                }
-
-                // Check for C3 master units. These are bit-masked values.
-                if (eq.hasFlag(WeaponType.F_C3M)) {
-                    networkMask |= NETWORK_C3_MASTER;
-                    if (ms.getEquipmentQuantities().get(i) > 1) {
-                        networkMask |= NETWORK_COMPANY_COMMAND;
-                    }
-                    losTech = true;
-                } else if (eq.hasFlag(WeaponType.F_C3MBS)) {
-                    networkMask |= NETWORK_BOOSTED_MASTER;
-                    if (ms.getEquipmentQuantities().get(i) > 1) {
-                        networkMask |= NETWORK_COMPANY_COMMAND;
-                    }
                     losTech = true;
                 }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -294,8 +294,10 @@ public class ModelRecord extends AbstractUnitRecord {
             if (eq instanceof WeaponType) {
                 totalBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
 
-                // Check for use against airborne targets
-                if (!(eq instanceof megamek.common.weapons.SwarmAttack) &&
+                // Check for use against airborne targets. Ignore small craft, DropShips, and other
+                // large space craft.
+                if (unitType < UnitType.SMALL_CRAFT &&
+                        !(eq instanceof megamek.common.weapons.SwarmAttack) &&
                         !(eq instanceof megamek.common.weapons.SwarmWeaponAttack) &&
                         !(eq instanceof megamek.common.weapons.LegAttack) &&
                         !(eq instanceof megamek.common.weapons.StopSwarmAttack)) {
@@ -474,6 +476,16 @@ public class ModelRecord extends AbstractUnitRecord {
         double not_effective = 0.2;
         double ineffective = 0.0;
 
+        if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
+            if (((megamek.common.weapons.Weapon) check_weapon).getAmmoType() == AmmoType.T_AC_LBX ||
+                    ((megamek.common.weapons.Weapon) check_weapon).getAmmoType() == AmmoType.T_HAG ||
+                    ((megamek.common.weapons.Weapon) check_weapon).getAmmoType() == AmmoType.T_SBGAUSS) {
+                return very_effective;
+            } else {
+                return ineffective;
+            }
+        }
+
         if (check_weapon instanceof megamek.common.weapons.artillery.ArtilleryWeapon) {
             return somewhat_effective;
         }
@@ -559,7 +571,9 @@ public class ModelRecord extends AbstractUnitRecord {
 
         if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
             if (((WeaponType) check_weapon).getExtAV() > 0 ||
-                    ((WeaponType) check_weapon).getLongAV() > 0) {
+                    ((WeaponType) check_weapon).getLongAV() > 0 ||
+                    check_weapon instanceof megamek.common.weapons.missiles.MMLWeapon ||
+                    check_weapon instanceof megamek.common.weapons.missiles.ATMWeapon) {
                 return fullRange;
             } else {
                 return shortRange;
@@ -605,7 +619,9 @@ public class ModelRecord extends AbstractUnitRecord {
         double longRange = 0.0;
 
         if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
-            if (((WeaponType) check_weapon).getMedAV() == 0) {
+            if (((WeaponType) check_weapon).getMedAV() == 0 ||
+                    check_weapon instanceof megamek.common.weapons.missiles.MMLWeapon ||
+                    check_weapon instanceof megamek.common.weapons.missiles.ATMWeapon) {
                 return shortRange;
             } else if (((WeaponType) check_weapon).getLongAV() == 0) {
                 return mediumRange;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -292,6 +292,22 @@ public class ModelRecord extends AbstractUnitRecord {
             speed++;
         }
 
+        weightClass = ms.getWeightClass();
+        // Adjust weight class for support vehicles
+        if (weightClass >= EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+            if (ms.getTons() <= 39) {
+                weightClass = EntityWeightClass.WEIGHT_LIGHT;
+            } else if (ms.getTons() <= 59) {
+                weightClass = EntityWeightClass.WEIGHT_MEDIUM;
+            } else if (ms.getTons() <= 79) {
+                weightClass = EntityWeightClass.WEIGHT_HEAVY;
+            } else if (ms.getTons() <= 100) {
+                weightClass = EntityWeightClass.WEIGHT_ASSAULT;
+            } else {
+                weightClass = EntityWeightClass.WEIGHT_COLOSSAL;
+            }
+        }
+
         double totalBV = 0.0;
         double flakBV = 0.0;
         double artilleryBV = 0.0;
@@ -520,21 +536,6 @@ public class ModelRecord extends AbstractUnitRecord {
             ammoRequirement = ammoBV / totalBV;
 
             apWeapons = apRating >= apThreshold;
-        }
-
-        weightClass = ms.getWeightClass();
-        if (weightClass >= EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            if (ms.getTons() <= 39) {
-                weightClass = EntityWeightClass.WEIGHT_LIGHT;
-            } else if (ms.getTons() <= 59) {
-                weightClass = EntityWeightClass.WEIGHT_MEDIUM;
-            } else if (ms.getTons() <= 79) {
-                weightClass = EntityWeightClass.WEIGHT_HEAVY;
-            } else if (ms.getTons() <= 100) {
-                weightClass = EntityWeightClass.WEIGHT_ASSAULT;
-            } else {
-                weightClass = EntityWeightClass.WEIGHT_COLOSSAL;
-            }
         }
 
         // Categorize by technology type

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -429,7 +429,6 @@ public class ModelRecord extends AbstractUnitRecord {
             losTech = unitHasLostech(unitData, false);
         }
 
-
         for (int i = 0; i < unitData.getEquipmentNames().size(); i++) {
 
             //EquipmentType.get is throwing an NPE intermittently, and the only possibility I can see
@@ -550,7 +549,7 @@ public class ModelRecord extends AbstractUnitRecord {
                         ammoFactor = 0.1;
                     }
 
-                    ammoBV += ammoFactor * eq.getBV(null) * ammoFactor *
+                    ammoBV += eq.getBV(null) * ammoFactor *
                             unitData.getEquipmentQuantities().get(i);
 
                 }
@@ -606,6 +605,8 @@ public class ModelRecord extends AbstractUnitRecord {
                 } else if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
                     magClamp = true;
                     losTech = true;
+                } else if (eq.hasFlag(MiscType.F_VIBROCLAW)) {
+                    apRating += 2;
                 } else if (eq.hasFlag(MiscType.F_PROTOMECH_MELEE)) {
                     shortRangeBV += 2.5;
                     totalWeaponBV += 2.5;
@@ -617,9 +618,8 @@ public class ModelRecord extends AbstractUnitRecord {
                     remoteDrone = true;
                     robotDrone = true;
                     losTech = true;
-                } else if (eq.hasFlag(MiscType.F_UMU)) {
-                    movementMode = EntityMovementMode.BIPED_SWIM;
-                    losTech = true;
+                } else if (eq.hasFlag(MiscType.F_SPACE_ADAPTATION)) {
+                    roles.add(MissionRole.MARINE);
                 // Save a bit of time, anything introduced after this date is assumed to be
                 // advanced
                 } else if (!losTech && (eq.getIntroductionDate() >= 3067)) {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -547,7 +547,7 @@ public class ModelRecord extends AbstractUnitRecord {
 
     /**
      * Get a BV modifier for a weapon for use at long range
-     * @param check_weapon
+     * @param check_weapon   Weapon to check
      * @return   between zero (not a long ranged weapon) and 1
      */
     private double getLongRangeModifier(EquipmentType check_weapon) {
@@ -556,6 +556,15 @@ public class ModelRecord extends AbstractUnitRecord {
         double partialRange = 0.8;
         double minRange = 0.4;
         double shortRange = 0.0;
+
+        if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
+            if (((WeaponType) check_weapon).getExtAV() > 0 ||
+                    ((WeaponType) check_weapon).getLongAV() > 0) {
+                return fullRange;
+            } else {
+                return shortRange;
+            }
+        }
 
         // Quick and dirty check for most indirect fire weapons
         boolean isIndirect = (check_weapon instanceof megamek.common.weapons.lrms.LRMWeapon &&
@@ -591,7 +600,7 @@ public class ModelRecord extends AbstractUnitRecord {
 
     /**
      * Get a BV modifier for a weapon for use at short range
-     * @param check_weapon
+     * @param check_weapon   Weapon to check
      * @return   between zero (not a short ranged weapon) and 1
      */
     private  double getShortRangeModifier (EquipmentType check_weapon) {
@@ -599,6 +608,16 @@ public class ModelRecord extends AbstractUnitRecord {
         double shortRange = 1.0;
         double mediumRange = 0.6;
         double longRange = 0.0;
+
+        if (unitType == UnitType.CONV_FIGHTER || unitType == UnitType.AEROSPACEFIGHTER) {
+            if (((WeaponType) check_weapon).getMedAV() == 0) {
+                return shortRange;
+            } else if (((WeaponType) check_weapon).getLongAV() == 0) {
+                return mediumRange;
+            } else {
+                return longRange;
+            }
+        }
 
         if (((WeaponType) check_weapon).getMinimumRange() <= 0)
         {

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -465,16 +465,23 @@ public class ModelRecord extends AbstractUnitRecord {
             // Various non-weapon equipment
             } else if (eq instanceof MiscType) {
 
+                if (eq.hasFlag(MiscType.F_DOUBLE_HEAT_SINK) ||
+                        eq.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE) ||
+                        eq.hasFlag(MiscType.F_LASER_HEAT_SINK) ||
+                        eq.hasFlag(MiscType.F_COMPACT_HEAT_SINK) ||
+                        eq.hasFlag(MiscType.F_RADICAL_HEATSINK) ||
+                        eq.hasFlag(MiscType.F_ECM) ||
+                        eq.hasFlag(MiscType.F_ANGEL_ECM) ||
+                        eq.hasFlag(MiscType.F_BAP) ||
+                        eq.hasFlag(MiscType.F_BLOODHOUND) ||
+                        eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
+                    losTech = true;
+                }
                 if (eq.hasFlag(MiscType.F_C3S)) {
                     networkMask |= NETWORK_C3_SLAVE;
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_C3I)) {
                     networkMask |= NETWORK_C3I;
-                    losTech = true;
-                } else if (eq.hasFlag(MiscType.F_ECM) ||
-                        eq.hasFlag(MiscType.F_ANGEL_ECM) ||
-                        eq.hasFlag(MiscType.F_BAP) ||
-                        eq.hasFlag(MiscType.F_BLOODHOUND)) {
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_C3SBS)) {
                     networkMask |= NETWORK_BOOSTED_SLAVE;
@@ -484,10 +491,10 @@ public class ModelRecord extends AbstractUnitRecord {
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
                     magClamp = true;
-                } else if (eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_UMU)) {
                     movementMode = EntityMovementMode.BIPED_SWIM;
+                    losTech = true;
                 }
 
             }
@@ -549,6 +556,9 @@ public class ModelRecord extends AbstractUnitRecord {
         // Primitive engines are not identified, so check for use of advanced types
         int engine_type = ms.getEngineType();
         if (unitType != UnitType.GUN_EMPLACEMENT &&
+                unitType != UnitType.SMALL_CRAFT &&
+                unitType != UnitType.DROPSHIP &&
+                unitType != UnitType.JUMPSHIP &&
                 (engine_type == Engine.XL_ENGINE ||
                 engine_type == Engine.LIGHT_ENGINE ||
                 engine_type == Engine.XXL_ENGINE ||
@@ -558,8 +568,7 @@ public class ModelRecord extends AbstractUnitRecord {
 
         // Primitive gyros are not identified, so check for use of advanced types
         if (unitType == UnitType.MEK) {
-            int gyro_type = ms.getGyroType();
-            if (gyro_type >= Mech.GYRO_COMPACT) {
+            if (ms.getGyroType() >= Mech.GYRO_COMPACT) {
                 return false;
             }
         }
@@ -581,8 +590,11 @@ public class ModelRecord extends AbstractUnitRecord {
                 !armor_type.contains(EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL)) {
             return false;
         } else if ((unitType == UnitType.CONV_FIGHTER ||
-                unitType == UnitType.AEROSPACEFIGHTER) &&
+                unitType == UnitType.AEROSPACEFIGHTER ||
+                unitType == UnitType.SMALL_CRAFT ||
+                unitType == UnitType.DROPSHIP) &&
                 !armor_type.contains(EquipmentType.T_ARMOR_STANDARD) &&
+                !armor_type.contains(EquipmentType.T_ARMOR_AEROSPACE) &&
                 !armor_type.contains(EquipmentType.T_ARMOR_PRIMITIVE_FIGHTER) &&
                 !armor_type.contains(EquipmentType.T_ARMOR_PRIMITIVE_AERO)) {
             return false;
@@ -640,8 +652,8 @@ public class ModelRecord extends AbstractUnitRecord {
         int engine_type = ms.getEngineType();
         if (unitType == UnitType.MEK &&
                 (engine_type == Engine.COMBUSTION_ENGINE ||
-                engine_type == Engine.FISSION
-                || engine_type == Engine.BATTERY)) {
+                        engine_type == Engine.FISSION ||
+                        engine_type == Engine.BATTERY)) {
             return true;
         } else if ((unitType == UnitType.TANK ||
                 unitType == UnitType.CONV_FIGHTER ||
@@ -715,8 +727,7 @@ public class ModelRecord extends AbstractUnitRecord {
 
         // Gyro. Star League has no advanced gyro types.
         if (unitType == UnitType.MEK && !sl_only) {
-            int gyro_type = ms.getGyroType();
-            if (gyro_type >= Mech.GYRO_COMPACT) {
+            if (ms.getGyroType() >= Mech.GYRO_COMPACT) {
                 return true;
             }
         }

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -25,6 +25,7 @@ import megamek.common.weapons.srms.SRMWeapon;
 
 import org.apache.logging.log4j.LogManager;
 
+import megamek.codeUtilities.MathUtility;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -66,7 +67,7 @@ public class ModelRecord extends AbstractUnitRecord {
     private ArrayList<String> requiredUnits;
     private ArrayList<String> excludedFactions;
     private int networkMask;
-    private double flak; //proportion of weapon BV that can fire flak ammo
+    private double flakBVProportion; //proportion of weapon BV that can fire flak ammo
 
     private double artilleryBVProportion;
     private double longRange; // Proportion of weapons BV with long range and/or indirect fire
@@ -93,7 +94,7 @@ public class ModelRecord extends AbstractUnitRecord {
         requiredUnits = new ArrayList<>();
         excludedFactions = new ArrayList<>();
         networkMask = NETWORK_NONE;
-        flak = 0.0;
+        flakBVProportion = 0.0;
         longRange = 0.0;
     }
 
@@ -117,11 +118,11 @@ public class ModelRecord extends AbstractUnitRecord {
         return movementMode;
     }
 
-    public boolean getIsQuad() {
+    public boolean isQuadMech() {
         return isQuad;
     }
 
-    public boolean getIsTripod () {
+    public boolean isTripodMech () {
         return isTripod;
     }
 
@@ -171,10 +172,10 @@ public class ModelRecord extends AbstractUnitRecord {
         this.networkMask = network;
     }
     public double getFlak() {
-        return flak;
+        return flakBVProportion;
     }
-    public void setFlak(double flak) {
-        this.flak = flak;
+    public void setFlak(double newProportion) {
+        flakBVProportion = MathUtility.clamp(newProportion, 0, 1);
     }
 
     public double getArtilleryProportion () {
@@ -579,7 +580,7 @@ public class ModelRecord extends AbstractUnitRecord {
         // Calculate BV proportions for all ground units, VTOL, blue water naval, gun emplacements
         // and fixed wing aircraft. Exclude Small craft, DropShips, and large space craft.
         if (totalBV > 0 && unitType <= UnitType.AEROSPACEFIGHTER) {
-            flak = flakBV / totalBV;
+            flakBVProportion = flakBV / totalBV;
             artilleryBVProportion = artilleryBV/totalBV;
             longRange = lrBV / totalBV;
             srBVProportion = srBV / totalBV;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -25,7 +25,6 @@ import megamek.common.weapons.srms.SRMWeapon;
 
 import org.apache.logging.log4j.LogManager;
 
-import megamek.codeUtilities.MathUtility;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -70,12 +69,12 @@ public class ModelRecord extends AbstractUnitRecord {
     private double flakBVProportion; //proportion of weapon BV that can fire flak ammo
 
     private double artilleryBVProportion;
-    private double longRange; // Proportion of weapons BV with long range and/or indirect fire
+    private double lrBVProportion; // Proportion of weapons BV with long range and/or indirect fire
 
     private double srBVProportion; // Proportion of weapons BV with short range
     private int speed;
     private boolean canJump;
-    private double ammoRequirement; //used to determine suitability for raider role
+    private double ammoBVProportion; // Proportion of weapons BV requiring ammo
     private boolean incendiary; //used to determine suitability for incindiary role
     private boolean apWeapons; //used to determine suitability for anti-infantry role
 
@@ -95,7 +94,7 @@ public class ModelRecord extends AbstractUnitRecord {
         excludedFactions = new ArrayList<>();
         networkMask = NETWORK_NONE;
         flakBVProportion = 0.0;
-        longRange = 0.0;
+        lrBVProportion = 0.0;
     }
 
     public ModelRecord(MechSummary unitData) {
@@ -174,16 +173,13 @@ public class ModelRecord extends AbstractUnitRecord {
     public double getFlak() {
         return flakBVProportion;
     }
-    public void setFlak(double newProportion) {
-        flakBVProportion = MathUtility.clamp(newProportion, 0, 1);
-    }
 
     public double getArtilleryProportion () {
         return artilleryBVProportion;
     }
 
     public double getLongRange() {
-        return longRange;
+        return lrBVProportion;
     }
 
     public double getSRProportion() {
@@ -199,7 +195,7 @@ public class ModelRecord extends AbstractUnitRecord {
     }
 
     public double getAmmoRequirement() {
-        return ammoRequirement;
+        return ammoBVProportion;
     }
 
     public boolean hasIncendiaryWeapon() {
@@ -210,10 +206,18 @@ public class ModelRecord extends AbstractUnitRecord {
         return apWeapons;
     }
 
+    /**
+     * Unit is a remotely operated drone
+     * @return
+     */
     public boolean getIsRemoteDrone () {
         return isRemoteDrone;
     }
 
+    /**
+     * Unit is an independently operating drone
+     * @return
+     */
     public boolean getIsRobotDrone () {
         return isRobotDrone;
     }
@@ -288,7 +292,7 @@ public class ModelRecord extends AbstractUnitRecord {
     }
 
     public void setMagClamp(boolean flag) {
-        this.magClamp = flag;
+        magClamp = flag;
     }
 
     public boolean getAntiMek(){
@@ -335,6 +339,7 @@ public class ModelRecord extends AbstractUnitRecord {
         }
 
         weightClass = unitData.getWeightClass();
+
         // Adjust weight class for support vehicles
         if (weightClass >= EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
             if (unitData.getTons() <= 39) {
@@ -582,9 +587,9 @@ public class ModelRecord extends AbstractUnitRecord {
         if (totalBV > 0 && unitType <= UnitType.AEROSPACEFIGHTER) {
             flakBVProportion = flakBV / totalBV;
             artilleryBVProportion = artilleryBV/totalBV;
-            longRange = lrBV / totalBV;
+            lrBVProportion = lrBV / totalBV;
             srBVProportion = srBV / totalBV;
-            ammoRequirement = ammoBV / totalBV;
+            ammoBVProportion = ammoBV / totalBV;
 
             apWeapons = apRating >= apThreshold;
         }

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -125,15 +125,6 @@ public class ModelRecord extends AbstractUnitRecord {
                     flakBV += getFlakBVModifier(eq) * eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
 
-                // If the unit has an artillery weapon but does not have an artillery role
-                // assume it is tactical support, and give it the MIXED_ARTILLERY role
-                if (eq.hasFlag(WeaponType.F_ARTILLERY) &&
-                        !roles.contains(MissionRole.ARTILLERY) &&
-                        !roles.contains(MissionRole.MISSILE_ARTILLERY) &&
-                        !roles.contains(MissionRole.MIXED_ARTILLERY)) {
-                    roles.add(MissionRole.MIXED_ARTILLERY);
-                }
-
                 // Don't check incendiary weapons for conventional infantry, fixed wing aircraft,
                 // and space-going units. Also, don't bother checking if it's already set or has
                 // the role.
@@ -436,6 +427,7 @@ public class ModelRecord extends AbstractUnitRecord {
     public boolean getAntiMek(){
         return canAntiMek;
     }
+
 
     /**
      * Get a BV modifier for a weapon for use against airborne targets

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -302,8 +302,10 @@ public class ModelRecord extends AbstractUnitRecord {
                     flakBV += getFlakBVModifier(eq) * eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
 
-                // Check for artillery weapons
-                if ((eq instanceof megamek.common.weapons.artillery.ArtilleryWeapon)) {
+                // Check for artillery weapons. Ignore aerospace fighters, small craft, and large
+                // space craft.
+                if (unitType <= UnitType.CONV_FIGHTER &&
+                        eq instanceof megamek.common.weapons.artillery.ArtilleryWeapon) {
                     artilleryBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -427,6 +427,7 @@ public class ModelRecord extends AbstractUnitRecord {
         int very_effective = 4;
         int somewhat_effective = 2;
         int not_effective = 1;
+        int ineffective = 0;
 
         // Common weapons
         if (check_weapon instanceof megamek.common.weapons.mgs.MGWeapon) {
@@ -438,8 +439,10 @@ public class ModelRecord extends AbstractUnitRecord {
             return extremely_effective;
         }
 
-        // Weapons found in later eras
-        if (check_weapon instanceof megamek.common.weapons.battlearmor.BAMGWeapon) {
+        // Weapons only found in later eras
+        if (check_weapon instanceof megamek.common.weapons.infantry.InfantryWeapon) {
+            return not_effective;
+        } else if (check_weapon instanceof megamek.common.weapons.battlearmor.BAMGWeapon) {
             return extremely_effective;
         } else if (check_weapon instanceof megamek.common.weapons.battlearmor.BAFlamerWeapon) {
             return extremely_effective;
@@ -462,7 +465,7 @@ public class ModelRecord extends AbstractUnitRecord {
             return not_effective;
         }
 
-        return 0;
+        return ineffective;
     }
 }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -23,7 +23,7 @@ import java.util.Set;
 /**
  * Specific unit variants; analyzes equipment to determine suitability for certain types
  * of missions in addition to what is formally declared in the data files.
- * 
+ *
  * @author Neoancient
  */
 public class ModelRecord extends AbstractUnitRecord {
@@ -114,10 +114,14 @@ public class ModelRecord extends AbstractUnitRecord {
                     case AmmoType.T_SBGAUSS:
                         flakBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i);
                 }
+                // Only add an artillery role if this model does not already have MIXED_ARTILLERY
                 if (eq.hasFlag(WeaponType.F_ARTILLERY)) {
                     flakBV += eq.getBV(null) * ms.getEquipmentQuantities().get(i) / 2.0;
-                    roles.add(((WeaponType) eq).getAmmoType() == AmmoType.T_ARROW_IV?
-                            MissionRole.MISSILE_ARTILLERY : MissionRole.ARTILLERY);
+
+                    if (!roles.contains(MissionRole.MIXED_ARTILLERY)) {
+                        roles.add(((WeaponType) eq).getAmmoType() == AmmoType.T_ARROW_IV ?
+                                MissionRole.MISSILE_ARTILLERY : MissionRole.ARTILLERY);
+                    }
                 }
                 if (eq.hasFlag(WeaponType.F_FLAMER) || eq.hasFlag(WeaponType.F_INFERNO)) {
                     incendiary = true;

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -58,6 +58,7 @@ public class ModelRecord extends AbstractUnitRecord {
 
     private double srBVProportion; // Proportion of weapons BV with short range
     private int speed;
+    private boolean canJump;
     private double ammoRequirement; //used to determine suitability for raider role
     private boolean incendiary; //used to determine suitability for incindiary role
     private boolean apWeapons; //used to determine suitability for anti-infantry role
@@ -168,6 +169,10 @@ public class ModelRecord extends AbstractUnitRecord {
         return speed;
     }
 
+    public boolean getJump() {
+        return canJump;
+    }
+
     public double getAmmoRequirement() {
         return ammoRequirement;
     }
@@ -265,6 +270,7 @@ public class ModelRecord extends AbstractUnitRecord {
      */
     private void analyzeModel (MechSummary ms) {
 
+        // Basic unit type and movement
         if (unitType == UnitType.MEK) {
             //TODO: id quads and tripods
             movementMode = EntityMovementMode.BIPED;
@@ -278,6 +284,12 @@ public class ModelRecord extends AbstractUnitRecord {
                 unitType == UnitType.CONV_FIGHTER ||
                 unitType == UnitType.AEROSPACEFIGHTER) {
             omni = ms.getOmni();
+        }
+
+        speed = ms.getWalkMp();
+        if (ms.getJumpMp() > 0) {
+            canJump = true;
+            speed++;
         }
 
         double totalBV = 0.0;
@@ -513,10 +525,6 @@ public class ModelRecord extends AbstractUnitRecord {
         primitive = base_primitive && !losTech && !clan;
         retrotech = base_primitive && (losTech || clan);
 
-        speed = ms.getWalkMp();
-        if (ms.getJumpMp() > 0) {
-            speed++;
-        }
 
     }
 

--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -469,12 +469,14 @@ public class ModelRecord extends AbstractUnitRecord {
                         eq.hasFlag(MiscType.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE) ||
                         eq.hasFlag(MiscType.F_LASER_HEAT_SINK) ||
                         eq.hasFlag(MiscType.F_COMPACT_HEAT_SINK) ||
-                        eq.hasFlag(MiscType.F_RADICAL_HEATSINK) ||
                         eq.hasFlag(MiscType.F_ECM) ||
                         eq.hasFlag(MiscType.F_ANGEL_ECM) ||
                         eq.hasFlag(MiscType.F_BAP) ||
                         eq.hasFlag(MiscType.F_BLOODHOUND) ||
-                        eq.hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
+                        eq.hasFlag(MiscType.F_TARGCOMP) ||
+                        eq.hasFlag(MiscType.F_ARTEMIS) ||
+                        eq.hasFlag(MiscType.F_ARTEMIS_V) ||
+                        eq.hasFlag(MiscType.F_APOLLO)) {
                     losTech = true;
                 }
                 if (eq.hasFlag(MiscType.F_C3S)) {
@@ -489,11 +491,17 @@ public class ModelRecord extends AbstractUnitRecord {
                 } else if (eq.hasFlag(MiscType.F_NOVA)) {
                     networkMask |= NETWORK_NOVA;
                     losTech = true;
+                } else if (eq.hasFlag(MiscType.F_AP_POD)) {
+                    apRating++;
                 } else if (eq.hasFlag(MiscType.F_MAGNETIC_CLAMP)) {
                     magClamp = true;
                     losTech = true;
                 } else if (eq.hasFlag(MiscType.F_UMU)) {
                     movementMode = EntityMovementMode.BIPED_SWIM;
+                    losTech = true;
+                // Save a bit of time, anything introduced after this date is assumed to be
+                // advanced
+                } else if (!losTech && (eq.getIntroductionDate() >= 3067)) {
                     losTech = true;
                 }
 


### PR DESCRIPTION
ModelRecord provides a convenient summary of unit capabilities for a number of uses, similar to explicitly declared roles in the RATGen/force generator but more general and automatically generated.  For example, when calling for random generation of units with the ANTI_AIRCRAFT role there may simply not be enough of the given unit type/weight class/etc.  So the ModelRecord entries provide a property to indicate how well other units do even without the role.

This update adds more detail to the existing analysis process, and adds a few additional points which may be useful e.g. remote drone and robot drone flags to assist with potentially generating all-drone forces at some point, and some basic primitive/retrotech checking.  Fills out a couple of legacy FIXME/TODOs.  Analysis has been pulled out of the constructor to it's own method, so quickly checking code flow from outside can just step over it.  Because this involves looping through all equipment on large numbers of units, extra work is done on loop optimization to avoid unnecessary checks and improve performance.