### PR TITLE
Revert unnecessary change that broke Princess bombing; add safety around diveBombing plans

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1933,9 +1933,13 @@ public class FireControl {
                                                                     guess,
                                                                     bombPayloads);
                 diveBombPlan.add(diveBomb);
+                // Hack to prevent adding more than one dive bomb action to the plan
+                // TODO: find out why too many actions are getting added
+                // Having more than one DiveBomb in the plan invalidates the whole plane
+                // (see WeaponAttackAction.java:2033
+                break;
             }
         }
-
         return diveBombPlan;
     }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1933,10 +1933,7 @@ public class FireControl {
                                                                     guess,
                                                                     bombPayloads);
                 diveBombPlan.add(diveBomb);
-                // Hack to prevent adding more than one dive bomb action to the plan
-                // TODO: find out why too many actions are getting added
-                // Having more than one DiveBomb in the plan invalidates the whole plane
-                // (see WeaponAttackAction.java:2033
+                //To prevent adding more than one dive bomb action to the plan
                 break;
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4313,7 +4313,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         weaponBayList.removeAll(bombAttacksToRemove);
 
         boolean foundSpaceBomb = false;
-        int numGroundBombs = 0;
+        int addedBombAttacks = 0;
 
         for (BombMounted m : getBombs()) {
             // Add the space bomb attack
@@ -4338,7 +4338,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     && m.getType().hasFlag(AmmoType.F_GROUND_BOMB)
                     && !((this instanceof LandAirMech)
                             && (getConversionMode() == LandAirMech.CONV_MODE_MECH))) {
-                if (numGroundBombs <= 1) {
+                if (addedBombAttacks < 1) {
                     try {
                         WeaponMounted bomb = (WeaponMounted) addEquipment(diveBomb, m.getLocation(), false);
                         if (hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
@@ -4350,7 +4350,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     }
                 }
 
-                if ((numGroundBombs <= 10) && isBomber()) {
+                if ((addedBombAttacks < 10) && isBomber()) {
                     try {
                         WeaponMounted bomb = (WeaponMounted) addEquipment(altBomb, m.getLocation(), false);
                         if (hasETypeFlag(ETYPE_FIGHTER_SQUADRON)) {
@@ -4361,7 +4361,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
                     }
                 }
-                numGroundBombs++;
+                addedBombAttacks++;
             }
         }
     }


### PR DESCRIPTION
I made a change in passing to resetBombAttacks() that was actually unnecessary _and_ broke bombing for Princess, thusly:

1. I misunderstood how Dive Bomb and Altitude Bomb attacks are added to the equipment list, and set them to add on <= X instead of < X.  This caused 1 additional Dive Bomb and 1 additional Altitude Bomb attack to be added to every Aerospace unit's list of equipment each turn _if_ it had bombs equipped.
2. If Princess sees two DiveBomb "weapons" in her unit's equipment, she will plan to use them both.  She DGAF.
3. The game itself, while handling attacks, will throw out _all_ actions by any entity that has 2 or more DiveBombAttacks declared.
4. Poof, all the drawbacks of dive-bombing, but none of the actual explosions!

Testing:
- Tested with various Princess-controlled ASF units using both internal and external bombs.
- Tested with various Player-controlled ASF units, likewise.
- Ran all 3 projects' unit tests