### PR TITLE
Quadvee damage mp reduction

### DIFF
--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -103,7 +103,7 @@ public class QuadVee extends QuadMek {
     }
 
     public static int getMotiveTypeForString(String inType) {
-        if ((inType == null) || (inType.length() < 1)) {
+        if ((inType == null) || (inType.isEmpty())) {
             return MOTIVE_UNKNOWN;
         }
         for (int x = 0; x < MOTIVE_STRING.length; x++) {
@@ -275,14 +275,11 @@ public class QuadVee extends QuadMek {
             return  mpBoosters;
         }
 
-        switch (mpBoosters) {
-            case MASC_AND_SUPERCHARGER:
-                return MPBoosters.SUPERCHARGER_ONLY;
-            case MASC_ONLY:
-                return MPBoosters.NONE;
-            default:
-                return mpBoosters;
-        }
+        return switch (mpBoosters) {
+            case MASC_AND_SUPERCHARGER -> MPBoosters.SUPERCHARGER_ONLY;
+            case MASC_ONLY -> MPBoosters.NONE;
+            default -> mpBoosters;
+        };
     }
 
     /**

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -161,9 +161,8 @@ public class QuadVee extends QuadMek {
             mp++;
         }
 
-        // If a leg or its track/wheel is destroyed, it is treated as major motive system damage,
-        // which we are interpreting as a cumulative 1/2 MP.
-        // bg.battletech.com/forums/index.php?topic=55261.msg1271935#msg1271935
+        // If a leg or its track/wheel is destroyed, it reduces movement by a cumulative -1/4 mp per leg.
+        // https://bg.battletech.com/forums/index.php?topic=63281.msg1469243#msg1469243
         int badTracks = 0;
         for (int loc = 0; loc < locations(); loc++) {
             if (locationIsLeg(loc) && (isLocationBad(loc) || getCritical(loc, 5).isHit())) {
@@ -173,8 +172,8 @@ public class QuadVee extends QuadMek {
 
         if (badTracks == 4) {
             return 0;
-        } else if (badTracks > 1) {
-            mp = mp / (1 << badTracks);
+        } else if (badTracks > 0) {
+            mp -= mp * badTracks / 4;
         }
 
         if (!mpCalculationSetting.ignoreModularArmor && hasModularArmor()) {


### PR DESCRIPTION
Updates the MP reduction for a QuadVee in vehicle mode to 1/4 MP per damaged or missing track/wheel. The original formula was based on a ruling from 2016. This one is from 2018. I don't know why the first bad track/wheel is being ignored in the current code, but that's irrelevant at this point.

I also made a couple of code updates.

Fixes part of #5752 