### PR TITLE
Validate RISC Hyper Lasers with engines

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1477,6 +1477,7 @@ public abstract class TestEntity implements TestEntityOption {
                 }
             }
         }
+
         Engine engine = getEntity().getEngine();
         if (!getEntity().hasEngine() || !(engine.isFusion() || engine.isFission())) {
             for (WeaponMounted m : getEntity().getWeaponList()) {
@@ -1488,9 +1489,13 @@ public abstract class TestEntity implements TestEntityOption {
                         && (m.getType().getAmmoType() == AmmoType.T_NA)) {
                     buff.append("Standard flamers require a fusion or fission engine\n");
                     illegal = true;
+                } else if (m.getType().hasFlag(WeaponType.F_HYPER)) {
+                    buff.append("RISC Hyper Lasers require a fusion or fission engine\n");
+                    illegal = true;
                 }
             }
         }
+
         if (hasExternalFuelTank
                 && (!getEntity().hasEngine() ||((getEntity().getEngine().getEngineType() != Engine.COMBUSTION_ENGINE)
                 && (getEntity().getEngine().getEngineType() != Engine.FUEL_CELL)))) {

--- a/megamek/src/megamek/common/verifier/TestMech.java
+++ b/megamek/src/megamek/common/verifier/TestMech.java
@@ -1414,17 +1414,11 @@ public class TestMech extends TestEntity {
                     illegal = true;
                 }
             }
-            if ((m.getType().hasFlag(WeaponType.F_TASER)
-                    || m.getType().hasFlag(WeaponType.F_HYPER))
+            if ((m.getType().hasFlag(WeaponType.F_TASER))
                     && !(mech.hasEngine() && mech.getEngine().isFusion())) {
                 buff.append(m.getType().getName()).append(" needs fusion engine\n");
                 illegal = true;
             }
-        }
-
-        if (mech.hasWorkingWeapon(WeaponType.F_HYPER) && !(mech.hasEngine() && mech.getEngine().isFusion())) {
-            buff.append("RISC Hyper Laser needs fusion engine\n");
-            illegal = true;
         }
 
         if (mech.hasFullHeadEject()) {


### PR DESCRIPTION
Updates RISC Hyper Laser vs engine validation to work for all unit types and correctly allow fusion and fission engines.
Fixes #5831 