### PR TITLE
Fixes #5989 Mini map selected unit lags behind when selecting next unit

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -653,17 +653,17 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         currentEntity = en;
         clientgui.setSelectedEntityNum(en);
+        updateUnitDisplay(ce);
+
         gear = MovementDisplay.GEAR_LAND;
-
         clientgui.getBoardView().setHighlightColor(GUIP.getMoveDefaultColor());
-        clear();
 
+        clear();
         updateButtonsLater();
 
         clientgui.getBoardView().highlight(ce.getPosition());
         clientgui.getBoardView().select(null);
         clientgui.getBoardView().cursor(null);
-        updateUnitDisplayLater(ce);
         if (!clientgui.getBoardView().isMovingUnits()) {
             clientgui.getBoardView().centerOnHex(ce.getPosition());
         }
@@ -682,6 +682,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         } else {
             setStatusBarText(yourTurnMsg);
         }
+
         clientgui.clearFieldOfFire();
         computeMovementEnvelope(ce);
         updateMove();
@@ -697,21 +698,15 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     /**
-     * Signals Unit Display to update later on the AWT event stack.
-     * See Issue:#4876 and #4444. This is done to prevent blank general tab when
-     * switching
-     * units when the map is zoomed all the way out.
+     * Updates the Unit Display Panels by selecting the current entity in the unit display
+     * and shows the MekPanelTabTrip if configured.
+     * @param ce
      */
-    private void updateUnitDisplayLater(Entity ce) {
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                clientgui.getUnitDisplay().displayEntity(ce);
-                if (GUIP.getMoveDisplayTabDuringMovePhases()) {
-                    clientgui.getUnitDisplay().showPanel(MekPanelTabStrip.SUMMARY);
-                }
-            }
-        });
+    private void updateUnitDisplay(final Entity ce) {
+        clientgui.getUnitDisplay().displayEntity(ce);
+        if (GUIP.getMoveDisplayTabDuringMovePhases()) {
+            clientgui.getUnitDisplay().showPanel(MekPanelTabStrip.SUMMARY);
+        }
     }
 
     /**
@@ -724,13 +719,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     private void updateButtonsLater() {
         SwingUtilities.invokeLater(new Runnable() {
-
             @Override
             public void run() {
                 updateButtons();
             }
-
-            ;
         });
     }
 

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -652,7 +652,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
 
         currentEntity = en;
-
+        clientgui.setSelectedEntityNum(en);
         gear = MovementDisplay.GEAR_LAND;
 
         clientgui.getBoardView().setHighlightColor(GUIP.getMoveDefaultColor());
@@ -707,8 +707,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
             @Override
             public void run() {
                 clientgui.getUnitDisplay().displayEntity(ce);
-                clientgui.getBoardView().redrawEntity(ce);
-                clientgui.setSelectedEntityNum(ce.getId());
                 if (GUIP.getMoveDisplayTabDuringMovePhases()) {
                     clientgui.getUnitDisplay().showPanel(MekPanelTabStrip.SUMMARY);
                 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -2918,7 +2918,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
 
         updateEcmList();
-        highlightSelectedEntity();
+        highlightSelectedEntity(getSelectedEntity());
         scheduleRedraw();
     }
 
@@ -3027,7 +3027,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         // Update ECM list, to ensure that Sprites are updated with ECM info
         updateEcmList();
         // Re-highlight a selected entity, if present
-        highlightSelectedEntity();
+        highlightSelectedEntity(getSelectedEntity());
 
         scheduleRedraw();
     }
@@ -4094,9 +4094,9 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         highlight(new Coords(x, y));
     }
 
-    public synchronized void highlightSelectedEntity() {
+    public synchronized void highlightSelectedEntity(Entity e) {
         for (EntitySprite sprite : entitySprites) {
-            sprite.setSelected(sprite.entity.equals(getSelectedEntity()));
+            sprite.setSelected(sprite.entity.equals(e));
         }
     }
 
@@ -4429,7 +4429,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
     public synchronized void selectEntity(Entity e) {
         checkFoVHexImageCacheClear();
         updateEcmList();
-        highlightSelectedEntity();
+        highlightSelectedEntity(e);
     }
 
     /**


### PR DESCRIPTION
Fixes #5989 - fixes mimmap selected unit lag when selecting next unit in the movement phase.
Fixes #5930 -> reworks FOV lag fix by undoing this fix and making it work with undoing #4444.
Fixes #4444 -> reworks the fix for this so that it doesn't require a delayed update.

This reworks prior fixes for lagging Field of View (FOV), lagging minimap selected units, and previously fixed missing display on zoomed out maps.

The prior fix for #4444 delayed the updates to the Unit Display in order to fix the issue with the blank display when zoomed out.  Then when code was refactored to remove the current entity from the ClientGUI and use the UnitDisplay selected unit instead, the FOV, minimap, and labels became out of sync with the selected unit.  

This change ensures these behaviors all work together.