### PR TITLE
FighterSquadron updates

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -68,7 +68,7 @@ MEGAMEK VERSION HISTORY:
 + Fix #5818: correct issue with minimap autodisplay using wrong function
 + PR #5822: Implement RFE 5361: enhance Princess handling of hazardous terrain
 + Issues #2577, #897, #353: Implement placeable/carryable cargo objects (for mechs and protomechs only at the moment)
-+ Fix #5811: Validation accepts Heavy Gauss Rifle with ICE
++ Fix #5811, #5831: Updates to unit validation (Heavy Gauss Rifles and RISC Hyper Laser vs. engines), allow Illegal Design quirk to validate illegal units
 
 0.49.20 (2024-06-28 2100 UTC) (THIS IS THE LAST VERSION TO SUPPORT JAVA 11)
 + PR #5281, #5327, #5308, #5336, #5318, #5383, #5369, #5384, #5455, #5505, #5541: Code internals: preparatory work for supporting game types such as SBF, code cleanup for string drawing, superclass change for BoardView,

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14228,13 +14228,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public boolean isTrapped() {
         if (getTransportId() != Entity.NONE) {
-            Entity transport = game.getEntity(getTransportId());
-            if (transport == null) {
-                transport = game.getOutOfGameEntity(getTransportId());
-            }
-            if (transport.isDestroyed()) {
-                return true;
-            }
+            Entity transport = game.getEntityFromAllSources(getTransportId());
+            return (transport != null) && transport.isDestroyed();
         }
         return false;
     }

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -197,9 +197,8 @@ public interface IAero {
      * Refresh the capital fighter weapons groups.
      */
     default void updateWeaponGroups() {
-        if (this instanceof FighterSquadron
-                || ((((Entity) this).game != null)
-                && ((Entity) this).game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_CAPITAL_FIGHTER))) {
+        if ((this instanceof Entity entity) && (entity.game != null)
+                && entity.game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_CAPITAL_FIGHTER)) {
             // first we need to reset all the weapons in our existing mounts to zero
             // until proven otherwise
             Set<String> set = getWeaponGroups().keySet();

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -29132,7 +29132,9 @@ public class GameManager extends AbstractGameManager {
                 entityUpdate(fighter.getId());
             }
         }
-        // If this is the lounge, we want to configure bombs
+        fs.updateSkills();
+        fs.updateWeaponGroups();
+        fs.updateSensors();
         fs.autoSetMaxBombPoints();
         if (!getGame().getPhase().isLounge()) {
             fs.applyBombs();

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -29128,14 +29128,14 @@ public class GameManager extends AbstractGameManager {
             if (null != fighter) {
                 formerCarriers.addAll(ServerLobbyHelper.lobbyUnload(game, List.of(fighter)));
                 fs.load(fighter, false);
-                fs.autoSetMaxBombPoints();
                 fighter.setTransportId(fs.getId());
-                // If this is the lounge, we want to configure bombs
-                if (getGame().getPhase().isLounge()) {
-                    ((IBomber) fighter).setBombChoices(fs.getExtBombChoices());
-                }
                 entityUpdate(fighter.getId());
             }
+        }
+        // If this is the lounge, we want to configure bombs
+        fs.autoSetMaxBombPoints();
+        if (!getGame().getPhase().isLounge()) {
+            fs.applyBombs();
         }
         if (!formerCarriers.isEmpty()) {
             send(new Packet(PacketCommand.ENTITY_MULTIUPDATE, formerCarriers));

--- a/megamek/src/megamek/utilities/DebugEntity.java
+++ b/megamek/src/megamek/utilities/DebugEntity.java
@@ -23,18 +23,14 @@ import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
 import java.util.List;
 
-import megamek.common.CriticalSlot;
-import megamek.common.Entity;
-import megamek.common.Infantry;
-import megamek.common.Mech;
-import megamek.common.Protomech;
-import megamek.common.Transporter;
+import megamek.common.*;
 import megamek.common.equipment.WeaponMounted;
 
 /**
  * This class is for debugging Entity with respect to the internal state of
  * equipment.
  */
+@SuppressWarnings("unused") // for debugging use
 public final class DebugEntity {
 
     /**
@@ -129,8 +125,7 @@ public final class DebugEntity {
             result.append("\nAn exception was encountered here. ").append(e.getMessage());
         }
 
-        if (entity instanceof FighterSquadron) {
-            FighterSquadron fighterSquadron = (FighterSquadron) entity;
+        if (entity instanceof FighterSquadron fighterSquadron) {
             for (Entity fighter : fighterSquadron.getLoadedUnits()) {
                 result.append("\n\n");
                 result.append(getEquipmentState(fighter));
@@ -140,6 +135,5 @@ public final class DebugEntity {
         return result.toString();
     }
 
-    private DebugEntity() {
-    }
+    private DebugEntity() { }
 }


### PR DESCRIPTION
This PR addresses a few issues around FighterSquadrons:
- in Entity, puts a null guard in the isTrapped check; this is a sad stopgap for when FS are created and the updates trickle in in separate packets; but dealing with this properly is a bigger thing
- a small code update in FS bomb creation, no change in result
- in IAero, update Cap Fighter weapon groups only when the Cap Fighter game option is active (normal fighters were constantly getting weapon groups assigned, curiously this was only visible when looking closely at the equipment using DebugEntity, it apparently didnt create any bugs)
- in GameManager, when creating an FS, changes code that erased bomb choices from the affected fighters and adds code to update the new FS appropriately
- For a FS, DebugEntity now outputs the fighter data as well as the FS itself
- adds a little dogfight scenario on a sky map (atmo map without terrain) as a version-independent test setup

In case anyone's wondering what DebugEntity does, it gives detailed equipment data; this is part of an output for a FS:


```
Chassis: >A Squadron<
Model: ><
Game ID: 5
Equipment:
[0] [Weapon] ISMediumPulseLaser (NOS) { Group, #Weapons: 4 }
[1] [Weapon] SRM 6 (WNG) { Linked: [Entity [Corax CRX-OA ID:1 (Legion of Vega), ID: 1]:4], Group, #Weapons: 4 }
[2] [Weapon] Small Laser (AFT) { Group, #Weapons: 8 }
[3] [Weapon] Medium Laser (WNG) { Group, #Weapons: 8 }

Locations:
NOS:
[0] Equipment Slot { [0] ISMediumPulseLaser -Group- }
LWG:
RWG:
AFT:
[0] Equipment Slot { [2] Small Laser -Group- }
WNG:
[0] Equipment Slot { [1] SRM 6 -Group- }
[1] Equipment Slot { [3] Medium Laser -Group- }
FSLG:


Chassis: >Corax<
Model: >CRX-OA<
Game ID: 1
Equipment:
[0] [Weapon] SRM 6 (LWG-Pod) { Linked: [4] }
[1] [Weapon] SRM 6 (RWG-Pod) { Linked: [4] }
[2] [Weapon] Small Laser (AFT-Pod) {  }
[3] [Weapon] Small Laser (AFT-Pod) {  }
[4] [Ammo] IS Ammo SRM-6 (FSLG-Pod) { LinkedBy: [Entity [A Squadron ID:5 (Legion of Vega), ID: 5]:1], Shots: 15 }
[5] [Ammo] IS Ammo SRM-6 (FSLG-Pod) { Shots: 15 }
[6] [Weapon] SRM 6 (WNG) { Linked: [4], Group, #Weapons: 2 }
[7] [Weapon] Small Laser (AFT) { Group, #Weapons: 2 }

Locations:
NOS:
LWG:
[0] Equipment Slot { [0] SRM 6 }
RWG:
[0] Equipment Slot { [1] SRM 6 }
AFT:
[0] Equipment Slot { [2] Small Laser }
[1] Equipment Slot { [3] Small Laser }
[2] Equipment Slot { [7] Small Laser -Group- }
WNG:
[0] Equipment Slot { [6] SRM 6 -Group- }
FSLG:
[0] Equipment Slot { [4] IS Ammo SRM-6 }
[1] Equipment Slot { [5] IS Ammo SRM-6 }

...

```
