### PR TITLE
Fix for long-standing NPE issue with Aerospace path generation on airless ground maps

### DIFF
--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -18,6 +18,8 @@ import megamek.client.bot.princess.AeroPathUtil;
 import megamek.common.*;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.pathfinder.AbstractPathFinder.Filter;
+import megamek.logging.MMLogger;
+import megamek.server.AbstractGameManager;
 import org.apache.logging.log4j.LogManager;
 
 import java.util.*;
@@ -30,9 +32,12 @@ import java.util.*;
  */
 public class AeroGroundPathFinder {
 
+    private static final MMLogger logger = MMLogger.create(AbstractGameManager.class);
     public static final int OPTIMAL_STRIKE_ALTITUDE = 5; // also great for dive bombs
     public static final int NAP_OF_THE_EARTH = 1;
     public static final int OPTIMAL_STRAFE_ALTITUDE = 3; // future use
+
+    protected static final int STACK_DEPTH = 512;
 
     protected int getMinimumVelocity(IAero mover) {
         return 1;
@@ -268,9 +273,13 @@ public class AeroGroundPathFinder {
     protected List<MovePath> generateSidePaths(MovePath mp, MoveStepType stepType) {
         List<MovePath> retval = new ArrayList<>();
         MovePath straightLine = mp.clone();
+        // TODO: remove
+        if (logger.isDebugEnabled() && STACK_DEPTH - mp.length() < 10) {
+            logger.debug("Aero pathing stack depth: " + mp.length() + " (out of " + STACK_DEPTH + ")");
+        }
 
         boolean firstTurn = true;
-        while (straightLine.getFinalVelocityLeft() > 0 &&
+        while (mp.length() < STACK_DEPTH && straightLine.getFinalVelocityLeft() > 0 &&
                 game.getBoard().contains(straightLine.getFinalCoords())) {
 
             // little dirty hack to get around the problem where if this is the first step of a path

--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -37,7 +37,7 @@ public class AeroGroundPathFinder {
     public static final int NAP_OF_THE_EARTH = 1;
     public static final int OPTIMAL_STRAFE_ALTITUDE = 3; // future use
 
-    protected static final int STACK_DEPTH = 512;
+    protected static final int STACK_DEPTH = 256;
 
     protected int getMinimumVelocity(IAero mover) {
         return 1;
@@ -273,7 +273,7 @@ public class AeroGroundPathFinder {
     protected List<MovePath> generateSidePaths(MovePath mp, MoveStepType stepType) {
         List<MovePath> retval = new ArrayList<>();
         MovePath straightLine = mp.clone();
-        // TODO: remove
+
         if (logger.isDebugEnabled() && STACK_DEPTH - mp.length() < 10) {
             logger.debug("Aero pathing stack depth: " + mp.length() + " (out of " + STACK_DEPTH + ")");
         }


### PR DESCRIPTION
Our current ground map pathing code for Aerospace units is fairly simplistic, and in the situation where turns are free (because ASFs on airless / trace atmosphere maps use Spheroid movement) will enter an infinite regress while trying to determine all possible valid moves.

The fix is to restrict Aerospace pathing to 1/2 default Java stack size; there's really no need to even go this far for every possible turn-move-turn combo, because (IIRC) the maximum hover path length on the ground map is 8 hexes, but I wanted to be circumspect.

In my testing I found that reducing the max pathing depth to 256 moves was actually quite fast, so we may wish to consider this in the future.
Note that Princess is actually not very good with Spheroid movement on ground maps but at least this will prevent the StackOverflow error.

Testing:
- Tested with previously-failing Airless ground map and a variety of enemy and friendly units.
- Ran all 3 projects' unit tests

Close #3595 
