### PR TITLE
Fix Reflective armor not appearing in MML dropdown

### DIFF
--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -780,7 +780,7 @@ public class ArmorType extends MiscType {
         armor.patchworkSlotsMechSV = 2;
         armor.patchworkSlotsCVFtr = 1;
         armor.flags = armor.flags.or(F_REFLECTIVE).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_VTOL_EQUIPMENT)
-                .or(F_SUPPORT_TANK_EQUIPMENT);
+                .or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
         armor.rulesRefs = "93, TO: AU&E";
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         armor.techAdvancement.setTechBase(TECH_BASE_IS).setTechRating(RATING_E)
@@ -809,7 +809,7 @@ public class ArmorType extends MiscType {
         armor.patchworkSlotsMechSV = 1;
         armor.patchworkSlotsCVFtr = 1;
         armor.flags = armor.flags.or(F_REFLECTIVE).or(F_MECH_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_VTOL_EQUIPMENT)
-                .or(F_SUPPORT_TANK_EQUIPMENT);
+                .or(F_SUPPORT_TANK_EQUIPMENT).or(F_FIGHTER_EQUIPMENT);
         armor.rulesRefs = "93, TO: AU&E";
         //Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         armor.techAdvancement.setTechBase(TECH_BASE_CLAN).setTechRating(RATING_F)


### PR DESCRIPTION
This was brought up during a conversation on #5795 but did not get its own bug.
The issue is that IS and Clan Reflective Armor did not have the flag marking it as available for Aerospace Fighters and Conventional Fighters, despite many examples of both _with_ Reflective Armor existing (and validating correctly).
This bug has probably existed a long time, but was exposed by the recent refactoring of Armor and Equipment types.

Testing:
- Built new ASF and CF units with Reflective
- Loaded existing ASF and CF units with Reflective
- Ran all 3 projects' unit tests