### PR TITLE
Always check if crew is KOed before rerolling edge

### DIFF
--- a/megamek/src/megamek/server/GameManager.java
+++ b/megamek/src/megamek/server/GameManager.java
@@ -20574,9 +20574,9 @@ public class GameManager extends AbstractGameManager {
                     // return true;
                 } // else
                 vDesc.add(r);
-            } while ((e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)
-                    && e.getCrew().isKoThisRound(crewPos))
-                    || e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO));
+            } while (e.getCrew().isKoThisRound(crewPos)
+                    && (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)
+                    || e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO)));
             // end of do-while
             if (e.getCrew().isKoThisRound(crewPos)) {
                 boolean wasPilot = e.getCrew().getCurrentPilotIndex() == crewPos;


### PR DESCRIPTION
#5855 introduced a bug where crew KOs would trigger rerolling edge until the pilot blacked out. This occurred because the `isKoThisRound()` check was accidentally grouped with `shouldUseEdge(OptionsConstants.EDGE_WHEN_KO`, and then the `|| EDGE_WHEN_AERO` condition was firing each time. This PR should fix the problem by re-grouping the conditions such that `isKoThisRound()` is always checked, and must be true with either of the EDGE options also true.

I tested this with mechs and it seems to show the expected behavior again:

![mechs](https://github.com/user-attachments/assets/2e102ce1-4b90-4b50-a742-be04a2f68db2)

Closes #5874