### PR TITLE
Allow bot vs bot in ScenarioV2 and test setup

### DIFF
--- a/megamek/data/scenarios/Test Setups/BotvBot.mms
+++ b/megamek/data/scenarios/Test Setups/BotvBot.mms
@@ -1,0 +1,19 @@
+MMSVersion: 2
+name: Bot vs Bot as Scenario
+description: A test fight bot vs bot
+map: AGoAC Maps/16x17 Grassland 2.board
+
+factions:
+- name: Observer
+
+- name: Legion of Vega
+  units:
+  - fullname: Atlas AS7-D
+  - fullname: Locust LCT-1M
+
+- name: 2nd Air Cavalry, Federated Suns
+  units:
+    - fullname: Atlas AS7-D
+    - fullname: Locust LCT-1M
+
+

--- a/megamek/src/megamek/common/scenario/ScenarioV2.java
+++ b/megamek/src/megamek/common/scenario/ScenarioV2.java
@@ -30,7 +30,6 @@ import megamek.common.icons.Camouflage;
 import megamek.common.icons.FileCamouflage;
 import megamek.common.jacksonadapters.BoardDeserializer;
 import megamek.common.jacksonadapters.MMUReader;
-import megamek.common.options.SBFRuleOptions;
 import megamek.common.planetaryconditions.PlanetaryConditions;
 import megamek.common.strategicBattleSystems.SBFGame;
 import megamek.server.IGameManager;
@@ -187,7 +186,7 @@ public class ScenarioV2 implements Scenario {
 
         for (Iterator<JsonNode> it = node.get(PARAM_FACTIONS).elements(); it.hasNext(); ) {
             JsonNode playerNode = it.next();
-            MMUReader.requireFields("Player", playerNode, NAME, UNITS);
+            MMUReader.requireFields("Player", playerNode, NAME);
 
             Player player = new Player(playerId, playerNode.get(NAME).textValue());
             result.add(player);
@@ -216,39 +215,41 @@ public class ScenarioV2 implements Scenario {
 
             //TODO minefields
 
-            JsonNode unitsNode = playerNode.get(UNITS);
-            if (game instanceof Game) {
-                List<Entity> units = new MMUReader(scenariofile).read(unitsNode, Entity.class).stream()
-                        .filter(o -> o instanceof Entity)
-                        .map(o -> (Entity) o)
-                        .collect(Collectors.toList());
-                int entityId = Math.max(smallestFreeUnitID(units), game.getNextEntityId());
-                for (Entity unit : units) {
-                    unit.setOwner(player);
-                    if (unit.getId() == Entity.NONE) {
-                        unit.setId(entityId);
-                        entityId++;
+            if (playerNode.has(UNITS)) {
+                JsonNode unitsNode = playerNode.get(UNITS);
+                if (game instanceof Game) {
+                    List<Entity> units = new MMUReader(scenariofile).read(unitsNode, Entity.class).stream()
+                            .filter(o -> o instanceof Entity)
+                            .map(o -> (Entity) o)
+                            .collect(Collectors.toList());
+                    int entityId = Math.max(smallestFreeUnitID(units), game.getNextEntityId());
+                    for (Entity unit : units) {
+                        unit.setOwner(player);
+                        if (unit.getId() == Entity.NONE) {
+                            unit.setId(entityId);
+                            entityId++;
+                        }
+                        ((Game) game).addEntity(unit);
+                        // Grounded DropShips don't set secondary positions unless they're part of a game and can verify
+                        // they're not on a space map.
+                        if (unit.isLargeCraft() && !unit.isAirborne()) {
+                            unit.setAltitude(0);
+                        }
                     }
-                    ((Game) game).addEntity(unit);
-                    // Grounded DropShips don't set secondary positions unless they're part of a game and can verify
-                    // they're not on a space map.
-                    if (unit.isLargeCraft() && !unit.isAirborne()) {
-                        unit.setAltitude(0);
+                } else if (game instanceof SBFGame) {
+                    List<InGameObject> units = new MMUReader(scenariofile).read(unitsNode).stream()
+                            .filter(o -> o instanceof InGameObject)
+                            .map(o -> (InGameObject) o)
+                            .collect(Collectors.toList());
+                    int entityId = Math.max(smallestFreeUnitID(units), game.getNextEntityId());
+                    for (InGameObject unit : units) {
+                        if (unit.getId() == Entity.NONE) {
+                            unit.setId(entityId);
+                            entityId++;
+                        }
+                        unit.setOwnerId(player.getId());
+                        ((SBFGame) game).addUnit(unit);
                     }
-                }
-            } else if (game instanceof SBFGame) {
-                List<InGameObject> units = new MMUReader(scenariofile).read(unitsNode).stream()
-                        .filter(o -> o instanceof InGameObject)
-                        .map(o -> (InGameObject) o)
-                        .collect(Collectors.toList());
-                int entityId = Math.max(smallestFreeUnitID(units), game.getNextEntityId());
-                for (InGameObject unit : units) {
-                    if (unit.getId() == Entity.NONE) {
-                        unit.setId(entityId);
-                        entityId++;
-                    }
-                    unit.setOwnerId(player.getId());
-                    ((SBFGame) game).addUnit(unit);
                 }
             }
             // TODO: look at unit individual camo and see if it's a file in the scenario directory; the entity parsers


### PR DESCRIPTION
A tiny change that allows leaving the human player in a scenario with no units and thus have two bots fight it out.

Best hide whitespace when reviewing. The diff looks big, but it only surrounds the unit reader with a check if there is a unit node, new line 218