### PR TITLE
Fix ammo auto config for Artemis skipping SRMs and MMLs

### DIFF
--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -728,7 +728,8 @@ public class TeamLoadoutGenerator {
         if (artemis) {
             for (AmmoMounted bin : e.getAmmo()) {
                 if (bin.getName().toUpperCase().contains(ammoClass)) {
-                    mt.insertImperative(e.getFullChassis(), e.getModel(), "any", ammoClass,
+                    String binType = bin.getType().getBaseName();
+                    mt.insertImperative(e.getFullChassis(), e.getModel(), "any", binType,
                             "Artemis-capable");
                 }
             }

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -721,21 +721,33 @@ public class TeamLoadoutGenerator {
         return swapped;
     }
 
-    // Set Artemis LRM carriers to use Artemis LRMs
-    private static boolean setLRMImperatives(Entity e, MunitionTree mt, ReconfigurationParameters rp) {
+    private static boolean insertArtemisImperatives(Entity e, MunitionTree mt, String ammoClass) {
         boolean artemis = !(e.getMiscEquipment(MiscType.F_ARTEMIS).isEmpty()
                 && e.getMiscEquipment(MiscType.F_ARTEMIS_V).isEmpty());
 
         if (artemis) {
-            for (Mounted wpn : e.getWeaponList()) {
-                if (wpn.getName().toLowerCase().contains("lrm")) {
-                    mt.insertImperative(e.getFullChassis(), e.getModel(), "any", wpn.getType().getShortName(),
+            for (AmmoMounted bin : e.getAmmo()) {
+                if (bin.getName().toUpperCase().contains(ammoClass)) {
+                    mt.insertImperative(e.getFullChassis(), e.getModel(), "any", ammoClass,
                             "Artemis-capable");
                 }
             }
             return true;
         }
         return false;
+    }
+
+    // Set Artemis LRM carriers to use Artemis LRMs
+    private static boolean setLRMImperatives(Entity e, MunitionTree mt, ReconfigurationParameters rp) {
+        return insertArtemisImperatives(e, mt, "LRM");
+    }
+
+    private static boolean setSRMImperatives(Entity e, MunitionTree mt, ReconfigurationParameters rp) {
+        return insertArtemisImperatives(e, mt, "SRM");
+    }
+
+    private static boolean setMMLImperatives(Entity e, MunitionTree mt, ReconfigurationParameters rp) {
+        return insertArtemisImperatives(e, mt, "MML");
     }
     // region Imperative mutators
 
@@ -945,6 +957,8 @@ public class TeamLoadoutGenerator {
             // utility
             setACImperatives(e, mt, rp);
             setLRMImperatives(e, mt, rp);
+            setSRMImperatives(e, mt, rp);
+            setMMLImperatives(e, mt, rp);
         }
 
         return mt;

--- a/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadoutGeneratorTest.java
@@ -36,6 +36,8 @@ class TeamLoadoutGeneratorTest {
     static AmmoType mockAC20AmmoType = (AmmoType) EquipmentType.get("ISAC20 Ammo");
     static AmmoType mockAC5AmmoType = (AmmoType) EquipmentType.get("ISAC5 Ammo");
     static AmmoType mockSRM6AmmoType = (AmmoType) EquipmentType.get("IS SRM 6 Ammo");
+    static AmmoType mockMML7LRMAmmoType = (AmmoType) EquipmentType.get("ISMML7 LRM Ammo");
+    static AmmoType mockMML7SRMAmmoType = (AmmoType) EquipmentType.get("ISMML7 SRM Ammo");
 
     @BeforeAll
     static void setUpAll() {
@@ -367,6 +369,38 @@ class TeamLoadoutGeneratorTest {
 
         for (Mounted bin : List.of(bin1, bin2, bin3, bin4, bin5, bin6, bin7)) {
             assertNotEquals("", ((AmmoType) bin.getType()).getSubMunitionName());
+        }
+    }
+
+    @Test
+    void testReconfigureBotTeamAllArtemis()  throws LocationFullException {
+        TeamLoadoutGenerator tlg = new TeamLoadoutGenerator(game);
+        Mech mockMech = createMech("Warhammer", "WHM-6Rb", "Asgard");
+        mockMech.addEquipment(EquipmentType.get("IS Artemis IV FCS"), Mech.LOC_RT);
+        Mech mockMech2 = createMech("Valkyrie", "VLK-QW5", "Wobbles");
+        mockMech2.addEquipment(EquipmentType.get("Clan Artemis IV FCS"), Mech.LOC_RT);
+        Mech mockMech3 = createMech("Cougar", "XR", "Sarandon");
+        mockMech3.addEquipment(EquipmentType.get("Clan Artemis V"), Mech.LOC_RT);
+        mockMech.setOwner(player);
+        mockMech2.setOwner(player);
+        mockMech3.setOwner(player);
+        game.setEntity(0, mockMech);
+        game.setEntity(1, mockMech2);
+        game.setEntity(2, mockMech3);
+
+        // Load ammo in 'mechs; locations are for fun
+        Mounted bin1 = mockMech.addEquipment(mockSRM6AmmoType, Mech.LOC_CT);
+        Mounted bin2 = mockMech2.addEquipment(mockMML7LRMAmmoType, Mech.LOC_LT);
+        Mounted bin3 = mockMech2.addEquipment(mockMML7SRMAmmoType, Mech.LOC_LT);
+        Mounted bin4 = mockMech3.addEquipment(mockLRM15AmmoType, Mech.LOC_LT);
+        Mounted bin5 = mockMech3.addEquipment(mockLRM15AmmoType, Mech.LOC_LT);
+
+        // Just check that the bins are populated still
+        tlg.reconfigureTeam(team, "IS", "");
+
+        for (Mounted bin : List.of(bin1, bin2, bin3, bin4, bin5)) {
+            assertNotEquals("Standard", ((AmmoType) bin.getType()).getSubMunitionName());
+            assertTrue(((AmmoType) bin.getType()).getSubMunitionName().contains("Artemis"));
         }
     }
 


### PR DESCRIPTION
~~Saklad5~~ @PhoenixHeart512 discovered that non-LRMs launchers with Artemis were being given non-Artemis munitions in 0.50.0 nightly builds.

This consolidates the Artemis handling and adds proper handling for SRM and MML launchers.

Testing:
- Test autoconfig on various units with each type of launcher and confirmed (via inspection and breakpoints) that proper munitions were selected.
- Ran all 3 projects' unit tests.