### PR TITLE
Prevent NPE by using interface rather than Aero casting

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -4422,13 +4422,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
 
         // Increment the entity's delta-v then compute the movement envelope.
-        Aero ae = (Aero)entity;
+        // LAM and Aeros both implement this interface
+        IAero ae = (IAero) entity;
         int currentVelocity = ae.getCurrentVelocity();
         ae.setCurrentVelocity(cmd.getFinalVelocity());
 
         // Refresh the new velocity envelope on the map.
         try {
-            computeMovementEnvelope(ae);
+            computeMovementEnvelope(entity);
             updateMove();
         } catch (Exception e) {
             LogManager.getLogger().error("An error occured trying to compute the move envelope for an Aero.");


### PR DESCRIPTION
Fixes #5705 by avoiding cast to Aero class when computing movement envelope.
While LAMs return true to `.isAero()` when they are in ASF form, they extend BipedMech rather than from Aero so the cast will fail.
But they implement the IAero interface, which has the same methods.

Testing:
- Ran several missions with LAMs in all three modes, including transforming, and performed various velocity changes and maneuvers.
- Ran all 3 projects' unit tests.

Close #5705 