### PR TITLE
Fix gradle createExe task to build locally on Windows and launch.

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -51,6 +51,7 @@ application {
 
 ext {
     mmJvmOptions = ['-Xmx4096m', '--add-opens', 'java.base/java.util=ALL-UNNAMED', '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED', '-Dsun.awt.disablegrab=true']
+    mmL4jJvmOptions = ['-Xmx4096m', '-Dsun.awt.disablegrab=true']
     data = 'data'
     unitFiles = "${data}/mechfiles"
     rats = "${data}/rat"
@@ -253,8 +254,9 @@ createExe {
     companyName = "MegaMek Development Team"
     outputs.file "${buildDir}/launch4j/${outfile}"
     outputs.file "${buildDir}/launch4j/${iniFile}"
-    jvmOptions = project.ext.mmJvmOptions
+    jvmOptions = project.ext.mmL4jJvmOptions
     jreMinVersion = '17'
+    doNotTrackState("Tell gradle not to track output")
     messagesJreNotFoundError = 'Go here for instructions on installing the correct version of Java: https://github.com/MegaMek/megamek/wiki/Updating-to-Adoptium'
     doLast {
         new File("${buildDir}/launch4j/${iniFile}").text = """# Launch4j runtime config


### PR DESCRIPTION
Gradle was failing to create the Launch4J exe when building locally from Gradle.  

Updated embedded exe jvm arguments to prevent hidden errors that were stopping megamek to launch when double-clicking the exe file.

The default jvm arguments are preserved in the MegaMek.l4j.ini file.