### PR TITLE
Removed 'Center Leg' from Wing Wraith TR4, TR6 and TR7

### DIFF
--- a/megamek/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR4.mtf
+++ b/megamek/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR4.mtf
@@ -146,20 +146,6 @@ Endo-Composite
 -Empty-
 -Empty-
 
-Center Leg:
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
-
 overview:The Wraith is a 'Mech that, when properly employed, can wreak havoc on an enemy with its astounding speed and maneuverability. Initially developed by Curtiss Militech, it later became a key asset for the Capellan Confederation following the company's financial distress post-Jihad. The Wraith's speed, firepower, and decent armor make it a considerable threat to many 'Mechs, some being almost twice its weight.
 
 capabilities:The “Wing” Wraith enhances the base design’s accurate and ammunition-independent loadout with improved heat dissipation and jump range. Despite the advantages of the partial-wing technology, the TR6 suffers from slower ground speed and a demanding maintenance schedule, making it a less popular export than the more straightforward TR5. However, both variants share parts and construction processes, making continued production a low-cost endeavor.

--- a/megamek/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR6.mtf
+++ b/megamek/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR6.mtf
@@ -147,20 +147,6 @@ Endo-Composite
 -Empty-
 -Empty-
 
-Center Leg:
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
-
 
 overview:The Wraith is a 'Mech that, when properly employed, can wreak havoc on an enemy with its astounding speed and maneuverability. Initially developed by Curtiss Militech, it later became a key asset for the Capellan Confederation following the company's financial distress post-Jihad. The Wraith's speed, firepower, and decent armor make it a considerable threat to many 'Mechs, some being almost twice its weight.
 

--- a/megamek/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR7.mtf
+++ b/megamek/data/mekfiles/meks/Shrapnel/Vol 17/Wing Wraith TR7.mtf
@@ -147,20 +147,6 @@ IS Stealth
 -Empty-
 -Empty-
 
-Center Leg:
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
--Empty-
-
 
 overview:The Wraith is a 'Mech that, when properly employed, can wreak havoc on an enemy with its astounding speed and maneuverability. Initially developed by Curtiss Militech, it later became a key asset for the Capellan Confederation following the company's financial distress post-Jihad. The Wraith's speed, firepower, and decent armor make it a considerable threat to many 'Mechs, some being almost twice its weight.
 


### PR DESCRIPTION
For some reason, the "Wing Wraith" Tr4, TR6 and TR7 have a `Center Leg:` entry in their MTF files, although they are biped mechs. This PR removes those entries.