### PR TITLE
adjust wind direction order

### DIFF
--- a/megamek/src/megamek/common/planetaryconditions/WindDirection.java
+++ b/megamek/src/megamek/common/planetaryconditions/WindDirection.java
@@ -21,12 +21,12 @@ package megamek.common.planetaryconditions;
 import megamek.common.Messages;
 
 public enum WindDirection {
-    NORTH("NORTH", "PlanetaryConditions.DisplayableName.WindDirection.North", "\u2193"),
-    NORTHEAST("NORTHEAST", "PlanetaryConditions.DisplayableName.WindDirection.Northeast", "\u2B0B"),
-    SOUTHEAST("SOUTHEAST", "PlanetaryConditions.DisplayableName.WindDirection.Southeast", "\u2B09"),
     SOUTH("SOUTH", "PlanetaryConditions.DisplayableName.WindDirection.South", "\u2191"),
     SOUTHWEST("SOUTHWEST", "PlanetaryConditions.DisplayableName.WindDirection.Southwest", "\u2B08"),
     NORTHWEST("NORTHWEST", "PlanetaryConditions.DisplayableName.WindDirection.Northwest", "\u2B0A"),
+    NORTH("NORTH", "PlanetaryConditions.DisplayableName.WindDirection.North", "\u2193"),
+    NORTHEAST("NORTHEAST", "PlanetaryConditions.DisplayableName.WindDirection.Northeast", "\u2B0B"),
+    SOUTHEAST("SOUTHEAST", "PlanetaryConditions.DisplayableName.WindDirection.Southeast", "\u2B09"),
     RANDOM("RANDOM", "PlanetaryConditions.DisplayableName.WindDirection.RandomWindDirection", "");
     private final String externalId;
     private final String name;


### PR DESCRIPTION
- fix issue with smoke drifting the wrong direction
- adjust wind direction order, to correct issue caused when converting the Planetary Conditions to Enums
- south should be 0 instead of north to match old logic 


old order
```
    private static String[] dirNames = { MSG_NAME_WINDDIRECTION_SOUTH, MSG_NAME_WINDDIRECTION_SOUTHWEST,
            MSG_NAME_WINDDIRECTION_NORTHWEST, MSG_NAME_WINDDIRECTION_NORTH, MSG_NAME_WINDDIRECTION_NORTHEAST,
            MSG_NAME_WINDDIRECTION_SOUTHEAST, MSG_NAME_WINDDIRECTION_RANDOM };
```