### PR TITLE
Fix 5596: Fix range updates and projections in space

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2920,11 +2920,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
     }
 
     public Optional<AmmoMounted> getDisplayedAmmo() {
-        AmmoMounted ammo = unitDisplay.wPan.getSelectedAmmo();
-        if (null == ammo) {
-            return Optional.empty();
-        }
-        return Optional.of(ammo);
+        return Optional.ofNullable(unitDisplay.wPan.getSelectedAmmo());
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -57,6 +57,7 @@ import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.GamePhase;
+import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.event.*;
 import megamek.common.icons.Camouflage;
@@ -2916,6 +2917,14 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
                     unitDisplay.wPan.getSelectedWeaponNum(), getDisplayedUnit());
             return Optional.empty();
         }
+    }
+
+    public Optional<AmmoMounted> getDisplayedAmmo() {
+        AmmoMounted ammo = unitDisplay.wPan.getSelectedAmmo();
+        if (null == ammo) {
+            return Optional.empty();
+        }
+        return Optional.of(ammo);
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1302,6 +1302,18 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
     }
 
     /**
+     *
+     * @return the AmmoMounted currently selected by the ammo selector combo box, not the linked ammo per se.
+     */
+    public AmmoMounted getSelectedAmmo() {
+        int selected = m_chAmmo.getSelectedIndex();
+        if (selected == -1) {
+            return null;
+        }
+        return vAmmo.get(m_chAmmo.getSelectedIndex());
+    }
+
+    /**
      * Returns the equipment ID number for the weapon currently selected
      */
     public int getSelectedWeaponNum() {
@@ -1877,9 +1889,11 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             wExtR.setText("" + extremeR);
         }
 
-        // Update the range display to account for the weapon's loaded ammo.
-        if ((mounted.getLinked() != null) && (mounted.getLinked() instanceof AmmoMounted)) {
-            updateRangeDisplayForAmmo((AmmoMounted) mounted.getLinked());
+        // Update the range display to account for the selected ammo, or the loaded ammo if none is selected
+        int curDisplayed = m_chAmmo.getSelectedIndex();
+        AmmoMounted mAmmo = (curDisplayed != -1) ? vAmmo.get(curDisplayed) : mounted.getLinkedAmmo();
+        if (mAmmo != null) {
+            updateRangeDisplayForAmmo(mAmmo);
         }
 
         if (aerospaceAttack) {
@@ -1893,11 +1907,11 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             // if this is a weapons bay, then I need to compile it to get
             // accurate results
             if (wtype instanceof BayWeapon) {
-                compileWeaponBay(mounted, wtype.isCapital());
+                compileWeaponBay(mounted, mAmmo, wtype.isCapital());
             } else {
                 // otherwise I need to replace range display with standard
                 // ranges and attack values
-                updateAttackValues(mounted, (AmmoMounted) mounted.getLinked());
+                updateAttackValues(mounted, mAmmo);
             }
 
         }
@@ -1920,7 +1934,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             }
         }
 
