### PR TITLE
BoardView sprite adaptations

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -4306,7 +4306,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
 
         overTerrainSprites.clear();
         behindTerrainHexSprites.clear();
-//        hexSprites.clear();
 
         super.clearSprites();
     }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -906,9 +906,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             drawSprites(g, flyOverSprites);
         }
 
-        // draw onscreen entities
-        drawSprites(g, entitySprites);
-
         // draw moving onscreen entities
         drawSprites(g, movingEntitySprites);
 
@@ -1626,9 +1623,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                 drawSprites(boardGraph, flyOverSprites);
             }
 
-            // draw onscreen entities
-            drawSprites(boardGraph, entitySprites);
-
             // draw moving onscreen entities
             drawSprites(boardGraph, movingEntitySprites);
 
@@ -1723,7 +1717,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                             if (GUIP.getShowWrecks()) {
                                 drawIsometricWreckSpritesForHex(c, g, isometricWreckSprites);
                             }
-                            drawIsometricSpritesForHex(c, g, isometricSprites);
+//                            drawIsometricSpritesForHex(c, g, isometricSprites);
                         }
                     }
                 }
@@ -1731,7 +1725,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             if (!saveBoardImage) {
                 // If we are using Isometric rendering, redraw the entity sprites at 50% transparent
                 // so sprites hidden behind hills can still be seen by the user.
-                drawIsometricSprites(g, isometricSprites);
+//                drawIsometricSprites(g, isometricSprites);
             }
         } else {
             // Draw hexes without regard to elevation when not using Isometric, since it does not
@@ -2622,6 +2616,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
 
         // Remove sprite for Entity, so it's not displayed while moving
         if (sprite != null) {
+            removeSprite(sprite);
             newSprites = new PriorityQueue<>(entitySprites);
             newSpriteIds = new HashMap<>(entitySpriteIds);
 
@@ -2633,6 +2628,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
         // Remove iso sprite for Entity, so it's not displayed while moving
         if (isoSprite != null) {
+            removeSprite(isoSprite);
             isoSprites = new PriorityQueue<>(isometricSprites);
             newIsoSpriteIds = new HashMap<>(isometricSpriteIds);
 
@@ -2814,10 +2810,16 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
 
         // Update Sprite state with new collections
+        removeSprites(entitySprites);
+        removeSprites(isometricSprites);
         entitySprites = newSprites;
         entitySpriteIds = newSpriteIds;
         isometricSprites = isoSprites;
         isometricSpriteIds = newIsoSpriteIds;
+        addSprites(entitySprites);
+        if (drawIsometric) {
+            addSprites(isometricSprites);
+        }
 
         // Remove C3 sprites
         for (Iterator<C3Sprite> i = c3Sprites.iterator(); i.hasNext(); ) {
@@ -2944,11 +2946,20 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             }
         }
 
+        removeSprites(entitySprites);
+        removeSprites(isometricSprites);
+
         entitySprites = newSprites;
         entitySpriteIds = newSpriteIds;
 
         isometricSprites = newIsometricSprites;
         isometricSpriteIds = newIsoSpriteIds;
+
+        addSprites(entitySprites);
+        if (drawIsometric) {
+            addSprites(isometricSprites);
+        }
+
 
         wreckSprites = newWrecks;
         isometricWreckSprites = newIsometricWrecks;
@@ -4883,6 +4894,10 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
 
         for (EntitySprite eS : entitySprites) {
+            eS.prepare();
+        }
+
+        for (IsometricSprite eS : isometricSprites) {
             eS.prepare();
         }
         boardPanel.repaint();

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1716,7 +1716,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                             if (GUIP.getShowWrecks()) {
                                 drawIsometricWreckSpritesForHex(c, g, isometricWreckSprites);
                             }
-//                            drawIsometricSpritesForHex(c, g, isometricSprites);
                         }
                     }
                 }
