### PR TITLE
RFE 5284: continue munition loadout generator development

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1610,6 +1610,17 @@ CustomMechDialog.StandardMunition=Standard
 CustomMechDialog.formatMissileTonnage=%s: %.0f tons/missile
 CustomMechDialog.formatShotsPerTon=%s: %d shots/ton
 CustomMechDialog.formatSmSVAmmoShots=%d shots/clip, %d clips
+# Autoconfig tooltips
+
+CustomMechDialog.acfPanelDesc=Ammunition Autoconfiguration tool.  Can select appropriate munitions for player's units,\nfaction, game era/year, day/night, and (unless playing Double Blind) enemy force \ncomposition.  Alternatively, can randomize munitions.\n Configuration only applied if user clicks <OK> button below.
+CustomMechDialog.acfFactionChooser=Faction to use when configuring, for determining available options
+CustomMechDialog.acfExecuteConfig=Run auto-configuration with current settings (revert with Restore button)
+CustomMechDialog.acfRandomizer=Randomize ammo for selected player's units (only damage-dealing ammo by default)
+CustomMechDialog.acfTrulyRandom=Switch randomizer to truly random mode: any valid ammunition may be selected
+CustomMechDialog.acfBanNukes=Prevent nuclear munitions from being selected, even if game options would allow them
+CustomMechDialog.acfSaveADF=Save current ammo configurations to a .adf file for editing or loading later
+CustomMechDialog.acfLoadADF=Load munition configuration imperatives from a .adf file (if applicable)
+CustomMechDialog.acfRestoreMunitionTree=Restore previous munition selections to each of player's units
 
 #Unit Deployment buttons, dialogs, nags...
 DeploymentDisplay.alertDialog.title=Invalid deployment
@@ -2850,7 +2861,7 @@ PlayerListDialog.TeamLess=\ (Unassigned)
 #Lobby Player Settings Dialog
 PlayerSettingsDialog.initMod=Initiative Modifier:
 PlayerSettingsDialog.header.botPlayer=Bot Player
-PlayerSettingsDialog.header.teamConfig=Team Ammunition Configuration
+PlayerSettingsDialog.header.autoConfig=Automatic Ammunition Configuration
 PlayerSettingsDialog.header.startPos=Deployment Area
 PlayerSettingsDialog.header.initMod=Initiative Modifier
 PlayerSettingsDialog.header.minefields=Minefields

