### PR TITLE
Fix 5796: Safety check for entities with no hex location, e.g. just-loaded infantry

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10042,6 +10042,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         boolean canHit = false;
         boolean friendlyFire = game.getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE);
 
+        if (getPosition() == null) {
+            return false; // not on board?
+        }
+
         if ((this instanceof Infantry)
                 && hasWorkingMisc(MiscType.F_TOOLS,
                         MiscType.S_DEMOLITION_CHARGE)) {
@@ -10051,6 +10055,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             }
             return hex.containsTerrain(Terrains.BUILDING);
         }
+
         // only mechs and protos have physical attacks (except tank charges)
         if (!((this instanceof Mech) || (this instanceof Protomech) || (this instanceof Infantry))) {
             return false;
@@ -10089,10 +10094,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if (moved == EntityMovementType.MOVE_SPRINT
                 || moved == EntityMovementType.MOVE_VTOL_SPRINT) {
             return false;
-        }
-
-        if (getPosition() == null) {
-            return false; // not on board?
         }
 
         // check if we have iNarc pods attached that can be brushed off

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10046,6 +10046,9 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 && hasWorkingMisc(MiscType.F_TOOLS,
                         MiscType.S_DEMOLITION_CHARGE)) {
             Hex hex = game.getBoard().getHex(getPosition());
+            if (hex == null) {
+                return false;
+            }
             return hex.containsTerrain(Terrains.BUILDING);
         }
         // only mechs and protos have physical attacks (except tank charges)


### PR DESCRIPTION
Prevents the NPE when hex is null due to the unit having just been loaded the previous Movement phase.

Testing:
- Ran saves from OP with and without fix, and confirmed via debugging that the just-loaded unit was at fault.
- Ran all 3 projects' unit tests

Close #5796 