### PR TITLE
Fixes #5650 Weapon unselect after torso twist.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/UnitDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/UnitDisplay.java
@@ -437,7 +437,8 @@ public class UnitDisplay extends JPanel implements IPreferenceChangeListener {
      * Displays the specified entity in the panel.
      */
     public void displayEntity(Entity en) {
-        if (en == null) {
+        if ((en == null) || (currentlyDisplaying == en)) {
+            // Issue #5650 - this method should not be executed if the currently displayed entity hasn't changed. 
             return;
         }
         currentlyDisplaying = en;


### PR DESCRIPTION
Revert a change to `UnitDisplay::displayEntity()` that was causing weapon selection after a torso twist to become unselected along with other potential entity state changes in various phases to become undone.