### PR TITLE
Edited Display Name for Transported Personnel Edge Use Option

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -99,6 +99,7 @@ MEGAMEK VERSION HISTORY:
 + FIX #5901: check for 0 weapons before determining the next-previous weapon index
 + FIX #5902: redisplay unit when clearing all attacks
 + PR #5919: A simple test that checks canonicity is working as intended
++ PR #5925: Fix to make mech file parser canon check unit testable in IDE
 
 0.49.20 (2024-06-28 2100 UTC) (THIS IS THE LAST VERSION TO SUPPORT JAVA 11)
 + PR #5281, #5327, #5308, #5336, #5318, #5383, #5369, #5384, #5455, #5505, #5541: Code internals: preparatory work for supporting game types such as SBF, code cleanup for string drawing, superclass change for BoardView,

--- a/megamek/i18n/megamek/common/options/messages.properties
+++ b/megamek/i18n/megamek/common/options/messages.properties
@@ -684,7 +684,7 @@ PilotOptionsInfo.option.edge_when_aero_lucky_crit.displayableName=(Aero) Use Edg
 PilotOptionsInfo.option.edge_when_aero_lucky_crit.description=Critical hits resulting from to-hit rolls of 12 will be rerolled with Edge.
 PilotOptionsInfo.option.edge_when_aero_nuke_crit.displayableName=(Aero) Use Edge for crits resulting from nuclear missile hits.
 PilotOptionsInfo.option.edge_when_aero_nuke_crit.description=Critical hits resulting in direct SI damage from nuclear missile hits will be rerolled with Edge.
-PilotOptionsInfo.option.edge_when_aero_unit_cargo_lost.displayableName=(Aero, SC/DS/JS/WS/SS only) Use Edge for crits resulting in the loss of transported units.
+PilotOptionsInfo.option.edge_when_aero_unit_cargo_lost.displayableName=(Aero, SC/DS/JS/WS/SS x) Use Edge for crits resulting in the loss of transported units.
 PilotOptionsInfo.option.edge_when_aero_unit_cargo_lost.description=Critical hits resulting in the loss of transported units will be rerolled with Edge.
 
 PilotOptionsInfo.group.md.displayableName=Manei Domini Implants


### PR DESCRIPTION
This reduces the length of the transported personnel edge use option, so that it doesn't get truncated when viewed through the Customize Person dialog in mhq.

This is the mm half of #4694