### PR TITLE
Movement handler refactor

### DIFF
--- a/megamek/src/megamek/server/totalwarfare/AbstractTWRuleHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/AbstractTWRuleHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package megamek.server.totalwarfare;
 
 import megamek.common.Game;

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -12,7 +12,10 @@ import org.apache.logging.log4j.LogManager;
 import java.util.*;
 import java.util.stream.Collectors;
 
-class MovementHandler extends AbstractTWRuleHandler {
+/**
+ * Processes an Entity's MovePath when an ENTITY_MOVE packet is received.
+ */
+class MovePathHandler extends AbstractTWRuleHandler {
     
     private final Entity entity;
     private final MovePath md;
@@ -86,7 +89,7 @@ class MovementHandler extends AbstractTWRuleHandler {
      *                 lot of LosEffects, so caching them can really speed
      *                 things up.
      */
-    MovementHandler(TWGameManager gameManager, Entity entity, MovePath md, Map<UnitTargetPair, LosEffects> losCache) {
+    MovePathHandler(TWGameManager gameManager, Entity entity, MovePath md, Map<UnitTargetPair, LosEffects> losCache) {
         super(gameManager);
         this.entity = entity;
         this.md = md;

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package megamek.server.totalwarfare;
 
 import megamek.MMConstants;

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -2027,7 +2027,7 @@ public class TWGameManager extends AbstractGameManager {
                 break;
             case MOVEMENT:
                 if (toSkip != null) {
-                    MovementHandler handler = new MovementHandler(this, toSkip, new MovePath(game, toSkip), null);
+                    MovePathHandler handler = new MovePathHandler(this, toSkip, new MovePath(game, toSkip), null);
                     handler.processMovement();
                 }
                 endCurrentTurn(toSkip);
@@ -3689,7 +3689,7 @@ public class TWGameManager extends AbstractGameManager {
         }
 
         // looks like mostly everything's okay
-        MovementHandler handler = new MovementHandler(this, entity, md, losCache);
+        MovePathHandler handler = new MovePathHandler(this, entity, md, losCache);
         handler.processMovement();
 
         // The attacker may choose to break a chain whip grapple by expending MP
@@ -4820,7 +4820,7 @@ public class TWGameManager extends AbstractGameManager {
                     }
                     game.removeTurnFor(target);
                     send(packetHelper.createTurnListPacket());
-                    MovementHandler handler = new MovementHandler(this, target, md, null);
+                    MovePathHandler handler = new MovePathHandler(this, target, md, null);
                     handler.processMovement();
                     // for some reason it is not clearing out turn
                 } else {


### PR DESCRIPTION
Extracts the main loop of processMovement to its own method, splitting it into two methods of ~1k lines and ~2k lines. Local variables have been moved to member fields so that smaller methods can be extracted and work on the same data.

I also changed the name from MovementHandler to MovePathHandler, which better reflects its scope.