### PR TITLE
Replace quirk 'compact_mech' with 'ubiquitous' for all Locusts

### DIFF
--- a/megamek/data/mechfiles/mechs/3039u/Locust LCT-1E.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Locust LCT-1E.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3039u/Locust LCT-1L.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Locust LCT-1L.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3039u/Locust LCT-1M.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Locust LCT-1M.mtf
@@ -11,7 +11,8 @@ role:Missile Boat
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3039u/Locust LCT-1S.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Locust LCT-1S.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3039u/Locust LCT-1V.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Locust LCT-1V.mtf
@@ -12,7 +12,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3039u/Locust LCT-3V.mtf
+++ b/megamek/data/mechfiles/mechs/3039u/Locust LCT-3V.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-1V2.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-1V2.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5M.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5M.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5T.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5T.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5V.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5V.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5W.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5W.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5W2.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-5W2.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-6M.mtf
+++ b/megamek/data/mechfiles/mechs/3085u/Phoenix/Locust LCT-6M.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Locust LCT-5M2.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Locust LCT-5M2.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/3145/NTNU RS/Locust LCT-5M3.mtf
+++ b/megamek/data/mechfiles/mechs/3145/NTNU RS/Locust LCT-5M3.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust C.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust C.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-1Vb.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-1Vb.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-3D.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-3D.mtf
@@ -11,7 +11,8 @@ role:Missile Boat
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-3M.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-3M.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-3S.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-3S.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-5S.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-5S.mtf
@@ -11,7 +11,8 @@ role:Striker
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-7S.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-7S.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-7V.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-7V.mtf
@@ -11,7 +11,8 @@ role:Scout
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms

--- a/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-7V2.mtf
+++ b/megamek/data/mechfiles/mechs/Rec Guides ilClan/Vol 16/Locust LCT-7V2.mtf
@@ -11,7 +11,8 @@ role:Sniper
 
 
 
-quirk:compact_mech
+quirk:ubiquitous_is
+quirk:ubiquitos_clan
 quirk:low_profile
 quirk:cramped_cockpit
 quirk:no_arms


### PR DESCRIPTION
Currently, all Locusts (not Locust IIC) have the `Compact 'Mech` quirk in MegaMek. That is also the case in the physical BattleMech Manual that I own (6th printing). However, in the latest edition (7th printing, PDF from 12/13/23) they changed the Locust's quirks and replaced `Compact 'Mech` with `Ubiquitous`. This PR changes the Locust MTF files accordingly.