-        // update ammo selector
+        // update ammo selector; reset to currently-displayed item if set.
         ((DefaultComboBoxModel<String>) m_chAmmo.getModel()).removeAllElements();
         WeaponMounted oldmount = mounted;
         if (wtype instanceof BayWeapon) {
@@ -2000,7 +2014,9 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
                     vAmmo.add(mountedAmmo);
                     m_chAmmo.addItem(formatAmmo(mountedAmmo));
-                    if ((mounted.getLinked() != null) &&
+                    if (curDisplayed != -1) {
+                        nCur = curDisplayed;
+                    } else if ((mounted.getLinked() != null) &&
                         mounted.getLinked().equals(mountedAmmo)) {
                         nCur = i;
                     }
@@ -2375,7 +2391,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
     }
 
-    private void compileWeaponBay(WeaponMounted weapon, boolean isCapital) {
+    private void compileWeaponBay(WeaponMounted weapon, AmmoMounted mAmmo, boolean isCapital) {
 
         List<WeaponMounted> bayWeapons = weapon.getBayWeapons();
         WeaponType wtype = weapon.getType();
@@ -2402,8 +2418,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 && !m.isMissing()
                 && !m.isDestroyed()
                 && !m.isJammed()
-                && ((m.getLinked() == null) || (m.getLinked()
-                                                 .getUsableShotsLeft() > 0))) {
+                && ((mAmmo == null) || (mAmmo.getUsableShotsLeft() > 0))) {
                 WeaponType bayWType = m.getType();
                 heat = heat + m.getCurrentHeat();
                 double mAVShort = bayWType.getShortAV();
@@ -2413,8 +2428,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 int mMaxR = bayWType.getMaxRange(m);
 
                 // deal with any ammo adjustments
-                if (null != m.getLinked()) {
-                    double[] changes = changeAttackValues((AmmoType) m.getLinked().getType(), mAVShort, mAVMed,
+                if (null != mAmmo) {
+                    double[] changes = changeAttackValues((AmmoType) mAmmo.getType(), mAVShort, mAVMed,
                                                           mAVLong, mAVExt, mMaxR);
                     mAVShort = changes[0];
                     mAVMed = changes[1];
@@ -2558,19 +2573,30 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         if (ev.getSource().equals(m_chAmmo)
                 && (m_chAmmo.getSelectedIndex() != -1)
                 && (clientgui != null)) {
+            int n = weaponList.getSelectedIndex();
+            if (n == -1) {
+                return;
+            }
+
+            // We can update display values without changing the selected unit's ammo;
+            // this allows displaying selected unit's ammo-based ranges without owning it
+            WeaponMounted mWeap = ((WeaponListModel) weaponList.getModel()).getWeaponAt(n);
+            WeaponMounted oldWeap = mWeap;
+            AmmoMounted oldAmmo = mWeap.getLinkedAmmo();
+            AmmoMounted mAmmo = vAmmo.get(m_chAmmo.getSelectedIndex());
+
+            weaponList.setSelectedIndex(n);
+            weaponList.ensureIndexIsVisible(n);
+            displaySelected();
+            // Update once prior to changing any actual loaded ammo
+            updateRangeDisplayForAmmo(mAmmo);
+
             // only change our own units
             if (!clientgui.getClient().getLocalPlayer()
                     .equals(entity.getOwner())) {
                 return;
             }
-            int n = weaponList.getSelectedIndex();
-            if (weaponList.getSelectedIndex() == -1) {
-                return;
-            }
-            WeaponMounted mWeap = ((WeaponListModel) weaponList.getModel()).getWeaponAt(n);
-            WeaponMounted oldWeap = mWeap;
-            AmmoMounted oldAmmo = mWeap.getLinkedAmmo();
-            AmmoMounted mAmmo = vAmmo.get(m_chAmmo.getSelectedIndex());
+
             // if this is a weapon bay, then this is not what we want
             boolean isBay = false;
             if (mWeap.getType() instanceof BayWeapon) {
@@ -2623,7 +2649,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             if (entity.isAirborne() || entity.usesWeaponBays()) {
                 WeaponType wtype = (WeaponType) mWeap.getType();
                 if (isBay) {
-                    compileWeaponBay(oldWeap, wtype.isCapital());
+                    compileWeaponBay(oldWeap, mAmmo, wtype.isCapital());
                 } else {
                     // otherwise I need to replace range display with
                     // standard ranges and attack values

--- a/megamek/src/megamek/common/weapons/bayweapons/BayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayweapons/BayWeapon.java
@@ -71,11 +71,13 @@ public abstract class BayWeapon extends Weapon {
     public int getMaxRange(WeaponMounted weapon, AmmoMounted ammo) {
         int mrange = RANGE_SHORT;
         Entity ae = weapon.getEntity();
+        AmmoMounted mAmmo;
         if (null != ae) {
             for (WeaponMounted bayW : weapon.getBayWeapons()) {
+                mAmmo = (ammo != null) ? ammo : bayW.getLinkedAmmo();
                 WeaponType bayWType = bayW.getType();
-                if (bayWType.getMaxRange(bayW) > mrange) {
-                    mrange = bayWType.getMaxRange(bayW);
+                if (bayWType.getMaxRange(bayW, mAmmo) > mrange) {
+                    mrange = bayWType.getMaxRange(bayW, mAmmo);
                 }
             }
         }


### PR DESCRIPTION
A variety of different updates appear to have broken the part of our firing arc draw code that stops adding arcs for shorter-ranged weapons, specifically:

- ASF weapons with variable range (e.g. ATMs)
- Bay weapons

This fix returns that functionality so that only the in-range sections of a weapon or bay's arc will display, and the range will accurately reflect the selected ammo.

This patch also adds the ability to select variable-range ammo for _enemy_ units and see their range bands without changing the loaded ammo on the viewed unit, for better turn planning by human players.

Testing:
- Ran all 3 projects' existing unit tests
- Tested extensively with ATM rounds on Aerospace units of various types
- Also confirmed ground unit firing arc display has not been impacted

Close #5596 