### PR TITLE
check for 0 weapons before determining the next-previous weapon index

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1349,6 +1349,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
     }
 
     public int getNextWeaponListIdx() {
+        if (weaponList.getModel().getSize() == 0) {
+            return -1;
+        }
+
         int selected = weaponList.getSelectedIndex();
         // In case nothing was selected
         if (selected == -1) {
@@ -1379,6 +1383,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
     }
 
     public int getPrevWeaponListIdx() {
+        if (weaponList.getModel().getSize() == 0) {
+            return -1;
+        }
+
         int selected = weaponList.getSelectedIndex();
         // In case nothing was selected
         if (selected == -1) {


### PR DESCRIPTION
- check for 0 weapons before determining the next-previous weapon index

fixes #5901