### PR TITLE
Princess -  advance to the front, not the rear for double-blind

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -331,7 +331,7 @@ public class PathEnumerator {
                 destinations = getOwner().getClusterTracker().getDestinationCoords(mover, getOwner().getHomeEdge(mover), true);
                 break;
             case MoveToContact:
-                CardinalEdge oppositeEdge = CardinalEdge.getOppositeEdge(BoardUtilities.determineOppositeEdge(mover));
+                CardinalEdge oppositeEdge = BoardUtilities.determineOppositeEdge(mover);
                 destinations = getOwner().getClusterTracker().getDestinationCoords(mover, oppositeEdge, true);
                 break;
             default:


### PR DESCRIPTION
Removes the double-reverse on which board edge to move towards if there are no contacts in double-blind.  Now, when double-blind rules are in play and Princess has no active or sensor contacts it will try to move to the map edge opposite from where it deployed.  If deployed in the center or edge, it's units will move away from the edge nearest each unit's current position effectively milling around in the center of the map.  At some point in the process it should either get direct or sensor contact on hostile targets and move to engage.