### PR TITLE
Fix for squadron ammo weapons

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -22,6 +22,7 @@ import megamek.client.ui.swing.widget.MegamekButton;
 import megamek.common.*;
 import megamek.common.actions.*;
 import megamek.common.enums.AimingMode;
+import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
@@ -1233,11 +1234,11 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             }
 
             if ((mounted.getLinked() != null)
-                    && (((WeaponType) mounted.getType()).getAmmoType() != AmmoType.T_NA)
+                    && (mounted.getType().getAmmoType() != AmmoType.T_NA)
                     && (mounted.getLinked().getType() instanceof AmmoType)) {
-                Mounted ammoMount = mounted.getLinked();
-                AmmoType ammoType = (AmmoType) ammoMount.getType();
-                waa.setAmmoId(ammoMount.getEntity().getEquipmentNum(ammoMount));
+                AmmoMounted ammoMount = mounted.getLinkedAmmo();
+                AmmoType ammoType = ammoMount.getType();
+                waa.setAmmoId(ammoMount.getEquipmentNum());
                 EnumSet<AmmoType.Munitions> ammoMunitionType = ammoType.getMunitionType();
                 waa.setAmmoMunitionType(ammoMunitionType);
                 waa.setAmmoCarrier(ammoMount.getEntity().getId());

--- a/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/PointblankShotDisplay.java
@@ -664,25 +664,28 @@ public class PointblankShotDisplay extends FiringDisplay implements ItemListener
                 if (aiming) {
                     toHit = WeaponAttackAction.toHit(game, currentEntity, target,
                             weaponId, ash.getAimingAt(), ash.getAimingMode(),
-                            false, false, null, null, false, true, -1);
+                            false, false, null, null, false, true,
+                            WeaponAttackAction.UNASSIGNED, WeaponAttackAction.UNASSIGNED);
                     clientgui.getUnitDisplay().wPan.setTarget(target, Messages.getFormattedString("MechDisplay.AimingAt", ash.getAimingLocation()));
 
                 } else {
                     toHit = WeaponAttackAction.toHit(game, currentEntity, target, weaponId, Entity.LOC_NONE,
                             AimingMode.NONE, false, false,
-                            null, null, false, true, -1);
+                            null, null, false, true,
+                            WeaponAttackAction.UNASSIGNED, WeaponAttackAction.UNASSIGNED);
                     clientgui.getUnitDisplay().wPan.setTarget(target, null);
                 }
                 ash.setPartialCover(toHit.getCover());
             } else {
                 toHit = WeaponAttackAction.toHit(game, currentEntity, target, weaponId, Entity.LOC_NONE,
                         AimingMode.NONE, false, false, null,
-                        null, false, true, -1);
+                        null, false, true,
+                        WeaponAttackAction.UNASSIGNED, WeaponAttackAction.UNASSIGNED);
                 clientgui.getUnitDisplay().wPan.setTarget(target, null);
             }
             int effectiveDistance = Compute.effectiveDistance(game, ce(), target);
             clientgui.getUnitDisplay().wPan.wRangeR.setText("" + effectiveDistance);
-            Mounted m = ce().getEquipment(weaponId);
+            WeaponMounted m = ce().getWeapon(weaponId);
             // If we have a Centurion Weapon System selected, we may need to
             //  update ranges.
             if (m.getType().hasFlag(WeaponType.F_CWS)) {

--- a/megamek/src/megamek/client/ui/swing/tooltip/EntityActionLog.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/EntityActionLog.java
@@ -22,6 +22,7 @@ package megamek.client.ui.swing.tooltip;
 import megamek.client.ui.Messages;
 import megamek.common.*;
 import megamek.common.actions.*;
+import megamek.common.equipment.AmmoMounted;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -198,8 +199,12 @@ public class EntityActionLog implements Collection<EntityAction> {
         final String buffer = toHit.getValueAsString() + ((!table.isEmpty()) ? ' ' + table : "");
         final Entity entity = game.getEntity(attack.getEntityId());
         final String weaponName = (entity.getEquipment(attack.getWeaponId()).getType()).getName();
-        final Mounted ammo = entity.getEquipment(attack.getAmmoId());
-        final String ammoName = (ammo == null) ? "" : " [" + ((AmmoType) ammo.getType()).getShortName() + "] ";
+        Entity ammoCarrier = game.getEntity(attack.getAmmoCarrier());
+        if (ammoCarrier == null) {
+            ammoCarrier = entity;
+        }
+        final AmmoMounted ammo = ammoCarrier.getAmmo(attack.getAmmoId());
+        final String ammoName = (ammo == null) ? "" : " [" + ammo.getType().getShortName() + "] ";
 
         //add to an existing entry if possible
         boolean found = false;


### PR DESCRIPTION
When determining the to-hit number for squadrons, the ammo is determined using the squadron's equipment list, but the ammo is on the individual fighters. The ammoCarrier field holds the id of the actual Entity with the ammo.

Fixes #5569