### PR TITLE
#5890: Update null guards in getElevation

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2158,20 +2158,19 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
-     * Returns the elevation of this entity, relative to the current Hex's
-     * surface
+     * @return The elevation of this Entity, relative to the current Hex's surface. When the unit is
+     * transported, returns the elevation of the carrier.
      */
     @Override
     public int getElevation() {
-        if (Entity.NONE != getTransportId()) {
-            return game.getEntity(getTransportId()).getElevation();
+        if (game != null) {
+            Entity carrier = game.getEntity(getTransportId());
+            if (carrier != null) {
+                return carrier.getElevation();
+            }
         }
 
-        if (isOffBoard()) {
-            return 0;
-        }
-
-        return elevation;
+        return isOffBoard() ? 0 : elevation;
     }
 
     public boolean canGoDown() {


### PR DESCRIPTION
Fixes #5890 
While this doesn't remove the cause of the bug (apparently, a unit thought itself being transported but the transport was either nonexistent or dead), it updates the guards in getElevation so that at least that method will not fail.