### PR TITLE
Munition autoconfig tweaks

### DIFF
--- a/megamek/mmconf/munitionLoadoutSettings.xml
+++ b/megamek/mmconf/munitionLoadoutSettings.xml
@@ -75,6 +75,7 @@
     <entry key="defaultStandardMunitionWeight">2.0</entry>
     <entry key="defaultMissileStandardMunitionWeight">2.0</entry>
     <entry key="defaultDeadFireMunitionWeight">3.0</entry>
+    <entry key="defaultArtemisCapableMunitionWeight">0.0</entry>
     <entry key="defaultATMMunitionWeight">2.0</entry>
     <entry key="defaultATMStandardWeight">1.0</entry>
     <entry key="increaseWeightFactor">2.0</entry>

--- a/megamek/mmconf/munitionLoadoutSettings.xml
+++ b/megamek/mmconf/munitionLoadoutSettings.xml
@@ -19,6 +19,8 @@
     <entry key="mtGuidedAmmoFriendlyMissileBoatFractionDivisor">3.0</entry>
     <entry key="mtUtilityAmmoOffboardUnitsThreshold">2.0</entry>
     <entry key="mtUtilityAmmoFriendlyVsEnemyFractionDivisor">1.0</entry>
+    <entry key="mtEnergyBoatEnemyFractionDivisor">4.0</entry>
+    <entry key="mtSeekingAmmoEnemyTSMExceedThreshold">1.0</entry>
     <entry key="commentTopMunitionsSubsetCount">This count determines how many munition types (out of all options) are actually selected</entry>
     <entry key="mtTopMunitionsSubsetCount">4</entry>
     <entry key="commentStartTLGBombArea">The following entries are used by Bombs:</entry>

--- a/megamek/mmconf/munitionLoadoutSettings.xml
+++ b/megamek/mmconf/munitionLoadoutSettings.xml
@@ -75,7 +75,7 @@
     <entry key="defaultStandardMunitionWeight">2.0</entry>
     <entry key="defaultMissileStandardMunitionWeight">2.0</entry>
     <entry key="defaultDeadFireMunitionWeight">3.0</entry>
-    <entry key="defaultArtemisCapableMunitionWeight">0.0</entry>
+    <entry key="defaultArtemiscapableMunitionWeight">0.0</entry>
     <entry key="defaultATMMunitionWeight">2.0</entry>
     <entry key="defaultATMStandardWeight">1.0</entry>
     <entry key="increaseWeightFactor">2.0</entry>