@@ -1724,7 +1723,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             if (!saveBoardImage) {
                 // If we are using Isometric rendering, redraw the entity sprites at 50% transparent
                 // so sprites hidden behind hills can still be seen by the user.
-//                drawIsometricSprites(g, isometricSprites);
+                drawIsometricSprites(g, isometricSprites);
             }
         } else {
             // Draw hexes without regard to elevation when not using Isometric, since it does not

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -378,7 +378,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
     // to specialized lists when created
     private final TreeSet<Sprite> overTerrainSprites = new TreeSet<>();
     private final TreeSet<HexSprite> behindTerrainHexSprites = new TreeSet<>();
-    private final TreeSet<HexSprite> hexSprites = new TreeSet<>();
 
     /**
      * Construct a new board view for the specified game
@@ -4308,7 +4307,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
 
         overTerrainSprites.clear();
         behindTerrainHexSprites.clear();
-        hexSprites.clear();
+//        hexSprites.clear();
 
         super.clearSprites();
     }
@@ -4880,7 +4879,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
     public boolean toggleIsometric() {
         drawIsometric = !drawIsometric;
         allSprites.forEach(Sprite::prepare);
-        hexSprites.forEach(HexSprite::updateBounds);
 
         clearHexImageCache();
         updateBoard();
@@ -5112,10 +5110,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                 .map(s -> (HexSprite) s)
                 .filter(HexSprite::isBehindTerrain)
                 .forEach(behindTerrainHexSprites::add);
-        sprites.stream()
-                .filter(s -> s instanceof HexSprite)
-                .map(s -> (HexSprite) s)
-                .forEach(hexSprites::add);
     }
 
     @Override
@@ -5123,6 +5117,5 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         super.removeSprites(sprites);
         overTerrainSprites.removeAll(sprites);
         behindTerrainHexSprites.removeAll(sprites);
-        hexSprites.removeAll(sprites);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/IsometricSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/IsometricSprite.java
@@ -237,6 +237,6 @@ class IsometricSprite extends Sprite {
 
     @Override
     protected int getSpritePriority() {
-        return entity.getSpriteDrawPriority();
+        return entity.getSpriteDrawPriority() + 10;
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/IsometricSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/IsometricSprite.java
@@ -16,7 +16,7 @@ import java.awt.image.ImageObserver;
 /**
  * Sprite used for isometric rendering to render an entity partially hidden behind a hill.
  */
-class IsometricSprite extends Sprite {
+class IsometricSprite extends HexSprite {
 
     Entity entity;
     private Image radarBlipImage;
@@ -26,7 +26,7 @@ class IsometricSprite extends Sprite {
     private static final GUIPreferences GUIP = GUIPreferences.getInstance();
 
     public IsometricSprite(BoardView boardView1, Entity entity, int secondaryPos, Image radarBlipImage) {
-        super(boardView1);
+        super(boardView1, secondaryPos == -1 ? entity.getPosition() : entity.getSecondaryPositions().get(secondaryPos));
         this.entity = entity;
         this.radarBlipImage = radarBlipImage;
         this.secondaryPos = secondaryPos;
@@ -176,6 +176,7 @@ class IsometricSprite extends Sprite {
 
     @Override
     public void prepare() {
+        updateBounds();
         // create image for buffer
         GraphicsConfiguration config = GraphicsEnvironment
                 .getLocalGraphicsEnvironment().getDefaultScreenDevice()

--- a/megamek/src/megamek/client/ui/swing/boardview/Sprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/Sprite.java
@@ -162,4 +162,9 @@ abstract public class Sprite implements ImageObserver, Comparable<Sprite> {
     public boolean equals(Object obj) {
         return super.equals(obj);
     }
+
+    @Override
+    public String toString() {
+        return "[" + getClass().getSimpleName() + "] Prio: " + getSpritePriority() + ((image == null) ? "; no image" : "");
+    }
 }


### PR DESCRIPTION
This is an addition for #5706 to either pull into that one or merge by itself. It allows Carryable sprites to draw under units. 