### PR TITLE
Torso twist fix

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -965,6 +965,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
             clearAttacks();
             addAttack(new TorsoTwistAction(currentEntity, direction));
             ce().setSecondaryFacing(direction);
+            clientgui.updateFiringArc(ce());
             refreshAll();
         }
     }
@@ -1020,8 +1021,8 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
         }
 
         if (b.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
-            if (phase.isOffboard() && (shiftheld || twisting)) {
-                if (ce() != null) {
+            if (shiftheld || twisting) {
+                if ((ce() != null) && !ce().getAlreadyTwisted()) {
                     updateFlipArms(false);
                     torsoTwist(b.getCoords());
                 }
@@ -1046,7 +1047,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
 
         if (client.isMyTurn() && (b.getCoords() != null)
                 && (ce() != null) && !b.getCoords().equals(ce().getPosition())) {
-            if (shiftheld && phase.isOffboard()) {
+            if (shiftheld && !ce().getAlreadyTwisted()) {
                 updateFlipArms(false);
                 torsoTwist(b.getCoords());
             } else if (phase.isTargeting()) {

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -356,7 +356,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
                 clientgui.getBoardView().centerOnHex(ce().getPosition());
             }
 
-            setTwistEnabled(phase.isOffboard() && ce().canChangeSecondaryFacing() && ce().getCrew().isActive());
+            setTwistEnabled(ce().canChangeSecondaryFacing() && ce().getCrew().isActive());
             setFlipArmsEnabled(ce().canFlipArms() && ce().getCrew().isActive());
             updateSearchlight();
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1900,7 +1900,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             if (getAlreadyTwisted()) {
                 return;
             }
-            if (phase.isOffboard() || phase.isFiring()) {
+            if (phase.isTargeting() || phase.isOffboard() || phase.isFiring()) {
                 // Only Offboard and Firing phases could conceivably have later phases with twisting
                 setAlreadyTwisted(true);
             }
@@ -2683,8 +2683,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 if (getAlreadyTwisted()) {
                     return;
                 }
-                if (phase.isOffboard() || phase.isFiring()) {
-                    // Only Offboard and Firing phases could conceivably have later phases with twisting
+                if (phase.isTargeting() || phase.isOffboard() || phase.isFiring()) {
                     setAlreadyTwisted(true);
                 }
             }


### PR DESCRIPTION
Fix #5827  - enable torso/turret twist for artillery, but you can only do torso twist once per round.

Note that "canChangeSecondaryFacing" already includes a check for "already twisted".