### PR TITLE
GameReports: remove error message and deal with missing rounds

### DIFF
--- a/megamek/src/megamek/common/GameReports.java
+++ b/megamek/src/megamek/common/GameReports.java
@@ -54,17 +54,13 @@ public class GameReports implements FullGameReport<Report> {
 
     @Override
     public List<Report> get(int round) {
-        if (round == 0) {
-            // Round 0 (deployment) reports are lumped in with round one.
-            round = 1;
-        }
+        // Rounds prior to 1 (initial deployment) are lumped in with round 1
+        round = Math.max(1, round);
         if (hasReportsforRound(round)) {
             return reports.get(round - 1);
+        } else {
+            return new ArrayList<>();
         }
-
-        LogManager.getLogger().error("GameReports.get() was asked for reports of round {} which it does not have",
-                round, new RuntimeException());
-        return null;
     }
 
     /**


### PR DESCRIPTION
This removes the unnecessary error message for getting a non-existent round report and instead just returns an empty list. 

Since the round reports are just a list, not a map of round->reports, they are brittle. But as long as every round gets a report, it works.

This is one of the issues in #5833