### PR TITLE
Princess - improved AMS handling

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1646,8 +1646,9 @@ public class FireControl {
         // cycle through my weapons
         for (final WeaponMounted weapon : shooter.getWeaponList()) {
             // respect restriction on manual AMS firing.
-            if (!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) &&
-                    weapon.getType().hasFlag(WeaponType.F_AMS)) {
+            if (weapon.getType().hasFlag(WeaponType.F_AMS) &&
+                    (!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) ||
+                            !weapon.curMode().equals(Weapon.MODE_AMS_MANUAL))) {
                 continue;
             }
 
@@ -1969,8 +1970,9 @@ public class FireControl {
             }
 
             // respect restriction on manual AMS firing.
-            if (!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) &&
-                    weapon.getType().hasFlag(WeaponType.F_AMS)) {
+            if (weapon.getType().hasFlag(WeaponType.F_AMS) &&
+                    (!game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS) ||
+                            !weapon.curMode().equals(Weapon.MODE_AMS_MANUAL))) {
                 continue;
             }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -57,6 +57,8 @@ public class Princess extends BotClient {
     private static final char PLUS = '+';
     private static final char MINUS = '-';
 
+    private static final int MAX_OVERHEAT_AMS = 14;
+
     private final IHonorUtil honorUtil = new HonorUtil();
 
     private boolean initialized = false;
@@ -2210,7 +2212,7 @@ public class Princess extends BotClient {
                 // Set default to on/automatic and test to see if it should be off or manual instead
                 EquipmentMode newAMSMode = EquipmentMode.getMode(Weapon.MODE_AMS_ON);
 
-                boolean isOverheating = (curEntity instanceof Mech) && (curEntity.getHeat() >= 14);
+                boolean isOverheating = (curEntity instanceof Mech) && (curEntity.getHeat() >= MAX_OVERHEAT_AMS);
 
                 // If there are enough nearby enemy infantry (only counted if the game option is
                 // set), choose manual fire

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2177,9 +2177,6 @@ public class Princess extends BotClient {
      * ammo on relatively undamaged units, and laser AMS may be turned off to help reduce
      * overheating. Manual use is reserved as an emergency anti-infantry measure.
      *
-     * FIXME: (remote) filter AMS selection on weapons to manual mode only
-     * FIXME: add tracking list for entity IDs for manual AMS fire
-     * FIXME: (remote) log entity as using manual AMS fire, same place where targeting is being set
      */
     private void setAMSModes() {
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2186,7 +2186,7 @@ public class Princess extends BotClient {
             for (Entity curEnemy : this.getEnemyEntities().stream().filter(Entity::isDeployed).collect(Collectors.toSet())) {
                 if (curEnemy.getPosition() != null && curEnemy.isVisibleToEnemy()) {
 
-                    if (curEnemy instanceof Infantry) {
+                    if (curEnemy instanceof Infantry && !(curEnemy instanceof EjectedCrew)) {
                         enemyInfantry.add(curEnemy);
                     }
 
@@ -2248,7 +2248,7 @@ public class Princess extends BotClient {
 
                             // Fighting a missile boat is more likely to require an active AMS
                             int lastTargetID = curEntity.getLastTarget();
-                            if (lastTargetID >= 1) {
+                            if (lastTargetID >= 0) {
                                 Entity lastTarget = game.getEntity(lastTargetID);
                                 if (lastTarget != null && lastTarget.getRole() == UnitRole.MISSILE_BOAT) {
                                     ammoTN += 4;


### PR DESCRIPTION
Currently, Princess will use AMS as a manual weapon without first switching it to the proper mode (this might warrant some checks inside ToHitData, similar to those which prevent combing called and aimed shots).  This PR ensures that Princess will only consider using it manually if the system has the correct mode set.

It also adds some code to the end phase to select an appropriate mode for the AMS systems each unit may be carrying.  Most of the time this will be on/automatic, but laser AMS may be shut off to assist with heat management on seriously overheating units and relatively undamaged units may turn off conventional AMS to conserve ammo when running low. Manual/use as a weapon mode is restricted to when the unit comes into close contact with infantry; once it breaks contact with the infantry and stops firing it the mode will reset to on/automatic.

Will close #5084 .