### PR TITLE
#5811 Some validation rules and illegal design quirk

### DIFF
--- a/megamek/data/mechfiles/mechs/XTRs/Caveat Emptor/Carbine CON-9M-D ConstructionMech MOD.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Caveat Emptor/Carbine CON-9M-D ConstructionMech MOD.mtf
@@ -9,6 +9,12 @@ source:XTR: Caveat Emptor
 rules level:5
 role:Ambusher
 
+quirk:illegal_design
+quirk:gas_hog
+quirk:stable
+quirk:exp_actuator
+quirk:no_twist
+
 mass:30
 engine:90 ICE Engine(IS)
 structure:IS Industrial

--- a/megamek/data/mechfiles/mechs/XTRs/Caveat Emptor/Crosscut IIC SolahmaMech.mtf
+++ b/megamek/data/mechfiles/mechs/XTRs/Caveat Emptor/Crosscut IIC SolahmaMech.mtf
@@ -14,6 +14,9 @@ engine:300 XXL (Clan) Engine(IS)
 structure:IS Industrial
 myomer:Standard
 
+quirk:illegal_design
+quirk:hard_pilot
+
 heat sinks:11 Single
 walk mp:10
 jump mp:0

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2341,7 +2341,8 @@ MechView.Pod=Pod
 MechView.Fixed=Fixed
 MechView.Quirks=Quirks
 MechView.WeaponQuirks=Weapon Quirks
-MechView.InvalidReasons=Invalid Reasons
+MechView.InvalidReasons=Invalid because:
+MechView.InvalidButIllegalQuirk=Illegal Design Quirk, would be invalid because:
 
 #Minelaying
 MineDensityDialog.title=Mine Density

--- a/megamek/src/megamek/common/MechView.java
+++ b/megamek/src/megamek/common/MechView.java
@@ -546,11 +546,16 @@ public class MechView {
         TestEntity testEntity = TestEntity.getEntityVerifier(entity);
 
         if (testEntity != null) {
-            testEntity.correctEntity(sb, entity.getTechLevel());
-
-            if (!sb.toString().isEmpty()) {
+            testEntity.correctEntity(sb);
+            if (!sb.isEmpty()) {
                 sInvalid.add(new SingleLine());
-                sInvalid.add(new LabeledElement(Messages.getString("MechView.InvalidReasons"), "\n" + sb));
+                String[] errorLines = sb.toString().split("\n");
+                String label = entity.hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) ?
+                        Messages.getString("MechView.InvalidButIllegalQuirk") :
+                        Messages.getString("MechView.InvalidReasons");
+                ItemList errorList = new ItemList(label);
+                Arrays.stream(errorLines).forEach(errorList::addItem);
+                sInvalid.add(errorList);
             }
         }
     }
