### PR TITLE
Fix MML 1537: cannot load sv blk files missing armor type field

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -374,6 +374,8 @@ public class BLKFile {
             }
             if (dataFile.exists("armor_tech")) {
                 sv.setArmorTechRating(dataFile.getDataAsInt("armor_tech")[0]);
+            } else if (dataFile.exists("armor_tech_rating")) {
+                sv.setArmorTechRating(dataFile.getDataAsInt("armor_tech_rating")[0]);
             }
         }
     }
@@ -584,7 +586,7 @@ public class BLKFile {
         }
     }
 
-    public static BuildingBlock getBlock(Entity t) {
+    public static BuildingBlock getBlock(Entity t) throws EntitySavingException{
         BuildingBlock blk = new BuildingBlock();
         blk.createNewBlock();
 
@@ -810,7 +812,9 @@ public class BLKFile {
                     blk.writeBlockData("clan_engine", Boolean.toString(t.getEngine().isClan()));
                 }
             }
-            if (!t.hasPatchworkArmor() && (t.getArmorType(1) != 0)) {
+
+            // Need to make sure that only "Unknown" armor gets skipped
+            if (!t.hasPatchworkArmor() && (t.getArmorType(1) != ArmorType.T_ARMOR_UNKNOWN)) {
                 blk.writeBlockData("armor_type", t.getArmorType(1));
                 blk.writeBlockData("armor_tech", t.getArmorTechLevel(1));
             } else if (t.hasPatchworkArmor()) {
@@ -825,6 +829,8 @@ public class BLKFile {
                         blk.writeBlockData(t.getLocationName(i) + "_barrating", armor.getBAR());
                     }
                 }
+            } else {
+                throw new EntitySavingException("Armor type unknown or not set; aborting save!");
             }
             if (t.getStructureType() != 0) {
                 blk.writeBlockData("internal_type", t.getStructureType());
@@ -932,7 +938,6 @@ public class BLKFile {
         if (t.isSupportVehicle()) {
             blk.writeBlockData("structural_tech_rating", t.getStructuralTechRating());
             blk.writeBlockData("engine_tech_rating", t.getEngineTechRating());
-            blk.writeBlockData("armor_tech_rating", t.getArmorTechRating());
         }
 
         if (t.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT) || t.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
@@ -1227,7 +1232,7 @@ public class BLKFile {
         return name;
     }
 
-    public static void encode(String fileName, Entity t) {
+    public static void encode(String fileName, Entity t) throws EntitySavingException{
         BuildingBlock blk = BLKFile.getBlock(t);
         blk.writeBlockFile(fileName);
     }

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -814,6 +814,7 @@ public class BLKFile {
             }
 
             // Need to make sure that only "Unknown" armor gets skipped
+            // barRating block written out later in SV-specific section
             if (!t.hasPatchworkArmor() && (t.getArmorType(1) != ArmorType.T_ARMOR_UNKNOWN)) {
                 blk.writeBlockData("armor_type", t.getArmorType(1));
                 blk.writeBlockData("armor_tech", t.getArmorTechLevel(1));

--- a/megamek/src/megamek/common/loaders/BLKSupportTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSupportTankFile.java
@@ -42,7 +42,7 @@ public class BLKSupportTankFile extends BLKFile implements IMechLoader {
                 return 0;
         }
     }
-    
+
     @Override
     public Entity getEntity() throws EntityLoadingException {
 
@@ -116,7 +116,7 @@ public class BLKSupportTankFile extends BLKFile implements IMechLoader {
         for (int x = 0; x < fullArmor.length; x++) {
             t.initializeArmor(fullArmor[x], x);
         }
-        
+
         // Set the structural tech rating
         if (!dataFile.exists("structural_tech_rating")) {
             throw new EntityLoadingException("Could not find " +
@@ -125,14 +125,18 @@ public class BLKSupportTankFile extends BLKFile implements IMechLoader {
         t.setStructuralTechRating(dataFile
                 .getDataAsInt("structural_tech_rating")[0]);
         // Set armor tech rating, if it exists (defaults to structural tr)
+        // Allow use of armor_tech field if provided
         if (dataFile.exists("armor_tech_rating")) {
             t.setArmorTechRating(dataFile
-                    .getDataAsInt("armor_tech_rating")[0]);            
+                    .getDataAsInt("armor_tech_rating")[0]);
+        } else if (dataFile.exists("armor_tech")) {
+            t.setArmorTechRating(dataFile
+                .getDataAsInt("armor_tech")[0]);
         }
         // Set engine tech rating, if it exists (defaults to structural tr)
         if (dataFile.exists("engine_tech_rating")) {
             t.setEngineTechRating(dataFile
-                    .getDataAsInt("engine_tech_rating")[0]);            
+                    .getDataAsInt("engine_tech_rating")[0]);
         }
 
         t.autoSetInternal();

--- a/megamek/src/megamek/common/loaders/EntitySavingException.java
+++ b/megamek/src/megamek/common/loaders/EntitySavingException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common.loaders;
+
+/**
+ * This exception is thrown if a mech or other cannot be properly saved from a
+ * file due to IO errors, file format errors, missing fields, or whatever.
+ *
+ * @author sleet01
+ */
+public class EntitySavingException extends Exception {
+    private static final long serialVersionUID = -4472736483205970852L;
+
+    /**
+     * Creates new <code>EntityLoadingException</code> without detail message.
+     */
+    public EntitySavingException() {
+
+    }
+
+    /**
+     * Constructs an <code>EntityLoadingException</code> with the specified
+     * detail message.
+     *
+     * @param msg the detail message.
+     */
+    public EntitySavingException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.
+     *
+     * @param message the detail message
+     * @param cause the cause
+     */
+    public EntitySavingException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
MM side of fix for various NPEs and loading issues in MegaMek/megameklab#1537.

Fix replaces a magic number in the BLK save code with a defined constant; the code was skipping Standard armor on SVs with Armored Chassis mod and leaving them in an un-loadable state since 0.49.19.

This also adds some handling for fields that had become mismatched between the old SV blk save code and the new loadSV() code, specifically, 'armor_tech[_rating]' which was using the long form to save and the short form to load, leading to undefined behavior.

Finally, there is an MML PR to disable the Armor Tech Rating chooser when non-BAR armor is chosen, to prevent confusion and also stop random fiddling with the chooser causing the Chassis Tech Rating (and thus weight) to fluctuate.

Testing:
- Loaded previously-failing files after adjusting them manually, then confirmed re-saving them with the patched code fixed all issues.
- Ran all three projects' unit test suites