### PR TITLE
Fix make mech file parser canon check unit testable

### DIFF
--- a/megamek/testresources/megamek/common/units/mockOfficialUnitList.txt
+++ b/megamek/testresources/megamek/common/units/mockOfficialUnitList.txt
@@ -1,0 +1,5 @@
+MegaMek Official Unit List
+This file can be regenerated with java -jar MegaMek.jar -oul
+Format is: Chassis Model|
+Exterminator EXT-4A|
+Kanga Medium Hovertank|

--- a/megamek/unittests/megamek/common/EntityTest.java
+++ b/megamek/unittests/megamek/common/EntityTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Vector;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -105,23 +106,50 @@ public class EntityTest {
         }
     }
 
+    /**
+     * Verify that if a unit's name appears in the list of canon unit names, it is canon
+     */
     @Test
     public void testCanon() {
         File f;
         MechFileParser mfp;
         Entity e;
+        Vector<String> unitNames = new Vector<>();
+        unitNames.add("Exterminator EXT-4A");
+        MechFileParser.setCanonUnitNames(unitNames);
 
         // Test 1/1
         try {
             f = new File("testresources/megamek/common/units/Exterminator EXT-4A.mtf");
             mfp  = new MechFileParser(f);
             e = mfp.getEntity();
-            assertEquals(e.isCanon(), true);
+            assertTrue(e.isCanon());
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
     }
 
+    /**
+     * Verify that if a unit's name does _not_ appear in the list of canon unit names, it is not canon
+     */
+    @Test
+    public void testForceCanonicityFailure() {
+        File f;
+        MechFileParser mfp;
+        Entity e;
+        Vector<String> unitNames = new Vector<>();
+        unitNames.add("Beheadanator BHD-999.666Z");
+        MechFileParser.setCanonUnitNames(unitNames);
+
+        try {
+            f = new File("testresources/megamek/common/units/Exterminator EXT-4A.mtf");
+            mfp  = new MechFileParser(f);
+            e = mfp.getEntity();
+            assertFalse(e.isCanon());
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
     /**
      * Verify new Tank method .isImmobilizedForJump() returns correct values in
      * various states.  Note: vehicles cannot lose individual Jump Jets via crits,

--- a/megamek/unittests/megamek/common/EntityTest.java
+++ b/megamek/unittests/megamek/common/EntityTest.java
@@ -150,6 +150,35 @@ public class EntityTest {
             fail(ex.getMessage());
         }
     }
+
+
+    /**
+     * Verify that if a unit's name does appear in the _file_ listing canon unit names, it is canon
+     */
+    @Test
+    public void testCanonUnitInCanonUnitListFile() {
+        File f;
+        MechFileParser mfp;
+        Entity e;
+        File oulDir = new File("testresources/megamek/common/units/");
+        MechFileParser.initCanonUnitNames(oulDir, "mockOfficialUnitList.txt");
+
+        try {
+            // MTF file check
+            f = new File("testresources/megamek/common/units/Exterminator EXT-4A.mtf");
+            mfp  = new MechFileParser(f);
+            e = mfp.getEntity();
+            assertTrue(e.isCanon());
+            // BLK file check
+            f = new File("testresources/megamek/common/units/Kanga Medium Hovertank.blk");
+            mfp  = new MechFileParser(f);
+            e = mfp.getEntity();
+            assertTrue(e.isCanon());
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
     /**
      * Verify new Tank method .isImmobilizedForJump() returns correct values in
      * various states.  Note: vehicles cannot lose individual Jump Jets via crits,


### PR DESCRIPTION
Fixes the `testCanon()` test that is currently failing when run from the IDE.

As-is, this code has pretty strong code smells:
1. mostly unchanged for about 20 years,
2. does critical state initialization in the middle of a static method called by a bunch of instance methods,
3. Meaningless nested try/catch clauses that do nothing.
4. Actively breaks unit testing by requiring a specific environment state to work

This fix adds some dependency injection capabilities (the ability to change the internal data for testing purposes):
1. we can specify arbitrary canon unit name list files and containing dir, or
2. we can construct the canonUnitNames Vector explicitly and set it directly.

This will allow unit tests that want to check a unit file's canonicity during parsing to do so, even within the IDE.