### PR TITLE
Fix patchwork armor weight calculation

### DIFF
--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -1487,11 +1487,6 @@ public class BattleArmor extends Infantry {
         return false;
     }
 
-    @Override
-    public boolean hasPatchworkArmor() {
-        return false;
-    }
-
     public void setIsExoskeleton(boolean exoskeleton) {
         this.exoskeleton = exoskeleton;
     }

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1926,4 +1926,9 @@ public class Infantry extends Entity {
     public int getGenericBattleValue() {
         return (int) Math.round(Math.exp(3.586 + 0.336 * Math.log(getWeight())));
     }
+
+    @Override
+    public boolean hasPatchworkArmor() {
+        return false;
+    }
 }

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -1437,4 +1437,9 @@ public class Jumpship extends Aero {
     public int getGenericBattleValue() {
         return (int) Math.round(Math.exp(0.0619 + 0.5607 * Math.log(getWeight())));
     }
+
+    @Override
+    public boolean hasPatchworkArmor() {
+        return false;
+    }
 }

--- a/megamek/src/megamek/common/ProtoMek.java
+++ b/megamek/src/megamek/common/ProtoMek.java
@@ -1628,4 +1628,9 @@ public class ProtoMek extends Entity {
     protected Map<Integer, List<Integer>> getBlockedFiringLocations() {
         return BLOCKED_FIRING_LOCATIONS;
     }
+
+    @Override
+    public boolean hasPatchworkArmor() {
+        return false;
+    }
 }

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -921,4 +921,9 @@ public class SmallCraft extends Aero {
     public int getGenericBattleValue() {
         return (int) Math.round(Math.exp(-0.068 + 1.421 * Math.log(getWeight())));
     }
+
+    @Override
+    public boolean hasPatchworkArmor() {
+        return false;
+    }
 }

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -981,7 +981,11 @@ public class TestAero extends TestEntity {
         weight += getWeightControls();
         weight += getWeightFuel();
         weight += getWeightHeatSinks();
-        weight += getWeightArmor();
+        if (getEntity().hasPatchworkArmor()) {
+            weight += getWeightAllocatedArmor();
+        } else {
+            weight += getWeightArmor();
+        }
         weight += getWeightMisc();
 
         weight += getWeightMiscEquip();

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -953,10 +953,8 @@ public abstract class TestEntity implements TestEntityOption {
     }
 
     /**
-     * According to TM p.22, unit weights are to be rounded up to the nearest half
-     * ton or kilo, but in MML
-     * for construction at least we should be able to show the exact weight. This
-     * method returns the unrounded
+     * According to TM p.22, unit weights are to be rounded up to the nearest half ton or kilo, but in MML
+     * for construction at least we should be able to show the exact weight. This method returns the unrounded
      * weight.
      *
      * @return The unrounded weight of the unit.
@@ -967,7 +965,11 @@ public abstract class TestEntity implements TestEntityOption {
         weight += getWeightStructure();
         weight += getWeightControls();
         weight += getWeightHeatSinks();
-        weight += getWeightArmor();
+        if (getEntity().hasPatchworkArmor()) {
+            weight += getWeightAllocatedArmor();
+        } else {
+            weight += getWeightArmor();
+        }
         weight += getWeightMisc();
 
         weight += getWeightMiscEquip();


### PR DESCRIPTION
Fixes MegaMek/megameklab#1516
Also adds direct overrides to hasPatchworkArmor() for unit types that can never have it according to IO p189