### PR TITLE
Use best hex for FoV highlighting for multi-hex units

### DIFF
--- a/megamek/data/scenarios/Test Setups/DS_LOS.mms
+++ b/megamek/data/scenarios/Test Setups/DS_LOS.mms
@@ -1,0 +1,15 @@
+MMSVersion: 2
+name: Grounded DS Test
+planet: None
+description: A grounded DS on a small map for use in range/LOS/FoV testing
+
+map: AGoAC Maps/16x17 Grassland 2.board
+
+factions:
+- name: Test Player
+
+  units:
+  - fullname: Intruder (3056)
+    at: [ 10, 9 ]
+    altitude: 0
+    

--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -75,10 +75,14 @@ class FovHighlightingAndDarkening {
         Coords src;
         boolean hasLoS = true;
         // in movement phase, calc LOS based on selected hex, otherwise use selected Entity
-        if (this.boardView1.game.getPhase().isMovement() && this.boardView1.selected != null) {
-            src = this.boardView1.selected;
-        } else if (this.boardView1.getSelectedEntity() != null) {
-            src = this.boardView1.getSelectedEntity().getPosition();
+        if (boardView1.game.getPhase().isMovement() && this.boardView1.selected != null) {
+            src = boardView1.selected;
+        } else if (boardView1.getSelectedEntity() != null) {
+            Entity viewer = boardView1.getSelectedEntity();
+            src = viewer.getPosition();
+            // multi-hex units look from the hex closest to the target to avoid self-blocking
+            src = viewer.getSecondaryPositions().values().stream()
+                    .min(Comparator.comparingInt(co -> co.distance(c))).orElse(src);
         } else {
             src = null;
         }


### PR DESCRIPTION
FoV highlighting was not considering secondary positions. Fixes #5785 
This also adds a little test scenario with a grounded DS which is going to continue to work in the next version (unlike a savegame).
