### PR TITLE
Add missing 'role' to ShadowHawk SHD-11CS2 MTF

### DIFF
--- a/megamek/data/mechfiles/mechs/RS Jihad/Shadow Hawk SHD-11CS2.mtf
+++ b/megamek/data/mechfiles/mechs/RS Jihad/Shadow Hawk SHD-11CS2.mtf
@@ -6,6 +6,7 @@ techbase:Inner Sphere
 era:3076
 source:TRO: Jihad
 rules level:2
+role: Missile Boat
 
 
 


### PR DESCRIPTION
This PR adds the missing 'role' entry to the ShadowHawk SHD-11CS2 MTF file (see http://www.masterunitlist.info/Unit/Details/5036/shadow-hawk-shd-11cs2).