### PR TITLE
Check if Edge is enabled in Game Options before using it

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15903,4 +15903,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public boolean countForStrengthSum() {
         return !isDestroyed() && !isTrapped() && !isPartOfFighterSquadron();
     }
+
+    /** @return True if the unit should use Edge based on the current options and assigned Edge points */
+    public boolean shouldUseEdge(String option) {
+          return (game.getOptions().booleanOption(OptionsConstants.EDGE)
+              && getCrew().hasEdgeRemaining()
+              && getCrew().getOptions().booleanOption(option));
+    }
 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15907,6 +15907,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /** @return True if the unit should use Edge based on the current options and assigned Edge points */
     public boolean shouldUseEdge(String option) {
           return (game.getOptions().booleanOption(OptionsConstants.EDGE)
+              && getCrew() != null
               && getCrew().hasEdgeRemaining()
               && getCrew().getOptions().booleanOption(option));
     }

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1971,7 +1971,8 @@ public abstract class Mech extends Entity {
                 // normal front hits
                 switch (roll) {
                     case 2:
-                        if ((getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && (getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
@@ -1997,7 +1998,8 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2012,7 +2014,8 @@ public abstract class Mech extends Entity {
                 // normal left side hits
                 switch (roll) {
                     case 2:
-                        if ((getCrew().hasEdgeRemaining() && getCrew()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining() && getCrew()
                                 .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
@@ -2049,7 +2052,8 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_RLEG);
                     case 12:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2064,7 +2068,8 @@ public abstract class Mech extends Entity {
                 // normal right side hits
                 switch (roll) {
                     case 2:
-                        if ((getCrew().hasEdgeRemaining() && getCrew()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining() && getCrew()
                                 .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
@@ -2101,7 +2106,8 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_LLEG);
                     case 12:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2119,7 +2125,8 @@ public abstract class Mech extends Entity {
                         && isProne()) {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining() && getCrew()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining() && getCrew()
                                     .getOptions()
                                     .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                     && !game.getOptions().booleanOption(
@@ -2149,7 +2156,8 @@ public abstract class Mech extends Entity {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                    && getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(
                                             OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
@@ -2164,7 +2172,8 @@ public abstract class Mech extends Entity {
                 } else {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining() && getCrew()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                    && (getCrew().hasEdgeRemaining() && getCrew()
                                     .getOptions()
                                     .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                     && !game.getOptions().booleanOption(
@@ -2194,7 +2203,8 @@ public abstract class Mech extends Entity {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                    && getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(
                                             OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
@@ -2239,7 +2249,8 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2263,7 +2274,8 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_LARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2287,7 +2299,8 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2313,7 +2326,8 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_RARM, true);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
@@ -2392,7 +2406,8 @@ public abstract class Mech extends Entity {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -2419,7 +2434,8 @@ public abstract class Mech extends Entity {
                 case 11:
                     return new HitData(Mech.LOC_CT, true, effects);
                 case 12:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                     OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
@@ -2460,7 +2476,8 @@ public abstract class Mech extends Entity {
                 case 5:
                     return new HitData(Mech.LOC_RARM, (side == ToHitData.SIDE_REAR));
                 case 6:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                     OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -1971,9 +1971,7 @@ public abstract class Mech extends Entity {
                 // normal front hits
                 switch (roll) {
                     case 2:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && (getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -1998,10 +1996,7 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);
@@ -2014,9 +2009,7 @@ public abstract class Mech extends Entity {
                 // normal left side hits
                 switch (roll) {
                     case 2:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining() && getCrew()
-                                .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -2052,7 +2045,7 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_RLEG);
                     case 12:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        if (shouldUseEdge(OptionsConstants.EDGE)
                                 && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                         OptionsConstants.EDGE_WHEN_HEADHIT)) {
@@ -2068,9 +2061,7 @@ public abstract class Mech extends Entity {
                 // normal right side hits
                 switch (roll) {
                     case 2:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining() && getCrew()
-                                .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -2106,10 +2097,7 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_LLEG);
                     case 12:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);
@@ -2125,10 +2113,7 @@ public abstract class Mech extends Entity {
                         && isProne()) {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining() && getCrew()
-                                    .getOptions()
-                                    .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                     && !game.getOptions().booleanOption(
                                             OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
@@ -2156,10 +2141,7 @@ public abstract class Mech extends Entity {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                    && getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(
-                                            OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side,
                                         aimedLocation, aimingMode, cover);
@@ -2172,10 +2154,7 @@ public abstract class Mech extends Entity {
                 } else {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                    && (getCrew().hasEdgeRemaining() && getCrew()
-                                    .getOptions()
-                                    .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                     && !game.getOptions().booleanOption(
                                             OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
@@ -2203,10 +2182,7 @@ public abstract class Mech extends Entity {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                    && getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(
-                                            OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side,
                                         aimedLocation, aimingMode, cover);
@@ -2249,10 +2225,7 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);
@@ -2274,10 +2247,7 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_LARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);
@@ -2299,10 +2269,7 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);
@@ -2326,10 +2293,7 @@ public abstract class Mech extends Entity {
                     case 5:
                         return new HitData(Mech.LOC_RARM, true);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);
@@ -2406,9 +2370,7 @@ public abstract class Mech extends Entity {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                         result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
@@ -2434,10 +2396,7 @@ public abstract class Mech extends Entity {
                 case 11:
                     return new HitData(Mech.LOC_CT, true, effects);
                 case 12:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
-                                    OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                 aimedLocation, aimingMode, cover);
@@ -2476,10 +2435,7 @@ public abstract class Mech extends Entity {
                 case 5:
                     return new HitData(Mech.LOC_RARM, (side == ToHitData.SIDE_REAR));
                 case 6:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
-                                    OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                 aimedLocation, aimingMode, cover);

--- a/megamek/src/megamek/common/Mech.java
+++ b/megamek/src/megamek/common/Mech.java
@@ -2045,10 +2045,7 @@ public abstract class Mech extends Entity {
                     case 11:
                         return new HitData(Mech.LOC_RLEG);
                     case 12:
-                        if (shouldUseEdge(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
-                                        OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                     aimedLocation, aimingMode, cover);

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -458,9 +458,7 @@ public class QuadMech extends Mech {
                     // normal front hits
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -485,9 +483,7 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_RLEG);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(new HitData(Mech.LOC_HEAD));
@@ -498,9 +494,7 @@ public class QuadMech extends Mech {
                 } else if (side == ToHitData.SIDE_REAR) {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -525,9 +519,7 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_RARM, true);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -538,9 +530,7 @@ public class QuadMech extends Mech {
                 } else if (side == ToHitData.SIDE_LEFT) {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -565,9 +555,7 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_RLEG);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(new HitData(Mech.LOC_HEAD));
@@ -578,9 +566,7 @@ public class QuadMech extends Mech {
                 } else if (side == ToHitData.SIDE_RIGHT) {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -605,9 +591,7 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LLEG);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining()
-                                    && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(new HitData(Mech.LOC_HEAD));
@@ -647,9 +631,7 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -670,9 +652,7 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RLEG, true);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -692,9 +672,7 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_LLEG);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -714,9 +692,7 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RLEG);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -785,9 +761,7 @@ public class QuadMech extends Mech {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                         result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));
@@ -813,9 +787,7 @@ public class QuadMech extends Mech {
                 case 11:
                     return new HitData(Mech.LOC_LT, false, effects);
                 case 12:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                         result.setUndoneLocation(new HitData(Mech.LOC_HEAD, false, effects));

--- a/megamek/src/megamek/common/QuadMech.java
+++ b/megamek/src/megamek/common/QuadMech.java
@@ -458,9 +458,10 @@ public class QuadMech extends Mech {
                     // normal front hits
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
-                                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
+                                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(tac(table, side, Mech.LOC_CT, cover, false));
@@ -484,7 +485,8 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_RLEG);
                         case 12:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -496,9 +498,10 @@ public class QuadMech extends Mech {
                 } else if (side == ToHitData.SIDE_REAR) {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
-                                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
+                                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(tac(table, side, Mech.LOC_CT, cover, true));
@@ -522,7 +525,8 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_RARM, true);
                         case 12:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -534,9 +538,10 @@ public class QuadMech extends Mech {
                 } else if (side == ToHitData.SIDE_LEFT) {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
-                                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
+                                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(tac(table, side, Mech.LOC_LT, cover, false));
@@ -560,7 +565,8 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_RLEG);
                         case 12:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -572,9 +578,10 @@ public class QuadMech extends Mech {
                 } else if (side == ToHitData.SIDE_RIGHT) {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
-                                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
+                                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                                 result.setUndoneLocation(tac(table, side, Mech.LOC_RT, cover, false));
@@ -598,7 +605,8 @@ public class QuadMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LLEG);
                         case 12:
-                            if ((getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining()
                                     && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT))) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -639,8 +647,9 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -661,8 +670,9 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RLEG, true);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -682,8 +692,9 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_LLEG);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -703,8 +714,9 @@ public class QuadMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RLEG);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
+                            && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
                             result.setUndoneLocation(new HitData(Mech.LOC_HEAD, true));
@@ -773,7 +785,8 @@ public class QuadMech extends Mech {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);
@@ -800,7 +813,8 @@ public class QuadMech extends Mech {
                 case 11:
                     return new HitData(Mech.LOC_LT, false, effects);
                 case 12:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side, aimedLocation, aimingMode, cover);

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -1029,7 +1029,8 @@ public class TripodMech extends Mech {
                 // normal front hits
                 switch (roll) {
                     case 2:
-                        if ((getCrew().hasEdgeRemaining() && getCrew()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && (getCrew().hasEdgeRemaining() && getCrew()
                                 .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
@@ -1063,7 +1064,8 @@ public class TripodMech extends Mech {
                     case 11:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
@@ -1078,7 +1080,8 @@ public class TripodMech extends Mech {
                 // normal left side hits
                 switch (roll) {
                     case 2:
-                        if ((getCrew().hasEdgeRemaining() && getCrew()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && (getCrew().hasEdgeRemaining() && getCrew()
                                 .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
@@ -1135,7 +1138,8 @@ public class TripodMech extends Mech {
                 // normal right side hits
                 switch (roll) {
                     case 2:
-                        if ((getCrew().hasEdgeRemaining() && getCrew()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && (getCrew().hasEdgeRemaining() && getCrew()
                                 .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
@@ -1177,7 +1181,8 @@ public class TripodMech extends Mech {
                     case 10:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
@@ -1195,7 +1200,8 @@ public class TripodMech extends Mech {
                     && isProne()) {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining() && getCrew()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining() && getCrew()
                                     .getOptions()
                                     .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                 && !game.getOptions().booleanOption(
@@ -1231,7 +1237,8 @@ public class TripodMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                     "edge_when_headhit")) {
                                 getCrew().decreaseEdge();
@@ -1246,7 +1253,8 @@ public class TripodMech extends Mech {
                 } else {
                     switch (roll) {
                         case 2:
-                            if ((getCrew().hasEdgeRemaining() && getCrew()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && (getCrew().hasEdgeRemaining() && getCrew()
                                     .getOptions()
                                     .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
                                 && !game.getOptions().booleanOption(
@@ -1282,7 +1290,8 @@ public class TripodMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (getCrew().hasEdgeRemaining()
+                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                && getCrew().hasEdgeRemaining()
                                 && getCrew().getOptions().booleanOption(
                                     "edge_when_headhit")) {
                                 getCrew().decreaseEdge();
@@ -1327,7 +1336,8 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
@@ -1351,7 +1361,8 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_LARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
@@ -1375,7 +1386,8 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
@@ -1401,7 +1413,8 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM, true);
                     case 6:
-                        if (getCrew().hasEdgeRemaining()
+                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && getCrew().hasEdgeRemaining()
                             && getCrew().getOptions().booleanOption(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
@@ -1491,7 +1504,8 @@ public class TripodMech extends Mech {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && getCrew().hasEdgeRemaining()
                         && getCrew().getOptions().booleanOption(
                             "edge_when_headhit")) {
                         getCrew().decreaseEdge();
@@ -1521,7 +1535,8 @@ public class TripodMech extends Mech {
                 case 11:
                     return new HitData(Mech.LOC_CT, true, effects);
                 case 12:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && getCrew().hasEdgeRemaining()
                         && getCrew().getOptions().booleanOption(
                             "edge_when_headhit")) {
                         getCrew().decreaseEdge();
@@ -1562,7 +1577,8 @@ public class TripodMech extends Mech {
                 case 5:
                     return new HitData(Mech.LOC_RARM, (side == ToHitData.SIDE_REAR));
                 case 6:
-                    if (getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && getCrew().hasEdgeRemaining()
                         && getCrew().getOptions().booleanOption(
                             "edge_when_headhit")) {
                         getCrew().decreaseEdge();

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -1062,8 +1062,7 @@ public class TripodMech extends Mech {
                     case 11:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (shouldUseEdge(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1117,9 +1116,7 @@ public class TripodMech extends Mech {
                     case 10:
                         return new HitData(Mech.LOC_RARM);
                     case 12:
-                        if (getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1173,8 +1170,7 @@ public class TripodMech extends Mech {
                     case 10:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (shouldUseEdge(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1224,8 +1220,7 @@ public class TripodMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (shouldUseEdge(
-                                    "edge_when_headhit")) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side,
                                                                  aimedLocation, aimingMode, cover);
@@ -1272,8 +1267,7 @@ public class TripodMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (shouldUseEdge(
-                                    "edge_when_headhit")) {
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side,
                                                                  aimedLocation, aimingMode, cover);
@@ -1316,8 +1310,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (shouldUseEdge(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1339,8 +1332,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_LARM);
                     case 6:
-                        if (shouldUseEdge(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1362,8 +1354,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (shouldUseEdge(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1387,7 +1378,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM, true);
                     case 6:
-                        if (shouldUseEdge("edge_when_headhit")) {
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1475,7 +1466,7 @@ public class TripodMech extends Mech {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (shouldUseEdge("edge_when_headhit")) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                                          aimedLocation, aimingMode, cover);
@@ -1503,7 +1494,7 @@ public class TripodMech extends Mech {
                 case 11:
                     return new HitData(Mech.LOC_CT, true, effects);
                 case 12:
-                    if (shouldUseEdge("edge_when_headhit")) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                                          aimedLocation, aimingMode, cover);
@@ -1542,7 +1533,7 @@ public class TripodMech extends Mech {
                 case 5:
                     return new HitData(Mech.LOC_RARM, (side == ToHitData.SIDE_REAR));
                 case 6:
-                    if (shouldUseEdge("edge_when_headhit")) {
+                    if (shouldUseEdge(OptionsConstants.EDGE_WHEN_HEADHIT)) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                                          aimedLocation, aimingMode, cover);

--- a/megamek/src/megamek/common/TripodMech.java
+++ b/megamek/src/megamek/common/TripodMech.java
@@ -1029,9 +1029,7 @@ public class TripodMech extends Mech {
                 // normal front hits
                 switch (roll) {
                     case 2:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && (getCrew().hasEdgeRemaining() && getCrew()
-                                .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1064,9 +1062,7 @@ public class TripodMech extends Mech {
                     case 11:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
+                        if (shouldUseEdge(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1080,9 +1076,7 @@ public class TripodMech extends Mech {
                 // normal left side hits
                 switch (roll) {
                     case 2:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && (getCrew().hasEdgeRemaining() && getCrew()
-                                .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1138,9 +1132,7 @@ public class TripodMech extends Mech {
                 // normal right side hits
                 switch (roll) {
                     case 2:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && (getCrew().hasEdgeRemaining() && getCrew()
-                                .getOptions().booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                        if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                             && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_NO_TAC)) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1181,9 +1173,7 @@ public class TripodMech extends Mech {
                     case 10:
                         return new HitData(Mech.LOC_LARM);
                     case 12:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
+                        if (shouldUseEdge(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1200,10 +1190,7 @@ public class TripodMech extends Mech {
                     && isProne()) {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining() && getCrew()
-                                    .getOptions()
-                                    .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(
                                     OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
@@ -1237,9 +1224,7 @@ public class TripodMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
+                            if (shouldUseEdge(
                                     "edge_when_headhit")) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side,
@@ -1253,10 +1238,7 @@ public class TripodMech extends Mech {
                 } else {
                     switch (roll) {
                         case 2:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && (getCrew().hasEdgeRemaining() && getCrew()
-                                    .getOptions()
-                                    .booleanOption(OptionsConstants.EDGE_WHEN_TAC))
+                            if (shouldUseEdge(OptionsConstants.EDGE_WHEN_TAC)
                                 && !game.getOptions().booleanOption(
                                     OptionsConstants.ADVCOMBAT_NO_TAC)) {
                                 getCrew().decreaseEdge();
@@ -1290,9 +1272,7 @@ public class TripodMech extends Mech {
                         case 11:
                             return new HitData(Mech.LOC_LARM, true);
                         case 12:
-                            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                && getCrew().hasEdgeRemaining()
-                                && getCrew().getOptions().booleanOption(
+                            if (shouldUseEdge(
                                     "edge_when_headhit")) {
                                 getCrew().decreaseEdge();
                                 HitData result = rollHitLocation(table, side,
@@ -1336,9 +1316,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
+                        if (shouldUseEdge(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1361,9 +1339,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_LARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
+                        if (shouldUseEdge(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1386,9 +1362,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
+                        if (shouldUseEdge(
                                 "edge_when_headhit")) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
@@ -1413,10 +1387,7 @@ public class TripodMech extends Mech {
                     case 5:
                         return new HitData(Mech.LOC_RARM, true);
                     case 6:
-                        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && getCrew().hasEdgeRemaining()
-                            && getCrew().getOptions().booleanOption(
-                                "edge_when_headhit")) {
+                        if (shouldUseEdge("edge_when_headhit")) {
                             getCrew().decreaseEdge();
                             HitData result = rollHitLocation(table, side,
                                                              aimedLocation, aimingMode, cover);
@@ -1504,10 +1475,7 @@ public class TripodMech extends Mech {
             // Swarm attack locations.
             switch (roll) {
                 case 2:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(
-                            "edge_when_headhit")) {
+                    if (shouldUseEdge("edge_when_headhit")) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                                          aimedLocation, aimingMode, cover);
@@ -1535,10 +1503,7 @@ public class TripodMech extends Mech {
                 case 11:
                     return new HitData(Mech.LOC_CT, true, effects);
                 case 12:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(
-                            "edge_when_headhit")) {
+                    if (shouldUseEdge("edge_when_headhit")) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                                          aimedLocation, aimingMode, cover);
@@ -1577,10 +1542,7 @@ public class TripodMech extends Mech {
                 case 5:
                     return new HitData(Mech.LOC_RARM, (side == ToHitData.SIDE_REAR));
                 case 6:
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && getCrew().hasEdgeRemaining()
-                        && getCrew().getOptions().booleanOption(
-                            "edge_when_headhit")) {
+                    if (shouldUseEdge("edge_when_headhit")) {
                         getCrew().decreaseEdge();
                         HitData result = rollHitLocation(table, side,
                                                          aimedLocation, aimingMode, cover);

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -20451,7 +20451,8 @@ public class GameManager extends AbstractGameManager {
                     // return true;
                 } // else
                 vDesc.add(r);
-            } while (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)
+            } while ((e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)
+                    && e.getCrew().isKoThisRound(crewPos))
                     || e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO));
             // end of do-while
             if (e.getCrew().isKoThisRound(crewPos)) {

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -8612,10 +8612,7 @@ public class GameManager extends AbstractGameManager {
         if (entity.checkForMASCFailure(md, vReport, crits)) {
             boolean mascFailure = true;
             // Check to see if the pilot can reroll due to Edge
-            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                    && entity.getCrew().hasEdgeRemaining()
-                    && entity.getCrew().getOptions()
-                    .booleanOption(OptionsConstants.EDGE_WHEN_MASC_FAILS)) {
+            if (entity.shouldUseEdge(OptionsConstants.EDGE_WHEN_MASC_FAILS)) {
                 entity.getCrew().decreaseEdge();
                 // Need to reset the MASCUsed flag
                 entity.setMASCUsed(false);
@@ -8666,10 +8663,7 @@ public class GameManager extends AbstractGameManager {
         if (entity.checkForSuperchargerFailure(md, vReport, crits)) {
             boolean superchargerFailure = true;
             // Check to see if the pilot can reroll due to Edge
-            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                    && entity.getCrew().hasEdgeRemaining()
-                    && entity.getCrew().getOptions()
-                    .booleanOption(OptionsConstants.EDGE_WHEN_MASC_FAILS)) {
+            if (entity.shouldUseEdge(OptionsConstants.EDGE_WHEN_MASC_FAILS)) {
                 entity.getCrew().decreaseEdge();
                 // Need to reset the SuperchargerUsed flag
                 entity.setSuperchargerUsed(false);
@@ -20059,9 +20053,7 @@ public class GameManager extends AbstractGameManager {
                                     if (e.getAltitude() <= 0
                                             // Don't waste the edge if it won't help
                                             && origAltitude > 1
-                                            && game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                            && e.getCrew().hasEdgeRemaining()
-                                            && e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_ALT_LOSS)) {
+                                            && e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_ALT_LOSS)) {
                                         Roll diceRoll3 = Compute.rollD6(1);
                                         int rollValue3 = diceRoll3.getIntValue();
                                         String rollReport3 = diceRoll3.getReport();
@@ -20446,10 +20438,8 @@ public class GameManager extends AbstractGameManager {
                 } else {
                     e.getCrew().setKoThisRound(true, crewPos);
                     r.choose(false);
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && e.getCrew().hasEdgeRemaining()
-                            && (e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_KO)
-                            || e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_KO))) {
+                    if (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)
+                            || e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO)) {
                         edgeUsed = true;
                         vDesc.add(r);
                         r = new Report(6520);
@@ -20461,11 +20451,8 @@ public class GameManager extends AbstractGameManager {
                     // return true;
                 } // else
                 vDesc.add(r);
-            } while (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                    && e.getCrew().hasEdgeRemaining()
-                    && e.getCrew().isKoThisRound(crewPos)
-                    && (e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_KO)
-                    || e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_KO)));
+            } while (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)
+                    || e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO));
             // end of do-while
             if (e.getCrew().isKoThisRound(crewPos)) {
                 boolean wasPilot = e.getCrew().getCurrentPilotIndex() == crewPos;
@@ -24227,10 +24214,7 @@ public class GameManager extends AbstractGameManager {
                 r.subject = aero.getId();
                 if (fuelroll >= boomTarget) {
                     // A chance to reroll the explosion with edge
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && aero.getCrew().hasEdgeRemaining()
-                            && aero.getCrew().getOptions().booleanOption(
-                            OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)) {
+                    if (aero.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)) {
                         // Reporting this is funky because 9120 only has room for 2 choices. Replace it.
                         r = new Report(9123);
                         r.subject = aero.getId();
@@ -24474,9 +24458,7 @@ public class GameManager extends AbstractGameManager {
                                 boomTarget = 10;
                                 r.choose(ammoRoll >= boomTarget);
                                 // A chance to reroll an explosion with edge
-                                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                        && aero.getCrew().hasEdgeRemaining()
-                                        && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)
+                                if (aero.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)
                                         && ammoRoll >= boomTarget) {
                                     // Report 9156 doesn't offer the right choices. Replace it.
                                     r = new Report(9158);
@@ -24530,9 +24512,7 @@ public class GameManager extends AbstractGameManager {
                             int ammoroll = Compute.d6(2);
                             if (ammoroll >= 10) {
                                 // A chance to reroll an explosion with edge
-                                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                                        && aero.getCrew().hasEdgeRemaining()
-                                        && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)) {
+                                if (aero.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)) {
                                     aero.getCrew().decreaseEdge();
                                     r = new Report(6530);
                                     r.subject = aero.getId();
@@ -24560,9 +24540,7 @@ public class GameManager extends AbstractGameManager {
                         }
                     }
                     // If the weapon is explosive, use edge to roll up a new one
-                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                            && aero.getCrew().hasEdgeRemaining()
-                            && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)
+                    if (aero.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)
                             && (equipmentHit.getType().isExplosive(equipmentHit) && !equipmentHit.isHit()
                             && !equipmentHit.isDestroyed())) {
                         aero.getCrew().decreaseEdge();
@@ -24834,9 +24812,7 @@ public class GameManager extends AbstractGameManager {
         int roll = Compute.d6(1);
         // A hit on a bay filled with transported units is devastating
         // allow a reroll with edge
-        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_UNIT_CARGO_LOST)
-                && aero.getCrew().hasEdgeRemaining() && roll > 3) {
+        if (aero.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_UNIT_CARGO_LOST) && roll > 3) {
             aero.getCrew().decreaseEdge();
             r = new Report(9172);
             r.subject = aero.getId();
@@ -25869,8 +25845,7 @@ public class GameManager extends AbstractGameManager {
 
             if (diceRoll.getIntValue() >= capitalMissile) {
                 // Allow a reroll with edge
-                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && a.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_NUKE_CRIT)
+                if (a.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_NUKE_CRIT)
                         && a.getCrew().hasEdgeRemaining()) {
                     a.getCrew().decreaseEdge();
                     r = new Report(9148);
@@ -25924,9 +25899,7 @@ public class GameManager extends AbstractGameManager {
         if (hit.rolledBoxCars()) {
             if (hit.isFirstHit()) {
                 // Allow edge use to ignore the critical roll
-                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && a.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_LUCKY_CRIT)
-                        && a.getCrew().hasEdgeRemaining()) {
+                if (a.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_LUCKY_CRIT)) {
                     a.getCrew().decreaseEdge();
                     r = new Report(9103);
                     r.subject = a.getId();
@@ -26292,9 +26265,7 @@ public class GameManager extends AbstractGameManager {
                 }
                 // if explosive use edge
                 if ((en instanceof Mech)
-                        && game.getOptions().booleanOption(OptionsConstants.EDGE)
-                        && (en.getCrew().hasEdgeRemaining() && en.getCrew().getOptions()
-                        .booleanOption(OptionsConstants.EDGE_WHEN_EXPLOSION))
+                        && en.shouldUseEdge(OptionsConstants.EDGE_WHEN_EXPLOSION)
                         && (slot.getType() == CriticalSlot.TYPE_EQUIPMENT)
                         && slot.getMount().getType().isExplosive(slot.getMount())) {
                     en.getCrew().decreaseEdge();

--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -8612,7 +8612,8 @@ public class GameManager extends AbstractGameManager {
         if (entity.checkForMASCFailure(md, vReport, crits)) {
             boolean mascFailure = true;
             // Check to see if the pilot can reroll due to Edge
-            if (entity.getCrew().hasEdgeRemaining()
+            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                    && entity.getCrew().hasEdgeRemaining()
                     && entity.getCrew().getOptions()
                     .booleanOption(OptionsConstants.EDGE_WHEN_MASC_FAILS)) {
                 entity.getCrew().decreaseEdge();
@@ -8665,7 +8666,8 @@ public class GameManager extends AbstractGameManager {
         if (entity.checkForSuperchargerFailure(md, vReport, crits)) {
             boolean superchargerFailure = true;
             // Check to see if the pilot can reroll due to Edge
-            if (entity.getCrew().hasEdgeRemaining()
+            if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                    && entity.getCrew().hasEdgeRemaining()
                     && entity.getCrew().getOptions()
                     .booleanOption(OptionsConstants.EDGE_WHEN_MASC_FAILS)) {
                 entity.getCrew().decreaseEdge();
@@ -20057,6 +20059,7 @@ public class GameManager extends AbstractGameManager {
                                     if (e.getAltitude() <= 0
                                             // Don't waste the edge if it won't help
                                             && origAltitude > 1
+                                            && game.getOptions().booleanOption(OptionsConstants.EDGE)
                                             && e.getCrew().hasEdgeRemaining()
                                             && e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_ALT_LOSS)) {
                                         Roll diceRoll3 = Compute.rollD6(1);
@@ -20443,7 +20446,8 @@ public class GameManager extends AbstractGameManager {
                 } else {
                     e.getCrew().setKoThisRound(true, crewPos);
                     r.choose(false);
-                    if (e.getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && e.getCrew().hasEdgeRemaining()
                             && (e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_KO)
                             || e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_KO))) {
                         edgeUsed = true;
@@ -20457,7 +20461,8 @@ public class GameManager extends AbstractGameManager {
                     // return true;
                 } // else
                 vDesc.add(r);
-            } while (e.getCrew().hasEdgeRemaining()
+            } while (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                    && e.getCrew().hasEdgeRemaining()
                     && e.getCrew().isKoThisRound(crewPos)
                     && (e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_KO)
                     || e.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_KO)));
@@ -24222,7 +24227,8 @@ public class GameManager extends AbstractGameManager {
                 r.subject = aero.getId();
                 if (fuelroll >= boomTarget) {
                     // A chance to reroll the explosion with edge
-                    if (aero.getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && aero.getCrew().hasEdgeRemaining()
                             && aero.getCrew().getOptions().booleanOption(
                             OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)) {
                         // Reporting this is funky because 9120 only has room for 2 choices. Replace it.
@@ -24468,7 +24474,8 @@ public class GameManager extends AbstractGameManager {
                                 boomTarget = 10;
                                 r.choose(ammoRoll >= boomTarget);
                                 // A chance to reroll an explosion with edge
-                                if (aero.getCrew().hasEdgeRemaining()
+                                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                        && aero.getCrew().hasEdgeRemaining()
                                         && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)
                                         && ammoRoll >= boomTarget) {
                                     // Report 9156 doesn't offer the right choices. Replace it.
@@ -24523,7 +24530,8 @@ public class GameManager extends AbstractGameManager {
                             int ammoroll = Compute.d6(2);
                             if (ammoroll >= 10) {
                                 // A chance to reroll an explosion with edge
-                                if (aero.getCrew().hasEdgeRemaining()
+                                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                                        && aero.getCrew().hasEdgeRemaining()
                                         && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)) {
                                     aero.getCrew().decreaseEdge();
                                     r = new Report(6530);
@@ -24552,7 +24560,8 @@ public class GameManager extends AbstractGameManager {
                         }
                     }
                     // If the weapon is explosive, use edge to roll up a new one
-                    if (aero.getCrew().hasEdgeRemaining()
+                    if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                            && aero.getCrew().hasEdgeRemaining()
                             && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_EXPLOSION)
                             && (equipmentHit.getType().isExplosive(equipmentHit) && !equipmentHit.isHit()
                             && !equipmentHit.isDestroyed())) {
@@ -24825,7 +24834,8 @@ public class GameManager extends AbstractGameManager {
         int roll = Compute.d6(1);
         // A hit on a bay filled with transported units is devastating
         // allow a reroll with edge
-        if (aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_UNIT_CARGO_LOST)
+        if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                && aero.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_UNIT_CARGO_LOST)
                 && aero.getCrew().hasEdgeRemaining() && roll > 3) {
             aero.getCrew().decreaseEdge();
             r = new Report(9172);
@@ -25859,7 +25869,8 @@ public class GameManager extends AbstractGameManager {
 
             if (diceRoll.getIntValue() >= capitalMissile) {
                 // Allow a reroll with edge
-                if (a.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_NUKE_CRIT)
+                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && a.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_NUKE_CRIT)
                         && a.getCrew().hasEdgeRemaining()) {
                     a.getCrew().decreaseEdge();
                     r = new Report(9148);
@@ -25913,7 +25924,8 @@ public class GameManager extends AbstractGameManager {
         if (hit.rolledBoxCars()) {
             if (hit.isFirstHit()) {
                 // Allow edge use to ignore the critical roll
-                if (a.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_LUCKY_CRIT)
+                if (game.getOptions().booleanOption(OptionsConstants.EDGE)
+                        && a.getCrew().getOptions().booleanOption(OptionsConstants.EDGE_WHEN_AERO_LUCKY_CRIT)
                         && a.getCrew().hasEdgeRemaining()) {
                     a.getCrew().decreaseEdge();
                     r = new Report(9103);
@@ -26280,6 +26292,7 @@ public class GameManager extends AbstractGameManager {
                 }
                 // if explosive use edge
                 if ((en instanceof Mech)
+                        && game.getOptions().booleanOption(OptionsConstants.EDGE)
                         && (en.getCrew().hasEdgeRemaining() && en.getCrew().getOptions()
                         .booleanOption(OptionsConstants.EDGE_WHEN_EXPLOSION))
                         && (slot.getType() == CriticalSlot.TYPE_EQUIPMENT)


### PR DESCRIPTION
When determining whether to roll edge on crits, the game only checked whether crews had Edge points remaining and not whether Edge was actually enabled. This led to weird situations where pilots who had edge points assigned would still roll edge even though it was disabled (as described in https://github.com/MegaMek/megamek/issues/5587).

This PR adds an additional check to see if Edge is enabled before checking whether the crew has edge points. I wish there was a cleaner way to do this than at each call site but it would've required more substantial refactoring which I was afraid to do. I looked at implementing it in the `Crew` object but it doesn't extend `Entity` and thus does not have access to `game`.

I tested in a game with all Mechs and they stopped rolling Edge when it was disabled, and rolled Edge when it was enabled, as expected.

Closes #5587