### PR TITLE
MM side of fix for MHQ 4755: NPE when opfor has no faction code

### DIFF
--- a/megamek/mmconf/munitionLoadoutSettings.xml
+++ b/megamek/mmconf/munitionLoadoutSettings.xml
@@ -22,7 +22,7 @@
     <entry key="mtEnergyBoatEnemyFractionDivisor">4.0</entry>
     <entry key="mtSeekingAmmoEnemyTSMExceedThreshold">1.0</entry>
     <entry key="commentTopMunitionsSubsetCount">This count determines how many munition types (out of all options) are actually selected</entry>
-    <entry key="mtTopMunitionsSubsetCount">4</entry>
+    <entry key="mtTopMunitionsSubsetCount">8</entry>
     <entry key="commentStartTLGBombArea">The following entries are used by Bombs:</entry>
     <entry key="bombMapGroundSpreadNormal">6</entry>
     <entry key="bombMapGroundSpreadAnti-Mek">3</entry>

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -589,8 +589,8 @@ public class TeamLoadoutGenerator {
     ) {
         ReconfigurationParameters rp = new ReconfigurationParameters();
 
-        // Set own faction and quality rating
-        rp.friendlyFaction = (friendlyFaction == null) ? "" : friendlyFaction;
+        // Set own faction and quality rating (default to generic IS if faction is not provided)
+        rp.friendlyFaction = (friendlyFaction == null) ? "IS" : friendlyFaction;
         rp.friendlyQuality = rating;
 
         // Fill desired bin fill ratio / percentage (as float)

--- a/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadoutGenerator.java
@@ -590,7 +590,7 @@ public class TeamLoadoutGenerator {
         ReconfigurationParameters rp = new ReconfigurationParameters();
 
         // Set own faction and quality rating
-        rp.friendlyFaction = friendlyFaction;
+        rp.friendlyFaction = (friendlyFaction == null) ? "" : friendlyFaction;
         rp.friendlyQuality = rating;
 
         // Fill desired bin fill ratio / percentage (as float)
@@ -812,6 +812,10 @@ public class TeamLoadoutGenerator {
             if (rp.enemyFliers >= rp.enemyCount / castPropertyDouble("mtFlakEnemyFliersFractionDivisor", 4.0)) {
                 mwc.increaseFlakMunitions();
             }
+            // Decrease if no bombers or fliers at all
+            if (rp.enemyBombers == 0 && rp.enemyFliers == 0) {
+                mwc.decreaseFlakMunitions();
+            }
 
             // Enemy fast movers make more precise ammo attractive
             if (rp.enemyFastMovers >= rp.enemyCount / castPropertyDouble("mtPrecisionAmmoFastEnemyFractionDivisor", 4.0)) {
@@ -918,7 +922,7 @@ public class TeamLoadoutGenerator {
             // Only increase utility rounds if we have more off-board units that the other guys
             if (rp.enemyOffBoard < rp.friendlyOffBoard /
                     castPropertyDouble("mtUtilityAmmoFriendlyVsEnemyFractionDivisor", 1.0)) {
-                mwc.increaseUtilityMunitions();
+                mwc.increaseArtilleryUtilityMunitions();
             }
         } else {
             // Reduce utility munition chances if we've only got a lance or so of arty
@@ -926,7 +930,8 @@ public class TeamLoadoutGenerator {
         }
 
         // Just for LOLs: when FS fights CC in 3028 ~ 3050, set Anti-TSM weight to 15.0
-        if (rp.friendlyFaction.equals("FS") && rp.enemyFactions.contains("CC")
+        if ((rp.friendlyFaction != null && rp.enemyFactions != null)
+                && rp.friendlyFaction.equals("FS") && rp.enemyFactions.contains("CC")
                 && (3028 <= rp.allowedYear && rp.allowedYear <= 3050)) {
             ArrayList<String> tsmOnly = new ArrayList<String>(List.of("Anti-TSM"));
             mwc.increaseMunitions(tsmOnly);
@@ -976,7 +981,7 @@ public class TeamLoadoutGenerator {
     public static MunitionTree applyWeightsToMunitionTree(MunitionWeightCollection mwc, MunitionTree mt) {
         // Iterate over every entry in the set of top-weighted munitions for each category
         HashMap<String, List<String>> topWeights = mwc.getTopN(
-                castPropertyInt("mtTopMunitionsSubsetCount", 4)
+                castPropertyInt("mtTopMunitionsSubsetCount", 8)
         );
 
         for (Map.Entry<String, List<String>> e : topWeights.entrySet()) {
@@ -1996,6 +2001,24 @@ class MunitionWeightCollection {
 
     public void decreaseUtilityMunitions() {
         decreaseMunitions(TeamLoadoutGenerator.UTILITY_MUNITIONS);
+    }
+
+    public void increaseArtilleryUtilityMunitions() {
+        modifyMatchingWeights(
+                mapTypeToWeights.get("Artillery"),
+                TeamLoadoutGenerator.UTILITY_MUNITIONS,
+                getPropDouble("increaseWeightFactor", 2.0),
+                getPropDouble("increaseWeightDecrement", 1.0)
+        );
+    }
+
+    public void decreaseArtilleryUtilityMunitions() {
+        modifyMatchingWeights(
+                mapTypeToWeights.get("Artillery"),
+                TeamLoadoutGenerator.UTILITY_MUNITIONS,
+                getPropDouble("decreaseWeightFactor", 0.5),
+                getPropDouble("decreaseWeightDecrement", 0.0)
+        );
     }
 
     public void increaseGuidedMunitions() {


### PR DESCRIPTION
MM portion of fix for MegaMek/mekhq#4755: prevents NPE when opfor has no faction code.

Safeties a check of specific faction codes, and also sets a default faction code if one is not provided during generation of ReconfigurationParameters object.

Also fixes:
- Too much smoke ammo for all weapon types when one side has off-board artillery but the other does not.
- Flak ammo weight too high when no airborne enemies present
- Imbalanced ammo selection when the era makes too many highly-weighted ammo types illegal

Testing:
- Tested with Op's campaign save
- Tested with separate save where enemy units all selected smoke rounds only
- Ran all 3 projects' unit tests

Note: this PR can be pulled independently of the MHQ part.