### PR TITLE
Fix #5287: Infernos do not ignite buildings when using "Ignite" target option

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -485,6 +485,24 @@ public class AmmoType extends EquipmentType {
     }
 
     /**
+     * Analog to WeaponType.getFireTNRoll(), but based on munitions.
+     * See TO:AR pg 42
+     * @return
+     */
+    public int getFireTN() {
+        if (munitionType.contains(Munitions.M_INFERNO)) {
+            return TargetRoll.AUTOMATIC_SUCCESS;
+        } else if (EnumSet.of(
+                Munitions.M_INCENDIARY,
+                Munitions.M_INCENDIARY_AC,
+                Munitions.M_INCENDIARY_LRM).containsAll(munitionType)) {
+            return 5;
+        } else {
+            return 9;
+        }
+    }
+
+    /**
      * Gets a value indicating whether this is a certain ammo type.
      *
      * @param ammoType The ammo type to compare against.

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -411,11 +411,11 @@ public class WeaponType extends EquipmentType {
         } else if (hasFlag(F_FLAMER)) {
             return 4;
         } else if (hasFlag(F_PLASMA)) {
-            return 2;
+            return TargetRoll.AUTOMATIC_SUCCESS;
         } else if (hasFlag(F_PLASMA_MFUK)) {
-            return 2;
+            return TargetRoll.AUTOMATIC_SUCCESS;
         } else if (hasFlag(F_INFERNO)) {
-            return 2;
+            return TargetRoll.AUTOMATIC_SUCCESS;
         } else if (hasFlag(F_INCENDIARY_NEEDLES)) {
             return 6;
         } else if (hasFlag(F_PPC) || hasFlag(F_LASER)) {

--- a/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileWeaponHandler.java
@@ -22,7 +22,6 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 import megamek.server.GameManager;
 
-import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
@@ -381,9 +380,13 @@ public class MissileWeaponHandler extends AmmoWeaponHandler {
         if ((entityTarget != null)
                 && !entityTarget.isAirborne()
                 && !entityTarget.isAirborneVTOLorWIGE()
-                && ((bldg == null) && (wtype.getFireTN() != TargetRoll.IMPOSSIBLE))) {
+                && ((bldg == null) && (
+                    wtype.getFireTN() != TargetRoll.IMPOSSIBLE
+                    && (atype == null || atype.getFireTN() != TargetRoll.IMPOSSIBLE)
+                )
+        )) {
             gameManager.tryIgniteHex(target.getPosition(), subjectId, false, false,
-                    new TargetRoll(wtype.getFireTN(), wtype.getName()), 3, vPhaseReport);
+                    getFireTNRoll(), 3, vPhaseReport);
         }
 
         // shots that miss an entity can also potential cause explosions in a

--- a/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
+++ b/megamek/src/megamek/common/weapons/SRMInfernoHandler.java
@@ -286,7 +286,7 @@ public class SRMInfernoHandler extends SRMHandler {
         if ((bldg != null)
                 && gameManager.tryIgniteHex(target.getPosition(), subjectId, false,
                         true,
-                        new TargetRoll(wtype.getFireTN(), wtype.getName()), 5,
+                        getFireTNRoll(), 5,
                         vPhaseReport)) {
             return;
         }

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -436,6 +436,12 @@ public class WeaponHandler implements AttackHandler, Serializable {
         gameManager = (GameManager) Server.getServerInstance().getGameManager();
     }
 
+    protected TargetRoll getFireTNRoll() {
+        int targetNumber = (atype == null) ? wtype.getFireTN()
+            : Math.min(wtype.getFireTN(), atype.getFireTN());
+        return new TargetRoll(targetNumber, wtype.getName());
+    }
+
     /**
      * @return a <code>boolean</code> value indicating whether or not this attack
      *         needs further calculating, like a missed shot hitting a building,
@@ -449,9 +455,13 @@ public class WeaponHandler implements AttackHandler, Serializable {
         if ((entityTarget != null)
                 && !entityTarget.isAirborne()
                 && !entityTarget.isAirborneVTOLorWIGE()
-                && ((bldg == null) && (wtype.getFireTN() != TargetRoll.IMPOSSIBLE))) {
+                && ((bldg == null) && (
+                        wtype.getFireTN() != TargetRoll.IMPOSSIBLE
+                        && (atype == null || atype.getFireTN() != TargetRoll.IMPOSSIBLE)
+                )
+        )) {
             gameManager.tryIgniteHex(target.getPosition(), subjectId, false, false,
-                    new TargetRoll(wtype.getFireTN(), wtype.getName()), 3,
+                    getFireTNRoll(), 3,
                     vPhaseReport);
         }
 
@@ -1643,7 +1653,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
             r.newlines = 0;
             vPhaseReport.addElement(r);
         }
-        TargetRoll tn = new TargetRoll(wtype.getFireTN(), wtype.getName());
+        TargetRoll tn = getFireTNRoll();
         if (tn.getValue() != TargetRoll.IMPOSSIBLE) {
             Report.addNewline(vPhaseReport);
             gameManager.tryIgniteHex(target.getPosition(), subjectId, false, false,
@@ -1678,7 +1688,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         // you do a normal ignition as though for intentional fires
         if ((bldg != null)
                 && gameManager.tryIgniteHex(target.getPosition(), subjectId, false, false,
-                        new TargetRoll(wtype.getFireTN(), wtype.getName()), 5, vPhaseReport)) {
+                        getFireTNRoll(), 5, vPhaseReport)) {
             return;
         }
         Vector<Report> clearReports = gameManager.tryClearHex(target.getPosition(), nDamage, subjectId);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -9649,6 +9649,7 @@ public class GameManager extends AbstractGameManager {
                 // fall through
             case Targetable.TYPE_HEX_CLEAR:
             case Targetable.TYPE_HEX_IGNITE:
+            case Targetable.TYPE_BLDG_IGNITE:
                 // Report that damage applied to terrain, if there's TF to damage
                 Hex h = game.getBoard().getHex(t.getPosition());
                 if ((h != null) && h.hasTerrainFactor()) {
@@ -9663,7 +9664,6 @@ public class GameManager extends AbstractGameManager {
                 tryIgniteHex(t.getPosition(), attId, false, true,
                         new TargetRoll(0, "inferno"), -1, vPhaseReport);
                 break;
-            case Targetable.TYPE_BLDG_IGNITE:
             case Targetable.TYPE_BUILDING:
                 Vector<Report> vBuildingReport = damageBuilding(game.getBoard().getBuildingAt(t.getPosition()),
                         2 * missiles, t.getPosition());
@@ -13811,6 +13811,7 @@ public class GameManager extends AbstractGameManager {
         }
 
         // is the hex ignitable (how are infernos handled?)
+        // TODO: implement TO:AR modifiers and impossibility check (p. 42)
         if (!hex.isIgnitable()) {
             return false;
         }


### PR DESCRIPTION
Fixes the issue where Inferno SRMs would not ignite buildings when the "Ignite" target option.
Also laid groundwork for removing / refactoring the SRMInfernoHandler, as most of its code lives in other classes (or directly copies theirs) and some things _definitely_ need review if not complete rewrites.

Not touched:
- Changing collapse to ignite buildings - this would break TW handling of Infernos; Ignite is a TacOps option.
- Infernos not doing double damage to hexes when clearing - I could not find a rule reference for this.

Testing:
- Ran tests with all combos of SRM Infernos, Inferno Bombs, Inferno Artillery, and confirmed all work correctly.
- Ran all 3 projects' unit tests.

Close #5287 