### PR TITLE
Fix #5755: princess no drop bomb no boom boom

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1883,6 +1883,8 @@ public class FireControl {
         final FiringPlan diveBombPlan = new FiringPlan(target);
         final HexTarget hexToBomb = new HexTarget(target.getPosition(),
                 shooter.isAero() ? Targetable.TYPE_HEX_AERO_BOMB : Targetable.TYPE_HEX_BOMB);
+        // Need this for to-hit calcs
+        BombMounted exampleBomb = null;
 
         // things that cause us to avoid calculating a bomb plan:
         // not having any bombs (in the first place)
@@ -1892,8 +1894,11 @@ public class FireControl {
         }
 
         // not having any bombs (due to expenditure/damage)
-        if (shooter.getBombs(BombType.F_GROUND_BOMB).isEmpty()) {
+        List<BombMounted> groundBombs = shooter.getBombs(BombType.F_GROUND_BOMB);
+        if (groundBombs.isEmpty()) {
             return diveBombPlan;
+        } else {
+            exampleBomb = groundBombs.get(0);
         }
 
         while (weaponIter.hasNext()) {
@@ -1922,7 +1927,7 @@ public class FireControl {
                                                                     hexToBomb,
                                                                     null,
                                                                     weapon,
-                                                                    null,
+                                                                    exampleBomb,
                                                                     game,
                                                                     passedOverTarget,
                                                                     guess,

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -717,7 +717,7 @@ public class Princess extends BotClient {
                             primaryFire.getTarget() != null &&
                             plan.stream().allMatch(curFire -> primaryFire.getTarget().getId() == targetID) &&
                             checkForEnhancedTargeting(shooter,
-                                    (Entity) primaryFire.getTarget(),
+                                    primaryFire.getTarget(),
                                     primaryFire.getToHit().getCover())) {
 
                         Entity aimTarget = (Mech) primaryFire.getTarget();
@@ -1214,13 +1214,17 @@ public class Princess extends BotClient {
      * against a given target. This includes some basic filtering for unit types and equipment such
      * targeting computers.
      * @param shooter           Entity doing the shooting
-     * @param target           Entity being shot at
+     * @param targetable        Hex, Building, or Entity being shot at (Enhanced Targeting only works on the last one)
      * @param cover            {@link LosEffects} constant for partial cover, derived from {@code ToHitData.getCover()}
      * @return                 true, if aimed or called shots should be checked
      */
     protected boolean checkForEnhancedTargeting (Entity shooter,
-                                                 Entity target,
+                                                 Targetable targetable,
                                                  int cover) {
+        // Only works on entities
+        if (!(targetable instanceof Entity)){
+            return false;
+        }
 
         if (!enableEnhancedTargeting) {
             return false;
@@ -1238,6 +1242,7 @@ public class Princess extends BotClient {
             return false;
         }
 
+        Entity target = (Entity) targetable;
         if (!isValidEnhancedTargetingTarget(target.getUnitType())) {
             return false;
         }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -713,6 +713,7 @@ public class Princess extends BotClient {
                         targetID = Entity.NONE;
                     }
 
+                    // TODO: gate this block on a game option or client option
                     if (targetID > Entity.NONE &&
                             primaryFire.getTarget() != null &&
                             plan.stream().allMatch(curFire -> primaryFire.getTarget().getId() == targetID) &&

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -690,16 +690,31 @@ public class WeaponFireInfo {
         final double ROLL_TWO = 0.028;
         setExpectedCriticals(ROLL_TWO * expectedCriticalHitCount * getProbabilityToHit());
 
+        // now guess how many critical hits will be done
         setKillProbability(0);
-        if (!(getTarget() instanceof Mech)) {
+        Mech targetMech = null;
+        Targetable potentialTarget = getTarget();
+
+        if (potentialTarget instanceof Mech) {
+            targetMech = (Mech) potentialTarget;
+        } else if (potentialTarget instanceof HexTarget || potentialTarget instanceof BuildingTarget) {
+            Coords c = potentialTarget.getPosition();
+            Iterator<Entity> targetEnemies = game.getEnemyEntities(c, this.shooter);
+            while (targetEnemies.hasNext()) {
+                Entity next = targetEnemies.next();
+                if (next instanceof Mech) {
+                    targetMech = (Mech) next;
+                    break;
+                }
+            }
+        }
+        // No target Mech found; nothing to do
+        if (null == targetMech) {
             if (debugging) {
                 LogManager.getLogger().debug(msg.toString());
             }
             return;
         }
-
-        // now guess how many critical hits will be done
-        final Mech targetMech = (Mech) getTarget();
 
         // A mech with a torso-mounted cockpit can survive losing its head.
         double headlessOdds = 0.0;

--- a/megamek/src/megamek/client/ui/swing/BombPayloadDialog.java
+++ b/megamek/src/megamek/client/ui/swing/BombPayloadDialog.java
@@ -185,13 +185,6 @@ public class BombPayloadDialog extends JDialog implements ActionListener, ItemLi
                 + (parent.getSize().height / 2)) - (size.height / 2));
     }
 
-    /**
-    @Override
-    public Dimension getPreferredSize() {
-        return new Dimension(500,200);
-    }
-    */
-
     private void setupButtons() {
         butOK.addActionListener(this);
         butCancel.addActionListener(this);


### PR DESCRIPTION
Fixes the recent development that Princess will no longer drop bombs (but will use air-launched missiles and rocket pods).

This was caused by two changes for 0.49.20, and was hidden by the fact that Princess couldn't use ammo weapons _at all_ in 0.49.20.  The root causes were:
1. the rework of Mounted<*> types, and subsequent addition of extra checks for linked ammo, which left Princess unable to find ammo to fire from her "Bomb" weapons, and thus unable to plan to use bombs or estimate their impact.
2. the addition of Enhanced Targeting / Called Shots in `Princess.java`, which only expects Entity-type targets and was throwing exceptions whenever a Hex or Building target was selected.

This fix returns the ability to use DiveBomb attacks, as well as adding the ability for Princess to estimate crit and kill chances for DiveBomb attacks.

This should also clear up the annoying 
```
megamek.client.bot.princess.Princess.calculateFiringTurn(Princess.java:857) - class megamek.common.HexTarget cannot be cast to class megamek.common.Entity (megamek.common.HexTarget and megamek.common.Entity are in unnamed module of loader 'app')
java.lang.ClassCastException: class megamek.common.HexTarget cannot be cast to class megamek.common.Entity (megamek.common.HexTarget and megamek.common.Entity are in unnamed module of loader 'app')
	at megamek.client.bot.princess.Princess.calculateFiringTurn(Princess.java:720)
	at megamek.client.bot.BotClient.calculateMyTurnWorker(BotClient.java:529)
	at megamek.client.bot.BotClient.calculateMyTurn(BotClient.java:487)
	at megamek.client.bot.BotClient$CalculateBotTurn.run(BotClient.java:65)
	at java.base/java.lang.Thread.run(Thread.java:833)
```
error messages we've been seeing lately.

Testing:
- Ran several missions with Princess-controlled bombers and confirmed bombs are working, both through inspection of the game board and via debugging.
- Ran all three projects' unit tests.

Close #5755 