@@ -659,21 +664,17 @@ public class MechView {
     public String getMechReadout(@Nullable String fontName) {
         String docStart = "";
         String docEnd = "";
-        String preStart = "";
-        String preEnd = "";
 
         if (formatting == ViewFormatting.HTML && (fontName != null)) {
             docStart = "<div style=\"font-family:" + fontName + ";\">";
             docEnd = "</div>";
-            preStart = "<PRE style=\"font-family:" + fontName + ";\">";
-            preEnd = "</PRE>";
         } else if (formatting == ViewFormatting.DISCORD) {
             docStart = "```ansi\n";
             docEnd = "```";
         }
         return docStart + getMechReadoutHead()
                 + getMechReadoutBasic() + getMechReadoutLoadout()
-                + getMechReadoutFluff() + preStart + getMechReadoutInvalid() + preEnd + docEnd;
+                + getMechReadoutFluff() + getMechReadoutInvalid() + docEnd;
     }
 
     private List<ViewElement> getInternalAndArmor() {

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -18,6 +18,7 @@ import megamek.common.*;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.WeaponMounted;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.capitalweapons.ScreenLauncherWeapon;
@@ -630,7 +631,9 @@ public class TestAdvancedAerospace extends TestAero {
         correct &= correctGravDecks(buff);
         correct &= correctBays(buff);
         correct &= correctCriticals(buff);
-
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -693,11 +693,6 @@ public class TestAero extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, aero.getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
 
@@ -750,7 +745,9 @@ public class TestAero extends TestEntity {
         correct &= !hasIllegalEquipmentCombinations(buff);
         correct &= !hasMismatchedLateralWeapons(buff);
         correct &= correctHeatSinks(buff);
-
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -17,6 +17,7 @@ package megamek.common.verifier;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
@@ -1021,11 +1022,6 @@ public class TestBattleArmor extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, getEntity().getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
         if (skip()) {
@@ -1059,7 +1055,9 @@ public class TestBattleArmor extends TestEntity {
         correct &= correctManipulators(buff);
 
         correct &= correctMovement(buff);
-
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -18,6 +18,7 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.MPBoosters;
 import megamek.common.equipment.ArmorType;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.util.StringUtil;
 
 import java.io.File;
@@ -74,7 +75,9 @@ public abstract class TestEntity implements TestEntityOption {
 
     public abstract String printWeightControls();
 
-    public abstract boolean correctEntity(StringBuffer buff);
+    public boolean correctEntity(StringBuffer buff) {
+        return correctEntity(buff, getEntity().getTechLevel());
+    }
 
     public abstract boolean correctEntity(StringBuffer buff, int ammoTechLvl);
 
@@ -1474,19 +1477,16 @@ public abstract class TestEntity implements TestEntityOption {
                 }
             }
         }
-        if ((isMech() || isTank() || isAero())
-                && (!getEntity().hasEngine()
-                        || (!getEntity().getEngine().isFusion()
-                                && (getEntity().getEngine().getEngineType() != Engine.FISSION)))) {
-            for (Mounted m : getEntity().getWeaponList()) {
-                if (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_IGAUSS_HEAVY) {
-                    buff.append("Improved Heavy Gauss requires a fusion or fission engine.\n");
+        Engine engine = getEntity().getEngine();
+        if (!getEntity().hasEngine() || !(engine.isFusion() || engine.isFission())) {
+            for (WeaponMounted m : getEntity().getWeaponList()) {
+                if ((m.getType().getAmmoType() == AmmoType.T_GAUSS_HEAVY)
+                        || (m.getType().getAmmoType() == AmmoType.T_IGAUSS_HEAVY)) {
+                    buff.append("Heavy Gauss Rifles require a fusion or fission engine\n");
                     illegal = true;
                 } else if (m.getType().hasFlag(WeaponType.F_FLAMER)
-                        && (((WeaponType) m.getType()).getAmmoType() == AmmoType.T_NA)
-                        && (!getEntity().hasEngine() || (!getEntity().getEngine().isFusion()
-                                && (getEntity().getEngine().getEngineType() != Engine.FISSION)))) {
-                    buff.append("Standard flamers require a fusion or fission engine.\n");
+                        && (m.getType().getAmmoType() == AmmoType.T_NA)) {
+                    buff.append("Standard flamers require a fusion or fission engine\n");
                     illegal = true;
                 }
             }

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -131,11 +131,6 @@ public class TestInfantry extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, getEntity().getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         Infantry inf = (Infantry) getEntity();
         boolean correct = true;
@@ -198,7 +193,9 @@ public class TestInfantry extends TestEntity {
             buff.append("Infantry may not have more than one armor kit!\n");
             correct = false;
         }
-
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
     

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -18,6 +18,8 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.WeaponMounted;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.Quirks;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
 import megamek.common.weapons.autocannons.ACWeapon;
@@ -681,11 +683,6 @@ public class TestMech extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, getEntity().getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
         if (skip()) {
@@ -732,6 +729,9 @@ public class TestMech extends TestEntity {
             correct = correct && checkMiscSpreadAllocation(mech, misc, buff);
         }
         correct = correct && correctMovement(buff);
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
 
@@ -1047,23 +1047,6 @@ public class TestMech extends TestEntity {
         }
 
         if (mech.isSuperHeavy()) {
-            switch (mech.hasEngine() ? mech.getEngine().getEngineType() : Engine.NONE) {
-                case Engine.NORMAL_ENGINE:
-                case Engine.LARGE_ENGINE:
-                    break;
-                case Engine.XL_ENGINE:
-                case Engine.XXL_ENGINE:
-                case Engine.COMPACT_ENGINE:
-                case Engine.LIGHT_ENGINE:
-                    if (mech.isIndustrial()) {
-                        buff.append("Superheavy industrialMechs can only use standard or large fusion engine\n");
-                        illegal = true;
-                    }
-                    break;
-                default:
-                    buff.append("Superheavy Mechs must use some type of fusion engine\n");
-                    illegal = true;
-            }
             if (mech.getGyroType() != Mech.GYRO_SUPERHEAVY) {
                 buff.append("Superheavy Mechs must use a superheavy gyro.\n");
                 illegal = true;
@@ -1098,6 +1081,26 @@ public class TestMech extends TestEntity {
             if ((mech.getGyroType() != Mech.GYRO_STANDARD) && (mech.getGyroType() != Mech.GYRO_SUPERHEAVY)) {
                 buff.append("industrial mechs can only mount standard gyros\n");
                 illegal = true;
+            }
+            if (hasDoubleHeatSinks()) {
+                buff.append("Industrial Meks cannot mount double heat sinks\n");
+                illegal = true;
+            }
+            switch (mech.hasEngine() ? engine.getEngineType() : Engine.NONE) {
+                case Engine.NORMAL_ENGINE:
+                    break;
+                case Engine.COMBUSTION_ENGINE:
+                case Engine.FUEL_CELL:
+                case Engine.FISSION:
+                    if (mech.isSuperHeavy()) {
+                        buff.append("Superheavy Industrial Meks can only use standard or large fusion engines\n");
+                        illegal = true;
+                    }
+                    break;
+                default:
+                    buff.append("Industrial Meks can only use standard and large fusion engines, ICEs, fuel cells or fission\n");
+                    illegal = true;
+                    break;
             }
         }
 

--- a/megamek/src/megamek/common/verifier/TestProtomech.java
+++ b/megamek/src/megamek/common/verifier/TestProtomech.java
@@ -17,6 +17,7 @@ import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 
 import java.util.HashMap;
@@ -214,11 +215,6 @@ public class TestProtomech extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, getEntity().getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
         if (skip()) {
@@ -249,6 +245,9 @@ public class TestProtomech extends TestEntity {
             correct = false;
         }
         correct = correct && correctMovement(buff);
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
     

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -18,6 +18,7 @@ import megamek.common.*;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.WeaponMounted;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 
 import java.math.BigInteger;
@@ -510,7 +511,9 @@ public class TestSmallCraft extends TestAero {
         correct &= correctHeatSinks(buff);
         correct &= correctCrew(buff);
         correct &= correctCriticals(buff);
-
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
+        }
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -17,6 +17,7 @@ package megamek.common.verifier;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.flamers.VehicleFlamerWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -920,11 +921,6 @@ public class TestSupportVehicle extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, getEntity().getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
         if (skip()) {
@@ -1118,6 +1114,9 @@ public class TestSupportVehicle extends TestEntity {
 
         if (!correctCriticals(buff)) {
             correct = false;
+        }
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
         }
         return correct;
     }

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -17,6 +17,7 @@ package megamek.common.verifier;
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
+import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.flamers.VehicleFlamerWeapon;
 import megamek.common.weapons.lasers.CLChemicalLaserWeapon;
@@ -284,11 +285,6 @@ public class TestTank extends TestEntity {
     }
 
     @Override
-    public boolean correctEntity(StringBuffer buff) {
-        return correctEntity(buff, getEntity().getTechLevel());
-    }
-
-    @Override
     public boolean correctEntity(StringBuffer buff, int ammoTechLvl) {
         boolean correct = true;
         if (skip()) {
@@ -391,6 +387,9 @@ public class TestTank extends TestEntity {
         }
         if (!correctCriticals(buff)) {
             correct = false;
+        }
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+            correct = true;
         }
         return correct;
     }


### PR DESCRIPTION
- adds a few tests to unit validation
- adds a check for the Illegal Design quirk which will make validation pass even when there are errors; the heavy gameplay penalties of this quirk are not implemented currently
- adds missing quirks to some units of XTRO Caveat Emptor
- updates the mechview to show errors with a different header when the illegal design quirk is present
- removes a redundant override from the various TestXYZ classes

Fixes #5811 

![image](https://github.com/user-attachments/assets/2f55e17d-b7d4-4347-92fc-96301291eb7c)
