### PR TITLE
Index guard for turn lookup to prevent error messages

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -607,7 +607,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
      * turns to play
      */
     public @Nullable GameTurn getTurnForPlayer(int pn) {
-        synchronized (turnVector) {
+        if ((turnIndex >= 0) && (turnIndex < turnVector.size())) {
             for (int i = turnIndex; i < turnVector.size(); i++) {
                 GameTurn gt = turnVector.get(i);
                 if (gt.isValid(pn, this)) {


### PR DESCRIPTION
This adds an index guard to Game.getTurnForPlayer() to prevent frequent log error messages. getTurnForPlayer() is called from Client.isMyTurn() when the phase is simultaneous which is the case for the PRE_* phases (activating hidden units). A similar guard is already present for Game.getTurn() which is used for non-simultaneous phases.

Removed the synchronized as MM is not multithreaded, even when simultaneous turns are used (and please let's keep it that way)

