### PR TITLE
Enable Visual range and Move Envelope to toggle individually

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2844,11 +2844,18 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
     }
 
     /**
+     * Removes visibility to the Movement Envelope.
+     */
+    public void clearMovementEnvelope() {
+        this.movementEnvelopeHandler.clear();
+    }
+
+    /**
      * Removes all temporary sprites from the board, such as pending actions, movement envelope,
      * collapse warnings etc. Does not remove game-state sprites such as units or flares.
      */
     public void clearTemporarySprites() {
-        movementEnvelopeHandler.clear();
+        clearMovementEnvelope();
         movementModifierSpriteHandler.clear();
         sensorRangeSpriteHandler.clear();
         collapseWarningSpriteHandler.clear();

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4345,7 +4345,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         // do nothing if deactivated in the settings
         if (!GUIP.getMoveEnvelope()) {
             // Issue #5700 : Move envelope doesn't clear when turning off move envelopes from menu or shortcut.
-            clientgui.clearTemporarySprites();
+            clientgui.clearMovementEnvelope();
             return;
         }
 


### PR DESCRIPTION
This PR fixes a side-effect that was introduced in PR #5712 to resolve #5700. 

The side-effect is:  When in the movement phase with Visual and Sensor range enabled, when the selected unit has no movement path, or Escape, or Backspace were pressed, the Visual and Sensor Range sprites would be removed.

The correct operation is that the Visual and Sensor Range must be able to be toggled on and off independently of the Movement Envelope and Movement Modifier sprites.