### PR TITLE
Fix 5720: fire control error concurrent modification

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -544,7 +544,7 @@ public class EquipmentType implements ITechnology {
             return false;
         }
 
-        // Iterator<Integer> iter = list.iterator(); iter.hasNext();
+        // Avoid Concurrent Modification exception with this one simple trick!
         for (Iterator<EquipmentMode> iterator = modes.iterator(); iterator.hasNext(); ) {
             if (iterator.next().getName().equals(modeType)) {
                 return true;

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -18,15 +18,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Vector;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -552,9 +544,9 @@ public class EquipmentType implements ITechnology {
             return false;
         }
 
-        // Beware concurrent modification
-        for (EquipmentMode mode : modes) {
-            if (mode.getName().equals(modeType)) {
+        // Iterator<Integer> iter = list.iterator(); iter.hasNext();
+        for (Iterator<EquipmentMode> iterator = modes.iterator(); iterator.hasNext(); ) {
+            if (iterator.next().getName().equals(modeType)) {
                 return true;
             }
         }


### PR DESCRIPTION
Apparently having two nested enhanced for loops accessing the same stuff is verboten; replace the lower-level loop with an iterator loop.

Testing:
- loaded and ran the save from #5720 
- Ran all 3 projects' unit tests.

Close #5720 