--- a/megamek/src/megamek/client/generator/ReconfigurationParameters.java
+++ b/megamek/src/megamek/client/generator/ReconfigurationParameters.java
@@ -33,6 +33,7 @@ public class ReconfigurationParameters {
     public HashSet<String> enemyFactions = new HashSet<String>();
 
     // Friendly stats
+    public String friendlyFaction = "";
     public long friendlyCount = 0;
     public long friendlyTAGs = 0;
     public long friendlyNARCs = 0;

--- a/megamek/src/megamek/client/generator/ReconfigurationParameters.java
+++ b/megamek/src/megamek/client/generator/ReconfigurationParameters.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package megamek.client.generator;
 
 import java.util.HashSet;

--- a/megamek/src/megamek/client/generator/ReconfigurationParameters.java
+++ b/megamek/src/megamek/client/generator/ReconfigurationParameters.java
@@ -19,6 +19,7 @@ public class ReconfigurationParameters {
     public long enemyFliers = 0;
     public long enemyBombers = 0;
     public long enemyInfantry = 0;
+    public long enemyBattleArmor = 0;
     public long enemyVehicles = 0;
     public long enemyMeks = 0;
     public long enemyEnergyBoats = 0;
@@ -39,6 +40,8 @@ public class ReconfigurationParameters {
     public long friendlyMissileBoats = 0;
     public long friendlyOffBoard = 0;
     public long friendlyECMCount = 0;
+    public long friendlyInfantry = 0;
+    public long friendlyBattleArmor = 0;
 
     // User-selected directives
     // Nukes may be banned for a given team but allowed in general (boo, hiss)

--- a/megamek/src/megamek/client/generator/ReconfigurationParameters.java
+++ b/megamek/src/megamek/client/generator/ReconfigurationParameters.java
@@ -1,0 +1,50 @@
+package megamek.client.generator;
+
+import java.util.HashSet;
+
+/**
+ * Bare data class to pass around and store configuration-influencing info
+ */
+public class ReconfigurationParameters {
+
+    // Game settings
+    public boolean enemiesVisible = true;
+    public int allowedYear = 3151;
+
+    // Map settings
+    public boolean darkEnvironment = false;
+
+    // Enemy stats
+    public long enemyCount = 0;
+    public long enemyFliers = 0;
+    public long enemyBombers = 0;
+    public long enemyInfantry = 0;
+    public long enemyVehicles = 0;
+    public long enemyMeks = 0;
+    public long enemyEnergyBoats = 0;
+    public long enemyMissileBoats = 0;
+    public long enemyAdvancedArmorCount = 0;
+    public long enemyReflectiveArmorCount = 0;
+    public long enemyFireproofArmorCount = 0;
+    public long enemyFastMovers = 0;
+    public long enemyOffBoard = 0;
+    public long enemyECMCount = 0;
+    public HashSet<String> enemyFactions = new HashSet<String>();
+
+    // Friendly stats
+    public long friendlyCount = 0;
+    public long friendlyTAGs = 0;
+    public long friendlyNARCs = 0;
+    public long friendlyEnergyBoats = 0;
+    public long friendlyMissileBoats = 0;
+    public long friendlyOffBoard = 0;
+    public long friendlyECMCount = 0;
+
+    // User-selected directives
+    // Nukes may be banned for a given team but allowed in general (boo, hiss)
+    public boolean nukesBannedForMe = true;
+
+    // Datatype for passing around game parameters the Loadout Generator cares about
+    ReconfigurationParameters() {
+    }
+}

--- a/megamek/src/megamek/client/generator/ReconfigurationParameters.java
+++ b/megamek/src/megamek/client/generator/ReconfigurationParameters.java
@@ -13,6 +13,7 @@ public class ReconfigurationParameters {
 
     // Map settings
     public boolean darkEnvironment = false;
+    public boolean spaceEnvironment = false;
 
     // Enemy stats
     public long enemyCount = 0;
@@ -43,6 +44,7 @@ public class ReconfigurationParameters {
     public long friendlyECMCount = 0;
     public long friendlyInfantry = 0;
     public long friendlyBattleArmor = 0;
+    public long friendlyHeatGens = 0;
 
     // User-selected directives
     // Nukes may be banned for a given team but allowed in general (boo, hiss)

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -1169,6 +1169,10 @@ class MunitionWeightCollection {
         return artyWeights;
     }
 
+    public HashMap<String, Double> getBombWeights() {
+        return bombWeights;
+    }
+
     public HashMap<String, Double> getArtyCannonWeights() {
         return artyCannonWeights;
     }

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -41,8 +41,6 @@ public class TeamLoadoutGenerator {
     public static final ArrayList<String> HIGH_POWER_MUNITIONS = new ArrayList<>(List.of(
             "Tandem-Charge", "Fuel-Air", "HE", "Dead-Fire", "Davy Crockett-M",
             "ASMissile Ammo", "FABombLarge Ammo", "FABombSmall Ammo", "AlamoMissile Ammo"
-
-
     ));
 
     public static final ArrayList<String> ANTI_INF_MUNITIONS = new ArrayList<>(List.of(
@@ -384,6 +382,12 @@ public class TeamLoadoutGenerator {
         return false;
     }
 
+    public static MunitionTree generateMunitionTree(ReconfigurationParameters rp, Team t, String defaultSettingsFile) {
+        // Based on various requirements from rp, set weights for some ammo types over others
+        MunitionWeightCollection mwc = new MunitionWeightCollection();
+        return generateMunitionTree(rp, t, defaultSettingsFile, mwc);
+    }
+
     /**
      * Generate the list of desired ammo load-outs for this team.
      * TODO: implement generateDetailedMunitionTree with more complex breakdowns per unit type
@@ -393,13 +397,10 @@ public class TeamLoadoutGenerator {
      * @param defaultSettingsFile
      * @return generated MunitionTree with imperatives for each weapon type
      */
-    public static MunitionTree generateMunitionTree(ReconfigurationParameters rp, Team t, String defaultSettingsFile) {
+    public static MunitionTree generateMunitionTree(ReconfigurationParameters rp, Team t, String defaultSettingsFile, MunitionWeightCollection mwc) {
 
         MunitionTree mt = (defaultSettingsFile == null | defaultSettingsFile.isBlank()) ?
                 new MunitionTree() : new MunitionTree(defaultSettingsFile);
-
-        // Based on various requirements from rp, set weights for some ammo types over others
-        MunitionWeightCollection mwc = new MunitionWeightCollection();
 
         // Modify weights for parameters
         if (rp.darkEnvironment) {

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package megamek.client.generator;
 
 import megamek.client.ui.swing.ClientGUI;

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -48,6 +48,10 @@ public class TeamLoadoutGenerator {
             "FABombSmall Ammo", "ClusterBomb", "HEBomb"
     ));
 
+    public static final ArrayList<String> ANTI_BA_MUNITIONS = new ArrayList<>(List.of(
+            "Inferno", "Fuel-Air", "Anti-personnel", "Acid", "FABombSmall Ammo", "HEBomb"
+    ));
+
     public static final ArrayList<String> HEAT_MUNITIONS = new ArrayList<>(List.of(
             "Inferno", "Incendiary", "InfernoBomb"
     ));
@@ -176,7 +180,11 @@ public class TeamLoadoutGenerator {
     }
 
     private static long checkForInfantry(ArrayList<Entity> el) {
-        return el.stream().filter(e -> e.isInfantry() || e.isBattleArmor()).count();
+        return el.stream().filter(e -> e.isInfantry() && !e.isBattleArmor()).count();
+    }
+
+    private static long checkForBattleArmor(ArrayList<Entity> el) {
+        return el.stream().filter(Entity::isBattleArmor).count();
     }
 
     private static long checkForVehicles(ArrayList<Entity> el) {
@@ -299,6 +307,7 @@ public class TeamLoadoutGenerator {
                 rp.enemyFliers += checkForFliers(etEntities);
                 rp.enemyBombers += checkForBombers(etEntities);
                 rp.enemyInfantry += checkForInfantry(etEntities);
+                rp.enemyBattleArmor += checkForBattleArmor(etEntities);
                 rp.enemyVehicles += checkForVehicles(etEntities);
                 rp.enemyMeks += checkForMeks(etEntities);
                 rp.enemyEnergyBoats += checkForEnergyBoats(etEntities);
@@ -326,6 +335,8 @@ public class TeamLoadoutGenerator {
         rp.friendlyNARCs = checkForNARC(ownTeamEntities);
         rp.friendlyOffBoard = checkForOffboard(ownTeamEntities);
         rp.friendlyECMCount = checkForECM(ownTeamEntities);
+        rp.friendlyInfantry = checkForInfantry(ownTeamEntities);
+        rp.friendlyBattleArmor = checkForBattleArmor(ownTeamEntities);
 
         // General parameters
         rp.darkEnvironment = g.getPlanetaryConditions().getLight().isDuskOrFullMoonOrMoonlessOrPitchBack();
@@ -928,6 +939,14 @@ class MunitionWeightCollection {
 
     public void decreaseAntiInfMunitions() {
         decreaseMunitions(TeamLoadoutGenerator.ANTI_INF_MUNITIONS);
+    }
+
+    public void increaseAntiBAMunitions() {
+        increaseMunitions(TeamLoadoutGenerator.ANTI_BA_MUNITIONS);
+    }
+
+    public void decreaseAntiBAMunitions() {
+        decreaseMunitions(TeamLoadoutGenerator.ANTI_BA_MUNITIONS);
     }
 
     public void increaseHeatMunitions() {

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -628,9 +628,15 @@ public class TeamLoadoutGenerator {
     public void reconfigureTeam(Game g, Team team, String faction, MunitionTree mt) {
         // configure team according to MunitionTree
         for (Player p: team.players()) {
+            ArrayList<Entity> aeros = new ArrayList<>();
             for (Entity e : g.getPlayerEntities(p, false)){
-                reconfigureEntity(e, mt, faction);
+                if (e.isAero()) {
+                    aeros.add(e);
+                } else {
+                    reconfigureEntity(e, mt, faction);
+                }
             }
+            populateAeroBombs(aeros, this.allowedYear, true);
         }
     }
 
@@ -686,6 +692,12 @@ public class TeamLoadoutGenerator {
         }
     }
     //endregion reconfigureEntity
+
+    //region reconfigureAero
+    public void reconfigureAero(Entity e, MunitionTree mt, String faction) {
+
+    }
+    //endregion reconfigureAero
 
     //region iterativelyLoadAmmo
     private void iterativelyLoadAmmo(

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -939,8 +939,8 @@ public class TeamLoadoutGenerator {
      * Helper function that makes some of the units in the given list of entities
      * carry bombs.
      * @param entityList The list of entities to process
-     * @param campaign Campaign object. In the future, may be used to check list of bombs
-     * for technological availability.
+     * @param year
+     * @param groundMap
      */
     public static void populateAeroBombs(List<Entity> entityList, int year, boolean groundMap) {
         if (entityList == null || entityList.size() < 1) {

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -504,6 +504,12 @@ public class TeamLoadoutGenerator {
             mwc.increaseMunitions(tsmOnly);
         }
 
+        // Set nukes to lowest possible weight if user has set the to unusuable /for this team/
+        // This is a seperate mechanism from the legality check.
+        if (rp.nukesBannedForMe) {
+            mwc.zeroMunitionsWeight(new ArrayList<>(List.of("Davy Crockett-M", "AlamoMissile Ammo")));
+        }
+
         // The main event!
         // Convert MWC to MunitionsTree for loading
         applyWeightsToMunitionTree(mt, mwc);
@@ -785,49 +791,6 @@ public class TeamLoadoutGenerator {
     }
 }
 
-/**
- * Bare data class to pass around and store configuration-influencing info
- */
-class ReconfigurationParameters {
-
-    // Game settings
-    public boolean enemiesVisible = true;
-    public int allowedYear = 3151;
-
-    // Map settings
-    public boolean darkEnvironment = false;
-
-    // Enemy stats
-    public long enemyCount = 0;
-    public long enemyFliers = 0;
-    public long enemyBombers = 0;
-    public long enemyInfantry = 0;
-    public long enemyVehicles = 0;
-    public long enemyMeks = 0;
-    public long enemyEnergyBoats = 0;
-    public long enemyMissileBoats = 0;
-    public long enemyAdvancedArmorCount = 0;
-    public long enemyReflectiveArmorCount = 0;
-    public long enemyFireproofArmorCount = 0;
-    public long enemyFastMovers = 0;
-    public long enemyOffBoard = 0;
-    public long enemyECMCount = 0;
-    public HashSet<String> enemyFactions = new HashSet<String>();
-
-    // Friendly stats
-    public long friendlyCount = 0;
-    public long friendlyTAGs = 0;
-    public long friendlyNARCs = 0;
-    public long friendlyEnergyBoats = 0;
-    public long friendlyMissileBoats = 0;
-    public long friendlyOffBoard = 0;
-    public long friendlyECMCount = 0;
-
-    // Datatype for passing around game parameters the Loadout Generator cares about
-    ReconfigurationParameters() {
-    }
-}
-
 class MunitionWeightCollection {
     private HashMap<String, Double> lrmWeights;
     private HashMap<String, Double> srmWeights;
@@ -924,6 +887,15 @@ class MunitionWeightCollection {
                 )
         );
     }
+
+    public void zeroMunitionsWeight(ArrayList<String> munitions) {
+        mapTypeToWeights.entrySet().forEach(
+                e -> modifyMatchingWeights(
+                        e.getValue(), munitions, 0.0, 0.0
+                )
+        );
+    }
+
 
     public void increaseAPMunitions() {
         increaseMunitions(TeamLoadoutGenerator.AP_MUNITIONS);

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -675,11 +675,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
 
         if (fc.getSelectedFile() != null) {
             String file = fc.getSelectedFile().getAbsolutePath();
-            if (null == munitionTree) {
-                munitionTree = new MunitionTree(file);
-            } else {
-                munitionTree.readFromADFFilename(file);
-            }
+            mt = new MunitionTree(file);
         }
         return mt;
     }

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -44,6 +44,7 @@ import org.apache.commons.collections.IteratorUtils;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
+import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.text.DefaultFormatterFactory;
 import javax.swing.text.NumberFormatter;
 
@@ -651,9 +652,18 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         }
     };
 
+    /**
+     * Let user select an ADF file (Autoconfiguration Definition File) from which to load munition loadout
+     * imperatives, which can then be applied to selected units.
+     * @return
+     */
     private MunitionTree loadLoadout() {
         MunitionTree mt = null;
         JFileChooser fc = new JFileChooser(MMConstants.USER_LOADOUTS_DIR);
+        FileNameExtensionFilter adfFilter = new FileNameExtensionFilter(
+                "adf files (*.adf)", "adf");
+        fc.addChoosableFileFilter(adfFilter);
+        fc.setFileFilter(adfFilter);
         fc.setLocation(this.getLocation().x + 150, this.getLocation().y + 100);
         fc.setDialogTitle(Messages.getString("ClientGui.LoadoutLoadDialog.title"));
 
@@ -677,6 +687,10 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
     private void saveLoadout(MunitionTree source) {
         //ignoreHotKeys = true;
         JFileChooser fc = new JFileChooser(MMConstants.USER_LOADOUTS_DIR);
+        FileNameExtensionFilter adfFilter = new FileNameExtensionFilter(
+                "adf files (*.adf)", "adf");
+        fc.addChoosableFileFilter(adfFilter);
+        fc.setFileFilter(adfFilter);
         fc.setLocation(this.getLocation().x + 150, this.getLocation().y + 100);
         fc.setDialogTitle(Messages.getString("ClientGui.LoadoutSaveDialog.title"));
 

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -701,6 +701,9 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         }
         if (fc.getSelectedFile() != null) {
             String file = fc.getSelectedFile().getAbsolutePath();
+            if (!file.toLowerCase().endsWith(".adf")) {
+                file = file + ".adf";
+            }
             source.writeToADFFilename(file);
         }
     }

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -24,6 +24,7 @@ import megamek.client.Client;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
+import megamek.client.generator.ReconfigurationParameters;
 import megamek.client.generator.TeamLoadoutGenerator;
 import megamek.client.ui.GBC;
 import megamek.client.ui.Messages;
@@ -213,6 +214,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
     private final JButton butAutoconfigure = new JButton(Messages.getString("PlayerSettingsDialog.autoConfig"));
     private final JButton butRandomize = new JButton(Messages.getString("PlayerSettingsDialog.randomize"));
     private Checkbox chkTrulyRandom = new Checkbox("Truly Random", false);
+    private Checkbox chkBanNukes = new Checkbox("No Nukes", false);
     private final JButton butSaveADF = new JButton(Messages.getString("PlayerSettingsDialog.saveADF"));
     private final JButton butLoadADF = new JButton(Messages.getString("PlayerSettingsDialog.loadADF"));
     private final JButton butRestoreMT = new JButton(Messages.getString("PlayerSettingsDialog.restore"));
@@ -278,6 +280,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         panContent.add(butRandomize, gbc);
         butRandomize.addActionListener(listener);
         panContent.add(chkTrulyRandom, gbc);
+        panContent.add(chkBanNukes, gbc);
         panContent.add(butSaveADF, gbc);
         butSaveADF.addActionListener(listener);
         panContent.add(butLoadADF, gbc);
@@ -591,7 +594,10 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
                 butRestoreMT.setEnabled(true);
                 butAutoconfigure.setEnabled(false);
                 butRandomize.setEnabled(true);
-                munitionTree = tlg.generateMunitionTree(tlg.generateParameters(team), team);
+                // Set nuke ban state before generating the tree
+                ReconfigurationParameters rp = tlg.generateParameters(team);
+                rp.nukesBannedForMe = chkBanNukes.getState();
+                munitionTree = tlg.generateMunitionTree(rp, team);
             }
 
             if (butRandomize.equals(e.getSource())) {

--- a/megamek/src/megamek/common/GameReports.java
+++ b/megamek/src/megamek/common/GameReports.java
@@ -49,7 +49,7 @@ public class GameReports implements FullGameReport<Report> {
 
     @Override
     public boolean hasReportsforRound(int round) {
-        return round <= reports.size();
+        return round >= 0 && round <= reports.size();
     }
 
     @Override

--- a/megamek/src/megamek/common/containers/MunitionTree.java
+++ b/megamek/src/megamek/common/containers/MunitionTree.java
@@ -82,7 +82,7 @@ public class MunitionTree {
 
     private static String HEADER = String.join(
             System.getProperty("line.separator"),
-            "# ADF (Autoconfiguration Definition File) from MegaMek.",
+            "# ADF (Autoconfiguration Data File) from MegaMek.",
             "# Lines are formatted as",
             "#      '<Chassis>:<Model>:<Pilot>::<Weapon type>:Muntion1[:Munition2[:...]]][::AmmoType2...]'",
             "# Values for <Chassis>, <Model>, <Pilot>, and <Weapon Type> may be 'any', or actual values.",
@@ -213,12 +213,13 @@ public class MunitionTree {
             HashMap<String, String> imperatives = new HashMap<>();
             for (Mounted m : e.getAmmo()) {
                 AmmoType aType = (AmmoType) m.getType();
+                String baseName = aType.getBaseName();
                 String sName = aType.getShortName();
-                String munition = (aType.getSubMunitionName() == aType.getBaseName()) ? "Standard" : aType.getSubMunitionName();
-                if (!(imperatives.containsKey(sName))) {
-                    imperatives.put(sName, munition);
+                String munition = (aType.getSubMunitionName() == baseName) ? "Standard" : aType.getSubMunitionName();
+                if (!(imperatives.containsKey(baseName))) {
+                    imperatives.put(baseName, munition);
                 } else {
-                    imperatives.put(sName, imperatives.get(sName) + ':' + munition);
+                    imperatives.put(baseName, imperatives.get(baseName) + ':' + munition);
                 }
             }
             root.insert(imperatives, e.getFullChassis(), e.getModel(), e.getCrew().getName(0));

--- a/megamek/src/megamek/common/containers/MunitionTree.java
+++ b/megamek/src/megamek/common/containers/MunitionTree.java
@@ -215,7 +215,7 @@ public class MunitionTree {
                 AmmoType aType = (AmmoType) m.getType();
                 String baseName = aType.getBaseName();
                 String sName = aType.getShortName();
-                String munition = (aType.getSubMunitionName() == baseName) ? "Standard" : aType.getSubMunitionName();
+                String munition = (aType.getSubMunitionName().equals(baseName)) ? "Standard" : aType.getSubMunitionName();
                 if (!(imperatives.containsKey(baseName))) {
                     imperatives.put(baseName, munition);
                 } else {

--- a/megamek/src/megamek/common/containers/MunitionTree.java
+++ b/megamek/src/megamek/common/containers/MunitionTree.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package megamek.common.containers;
 
 import megamek.common.AmmoType;

--- a/megamek/src/megamek/common/containers/MunitionTree.java
+++ b/megamek/src/megamek/common/containers/MunitionTree.java
@@ -63,7 +63,7 @@ public class MunitionTree {
 
     private static String HEADER = String.join(
             System.getProperty("line.separator"),
-            "# ADF (Autoconfiguration Data File) from MegaMek.",
+            "# ADF (Autoconfiguration Definition File) from MegaMek.",
             "# Lines are formatted as",
             "#      '<Chassis>:<Model>:<Pilot>::<Weapon type>:Muntion1[:Munition2[:...]]][::AmmoType2...]'",
             "# Values for <Chassis>, <Model>, <Pilot>, and <Weapon Type> may be 'any', or actual values.",

--- a/megamek/src/megamek/common/equipment/BombMounted.java
+++ b/megamek/src/megamek/common/equipment/BombMounted.java
@@ -22,14 +22,10 @@ package megamek.common.equipment;
 
 import megamek.common.BombType;
 import megamek.common.Entity;
+import megamek.common.Mounted;
 
-public class BombMounted extends AmmoMounted {
+public class BombMounted extends Mounted<BombType> {
     public BombMounted(Entity entity, BombType type) {
         super(entity, type);
-    }
-
-    @Override
-    public BombType getType() {
-        return (BombType) super.getType();
     }
 }

--- a/megamek/src/megamek/common/equipment/BombMounted.java
+++ b/megamek/src/megamek/common/equipment/BombMounted.java
@@ -22,10 +22,14 @@ package megamek.common.equipment;
 
 import megamek.common.BombType;
 import megamek.common.Entity;
-import megamek.common.Mounted;
 
-public class BombMounted extends Mounted<BombType> {
+public class BombMounted extends AmmoMounted {
     public BombMounted(Entity entity, BombType type) {
         super(entity, type);
+    }
+
+    @Override
+    public BombType getType() {
+        return (BombType) super.getType();
     }
 }

--- a/megamek/unittests/megamek/client/generator/MunitionTreeTest.java
+++ b/megamek/unittests/megamek/client/generator/MunitionTreeTest.java
@@ -1,12 +1,9 @@
 package megamek.client.generator;
 
-import megamek.common.BipedMech;
-import megamek.common.Entity;
 import megamek.common.MechSummary;
 import megamek.common.MechSummaryCache;
 import megamek.common.containers.MunitionTree;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -22,7 +19,6 @@ class MunitionTreeTest {
     HashMap<String, String> lrmHash = new HashMap<>();
     HashMap<String, String> acHash = new HashMap<>();
     HashMap<String, String> ltHash = new HashMap<>();
-    HashMap<String, String> mgHash = new HashMap<>();
 
     @BeforeAll
     static void setUp() {
@@ -127,7 +123,7 @@ class MunitionTreeTest {
     }
 
     @Test
-    @Disabled("Runtime is > 20 seconds")
+    //@Disabled("Runtime is > 20 seconds")
     void testPopulateAllPossibleUnits() {
         MechSummaryCache instance = MechSummaryCache.getInstance(true);
         // Make sure no units failed loading

--- a/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
@@ -472,10 +472,10 @@ class TeamLoadoutGeneratorTest {
         MunitionWeightCollection mwc = new MunitionWeightCollection();
         TeamLoadoutGenerator tlg = new TeamLoadoutGenerator(cg);
 
-        // Have the Munition Tree generator use our pre-made mwc so we can get see its changes
+        // Have the Munition Tree generator use our pre-made mwc so we can see its changes
         MunitionTree mt = tlg.generateMunitionTree(rp, team, "", mwc);
 
         assertEquals(0.0, mwc.getArtyWeights().get("Davy Crockett-M"));
-        assertEquals(0.0, mwc.getArtyWeights().get("AlamoMissile"));
+        assertEquals(0.0, mwc.getBombWeights().get("AlamoMissile Ammo"));
     }
 }

--- a/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
@@ -4,7 +4,6 @@ import megamek.client.Client;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.common.*;
 import megamek.common.containers.MunitionTree;
-import megamek.client.generator.ReconfigurationParameters;
 import megamek.common.options.*;
 import org.apache.commons.collections.IteratorUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -257,7 +256,7 @@ class TeamLoadoutGeneratorTest {
         // Kintaro's go under different keys
         mt.insertImperative("Kintaro", "KTO-18", "any", "SRM", "Inferno:Standard");
 
-        tlg.reconfigureTeam(game, team, "FS", mt);
+        tlg.reconfigureEntities(game.getPlayerEntities(player, false), "FS", mt);
 
         // Check loadouts
         // 1. AC20 HBK should have two tons of Caseless
@@ -358,7 +357,7 @@ class TeamLoadoutGeneratorTest {
         Mounted bin7 = mockMech3.addEquipment(mockSRM6AmmoType, Mech.LOC_CT);
 
         // Just check that the bins are populated still
-        tlg.reconfigureTeam(team,"CL", "");
+        tlg.reconfigureTeam(team, "CL", "");
 
         for (Mounted bin: List.of(bin1, bin2, bin3, bin4, bin5, bin6, bin7)) {
             assertNotEquals("", ((AmmoType) bin.getType()).getSubMunitionName());

--- a/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
@@ -6,6 +6,7 @@ import megamek.common.*;
 import megamek.common.containers.MunitionTree;
 import megamek.client.generator.ReconfigurationParameters;
 import megamek.common.options.*;
+import org.apache.commons.collections.IteratorUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -473,7 +474,9 @@ class TeamLoadoutGeneratorTest {
         TeamLoadoutGenerator tlg = new TeamLoadoutGenerator(cg);
 
         // Have the Munition Tree generator use our pre-made mwc so we can see its changes
-        MunitionTree mt = tlg.generateMunitionTree(rp, team, "", mwc);
+
+        ArrayList<Entity> ownTeamEntities = (ArrayList<Entity>) IteratorUtils.toList(game.getTeamEntities(team));
+        MunitionTree mt = tlg.generateMunitionTree(rp, ownTeamEntities, "", mwc);
 
         assertEquals(0.0, mwc.getArtyWeights().get("Davy Crockett-M"));
         assertEquals(0.0, mwc.getBombWeights().get("AlamoMissile Ammo"));

--- a/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
@@ -4,6 +4,7 @@ import megamek.client.Client;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.common.*;
 import megamek.common.containers.MunitionTree;
+import megamek.client.generator.ReconfigurationParameters;
 import megamek.common.options.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -462,5 +463,19 @@ class TeamLoadoutGeneratorTest {
         mwc.increaseMunitions(tsmOnly);
         assertEquals(15.0, mwc.getSrmWeights().get("Anti-TSM"));
         assertEquals("Anti-TSM=15.0", mwc.getTopN(1).get("SRM").get(0));
+    }
+
+    @Test
+    void testNukeToggleDecreasesNukeWeightToZero() {
+        ReconfigurationParameters rp = new ReconfigurationParameters();
+        rp.nukesBannedForMe = true;
+        MunitionWeightCollection mwc = new MunitionWeightCollection();
+        TeamLoadoutGenerator tlg = new TeamLoadoutGenerator(cg);
+
+        // Have the Munition Tree generator use our pre-made mwc so we can get see its changes
+        MunitionTree mt = tlg.generateMunitionTree(rp, team, "", mwc);
+
+        assertEquals(0.0, mwc.getArtyWeights().get("Davy Crockett-M"));
+        assertEquals(0.0, mwc.getArtyWeights().get("AlamoMissile"));
     }
 }


### PR DESCRIPTION
Stage 2 in the automatic munition configuration project.

Adds:
- Separate "No Nukes" checkbox to prevent specific players from accessing nukes.
- More granular BA/CI accounting for Anti-personnel munition weighting.
- Tooltips for all controls in the Configure Player dialog.
- First-pass integration of bomb loadout configuration (currently mostly random, a copy of the old MHQ code).
- Faction selection box uses era-appropriate names rather than key codes.
- More robust file saving and loading.
- Changed per-team configuration to per-player configuration, using code updates that will also enable Lobby context menu actions.

Not yet in:
- Lobby context menu options
- GUI options to enable automatic configuration for Princess forces,
- MHQ integration

Testing:
- Extensive testing with land- and airborne units.
- Ran all 3 projects' unit tests.

#5284 