--- a/megamek/src/megamek/client/generator/ReconfigurationParameters.java
+++ b/megamek/src/megamek/client/generator/ReconfigurationParameters.java
@@ -53,6 +53,7 @@ public class ReconfigurationParameters {
     public long enemyFastMovers = 0;
     public long enemyOffBoard = 0;
     public long enemyECMCount = 0;
+    public long enemyTSMCount = 0;
     public HashSet<String> enemyFactions = new HashSet<String>();
 
     // Friendly stats

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -317,12 +317,13 @@ public class TeamLoadoutGenerator {
     }
 
     /**
-     * Calculates legality of
-     * @param aType
-     * @param faction
-     * @param techBase
-     * @param mixedTech
-     * @return
+     * Calculates legality of ammo types given a faction, tech base (IS/CL), mixed tech, and the instance's
+     * already-set year, tech level, and option for showing extinct equipment.
+     * @param aType the AmmoType of the munition under consideration.  q.v.
+     * @param faction MM-style faction code, per factions.xml and FactionRecord keys
+     * @param techBase either 'IS' or 'CL', used for clan boolean check.
+     * @param mixedTech makes munitions checks more lenient by allowing faction to access both IS and CL techbases.
+     * @return boolean true if legal for combination of inputs, false otherwise.  Determins if an AmmoType is loaded.
      */
     public boolean checkLegality(AmmoType aType, String faction, String techBase, boolean mixedTech) {
         boolean legal = false;

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -1810,6 +1810,8 @@ class MunitionWeightCollection {
         weights.put("Standard", getPropDouble("defaultMissileStandardMunitionWeight", 2.0));
         // Dead-Fire should be even higher to start
         weights.put("Dead-Fire", getPropDouble("defaultDeadFireMunitionWeight", 3.0));
+        // Artemis should be zeroed; Artemis-equipped launchers will be handled separately
+        weights.put("Artemis-capable", getPropDouble("defaultArtemisCapableMunitionWeight", 0.0));
         return weights;
     }
 

--- a/megamek/src/megamek/common/ITechnology.java
+++ b/megamek/src/megamek/common/ITechnology.java
@@ -284,6 +284,9 @@ public interface ITechnology {
     }
 
     default boolean isAvailableIn(int year, boolean clan, boolean ignoreExtinction) {
+        // For technology created in the IS after the Clan Invasion, Clan availability
+        // matches IS (TO pg 33)
+        clan = clan && ITechnology.getTechEra(year) < ITechnology.ERA_CLAN;
         return year >= getIntroductionDate(clan) && (getIntroductionDate(clan) != DATE_NONE)
                 && (ignoreExtinction || !isExtinct(year, clan));
     }
@@ -294,6 +297,9 @@ public interface ITechnology {
     }
 
     default boolean isAvailableIn(int year, boolean clan, int faction) {
+        // For technology created in the IS after the Clan Invasion, Clan availability
+        // matches IS (TO pg 33)
+        clan = clan && ITechnology.getTechEra(year) < ITechnology.ERA_CLAN;
         return year >= getIntroductionDate(clan, faction)
                 && getIntroductionDate(clan, faction) != DATE_NONE  && !isExtinct(year, clan, faction);
     }
@@ -304,6 +310,9 @@ public interface ITechnology {
     }
 
     default boolean isLegal(int year, SimpleTechLevel simpleRulesLevel, boolean clanBase, boolean mixedTech, boolean ignoreExtinct) {
+        // For technology created in the IS after the Clan Invasion, Clan availability
+        // matches IS (TO pg 33)
+        clanBase = clanBase && ITechnology.getTechEra(year) < ITechnology.ERA_CLAN;
         if (mixedTech) {
             if (!isAvailableIn(year, ignoreExtinct)) {
                 return false;

--- a/megamek/src/megamek/common/TechAdvancement.java
+++ b/megamek/src/megamek/common/TechAdvancement.java
@@ -269,8 +269,10 @@ public class TechAdvancement implements ITechnology {
             // other factions after 3d6+5 years if it hasn't gone extinct by then.
             // Using the minimum value here.
             int date = getDate(PROTOTYPE, clan) + 8;
-            if ((getDate(PRODUCTION, clan) < date)
-                    || (getDate(COMMON, clan) < date)
+            int dateProduction = getDate(PRODUCTION, clan);
+            int dateCommon = getDate(COMMON, clan);
+            if ((dateProduction != DATE_NONE && dateProduction < date)
+                    || (dateCommon != DATE_NONE && dateCommon < date)
                     || isExtinct(date, clan)) {
                 return DATE_NONE;
             }
@@ -311,7 +313,7 @@ public class TechAdvancement implements ITechnology {
             // Per IO p. 34, tech with no common date becomes available to
             // other factions after 10 years if it hasn't gone extinct by then.
             int date = getDate(PRODUCTION, clan) + 10;
-            if ((getDate(COMMON, clan) <= date)
+            if ((getDate(COMMON, clan) != DATE_NONE && getDate(COMMON, clan) <= date)
                     || isExtinct(date, clan)) {
                 return DATE_NONE;
             }

--- a/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
@@ -385,17 +385,17 @@ class TeamLoadoutGeneratorTest {
         assertFalse(tlg.checkLegality(mType, "CC", "IS", false));
         assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
         assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "CL", "CL", false));
-        assertFalse(tlg.checkLegality(mType, "CL", "CL", true));
+        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", false));
+        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
 
-        // Should be available to everyone, although only as Mixed Tech for Clans
+        // Should be available to everyone
         when(mockGameOptions.stringOption(OptionsConstants.ALLOWED_TECHLEVEL)).thenReturn("Advanced");
         tlg.updateOptionValues();
         assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
         assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
         assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "CL", "CL", true));
-        assertFalse(tlg.checkLegality(mType, "CL", "CL", false));
+        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
+        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
     }
 
     @Test
@@ -408,7 +408,9 @@ class TeamLoadoutGeneratorTest {
         assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
         assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
         assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "CL", "CL", true));
+        // Check mixed-tech and regular Clan tech, which should match IS at this point
+        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
+        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", false));
 
         // Set year back to 3025
         when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3025);
@@ -416,7 +418,7 @@ class TeamLoadoutGeneratorTest {
         assertFalse(tlg.checkLegality(mType, "CC", "IS", false));
         assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
         assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "CL", "CL", true));
+        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
 
         // Move up to 3070. Because of game settings and lack of "Common" year, ADA
         // becomes available
@@ -424,9 +426,9 @@ class TeamLoadoutGeneratorTest {
         when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3070);
         tlg.updateOptionValues();
         assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "CL", "CL", false));
+        assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
+        assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
+        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
     }
 
     @Test


### PR DESCRIPTION
Thanks to some early QA work, a number of errors in the "final" munition autoconfig code have been identified.
This patch will:

1.  Fix Artemis munitions being selected for non-Artemis launchers;
2.  Update legality check on ammo types to always use year restrictions with the _option_ to use variable era tech levels;
3. Add tracking of enemy TSM units for consideration when weighting heat-producing munitions;
4. Split "missing munitionLoadoutSettings.xml" error into user warning and debug message with full exception;
5. Adjust "energy boat" unit accounting to only care about those that track heat;
6. Updated some `isAvailable()` methods to allow Clans access to IS equipment at the same availability from the Clan Invasion era onward, per IO pg 33.
7. Fix errors in getPrototypeDate and getProductionDate that would return no date for munitions missing the Common and/or Production entry (e.g. Air-Defence Arrow Missiles), causing some tech to be unavailable to certain combinations of faction and clan/mixed tech bases.
8. Updated unit tests

Testing:
- Ran all 3 projects' unit tests
- Tested with a number of factions, Clan/IS/Mixed tech levels, and eras, alternating Variable Tech off and on.
