### PR TITLE
Use OptionsConstants instead of hard-coded strings

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2443,7 +2443,7 @@ public class Compute {
         if (attacker.getCrew().hasDedicatedGunner()) {
             maxPrimary = attacker.getCrew().getCrewType().getMaxPrimaryTargets();
         }
-        if (game.getOptions().booleanOption("tacops_tank_crews")
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_TANK_CREWS)
             && (attacker instanceof Tank)) {
 
             // If we are a tank, and only have 1 crew then we have some special

--- a/megamek/src/megamek/common/FighterSquadron.java
+++ b/megamek/src/megamek/common/FighterSquadron.java
@@ -529,7 +529,7 @@ public class FighterSquadron extends AeroSpaceFighter {
         }
 
         // Now that we know our bomb choices, load 'em
-        int gameTL = TechConstants.getSimpleLevel(game.getOptions().stringOption("techlevel"));
+        int gameTL = TechConstants.getSimpleLevel(game.getOptions().stringOption(OptionsConstants.ALLOWED_TECHLEVEL));
         for (int type = 0; type < BombType.B_NUM; type++) {
             for (int i = 0; i < extBombChoices[type]; i++) {
                 if ((type == BombType.B_ALAMO)

--- a/megamek/src/megamek/common/IBomber.java
+++ b/megamek/src/megamek/common/IBomber.java
@@ -208,7 +208,7 @@ public interface IBomber {
      */
     default void applyBombs() {
         Game game = ((Entity) this).getGame();
-        int gameTL = TechConstants.getSimpleLevel(game.getOptions().stringOption("techlevel"));
+        int gameTL = TechConstants.getSimpleLevel(game.getOptions().stringOption(OptionsConstants.ALLOWED_TECHLEVEL));
         Integer[] iSorted = new Integer[BombType.B_NUM];
         // Apply the largest bombs first because we need to fit larger bombs into a single location
         // in LAMs.

--- a/megamek/src/megamek/common/TechConstants.java
+++ b/megamek/src/megamek/common/TechConstants.java
@@ -15,6 +15,8 @@
 */
 package megamek.common;
 
+import megamek.common.options.OptionsConstants;
+
 /**
  * Contains some constants representing equipment/unit tech levels
  *
@@ -166,7 +168,7 @@ public class TechConstants {
      * @return  the Game's tech level as an integer.
      */
     public static int getSimpleLevel(Game game) {
-        return getSimpleLevel(game.getOptions().stringOption("techlevel"));
+        return getSimpleLevel(game.getOptions().stringOption(OptionsConstants.ALLOWED_TECHLEVEL));
     }
 
     /**

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectHomingHandler.java
@@ -162,7 +162,7 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
 
         // Set Margin of Success/Failure.
         toHit.setMoS(roll.getIntValue() - Math.max(2, toHit.getValue()));
-        bDirect = game.getOptions().booleanOption("tacops_direct_blow")
+        bDirect = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_DIRECT_BLOW)
                 && ((toHit.getMoS() / 3) >= 1) && (entityTarget != null);
         if (bDirect) {
             r = new Report(3189);


### PR DESCRIPTION
I found a few more instances in the codebase where game options were being queried with hard-coded strings rather than using the `OptionsConstants` enum. This was using a find all for `game.getOptions()`--I checked all of them and I believe these are the last.