### PR TITLE
Fix aerospace attack values for LBX autocannons

### DIFF
--- a/megamek/src/megamek/common/weapons/autocannons/CLLB10XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB10XAC.java
@@ -39,8 +39,8 @@ public class CLLB10XAC extends LBXACWeapon {
         this.criticals = 5;
         this.bv = 148;
         this.cost = 400000;
-        this.shortAV = 10;
-        this.medAV = 10;
+        this.shortAV = 6;
+        this.medAV = 6;
         this.maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB20XAC.java
@@ -39,8 +39,8 @@ public class CLLB20XAC extends LBXACWeapon {
         criticals = 9;
         bv = 237;
         cost = 600000;
-        shortAV = 20;
-        medAV = 20;
+        shortAV = 12;
+        medAV = 12;
         maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         flags = flags.andNot(F_PROTO_WEAPON);

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
@@ -40,9 +40,9 @@ public class CLLB5XAC extends LBXACWeapon {
         criticals = 4;
         bv = 93;
         cost = 250000;
-        shortAV = 5;
-        medAV = 5;
-        longAV = 5;
+        shortAV = 3;
+        medAV = 3;
+        longAV = 3;
         maxRange = RANGE_LONG;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB10XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB10XAC.java
@@ -38,8 +38,8 @@ public class ISLB10XAC extends LBXACWeapon {
         this.criticals = 6;
         this.bv = 148;
         this.cost = 400000;
-        this.shortAV = 10;
-        this.medAV = 10;
+        this.shortAV = 6;
+        this.medAV = 6;
         this.maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB20XAC.java
@@ -38,8 +38,8 @@ public class ISLB20XAC extends LBXACWeapon {
         criticals = 11;
         bv = 237;
         cost = 600000;
-        shortAV = 20;
-        medAV = 20;
+        shortAV = 12;
+        medAV = 12;
         maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
@@ -40,9 +40,9 @@ public class ISLB5XAC extends LBXACWeapon {
         criticals = 5;
         bv = 83;
         cost = 250000;
-        shortAV = 5;
-        medAV = 5;
-        longAV = 5;
+        shortAV = 3;
+        medAV = 3;
+        longAV = 3;
         maxRange = RANGE_LONG;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)


### PR DESCRIPTION
The AV for LBX autocannons (other than the LB2X) are incorrect. See TW, pp. 303-4.