### PR TITLE
Fixes structure collapse warning sprite appearing beneath terrain.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/CollapseWarningSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/CollapseWarningSprite.java
@@ -80,4 +80,13 @@ public class CollapseWarningSprite extends HexSprite {
         graph.setFont(FontHandler.symbolFont());
         return graph;
     }
+
+    /*
+     * The Collapse Warning sprite should be displayed on top of bridges and buildings in
+     * isometric view.
+     */
+    @Override
+    protected boolean isBehindTerrain() {
+        return false;
+    }
 }


### PR DESCRIPTION
Fixes #5219 structure collapse warning signs were appearing beneath buildings and bridges.  

This fix overrides the `HexSprite::isBehindTerrain()` method to indicate that this type of sprite should be displayed on top of terrain and not behind it in isometric view.

This can be tested by deploying an assault mek on a map with bridges or building with a construction factor less than the tonnage of the deployed mek and then using the "T" key to toggle between isometric and standard view.  (I used the "Snowy Trench 1" map and deployed an Atlas (or any 100 ton mek) near one of the bridges.