### PR TITLE
Fixes double blind ghost sprite

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -2711,6 +2711,12 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             oldEntity = entity;
         }
 
+        // Remove sprites from backing sprite collections before modifying the
+        // entitySprites and isometricSprites.  Otherwise orphaned overTerrainSprites
+        // or behindTerrainHexSprites can result.
+        removeSprites(entitySprites);
+        removeSprites(isometricSprites);
+
         // If the entity we are updating doesn't have a position, ensure we
         // remove all of its old sprites
         if (entity.getPosition() == null) {
@@ -2821,8 +2827,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
 
         // Update Sprite state with new collections
-        removeSprites(entitySprites);
-        removeSprites(isometricSprites);
         entitySprites = newSprites;
         entitySpriteIds = newSpriteIds;
         isometricSprites = isoSprites;

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -2673,15 +2673,6 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
     }
 
     /**
-     * Clears the sprite for an entity and prepares it to be re-drawn. Replaces
-     * the old sprite with the new! Try to prevent annoying
-     * ConcurrentModificationExceptions
-     */
-    public void redrawEntity(Entity entity) {
-        redrawEntity(entity, null);
-    }
-
-    /**
      * Convenience method for returning a Key value for the entitySpriteIds and isometricSprite
      * maps. The List contains as the first element the Entity ID and as the second element its
      * location ID: either -1 if the Entity has no secondary locations, or the index of its
@@ -2705,11 +2696,8 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
      * DropShips taking off (airborne DropShips lose their secondary hexes). Try
      * to prevent annoying ConcurrentModificationExceptions
      */
-    public void redrawEntity(Entity entity, Entity oldEntity) {
+    public void redrawEntity(Entity entity) {
         Integer entityId = entity.getId();
-        if (oldEntity == null) {
-            oldEntity = entity;
-        }
 
         // Remove sprites from backing sprite collections before modifying the
         // entitySprites and isometricSprites.  Otherwise orphaned overTerrainSprites
@@ -2778,7 +2766,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             isoSprites.remove(isoSprite);
         }
 
-        for (int secondaryPos : oldEntity.getSecondaryPositions().keySet()) {
+        for (int secondaryPos : entity.getSecondaryPositions().keySet()) {
             sprite = entitySpriteIds.get(getIdAndLoc(entityId, secondaryPos));
             if (sprite != null) {
                 newSprites.remove(sprite);


### PR DESCRIPTION
Fixes #5951 - When a player selects next unit, or a different unit from the unit list during the deployment phase, the units position is set to null (the correct thing to do here), which resulted in the enity sprite list being cleaned up before the backing sprites were removed effectively orphaning the sprite reference in the `overTerrainSprites` collection.

```mermaid
sequenceDiagram
    actor player
    player ->> DeploymentDisplay: actionPerformed "Next Unit"
    DeploymentDisplay ->> Entity: setPosition(null)
    DeploymentDisplay ->> +BoardView: redrawEntity()
    opt Entity position is null
        BoardView ->> +EntitySprites: remove Sprite
        note over BoardView, EntitySprites: Current sprite is no longer in <br/> EntitySprites collection
    
    end
    BoardView ->> BoardView: removeSprites(EntitySprites)
    note over BoardView: when position was null, removeSprites <br/> does nothing and sprite is orphaned.
    BoardView -->> -DeploymentDisplay: return
```

To fix this, I moved the calls to clear out the backing sprite collections before the enitity sprite collection removes them.
> [!NOTE]
> The methods to maintain the backing sprite lists, `overTerrainSprites` and `behindTerrainHexSprites` require a reference to the sprites in order to remove them.

```mermaid
sequenceDiagram
    actor player
    player ->> DeploymentDisplay: actionPerformed "Next Unit"
    DeploymentDisplay ->> Entity: setPosition(null)
    DeploymentDisplay ->> +BoardView: redrawEntity()
    BoardView ->> BoardView: removeSprites(EntitySprites)
    opt Entity position is null
        BoardView ->> +EntitySprites: remove Sprite
        note over BoardView, EntitySprites: Current sprite is no longer in <br/> EntitySprites collection
    
    end
    BoardView ->> BoardView: addSprites(newSprites)
    BoardView -->> -DeploymentDisplay: return
```

> [!NOTE]
> Also removed unused `redrawEntity(Entity)` as it was never used and cleaned up the unused parameter in `redrawEntity(Entity, Entity)`.