### PR TITLE
Remove incorrect dedicated pilot mod for QuadVee PSR.

### DIFF
--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -466,9 +466,7 @@ public class QuadVee extends QuadMek {
      */
     @Override
     public PilotingRollData addEntityBonuses(PilotingRollData roll) {
-        if (getCrew().hasDedicatedPilot()) {
-            roll.addModifier(-1, "dedicated pilot");
-        } else {
+        if (!getCrew().hasDedicatedPilot()) {
             roll.addModifier(2, "pilot incapacitated");
         }
 


### PR DESCRIPTION
There is no benefit to having a dedicated pilot in a QuadVee (IO, p. 133) (though not having the pilot still confers a penalty).

#5752 