### PR TITLE
Exclude units by role on random generation, force generator table calculation updates

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/AbstractUnitRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/AbstractUnitRecord.java
@@ -42,9 +42,7 @@ public class AbstractUnitRecord {
     /**
      * Returns availability value modified for rating differential on +/- rating, and adjusted for
      * the first few years before introduction (field experiments, etc.) and immediately after
-     * introduction (production lines working out problems).
-     *
-     * rating differential
+     * introduction (low rate initial production).
      *
      * @param initialAv        AvailabilityRating for the chassis or model.
      * @param formationRating  force equipment rating.

--- a/megamek/src/megamek/client/ratgenerator/AbstractUnitRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/AbstractUnitRecord.java
@@ -40,25 +40,33 @@ public class AbstractUnitRecord {
     }
 
     /**
-     * Adjusts availability rating for the first couple years after introduction.
+     * Returns availability value modified for rating differential on +/- rating, and adjusted for
+     * the first few years before introduction (field experiments, etc.) and immediately after
+     * introduction (production lines working out problems).
      *
-     * @param ar The AvailabilityRecord for the chassis or model.
-     * @param rating The force equipment rating.
-     * @param ratingLevels The number of equipment rating levels used by the faction.
-     * @param year The game year
-     * @return The adjusted availability rating.
+     * rating differential
+     *
+     * @param initialAv        AvailabilityRating for the chassis or model.
+     * @param formationRating  force equipment rating.
+     * @param ratingLevels     number of equipment rating levels used by the faction.
+     * @param year             game year
+     * @return                 adjusted availability rating.
      */
-    public int calcAvailability(AvailabilityRating ar, int rating, int ratingLevels, int year) {
-        int retVal = ar.adjustForRating(rating, ratingLevels);
+    public int calcAvailability(AvailabilityRating initialAv, int formationRating, int ratingLevels, int year) {
+        int avRating = initialAv.adjustForRating(formationRating, ratingLevels);
 
-        if (introYear == year) {
-            retVal -= 2;
+        if (year < introYear - 2) {
+            return 0;
+        } else if (year <= introYear) {
+            avRating -= 2;
+        } else if (year <= introYear + 1) {
+            avRating -= 1;
         }
-        if (introYear == year + 1) {
-            retVal -= 1;
-        }
-        return Math.max(retVal, 0);
+
+        return Math.max(avRating, 0);
     }
+
+
 
     public String getChassis() {
         return chassis;

--- a/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
+++ b/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
@@ -107,13 +107,26 @@ public class AvailabilityRating {
         return availability;
     }
 
-    public int adjustForRating(int rating, int numLevels) {
-        if (rating < 0 || ratingAdjustment == 0) {
+    /**
+     * Return the availability taking into account +/- modifiers and a supplied rating. For example,
+     * an availability of 5+ will return 5 for an A-rating, 4 for a B rating, and so on; an
+     * availability of 5- will return 5 for an F-rating, 4 for a D-rating, and so on.
+     * @param rating     numerical equivalent of rating value, from 0 to numLevels - 1
+     * @param numLevels  how many ratings are in this system
+     * @return           availability rating, modified for the provided rating; may return values
+     *                   less than zero
+     */
+    public int adjustForRating (int rating, int numLevels) {
+        if (rating < 0 ||
+                ratingAdjustment == 0 ||
+                rating > numLevels - 1) {
             return availability;
         } else if (ratingAdjustment < 0) {
+            // '-' modifier provides a 0 modifier at the lowest rating
             return availability - rating;
         } else {
-            return availability - (numLevels - rating);
+            // '+' modifier provides a 0 modifier at the highest rating
+            return availability - ((numLevels - 1) - rating);
         }
     }
 

--- a/megamek/src/megamek/client/ratgenerator/ChassisRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ChassisRecord.java
@@ -110,6 +110,7 @@ public class ChassisRecord extends AbstractUnitRecord {
     public int totalFilteredModelWeight (int era,
                                          FactionRecord factionEraData,
                                          int rating,
+                                         int ratingCounts,
                                          int year,
                                          Collection<Integer> weightFilter,
                                          int networkFilter,
@@ -155,7 +156,7 @@ public class ChassisRecord extends AbstractUnitRecord {
             if (modelAvRating != null) {
 
                 Double adjustedAvRating = (double) curModel.calcAvailability(modelAvRating,
-                        rating, 5, year);
+                        rating, ratingCounts, year);
 
                 adjustedAvRating = MissionRole.adjustAvailabilityByRole(adjustedAvRating, roles, curModel, year, roleStrictness);
                 if (adjustedAvRating != null && adjustedAvRating > 0) {

--- a/megamek/src/megamek/client/ratgenerator/ChassisRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ChassisRecord.java
@@ -13,46 +13,45 @@
  */
 package megamek.client.ratgenerator;
 
+import megamek.common.EntityMovementMode;
+import megamek.common.EntityWeightClass;
 import org.apache.logging.log4j.LogManager;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 /**
  * The ChassisRecord tracks all available variants and determines how much total weight
  * is to be distributed among the various models.
- * 
+ *
  * @author Neoancient
  */
 public class ChassisRecord extends AbstractUnitRecord {
 
     protected HashSet<ModelRecord> models;
-    
+
     public ChassisRecord(String chassis) {
         super(chassis);
         models = new HashSet<>();
     }
-    
+
     public void addModel(ModelRecord model) {
         models.add(model);
         if (introYear == 0 || model.getIntroYear() < getIntroYear()) {
             introYear = model.getIntroYear();
         }
     }
-    
+
     public HashSet<ModelRecord> getModels() {
         return models;
     }
-    
-    public List<ModelRecord> getSortedModels() { 
+
+    public List<ModelRecord> getSortedModels() {
         List<ModelRecord> sortedModels = new ArrayList<>(models);
         sortedModels.sort(Comparator.comparing(ModelRecord::getModel));
         return sortedModels;
-        
+
     }
-    
+
     public int totalModelWeight(int era, String fKey) {
         FactionRecord fRec = RATGenerator.getInstance().getFaction(fKey);
         if (fRec == null) {
@@ -61,11 +60,21 @@ public class ChassisRecord extends AbstractUnitRecord {
         }
         return totalModelWeight(era, fRec);
     }
-    
+
+    /**
+     * Calculate the total 'bucket weight' of all models for this chassis, first converting
+     * availability numbers to actual weight values (typically 2 ^ (AV / 2.0) ).
+     * Models which are introduced close to the era year may be included, even when the model's
+     * introduction date is later.
+     * @param era    Year designator for the era to check e.g. 2765, 3058, 3067
+     * @param fRec   RAT building data for the desired faction
+     * @return       sum of all converted weights
+     */
+
     public int totalModelWeight(int era, FactionRecord fRec) {
         int retVal = 0;
         RATGenerator rg = RATGenerator.getInstance();
-        
+
         for (ModelRecord mr : models) {
             AvailabilityRating ar = rg.findModelAvailabilityRecord(era,
                     mr.getKey(), fRec);
@@ -73,7 +82,89 @@ public class ChassisRecord extends AbstractUnitRecord {
                 retVal += AvailabilityRating.calcWeight(ar.getAvailability());
             }
         }
-        
+
         return retVal;
     }
+
+
+    /**
+     *  Calculate the total 'bucket weight' of models for this chassis, first converting
+     *  availability numbers to actual weight values (typically 2 ^ (AV / 2.0) ).
+     *  This overload allows a total weight to reflect various filter requirements, with models
+     *  that don't meet filter requirements excluded from the total.
+     *
+     * @param era              Year designator for the era to check e.g. 2765, 3058, 3067
+     * @param factionEraData   RAT building data for the desired faction
+     * @param rating           Formation rating
+     * @param year             Specific year to check
+     * @param weightFilter     {@link EntityWeightClass} constants with valid weight classes, or
+     *                         empty set to accept all
+     * @param networkFilter    Mask for checking various C3 systems
+     * @param movementFilter   Model must use at least one of these movement types
+     * @param roleStrictness
+     * @param rolesExcludeFilter  Model may not have any of these roles
+     * @param roles            Roles to select for
+     * @return                 int with total value of weight of all units which meet the filter
+     *                         requirements
+     */
+    public int totalFilteredModelWeight (int era,
+                                         FactionRecord factionEraData,
+                                         int rating,
+                                         int year,
+                                         Collection<Integer> weightFilter,
+                                         int networkFilter,
+                                         Collection<EntityMovementMode> movementFilter,
+                                         int roleStrictness,
+                                         Collection<MissionRole> roles,
+                                         Collection<MissionRole> rolesExcludeFilter) {
+        double totalWeight = 0;
+        RATGenerator generator = RATGenerator.getInstance();
+
+        for (ModelRecord curModel : models) {
+
+            // Models introduced more than 2 years from the current date are ignored. Those within
+            // two years are considered field testing/prototypes.
+            if (year < curModel.getIntroYear() - 2) {
+                continue;
+            }
+
+            // Weight class
+            if (!weightFilter.isEmpty() && !weightFilter.contains(curModel.getWeightClass())) {
+                continue;
+            }
+
+            // Movement types
+            if (!movementFilter.isEmpty() && !movementFilter.contains(curModel.getMovementMode())) {
+                continue;
+            }
+
+            // Invalid roles
+            if (!rolesExcludeFilter.isEmpty() && curModel.getRoles().stream().anyMatch(rolesExcludeFilter::contains)) {
+                continue;
+            }
+
+            // C3 systems
+            if ((networkFilter & curModel.getNetworkMask()) != networkFilter) {
+                continue;
+            }
+
+            // If the model is considered available, convert the value to a weight and add it
+            // to the total
+            AvailabilityRating modelAvRating = generator.findModelAvailabilityRecord(era, curModel.getKey(), factionEraData);
+            if (modelAvRating != null) {
+
+
+                Double adjustedAvRating = (double) curModel.calcAvailability(modelAvRating, rating, 5, year); // (double) modelAvRating.adjustForRating(rating, 5);
+
+                adjustedAvRating = MissionRole.adjustAvailabilityByRole(adjustedAvRating, roles, curModel, year, roleStrictness);
+                if (adjustedAvRating != null && adjustedAvRating > 0) {
+                    totalWeight += AvailabilityRating.calcWeight(adjustedAvRating);
+                }
+            }
+
+        }
+
+        return (int) Math.floor(totalWeight);
+    }
+
 }

--- a/megamek/src/megamek/client/ratgenerator/ChassisRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ChassisRecord.java
@@ -150,11 +150,12 @@ public class ChassisRecord extends AbstractUnitRecord {
 
             // If the model is considered available, convert the value to a weight and add it
             // to the total
-            AvailabilityRating modelAvRating = generator.findModelAvailabilityRecord(era, curModel.getKey(), factionEraData);
+            AvailabilityRating modelAvRating = generator.findModelAvailabilityRecord(era,
+                    curModel.getKey(), factionEraData);
             if (modelAvRating != null) {
 
-
-                Double adjustedAvRating = (double) curModel.calcAvailability(modelAvRating, rating, 5, year); // (double) modelAvRating.adjustForRating(rating, 5);
+                Double adjustedAvRating = (double) curModel.calcAvailability(modelAvRating,
+                        rating, 5, year);
 
                 adjustedAvRating = MissionRole.adjustAvailabilityByRole(adjustedAvRating, roles, curModel, year, roleStrictness);
                 if (adjustedAvRating != null && adjustedAvRating > 0) {

--- a/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
@@ -324,7 +324,7 @@ public class ForceDescriptor {
         for (ForceDescriptor sub : subs) {
             paramCount.merge(new UnitTable.Parameters(sub.getFactionRec(),
                     sub.getUnitType(), sub.getYear(), sub.ratGeneratorRating(), null, networkMask,
-                    sub.getMovementModes(), sub.getRoles(), 0, sub.getFactionRec()), 1, Integer::sum);
+                    sub.getMovementModes(), sub.getRoles(), null, 0, sub.getFactionRec()), 1, Integer::sum);
         }
 
         List<UnitTable.Parameters> params = new ArrayList<>();

--- a/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
@@ -324,7 +324,7 @@ public class ForceDescriptor {
         for (ForceDescriptor sub : subs) {
             paramCount.merge(new UnitTable.Parameters(sub.getFactionRec(),
                     sub.getUnitType(), sub.getYear(), sub.ratGeneratorRating(), null, networkMask,
-                    sub.getMovementModes(), sub.getRoles(), null, 0, sub.getFactionRec()), 1, Integer::sum);
+                    sub.getMovementModes(), sub.getRoles(), new ArrayList<>(), 0, sub.getFactionRec()), 1, Integer::sum);
         }
 
         List<UnitTable.Parameters> params = new ArrayList<>();

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -523,7 +523,6 @@ public class RATGenerator {
             if (ar == null) {
                 continue;
             }
-            // FIXME: experimental/intro/early modifier calculation is suspect
             double cAv = cRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);
             cAv = interpolate(cAv,
                     cRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
@@ -532,8 +531,18 @@ public class RATGenerator {
                 // FIXME: this is counting models that are not yet available, which skews availability
                 //  (denominator line 559)
                 //  The method for generating weight needs an overload for filtering
-                double totalModelWeight = cRec.totalModelWeight(early,
-                        cRec.isOmni() ? user : fRec);
+//                double totalModelWeight = cRec.totalModelWeight(early,
+//                        cRec.isOmni() ? user : fRec);
+                double totalModelWeight = cRec.totalFilteredModelWeight(early,
+                        cRec.isOmni() ? user : fRec,
+                        ratingLevel,
+                        year,
+                        weightClasses,
+                        networkMask,
+                        movementModes,
+                        roleStrictness,
+                        roles,
+                        rolesExcluded);
                 for (ModelRecord mRec : cRec.getModels()) {
 
                     // FIXME: introduction year should be acceptable (<=), but it looks like there
@@ -555,9 +564,7 @@ public class RATGenerator {
                     if (rolesExcluded != null && mRec.getRoles().stream().anyMatch(rolesExcluded::contains)) {
                         continue;
                     }
-                    // FIXME: experimental/intro/early modifier calculation is suspect
                     double mAv = mRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);
-                    // FIXME: experimental/intro/early modifier calculation is suspect
                     mAv = interpolate(mAv,
                             mRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
                             Math.max(early, mRec.getIntroYear()), late, year);

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -414,11 +414,50 @@ public class RATGenerator {
                 + (av2.doubleValue() - av1.doubleValue()) * (now - year1) / (year2 - year1);
     }
 
-    public List<UnitTable.TableEntry> generateTable(FactionRecord fRec, int unitType, int year,
-            String rating, Collection<Integer> weightClasses, int networkMask,
-            Collection<EntityMovementMode> movementModes,
-            Collection<MissionRole> roles, int roleStrictness,
-            FactionRecord user) {
+
+    /**
+     * Convenience overload method provided for generating a table with no excluded roles
+     */
+    public List<UnitTable.TableEntry> generateTable (FactionRecord fRec,
+                                                     int unitType,
+                                                     int year,
+                                                     String rating,
+                                                     Collection<Integer> weightClasses,
+                                                     int networkMask,
+                                                     Collection<EntityMovementMode> movementModes,
+                                                     Collection<MissionRole> roles,
+                                                     int roleStrictness,
+                                                     FactionRecord user) {
+        return generateTable(fRec, unitType, year, rating, weightClasses, networkMask,
+                movementModes, roles, null, roleStrictness, user);
+    }
+
+    /**
+     *
+     * @param fRec
+     * @param unitType
+     * @param year
+     * @param rating
+     * @param weightClasses
+     * @param networkMask
+     * @param movementModes
+     * @param roles
+     * @param rolesExcluded
+     * @param roleStrictness
+     * @param user
+     * @return
+     */
+    public List<UnitTable.TableEntry> generateTable (FactionRecord fRec,
+                                                     int unitType,
+                                                     int year,
+                                                     String rating,
+                                                     Collection<Integer> weightClasses,
+                                                     int networkMask,
+                                                     Collection<EntityMovementMode> movementModes,
+                                                     Collection<MissionRole> roles,
+                                                     Collection<MissionRole> rolesExcluded,
+                                                     int roleStrictness,
+                                                     FactionRecord user) {
         HashMap<ModelRecord, Double> unitWeights = new HashMap<>();
         HashMap<FactionRecord, Double> salvageWeights = new HashMap<>();
 

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -429,7 +429,7 @@ public class RATGenerator {
                                                      int roleStrictness,
                                                      FactionRecord user) {
         return generateTable(fRec, unitType, year, rating, weightClasses, networkMask,
-                movementModes, roles, null, roleStrictness, user);
+                movementModes, roles, new ArrayList<>(), roleStrictness, user);
     }
 
     /**
@@ -543,6 +543,9 @@ public class RATGenerator {
                     }
                     ar = findModelAvailabilityRecord(early, mRec.getKey(), fRec);
                     if ((ar == null) || (ar.getAvailability() == 0)) {
+                        continue;
+                    }
+                    if (rolesExcluded != null && mRec.getRoles().stream().anyMatch(rolesExcluded::contains)) {
                         continue;
                     }
                     double mAv = mRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -523,14 +523,21 @@ public class RATGenerator {
             if (ar == null) {
                 continue;
             }
+            // FIXME: experimental/intro/early modifier calculation is suspect
             double cAv = cRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);
             cAv = interpolate(cAv,
                     cRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
                     Math.max(early, cRec.getIntroYear()), late, year);
             if (cAv > 0) {
+                // FIXME: this is counting models that are not yet available, which skews availability
+                //  (denominator line 559)
+                //  The method for generating weight needs an overload for filtering
                 double totalModelWeight = cRec.totalModelWeight(early,
                         cRec.isOmni() ? user : fRec);
                 for (ModelRecord mRec : cRec.getModels()) {
+
+                    // FIXME: introduction year should be acceptable (<=), but it looks like there
+                    //  should be a two-year grace period for pre-production/experimental?
                     if (mRec.getIntroYear() > year
                             || (!weightClasses.isEmpty()
                                     && !weightClasses.contains(mRec.getWeightClass()))
@@ -548,7 +555,9 @@ public class RATGenerator {
                     if (rolesExcluded != null && mRec.getRoles().stream().anyMatch(rolesExcluded::contains)) {
                         continue;
                     }
+                    // FIXME: experimental/intro/early modifier calculation is suspect
                     double mAv = mRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);
+                    // FIXME: experimental/intro/early modifier calculation is suspect
                     mAv = interpolate(mAv,
                             mRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
                             Math.max(early, mRec.getIntroYear()), late, year);

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -387,31 +387,46 @@ public class RATGenerator {
     }
 
     /**
-     * Given values for two years, interpolates or extrapolates value for another given year.
-     * If one of the two values is null, it is treated as 0.
+     * Interpolates a value for a year, given values for earlier and later years. If one of the two
+     * values is null, it is treated as 0. If both values are null, null is also returned.
+     * This is primarily intended to work between the early and late years, but can be used with
+     * a target year earlier or later.
      *
-     * @param av1 The first value.
-     * @param av2 The second value.
-     * @param year1 The year for the first value.
-     * @param year2 The year for the second value.
-     * @param now The year for which to calculate a value.
-     * @return The value for the year in question. Returns null if av1 and av2 are both null.
+     * @param inputEarly  Value for earlier year
+     * @param inputLate   Value for later year
+     * @param yearEarly   Earlier year
+     * @param yearLate    Later year
+     * @param testYear    Intermediate year to interpolate value for
+     * @return       double between the two values, proportionally scaled for the relationship
+     *               between the early, test, and late years. Returns null if both early and late
+     *               years are null.
+     * @throws       IllegalArgumentException if yearLate is earlier than yearEarly
      */
-    private Double interpolate(Number av1, Number av2, int year1, int year2, int now) {
-        if (av1 == null && av2 == null) {
+    private Double interpolate (Number inputEarly, Number inputLate, int yearEarly, int yearLate, int testYear) {
+
+        // Calculations are only valid if the boundary years are in the correct order
+        if (yearEarly > yearLate) {
+            throw new IllegalArgumentException(String.format("Interpolation requires correctly ordered early (%d) and late (%d) years.", yearEarly, yearLate));
+        }
+
+        if ((inputEarly == null && inputLate == null)) {
             return null;
         }
-        if (av1 == null) {
-            av1 = 0.0;
+
+        // No point interpolating if the years or values are the same value
+        if (yearEarly == yearLate) {
+            return inputEarly == null ? 0.0 : inputEarly.doubleValue();
         }
-        if (av2 == null) {
-            av2 = 0.0;
+
+        double valueEarly = inputEarly == null ? 0.0 : inputEarly.doubleValue();
+        double valueLate = inputLate == null ? 0.0 : inputLate.doubleValue();
+
+        if (valueEarly == valueLate) {
+            return valueEarly;
         }
-        if (year1 == year2) {
-            return av1.doubleValue();
-        }
-        return av1.doubleValue()
-                + (av2.doubleValue() - av1.doubleValue()) * (now - year1) / (year2 - year1);
+
+        return valueEarly +
+                (valueLate - valueEarly) * (testYear - yearEarly) / (yearLate - yearEarly);
     }
 
 
@@ -530,12 +545,22 @@ public class RATGenerator {
             if (ar == null) {
                 continue;
             }
-            double cAv = cRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);
-            cAv = interpolate(cAv,
-                    cRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
-                    Math.max(early, cRec.getIntroYear()),
-                    late,
-                    year);
+            double cAv = cRec.calcAvailability(ar, ratingLevel, numRatingLevels, year);
+
+            // If the current year is somewhere between era data sets, the availability may need
+            // interpolation
+            if (early.intValue() != late.intValue()) {
+                Double interpolated = interpolate(
+                        early < cRec.introYear - 2 ? 0 : cRec.calcAvailability(ar, ratingLevel, numRatingLevels, early),
+                        cRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
+                        early,
+                        late,
+                        year);
+                if (interpolated != null) {
+                    cAv = interpolated;
+                }
+            }
+
             if (cAv > 0) {
 
                 // Calculate the total random selection weight of all models, filtering out those
@@ -544,6 +569,7 @@ public class RATGenerator {
                 double totalModelWeight = cRec.totalFilteredModelWeight(early,
                         cRec.isOmni() ? user : fRec,
                         ratingLevel,
+                        numRatingLevels,
                         year,
                         weightClasses,
                         networkMask,
@@ -581,22 +607,29 @@ public class RATGenerator {
                         continue;
                     }
 
-                    // Get the availability rating of the model
+                    // Get the availability rating data for this model
                     ar = findModelAvailabilityRecord(early, mRec.getKey(), fRec);
                     if ((ar == null) || (ar.getAvailability() == 0)) {
                         continue;
                     }
 
-                    // Get the availability of the model relative to others of the same chassis,
-                    // including modifiers for rating (+/- indicator) and pre-early production
-                    double mAv = mRec.calcAvailability(ar, ratingLevel, numRatingLevels, early);
+                    // Get the availability value of the model, including modifiers for rating
+                    // (+/- indicator) and pre/early production
+                    double mAv = mRec.calcAvailability(ar, ratingLevel, numRatingLevels, year);
 
-                    // If needed, interpolate
-                    mAv = interpolate(mAv,
-                            mRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
-                            Math.max(early, mRec.getIntroYear()),
-                            late,
-                            year);
+                    // If the current year is between era data sets, the availability may need
+                    // interpolation
+                    if (early.intValue() != late.intValue()) {
+                        Double interpolated = interpolate(
+                                early < mRec.getIntroYear() - 2 ? 0 : mRec.calcAvailability(ar, ratingLevel, numRatingLevels, early),
+                                mRec.calcAvailability(ar, ratingLevel, numRatingLevels, late),
+                                early,
+                                late,
+                                year);
+                        if (interpolated != null) {
+                            mAv = interpolated;
+                        }
+                    }
 
                     Double adjMAv = MissionRole.adjustAvailabilityByRole(mAv, roles, mRec, year, roleStrictness);
                     if (adjMAv != null) {

--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -59,20 +59,21 @@ public class UnitTable {
      * found, generates it and adds it to the cache.
      * This method is provided as a convenience for when there are no excluded roles.
      *
-     * @param faction - The faction for which to generate a table
-     * @param unitType - a UnitType constant
-     * @param year - the game year
-     * @param rating - the unit's equipment rating; if null, the table is not adjusted for unit rating.
-     * @param weightClasses - a collection of EntityWeightClass constants to include in the table;
-     * if null or empty all weight classes are included
-     * @param networkMask - a ModelRecord.NETWORK_* constant
-     * @param movementModes - the movement modes allowed to appear in the table; if null or empty, no filtering
-     * is applied.
-     * @param roles - the roles for which to adjust the availability
-     * @param roleStrictness - how rigidly to apply the role adjustments; normal range is &lt;= 4
-     * @param deployingFaction - when using the salvage/isorla mechanism, any omni unit will select
-     * the configuration based on the faction actually deploying
-     * @return - a table containing the available units and their relative weights
+     * @param faction        The faction the table filters for
+     * @param unitType       {@link megamek.common.UnitType} constant with the type of unit
+     * @param year           the game year
+     * @param rating         the unit's equipment rating; if null, the table is not adjusted for unit rating.
+     * @param weightClasses  a collection of {@link megamek.common.EntityWeightClass} constants to include in the table;
+     *                       if null or empty all weight classes are included
+     * @param networkMask    One of the {@link MOdelRecord} NETWORK constants, for filtering various C3 systems
+     * @param movementModes  the movement modes covered by the table, null/empty for all modes
+     * @param roles          {@link MissionRole} types the units should qualify for, null/empty for no role
+     *                       filtering
+     * @param roleStrictness how strongly to apply roles, zero for none/minimal with higher being more
+     *                       restrictive; typically no higher than 5
+     * @param deployingFaction when using the salvage/isorla mechanism, any omni unit will select
+     *                         the configuration based on the faction actually deploying
+     * @return               table containing units which fit all parameters and their relative weights
      */
     public static UnitTable findTable (FactionRecord faction,
                                        int unitType,
@@ -93,18 +94,23 @@ public class UnitTable {
 
     /**
      * Overloaded method, with additional argument for excluded roles
-     * @param faction
-     * @param unitType
-     * @param year
-     * @param rating
-     * @param weightClasses
-     * @param networkMask
-     * @param movementModes
-     * @param roles
-     * @param rolesExcluded
-     * @param roleStrictness
-     * @param deployingFaction
-     * @return
+     * @param faction        The faction the table filters for
+     * @param unitType       {@link megamek.common.UnitType} constant with the type of unit
+     * @param year           the game year
+     * @param rating         the unit's equipment rating; if null, the table is not adjusted for unit rating.
+     * @param weightClassesa collection of {@link megamek.common.EntityWeightClass} constants to include in the table;
+     *                       if null or empty all weight classes are included
+     * @param networkMask    One of the {@link MOdelRecord} NETWORK constants, for filtering various C3 systems
+     * @param movementModes  the movement modes covered by the table, null/empty for all modes
+     * @param roles          {@link MissionRole} types the units should qualify for, null/empty for no role
+     *                       filtering
+     * @param rolesExcluded  {@link MissionRole} types the units should not contain, null empty to
+     *                       allow all roles
+     * @param roleStrictness how strongly to apply roles, zero for none/minimal with higher being more
+     *                       restrictive; typically no higher than 5
+     * @param deployingFaction when using the salvage/isorla mechanism, any omni unit will select
+     *                         the configuration based on the faction actually deploying
+     * @return               table containing units which fit all parameters and their relative weights
      */
     public static UnitTable findTable (FactionRecord faction,
                                        int unitType,

--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -86,9 +86,8 @@ public class UnitTable {
                                        int roleStrictness,
                                        FactionRecord deployingFaction) {
         Objects.requireNonNull(faction);
-        // FIXME: pass in the excluded roles collection
         Parameters params = new Parameters(faction, unitType, year, rating, weightClasses, networkMask,
-                movementModes, roles, null, roleStrictness, deployingFaction);
+                movementModes, roles, new ArrayList<>(), roleStrictness, deployingFaction);
         return findTable(params);
     }
 

--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -57,6 +57,7 @@ public class UnitTable {
     /**
      * Checks the cache for a previously generated table meeting the criteria. If none is
      * found, generates it and adds it to the cache.
+     * This method is provided as a convenience for when there are no excluded roles.
      *
      * @param faction - The faction for which to generate a table
      * @param unitType - a UnitType constant
@@ -87,6 +88,38 @@ public class UnitTable {
         // FIXME: pass in the excluded roles collection
         Parameters params = new Parameters(faction, unitType, year, rating, weightClasses, networkMask,
                 movementModes, roles, null, roleStrictness, deployingFaction);
+        return findTable(params);
+    }
+
+    /**
+     * Overloaded method, with additional argument for excluded roles
+     * @param faction
+     * @param unitType
+     * @param year
+     * @param rating
+     * @param weightClasses
+     * @param networkMask
+     * @param movementModes
+     * @param roles
+     * @param rolesExcluded
+     * @param roleStrictness
+     * @param deployingFaction
+     * @return
+     */
+    public static UnitTable findTable (FactionRecord faction,
+                                       int unitType,
+                                       int year,
+                                       String rating,
+                                       Collection<Integer> weightClasses,
+                                       int networkMask,
+                                       Collection<EntityMovementMode> movementModes,
+                                       Collection<MissionRole> roles,
+                                       Collection<MissionRole> rolesExcluded,
+                                       int roleStrictness,
+                                       FactionRecord deployingFaction) {
+        Objects.requireNonNull(faction);
+        Parameters params = new Parameters(faction, unitType, year, rating, weightClasses, networkMask,
+                movementModes, roles, rolesExcluded, roleStrictness, deployingFaction);
         return findTable(params);
     }
 
@@ -139,22 +172,31 @@ public class UnitTable {
     int salvagePct;
 
     /**
-     * Initializes table based on values provided by key
+     * Initializes table based on restrictions provided by a Parameters object
      *
-     * @param key - a structure providing the parameters for generating the table
+     * @param key   a {@link Parameters} structure providing the parameters for generating the table
      */
-    protected UnitTable(Parameters key) {
+    protected UnitTable (Parameters key) {
         this.key = key;
         /*
          * Generate the RAT, then go through it to build the NavigableMaps that
          * will be used for random selection.
          */
         if (key.getFaction() != null ) {
+
+            // Simple check if the faction is active now
             if (key.getFaction().isActiveInYear(key.getYear())) {
+
                 List<TableEntry> table = RATGenerator.getInstance().generateTable(key.getFaction(),
-                        key.getUnitType(), key.getYear(), key.getRating(), key.getWeightClasses(),
-                        key.getNetworkMask(), key.getMovementModes(),
-                        key.getRoles(), key.getRoleStrictness(), key.getDeployingFaction());
+                        key.getUnitType(),
+                        key.getYear(),
+                        key.getRating(),
+                        key.getWeightClasses(),
+                        key.getNetworkMask(),
+                        key.getMovementModes(),
+                        key.getRoles(),
+                        key.getRoleStrictness(),
+                        key.getDeployingFaction());
                 Collections.sort(table);
 
                 table.forEach(te -> {

--- a/megamek/src/megamek/client/ratgenerator/UnitTable.java
+++ b/megamek/src/megamek/client/ratgenerator/UnitTable.java
@@ -97,9 +97,9 @@ public class UnitTable {
      * @param unitType       {@link megamek.common.UnitType} constant with the type of unit
      * @param year           the game year
      * @param rating         the unit's equipment rating; if null, the table is not adjusted for unit rating.
-     * @param weightClassesa collection of {@link megamek.common.EntityWeightClass} constants to include in the table;
+     * @param weightClasses  collection of {@link megamek.common.EntityWeightClass} constants to include in the table;
      *                       if null or empty all weight classes are included
-     * @param networkMask    One of the {@link MOdelRecord} NETWORK constants, for filtering various C3 systems
+     * @param networkMask    One of the {@link ModelRecord} NETWORK constants, for filtering various C3 systems
      * @param movementModes  the movement modes covered by the table, null/empty for all modes
      * @param roles          {@link MissionRole} types the units should qualify for, null/empty for no role
      *                       filtering

--- a/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
@@ -1202,6 +1202,7 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
                     .boxed().collect(Collectors.toList()),
                     ModelRecord.NETWORK_NONE, EnumSet.noneOf(EntityMovementMode.class),
                     ft.getMissionRoles(),
+                    null,
                     2, getFaction());
             params.add(p);
             int numUnits = getNumUnits();

--- a/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
@@ -1202,7 +1202,7 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
                     .boxed().collect(Collectors.toList()),
                     ModelRecord.NETWORK_NONE, EnumSet.noneOf(EntityMovementMode.class),
                     ft.getMissionRoles(),
-                    null,
+                    new ArrayList<>(),
                     2, getFaction());
             params.add(p);
             int numUnits = getNumUnits();

--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -770,7 +770,9 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                             m_pFormationOptions.getRating(), null,
                             ModelRecord.NETWORK_NONE,
                             EnumSet.noneOf(EntityMovementMode.class),
-                            EnumSet.noneOf(MissionRole.class), 0, fRec));
+                            EnumSet.noneOf(MissionRole.class),
+                            null,
+                            0, fRec));
                     List<Integer> numUnits = new ArrayList<>();
                     numUnits.add(m_pFormationOptions.getNumUnits());
 
@@ -781,7 +783,9 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                                     m_pFormationOptions.getYear(), m_pFormationOptions.getRating(), null,
                                     ModelRecord.NETWORK_NONE,
                                     EnumSet.noneOf(EntityMovementMode.class),
-                                    EnumSet.noneOf(MissionRole.class), 0, fRec));
+                                    EnumSet.noneOf(MissionRole.class),
+                                    null,
+                                    0, fRec));
                             numUnits.add(m_pFormationOptions.getIntegerOption("numOtherUnits"));
                         } else if (m_pFormationOptions.getBooleanOption("mechBA")) {
                             // Make sure at least a number units equals to the number of BA points/squads are omni
@@ -807,7 +811,8 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                                         m_pFormationOptions.getYear(), m_pFormationOptions.getRating(), null,
                                         ModelRecord.NETWORK_NONE,
                                         EnumSet.noneOf(EntityMovementMode.class),
-                                        EnumSet.of(MissionRole.MECHANIZED_BA), 0, fRec);
+                                        EnumSet.of(MissionRole.MECHANIZED_BA),
+                                        null,0, fRec);
                                 List<MechSummary> ba = ft.generateFormation(p,
                                         m_pFormationOptions.getIntegerOption("numOtherUnits"),
                                         ModelRecord.NETWORK_NONE, true);

--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -771,7 +771,7 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                             ModelRecord.NETWORK_NONE,
                             EnumSet.noneOf(EntityMovementMode.class),
                             EnumSet.noneOf(MissionRole.class),
-                            null,
+                            new ArrayList<>(),
                             0, fRec));
                     List<Integer> numUnits = new ArrayList<>();
                     numUnits.add(m_pFormationOptions.getNumUnits());
@@ -784,7 +784,7 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                                     ModelRecord.NETWORK_NONE,
                                     EnumSet.noneOf(EntityMovementMode.class),
                                     EnumSet.noneOf(MissionRole.class),
-                                    null,
+                                    new ArrayList<>(),
                                     0, fRec));
                             numUnits.add(m_pFormationOptions.getIntegerOption("numOtherUnits"));
                         } else if (m_pFormationOptions.getBooleanOption("mechBA")) {
@@ -812,7 +812,7 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                                         ModelRecord.NETWORK_NONE,
                                         EnumSet.noneOf(EntityMovementMode.class),
                                         EnumSet.of(MissionRole.MECHANIZED_BA),
-                                        null,0, fRec);
+                                        new ArrayList<>(),0, fRec);
                                 List<MechSummary> ba = ft.generateFormation(p,
                                         m_pFormationOptions.getIntegerOption("numOtherUnits"),
                                         ModelRecord.NETWORK_NONE, true);


### PR DESCRIPTION
The initial intention in this work was to change random selection parameters to allow excluding some units from random selection by role, to close #5564. Turns out the selection table math in the same place has a few kinks, so those fixes got rolled in.

Math fixes first:

- calculating the total weight for the weighted random selection was including units that would then be filtered out for various reasons.  This resulted in a much higher total weight, and lower than intended weight for all the models of that chassis.  The total weight is now calculated based on the same units that are processed into the random selection table.
- calculations that changed availability numbers to weights ( 2 ^ (av/2) ) returned doubles, which were being truncated to int while added to the total weight, and then the total weight used in other double-producing calculations.  Doubles are now being used throughout the calculations to preserve accuracy.
- year comparisons for pre-/early production availability modifiers have been adjusted to do the intended comparisons
- the method for adjusting availability with the dynamic +/- adjustment system has  small tweak to handle a 1-point difference
- interpolation of availability values for years between era data points have been tweaked

There are a few bit of weirdness showing up, such as RAC/LAC field gun platoons being processed in 3058 even though they have much later introduction date (3062 for the former, 3068 for the latter).  The LAC field gun models are not even present in the 3058.xml file.  These models may be getting processed based on tech availability date rather than the keyed-in introduction date, but I'm treating that as out-of-scope for this PR and the calculations are successfully filtering them out.

These should not result in many changes for units like Mechs with few models per chassis.  The largest changes will be seen with conventional infantry where there are regularly 10+ models per chassis, with the RATGen/force generator table numbers now more consistent with the availability numbers.