### PR TITLE
Lobby: export full chassis to clipboard for meks with clan/is names

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2607,7 +2607,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         StringBuilder result = new StringBuilder();
         for (Entity entity: entities) {
             // Chassis
-            result.append(entity.getChassis()).append("\t");
+            result.append(entity.getFullChassis()).append("\t");
             // Model
             result.append(entity.getModel()).append("\t");
             // Weight; format for locale to avoid wrong ",." etc.


### PR DESCRIPTION
... so pasting works again. Fixes #5740