### PR TITLE
More guards for the FiringarcHandler

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/FiringArcSpriteHandler.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FiringArcSpriteHandler.java
@@ -67,6 +67,11 @@ public class FiringArcSpriteHandler extends BoardViewSpriteHandler implements IP
     public void update(Entity entity, WeaponMounted weapon, @Nullable MovePath movePath) {
         firingEntity = entity;
         int weaponId = entity.getEquipmentNum(weapon);
+        if (weaponId == -1) {
+            // entities are replaced all the time by server-sent changes, must always guard
+            clearValues();
+            return;
+        }
         // findRanges must be called before any call to testUnderWater due to usage of 
         // global-style variables for some reason
         findRanges(weapon);

--- a/megamek/src/megamek/client/ui/swing/boardview/FiringArcSpriteHandler.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FiringArcSpriteHandler.java
@@ -64,8 +64,12 @@ public class FiringArcSpriteHandler extends BoardViewSpriteHandler implements IP
      * @param weapon the selected weapon
      * @param movePath planned movement in the movement phase
      */
-    public void update(Entity entity, WeaponMounted weapon, @Nullable MovePath movePath) {
+    public void update(@Nullable Entity entity, @Nullable WeaponMounted weapon, @Nullable MovePath movePath) {
         firingEntity = entity;
+        if ((entity == null) || (weapon == null)) {
+            clearValues();
+            return;
+        }
         int weaponId = entity.getEquipmentNum(weapon);
         if (weaponId == -1) {
             // entities are replaced all the time by server-sent changes, must always guard


### PR DESCRIPTION
I think this fixes #5789 

The fact that our Entities get constantly replaced by server-sent new objects leads to problems wherever Entities and Mounteds are cached. Must guard against all things, including that the weapon is not found on the entity.