### PR TITLE
#5848: FontHandler log entries at debug level

### DIFF
--- a/megamek/src/megamek/client/ui/swing/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/swing/util/FontHandler.java
@@ -150,7 +150,7 @@ public final class FontHandler {
                 errors.add("    Failed to read font " + fontFile);
             }
         }
-        logger.warn("Could not register some fonts\n{}", String.join("\n", errors));
+        logger.debug("Could not register some fonts\n{}", String.join("\n", errors));
     }
 
     private static void ensureInitialization() {


### PR DESCRIPTION
Since the FontHandler log entries (could not register font ...) usually only mean that a font is already installed at system level, this changes their report level to DEBUG so they don't usually appear in the log.

Fix #5848 