### PR TITLE
prevent various NPEs and other exceptions

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -2501,7 +2501,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
     }
 
     Point getHexLocation(Coords c) {
-        return getHexLocation(c.getX(), c.getY(), false);
+        return c == null ? null : getHexLocation(c.getX(), c.getY(), false);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -249,25 +249,25 @@ class EntitySprite extends Sprite {
         
         if (position != null) {			
             if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
-        	    labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
-        	    labelPos = Positioning.RIGHT;
-        	} else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {
-        	    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
-        	            (int) (0.25 * bv.hex_size.height) - labelRect.height);
-        	    labelPos = Positioning.LEFT;
-        	} else if (bv.game.getEntitiesVector(position.translated("NE"), true).isEmpty()) {
-        	    labelRect.setLocation((int) (bv.hex_size.width * 0.55),
-        	            (int) (0.25 * bv.hex_size.height) - labelRect.height);
-        	    labelPos = Positioning.RIGHT;
-        	} else if (bv.game.getEntitiesVector(position.translated("SW"), true).isEmpty()) {
-        	    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
-        	            (int) (0.75 * bv.hex_size.height));
-        	    labelPos = Positioning.LEFT;
-        	} else {
-        	    labelRect.setLocation(bv.hex_size.width / 2 - labelRect.width / 2,
-        	            (int) (0.75 * bv.hex_size.height));
-        	    labelPos = Positioning.RIGHT;
-        	}
+                labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
+                labelPos = Positioning.RIGHT;
+            } else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {
+                labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
+                        (int) (0.25 * bv.hex_size.height) - labelRect.height);
+                labelPos = Positioning.LEFT;
+            } else if (bv.game.getEntitiesVector(position.translated("NE"), true).isEmpty()) {
+                labelRect.setLocation((int) (bv.hex_size.width * 0.55),
+                        (int) (0.25 * bv.hex_size.height) - labelRect.height);
+                labelPos = Positioning.RIGHT;
+            } else if (bv.game.getEntitiesVector(position.translated("SW"), true).isEmpty()) {
+                labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
+                        (int) (0.75 * bv.hex_size.height));
+                labelPos = Positioning.LEFT;
+            } else {
+                labelRect.setLocation(bv.hex_size.width / 2 - labelRect.width / 2,
+                        (int) (0.75 * bv.hex_size.height));
+                labelPos = Positioning.RIGHT;
+            }
         }
 
         // If multiple units are present in a hex, fan out the labels

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -219,7 +219,7 @@ class EntitySprite extends Sprite {
         }
         
         if (ePos != null) {
-        	bounds.setLocation(hexOrigin.x + ePos.x, hexOrigin.y + ePos.y);
+            bounds.setLocation(hexOrigin.x + ePos.x, hexOrigin.y + ePos.y);
         }
 
         entityRect = new Rectangle(bounds.x + (int) (20 * bv.scale), bounds.y

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -248,7 +248,7 @@ class EntitySprite extends Sprite {
         Coords position = entity.getPosition();
         
         if (position != null) {			
-        	if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
+            if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
         	    labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
         	    labelPos = Positioning.RIGHT;
         	} else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -217,7 +217,10 @@ class EntitySprite extends Sprite {
         } else {
             ePos = bv.getHexLocation(entity.getSecondaryPositions().get(secondaryPos));
         }
-        bounds.setLocation(hexOrigin.x + ePos.x, hexOrigin.y + ePos.y);
+        
+        if (ePos != null) {
+        	bounds.setLocation(hexOrigin.x + ePos.x, hexOrigin.y + ePos.y);
+        }
 
         entityRect = new Rectangle(bounds.x + (int) (20 * bv.scale), bounds.y
                 + (int) (14 * bv.scale), (int) (44 * bv.scale),
@@ -243,25 +246,28 @@ class EntitySprite extends Sprite {
                 bv.getPanel().getFontMetrics(labelFont).getAscent() + 2);
 
         Coords position = entity.getPosition();
-        if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
-            labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
-            labelPos = Positioning.RIGHT;
-        } else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {
-            labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
-                    (int) (0.25 * bv.hex_size.height) - labelRect.height);
-            labelPos = Positioning.LEFT;
-        } else if (bv.game.getEntitiesVector(position.translated("NE"), true).isEmpty()) {
-            labelRect.setLocation((int) (bv.hex_size.width * 0.55),
-                    (int) (0.25 * bv.hex_size.height) - labelRect.height);
-            labelPos = Positioning.RIGHT;
-        } else if (bv.game.getEntitiesVector(position.translated("SW"), true).isEmpty()) {
-            labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
-                    (int) (0.75 * bv.hex_size.height));
-            labelPos = Positioning.LEFT;
-        } else {
-            labelRect.setLocation(bv.hex_size.width / 2 - labelRect.width / 2,
-                    (int) (0.75 * bv.hex_size.height));
-            labelPos = Positioning.RIGHT;
+        
+        if (position != null) {			
+			if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
+			    labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
+			    labelPos = Positioning.RIGHT;
+			} else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {
+			    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
+			            (int) (0.25 * bv.hex_size.height) - labelRect.height);
+			    labelPos = Positioning.LEFT;
+			} else if (bv.game.getEntitiesVector(position.translated("NE"), true).isEmpty()) {
+			    labelRect.setLocation((int) (bv.hex_size.width * 0.55),
+			            (int) (0.25 * bv.hex_size.height) - labelRect.height);
+			    labelPos = Positioning.RIGHT;
+			} else if (bv.game.getEntitiesVector(position.translated("SW"), true).isEmpty()) {
+			    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
+			            (int) (0.75 * bv.hex_size.height));
+			    labelPos = Positioning.LEFT;
+			} else {
+			    labelRect.setLocation(bv.hex_size.width / 2 - labelRect.width / 2,
+			            (int) (0.75 * bv.hex_size.height));
+			    labelPos = Positioning.RIGHT;
+			}
         }
 
         // If multiple units are present in a hex, fan out the labels

