### PR TITLE
Fixes #5700 Clear move modifiers on escape and clear envelope when turned off.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1204,6 +1204,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
         // clear board cursors
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().cursor(null);
+        // Needed to clear best move modifiers
+        clientgui.clearTemporarySprites();
 
         if (ce == null) {
             return;
@@ -4342,6 +4344,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
     public void computeMovementEnvelope(Entity suggestion) {
         // do nothing if deactivated in the settings
         if (!GUIP.getMoveEnvelope()) {
+            // Issue #5700 : Move envelope doesn't clear when turning off move envelopes from menu or shortcut.
+            clientgui.clearTemporarySprites();
             return;
         }
 


### PR DESCRIPTION
Fixes #5700.  

Some refactoring cleanup broke the functionality of clearing the movement modifier sprites and move envelope sprites when turning off in the menu or shortcuts.