### PR TITLE
Fix 5614 princess does no pathing during deployment

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -794,7 +794,7 @@ public class BasicPathRanker extends PathRanker {
                         game.getBoard(), logMsg);
                 previousCoords = coords;
             }
-            logMsg.append("Compiled Hazard for Path (")
+            logMsg.append("\nCompiled Hazard for Path (")
                     .append(path.toString()).append("): ").append(LOG_DECIMAL.format(totalHazard));
 
             return totalHazard;

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -749,7 +749,7 @@ public class BasicPathRanker extends PathRanker {
         return minimum;
     }
 
-    double checkPathForHazards(MovePath path, Entity movingUnit, Game game) {
+    public double checkPathForHazards(MovePath path, Entity movingUnit, Game game) {
         StringBuilder logMsg = new StringBuilder("Checking Path (")
                 .append(path.toString()).append(") for hazards.");
 

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -301,6 +301,9 @@ public class PathEnumerator {
             getUnitMovableAreas().put(mover.getId(), myArea);
 
             return true;
+        } catch (IllegalArgumentException ex) {
+            LogManager.getLogger().debug("Lost sight of a unit while plotting predicted paths", ex);
+            return false;
         } catch (Exception e) {
             LogManager.getLogger().error("", e);
             return false;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -634,14 +634,17 @@ public class Princess extends BotClient {
         double rank;
         // allAtDistance uses a concept of radius that is 1 smaller.
         ArrayList<Coords> kernel = start.getFinalCoords().allAtDistance(radius+1);
-        ShortestPathFinder pf;
-        // Get all paths that meet criteria.
-        pf = ShortestPathFinder.newInstanceOfOneToAll(radius, MoveStepType.FORWARDS, game);
+
+        // Get all paths from the start point to the outer hexes that use "radius" MP
+        // Worse starting hexes have fewer, and shorter, paths
+        ShortestPathFinder pf = ShortestPathFinder.newInstanceOfOneToAll(
+                                        radius, MoveStepType.FORWARDS, game);
         pf.run(start);
 
         // Lower rank is better; 0.0 is minimum at this point.
         rank = Math.max(kernel.size() - pf.getAllComputedPaths().size(), 0.0);
         for (MovePath mp: pf.getAllComputedPaths().values()) {
+            rank -= mp.getHexesMoved();
             rank += ranker.checkPathForHazards(mp, deployedUnit, game);
         }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -694,8 +694,6 @@ public class Princess extends BotClient {
 
         // Shallow copy of refs list
         ArrayList<Coords> localCopy = new ArrayList(possibleDeployCoords);
-        // Shuffle
-        Collections.shuffle(localCopy);
 
         // Hacky, but really, "DEPLOY" should be a path step...
         MovePath mp = new MovePath(game, deployedUnit);
@@ -704,7 +702,11 @@ public class Princess extends BotClient {
         IPathRanker ranker = getPathRanker(deployedUnit);
         HashMap<Double, ArrayList<Coords>> rankedCoords = new HashMap<>();
 
-        if (!deployedUnit.isAero()) {
+        // Units that deploy airborne don't need to worry about all this
+        if (!(deployedUnit.isAero()
+                || ((deployedUnit.getMovementMode().isVTOL() || deployedUnit.getMovementMode().isWiGE())
+                    && deployedUnit.getElevation() > 0)
+        )) {
             double hazard;
             int longest = 0;
             int size = 0;
@@ -762,7 +764,7 @@ public class Princess extends BotClient {
             }
         } else {
             if (sb != null) {
-                sb.append("\n\tAerospace units don't worry about ground level hazards;");
+                sb.append("\n\tAerospace / flying ground units don't worry about ground level hazards;");
             }
         }
 

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -657,11 +657,11 @@ public class Princess extends BotClient {
         }
 
         if (sb != null) {
-            sb.append("\tAll computed ")
+            sb.append("\n\tAll computed ")
                     .append(radius)
                     .append("-length paths: ")
                     .append(pf.getAllComputedPaths().size());
-            sb.append("\tFinal rank (including hazards): ").append(rank);
+            sb.append("\n\tFinal rank (including hazards): ").append(rank);
             logger.debug(sb.toString());
         }
 
@@ -720,7 +720,7 @@ public class Princess extends BotClient {
                     longest = Math.max(size, longest);
 
                     if (sb != null) {
-                        sb.append("\tFound valid coordinates (").append(dest.toString())
+                        sb.append("\n\tFound valid coordinates (").append(dest.toString())
                                 .append(") with initial hazard of: ")
                                 .append(hazard);
                     }
@@ -750,7 +750,7 @@ public class Princess extends BotClient {
                 }
                 if (bestCandidate != null) {
                     if (sb != null) {
-                        sb.append("\tFound best candidate (").append(bestCandidate.toString())
+                        sb.append("\n\tFound best candidate (").append(bestCandidate.toString())
                                 .append(") out of ")
                                 .append(candidates.size())
                                 .append(" with a score of ")
@@ -762,12 +762,12 @@ public class Princess extends BotClient {
             }
         } else {
             if (sb != null) {
-                sb.append("\tAerospace units don't worry about ground level hazards;");
+                sb.append("\n\tAerospace units don't worry about ground level hazards;");
             }
         }
 
         if (sb != null) {
-            sb.append("\tFalling back to default getFirstValidCoords method!");
+            sb.append("\n\tFalling back to default getFirstValidCoords method!");
             logger.debug(sb.toString());
         }
         // Fall back on old method

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -639,8 +639,8 @@ public class Princess extends BotClient {
         pf = ShortestPathFinder.newInstanceOfOneToAll(radius, MoveStepType.FORWARDS, game);
         pf.run(start);
 
-        // Lower rank is better
-        rank = kernel.size() - pf.getAllComputedPaths().size();
+        // Lower rank is better; 0.0 is minimum at this point.
+        rank = Math.max(kernel.size() - pf.getAllComputedPaths().size(), 0.0);
         for (MovePath mp: pf.getAllComputedPaths().values()) {
             rank += ranker.checkPathForHazards(mp, deployedUnit, game);
         }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -630,10 +630,9 @@ public class Princess extends BotClient {
         return (building.getCurrentCF(coords) + hex.terrainLevel(Terrains.BLDG_ELEV) * 2) / turretCount;
     }
 
-    protected double rankKernelAroundCoordsReverse(MovePath start, Entity deployedUnit, int radius, BasicPathRanker ranker) {
+    protected double rankKernelAroundCoords(MovePath start, Entity deployedUnit, int radius, BasicPathRanker ranker) {
         double rank;
         // allAtDistance uses a concept of radius that is 1 smaller.
-        // ArrayList<Coords> kernel = start.getFinalCoords().allAtDistanceOrLess(radius+1);
         ArrayList<Coords> kernel = start.getFinalCoords().allAtDistance(radius+1);
         ShortestPathFinder pf;
         // Get all paths that meet criteria.
@@ -665,7 +664,7 @@ public class Princess extends BotClient {
     protected Coords rankDeploymentCoords(Entity deployedUnit, List<Coords> possibleDeployCoords) {
         // Sample LIMIT number of valid starting hexes, check accessibility and hazards within RADIUS
         int LIMIT = 20;
-        int RADIUS = 2;
+        int RADIUS = 3;
 
         // Shallow copy of refs list
         ArrayList<Coords> localCopy = new ArrayList(possibleDeployCoords);
@@ -708,9 +707,9 @@ public class Princess extends BotClient {
                 ArrayList<Coords> candidates = rankedCoords.get(bestRank);
                 for (Coords c: candidates) {
                     mp.clear();
-                    mp.addStep(MoveStepType.NONE);
+                    mp.addStep((deployedUnit.getJumpMP() == 0) ? MoveStepType.NONE: MoveStepType.START_JUMP);
                     mp.getLastStep().setPosition(c);
-                    current = bestRank - rankKernelAroundCoordsReverse(
+                    current = bestRank - rankKernelAroundCoords(
                             mp, deployedUnit, RADIUS, (BasicPathRanker) ranker);
                     if (current > scoreToBeat) {
                         scoreToBeat = current;
@@ -718,7 +717,7 @@ public class Princess extends BotClient {
                     }
                 }
                 if (bestCandidate != null) {
-                    return candidates.get(new Random().nextInt(candidates.size()));
+                    return bestCandidate;
                 }
             }
         }

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -1714,6 +1714,10 @@ public class MoveStep implements Serializable {
         return position;
     }
 
+    public void setPosition(Coords c) {
+        position = c;
+    }
+
     public boolean isPrevStepOnPavement() {
         return prevStepOnPavement;
     }


### PR DESCRIPTION
Adds hazard assessment for initial deployment hexes, and path opportunities + hazard assessments in a radius around the highest-ranking (lowest hazard) hexes.
Falls back to original deployment hex selection algorithm if the new search algorithm fails.

Performance appears to be the same as, or faster than, the original naive deployment algorithm while avoiding various pitfalls:
- Stranding non-jump units on buildings
- Stranding non-jump units in pits or inner courtyards that they cannot escape
- Placing units in hazardous hexes
The new algorithm uses sampling (of all valid deployment hexes) and a small kernel radius for determining surrounding path options and hazards to rank the best of a subset of candidate hexes against each other.
Because of this, there will be some (very few) instances when deployment may slow down, and units may be placed sub-optimally, due to the sampled subset containing no valid hexes and the fall-back algorithm being subsequently used.
I believe the improvements are worth this possible slight inconvenience, however:

<img width="1341" alt="image" src="https://github.com/user-attachments/assets/990856a0-c529-4d84-b6ed-fefe37bd98ff">

Notice that no units were deployed in cul-de-sacs or trapped on top of buildings, nor in water or on hazardous terrain hexes.


Note: this patch does not provide an option to disable the new search algorithm, nor controls to adjust the kernel size.

Testing:
- Ran a number of tests with various unit types in cities, hazardous environments / maps, jump and non-jump-equipped units.
- Ran all 3 projects' unit tests.


Close #5614 