### PR TITLE
Fix #5903 with a null check before dereferencing Coords cp

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1126,7 +1126,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             Coords cp = sprite.getPosition();
             // This can potentially be an expensive operation
             Rectangle spriteBounds = sprite.getBounds();
-            if (cp.equals(c) && view.intersects(spriteBounds) && !sprite.isHidden()) {
+            if (cp != null && cp.equals(c) && view.intersects(spriteBounds) && !sprite.isHidden()) {
                 if (!sprite.isReady()) {
                     sprite.prepare();
                 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1124,9 +1124,12 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
 
         for (HexSprite sprite : spriteArrayList) {
             Coords cp = sprite.getPosition();
+            if (cp == null) {
+                continue;
+            }
             // This can potentially be an expensive operation
             Rectangle spriteBounds = sprite.getBounds();
-            if (cp != null && cp.equals(c) && view.intersects(spriteBounds) && !sprite.isHidden()) {
+            if (cp.equals(c) && view.intersects(spriteBounds) && !sprite.isHidden()) {
                 if (!sprite.isReady()) {
                     sprite.prepare();
                 }


### PR DESCRIPTION
@phoenixheart512 found a nasty NPE storm while switching units when deploying with Isometric view active.
It looks like this is caused by trying to get the sprite information for a unit that has not yet been placed on the map when preparing to draw the new unit's sprite, leaving the sprite position as null.

This fix just safeties that redraw operation in such a case.

Testing:
- Ran with OP's save and repro steps
- Ran all 3 projects' unit tests

Close #5903 