### PR TITLE
(Possible) fix to dedicated server loading issues

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -149,6 +149,7 @@ public class GameManager extends AbstractGameManager {
     private final ConcurrentLinkedQueue<Server.ReceivedPacket> cfrPacketQueue = new ConcurrentLinkedQueue<>();
 
     public GameManager() {
+        EquipmentType.initializeTypes();
         game.getOptions().initialize();
         game.getOptions().loadOptions();
 


### PR DESCRIPTION
I'm hoping the issue comes from the equipmenttypes not being initialized (at least, not in time)

Relates to #5539 