### PR TITLE
Fix ammo carrier issue that prevents Princess from firing ammo-based weapons

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -320,7 +320,7 @@ public class WeaponAttackAction extends AbstractAttackAction implements Serializ
         if (ammoId == UNASSIGNED) {
             linkedAmmo = weapon.getLinkedAmmo();
         } else {
-            Entity carrier = game.getEntity(ammoCarrier);
+            Entity carrier = (ammoCarrier == UNASSIGNED) ? ae : game.getEntity(ammoCarrier);
             linkedAmmo = (carrier == null) ? null : carrier.getAmmo(ammoId);
         }
 


### PR DESCRIPTION
Noticed while testing the 0.49.20 MekHQ version of MegaMek: Princess does not fire any weapons that use ammo.

Solution: consider the current unit the "ammo carrier" if no ammo carrier ID is provided.

Testing:
- Ran several Princess v. Princess matches with ammo-based weapons, both Ground and Low Alt, including meks, BA, infantry, field artillery/guns, tanks, VTOLs, and ASF.
- Ran all three projects' unit tests.