--- a/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/EntitySprite.java
@@ -248,26 +248,26 @@ class EntitySprite extends Sprite {
         Coords position = entity.getPosition();
         
         if (position != null) {			
-			if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
-			    labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
-			    labelPos = Positioning.RIGHT;
-			} else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {
-			    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
-			            (int) (0.25 * bv.hex_size.height) - labelRect.height);
-			    labelPos = Positioning.LEFT;
-			} else if (bv.game.getEntitiesVector(position.translated("NE"), true).isEmpty()) {
-			    labelRect.setLocation((int) (bv.hex_size.width * 0.55),
-			            (int) (0.25 * bv.hex_size.height) - labelRect.height);
-			    labelPos = Positioning.RIGHT;
-			} else if (bv.game.getEntitiesVector(position.translated("SW"), true).isEmpty()) {
-			    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
-			            (int) (0.75 * bv.hex_size.height));
-			    labelPos = Positioning.LEFT;
-			} else {
-			    labelRect.setLocation(bv.hex_size.width / 2 - labelRect.width / 2,
-			            (int) (0.75 * bv.hex_size.height));
-			    labelPos = Positioning.RIGHT;
-			}
+        	if (bv.game.getEntitiesVector(position.translated("SE"), true).isEmpty()) {
+        	    labelRect.setLocation((int) (bv.hex_size.width * 0.55), (int) (0.75 * bv.hex_size.height));
+        	    labelPos = Positioning.RIGHT;
+        	} else if (bv.game.getEntitiesVector(position.translated("NW"), true).isEmpty()) {
+        	    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
+        	            (int) (0.25 * bv.hex_size.height) - labelRect.height);
+        	    labelPos = Positioning.LEFT;
+        	} else if (bv.game.getEntitiesVector(position.translated("NE"), true).isEmpty()) {
+        	    labelRect.setLocation((int) (bv.hex_size.width * 0.55),
+        	            (int) (0.25 * bv.hex_size.height) - labelRect.height);
+        	    labelPos = Positioning.RIGHT;
+        	} else if (bv.game.getEntitiesVector(position.translated("SW"), true).isEmpty()) {
+        	    labelRect.setLocation((int) (bv.hex_size.width * 0.45) - labelRect.width,
+        	            (int) (0.75 * bv.hex_size.height));
+        	    labelPos = Positioning.LEFT;
+        	} else {
+        	    labelRect.setLocation(bv.hex_size.width / 2 - labelRect.width / 2,
+        	            (int) (0.75 * bv.hex_size.height));
+        	    labelPos = Positioning.RIGHT;
+        	}
         }
 
         // If multiple units are present in a hex, fan out the labels

--- a/megamek/src/megamek/logging/MMLogger.java
+++ b/megamek/src/megamek/logging/MMLogger.java
@@ -155,7 +155,6 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     public void error(Throwable exception, String message, String title) {
         error(exception, message);
-        JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
     }
 
     /**
@@ -167,7 +166,12 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     public void error(String message, String title) {
         error(message);
-        JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
+        try {
+        	JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
+        }
+        catch (Exception ignored) {
+        	// if the message dialog crashes, we don't really care
+        }
     }
 
     /**

--- a/megamek/src/megamek/logging/MMLogger.java
+++ b/megamek/src/megamek/logging/MMLogger.java
@@ -167,10 +167,10 @@ public class MMLogger extends ExtendedLoggerWrapper {
     public void error(String message, String title) {
         error(message);
         try {
-        	JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
         }
         catch (Exception ignored) {
-        	// if the message dialog crashes, we don't really care
+            // if the message dialog crashes, we don't really care
         }
     }
 


### PR DESCRIPTION
Prevents an infinite popup loop and an actual exception that occurs when selecting a different unit during the deploy phase after placing a unit on the board but not finalizing deployment.