### PR TITLE
Fixes a "nagging" issue that allows ASF to make an illegal moves.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
@@ -172,144 +172,57 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
         return !isTimerExpired();
     }
 
-    protected boolean checkNagForNoAction(String title, String body) {
+    private boolean doYesNoBotherDialog(String title, String body, Runnable setNag) {
         ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
         if (nag.getAnswer()) {
             // do they want to be bothered again?
             if (!nag.getShowAgain()) {
-                GUIP.setNagForNoAction(false);
+                setNag.run();
             }
         } else {
             return true;
         }
-
         return false;
+    }
+
+    protected boolean checkNagForNoAction(String title, String body) {
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForNoAction(false));
     }
 
     protected boolean checkNagForNoUnJamRAC(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForNoUnJamRAC(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForNoUnJamRAC(false));
     }
 
     protected boolean checkNagForMASC(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForMASC(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForMASC(false));
     }
 
     protected boolean checkNagForSprint(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForSprint(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForSprint(false));
     }
 
     protected boolean checkNagForPSR(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForPSR(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForPSR(false));
     }
 
     protected boolean checkNagForMechanicalJumpFallDamage(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForMechanicalJumpFallDamage(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForMechanicalJumpFallDamage(false));
     }
 
     protected boolean checkNagForCrushingBuildings(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForCrushingBuildings(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForCrushingBuildings(false));
     }
 
     protected boolean checkNagForWiGELanding(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForWiGELanding(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForWiGELanding(false));
     }
 
     protected boolean checkNagForOverheat(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForOverheat(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForOverheat(false));
     }
 
     protected boolean checkNagLaunchDoors(String title, String body) {
-        ConfirmDialog nag = clientgui.doYesNoBotherDialog(title, body);
-        if (nag.getAnswer()) {
-            // do they want to be bothered again?
-            if (!nag.getShowAgain()) {
-                GUIP.setNagForLaunchDoors(false);
-            }
-        } else {
-            return true;
-        }
-
-        return false;
+        return doYesNoBotherDialog(title, body, () -> GUIP.setNagForLaunchDoors(false));
     }
 
     /** set labels and enables on the done and skip buttons depending on the GUIP getNagForNoAction option

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -1558,6 +1558,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
 
+        // Check for unused velocity for airborne and space craft.
         if (needNagForOther()) {
             if ((ce() != null)
                     && (null != cmd)
@@ -1582,9 +1583,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
                         && !cmd.contains(MoveStepType.EJECT)) {
                     String title = Messages.getString("MovementDisplay.VelocityLeft.title");
                     String body = Messages.getString("MovementDisplay.VelocityLeft.message");
-                    if (!clientgui.doYesNoDialog(title, body)) {
-                        return true;
-                    }
+                    clientgui.doAlertDialog(title, body);
+                    // always return true here, or airborne units will make illegal moves.
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
It was brought up in Discord chat that Aerospace fighters can make a partial move where they have not used up all their velocity points and then hit "skip movement" and make an illegal move.

This occurs since 0.49.19 because the 'unused velocity' nag was changed from an Alert dialog to a Yes/No dialog.  The problem is that if a player clicks "no" on this velocity nag, the application proceeds to make the partial illegal move and continue on as normal.

This change makes the ASF unused velocity nag back to an alert dialog (Only an "OK" button, not a "yes/no" dialog) which is the prior behavior and prevents illegal moves and skip moves to be made.

If an ASF is mid-flight and you skip move, you get this yes/no dialog.

![image](https://github.com/user-attachments/assets/785b4ad0-e6e0-4c84-8704-ff4d987a4846)

If you press, "yes" - then the ASF executes the movement without using all its assigned velocity.

![image](https://github.com/user-attachments/assets/c2c61c1c-35c7-45d6-80aa-d44df71c6219)


> [!NOTE]
> Also, there was an opportunity to clean up some redundant code in the set of nag checks that only varied by one line each that turns off the nag preferences.