### PR TITLE
#5930: Fix selected unit label and fov lagging behind

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -643,7 +643,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
 
         currentEntity = en;
-        clientgui.setSelectedEntityNum(en);
+
         gear = MovementDisplay.GEAR_LAND;
 
         clientgui.getBoardView().setHighlightColor(GUIP.getMoveDefaultColor());
@@ -697,6 +697,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
             @Override
             public void run() {
                 clientgui.getUnitDisplay().displayEntity(ce);
+                clientgui.getBoardView().redrawEntity(ce);
+                clientgui.setSelectedEntityNum(ce.getId());
                 if (GUIP.getMoveDisplayTabDuringMovePhases()) {
                     clientgui.getUnitDisplay().showPanel(MechPanelTabStrip.SUMMARY);
                 }


### PR DESCRIPTION
Fixes #5930

The problem here was an earlier fix for #4444 that postponed selected unit updates.

This is at best a stopgap like most of the other recent fixes w.r.t. unit display and related display problems. I wonder what problems this fix creates.

