### PR TITLE
Fix incorrect onGround usage and make sure ASF bombs are always cleared before refitting

### DIFF
--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -537,8 +537,8 @@ public class TeamLoadoutGenerator {
         boolean blind = gOpts.booleanOption(OptionsConstants.BASE_BLIND_DROP)
                 || gOpts.booleanOption(OptionsConstants.BASE_REAL_BLIND_DROP);
         boolean darkEnvironment = g.getPlanetaryConditions().getLight().isDuskOrFullMoonOrMoonlessOrPitchBack();
-        boolean groundMap = g.getBoard().onGround();
-        boolean spaceEnvironment = g.getBoard().inSpace();
+        boolean groundMap = (g.getMapSettings().getMedium() == MapSettings.MEDIUM_GROUND);
+        boolean spaceEnvironment = (g.getMapSettings().getMedium() == MapSettings.MEDIUM_SPACE);
 
         if (blind) {
             enemyEntities.clear();

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekPopupActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekPopupActions.java
@@ -380,13 +380,13 @@ public class LobbyMekPopupActions implements ActionListener {
         switch (command) {
             case LMP_AUTOCONFIG:
                 mt = tlg.generateMunitionTree(rp, el, "");
-                resetBombChoices(clientgui, el);
+                resetBombChoices(clientgui, lobby.game(), el);
                 tlg.reconfigureEntities(el, faction, mt, rp);
                 reconfigured = true;
                 break;
             case LMP_RANDOMCONFIG:
                 mt = TeamLoadoutGenerator.generateRandomizedMT();
-                resetBombChoices(clientgui, el);
+                resetBombChoices(clientgui, lobby.game(), el);
                 tlg.reconfigureEntities(el, faction, mt, rp);
                 reconfigured = true;
                 break;
@@ -398,7 +398,7 @@ public class LobbyMekPopupActions implements ActionListener {
                 mt = loadLoadout();
                 if (null != mt && null != clientgui) {
                     // Apply to entities
-                    resetBombChoices(clientgui, el);
+                    resetBombChoices(clientgui, lobby.game(), el);
                     tlg.reconfigureEntities(el, faction, mt, rp);
                     reconfigured = true;
                 }
@@ -410,7 +410,7 @@ public class LobbyMekPopupActions implements ActionListener {
         }
     }
 
-    private void resetBombChoices(ClientGUI clientgui, ArrayList<Entity> el) {
+    public static void resetBombChoices(ClientGUI clientgui, Game game, ArrayList<Entity> el) {
         ArrayList<Entity> resetBombers = new ArrayList();
         for (Entity entity: el) {
             if (entity.isBomber() && !entity.isVehicle()) {
@@ -422,7 +422,7 @@ public class LobbyMekPopupActions implements ActionListener {
             }
         }
         if (!resetBombers.isEmpty()) {
-            clientgui.chatlounge.sendProxyUpdates(resetBombers, lobby.game().getPlayer(el.get(0).getOwnerId()));
+            clientgui.chatlounge.sendProxyUpdates(resetBombers, game.getPlayer(el.get(0).getOwnerId()));
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -58,6 +58,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static megamek.client.ui.Messages.getString;
+import static megamek.client.ui.swing.lobby.LobbyMekPopupActions.resetBombChoices;
 import static megamek.client.ui.swing.lobby.LobbyUtility.isValidStartPos;
 import static megamek.client.ui.swing.util.UIUtil.*;
 
@@ -435,7 +436,8 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
             if (null != munitionTree && null != rp) {
                 rp.friendlyFaction = faction;
                 rp.binFillPercent = (rp.isPirate) ? TeamLoadoutGenerator.UNSET_FILL_RATIO : 1.0f;
-                // TODO: create and set up default adf file path for bots
+                // Clear any bomb assignments
+                resetBombChoices(clientgui, client.getGame(), updateEntities);
                 tlg.reconfigureEntities(updateEntities, faction, munitionTree, rp);
                 // Use sendUpdate because we want the Game to allow us to change on Bot's behalf.
                 clientgui.chatlounge.sendProxyUpdates(updateEntities, client.getLocalPlayer());


### PR DESCRIPTION
Issue was querying the board state rather than the game state; the Board is not set up until entering the game (or previewing the map) so it always returned `onGround() = true;`.

As an added safety measure, make sure that all Aero units' bomb choices are cleared prior to reconfiguring, in case they are loaded in with bombs already configured.

Testing:
- Refitted a number of ASF on ground, low-alt, and space maps.
- Ran all 3 projects' unit tests.

Close #5730 