### PR TITLE
Fix broken torso twist regression while updating weapon panel heat.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -1420,7 +1420,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             phaseInternalBombs = ((IBomber)ce()).getUsedInternalBombs();
         }
 
-        clientgui.getUnitDisplay().wPan.displayMech(ce());
+        clientgui.getUnitDisplay().wPan.updateForEntity(ce());
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2736,4 +2736,20 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             tWeaponScroll.repaint();
         }
     }
+
+    /**
+     * Updates the Weapon Panel with the information for the given entity.  If the given entity
+     * is `null`, this method will do nothing.
+     * @param entity - The weapon panel will update info based on the {@link Entity} provided.
+     */
+    public void updateForEntity(Entity entity) {
+        if (entity == null) {
+            return;
+        }
+
+        // Takes note of the selected weapon to re-select after the call to `displayMech()`
+        int weaponNum = getSelectedWeaponNum();
+        displayMech(entity);
+        selectWeapon(weaponNum);
+    }
 }


### PR DESCRIPTION
This PR is to fix to update #5910 which inadvertently broke torso twisting when fixing #5902.  

The reason #5910 broke torso twisting is because the call to re-display mech also resets the weapon list model.

This fix uses the same approach but remembers the currently selected unit's selected weapon and then resets it when clearing attacks.

Fixes #5650 again.