### PR TITLE
#5995 - Prevent Field Guns from exploding/jamming

### DIFF
--- a/megamek/src/megamek/common/weapons/ACCaselessHandler.java
+++ b/megamek/src/megamek/common/weapons/ACCaselessHandler.java
@@ -48,7 +48,7 @@ public class ACCaselessHandler extends ACWeaponHandler {
             return true;
         }
         
-        if ((roll.getIntValue() <= 2) && !(ae instanceof Infantry)) {
+        if ((roll.getIntValue() <= 2) && !ae.isConventionalInfantry()) {
             Roll diceRoll = Compute.rollD6(2);
 
             Report r = new Report(3164);

--- a/megamek/src/megamek/common/weapons/AmmoWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/AmmoWeaponHandler.java
@@ -113,7 +113,7 @@ public class AmmoWeaponHandler extends WeaponHandler {
         if (!weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_AMMO_FEED_PROBLEMS)) {
             return false;
             // attack roll was a 2, may explode
-        } else if (roll.getIntValue() <= 2) {
+        } else if ((roll.getIntValue() <= 2) && !ae.isConventionalInfantry()) {
             Roll diceRoll = Compute.rollD6(2);
 
             Report r = new Report(3173);

--- a/megamek/src/megamek/common/weapons/AmmoWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/AmmoWeaponHandler.java
@@ -112,8 +112,8 @@ public class AmmoWeaponHandler extends WeaponHandler {
         // don't have neg ammo feed problem quirk
         if (!weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_NEG_AMMO_FEED_PROBLEMS)) {
             return false;
-            // attack roll was a 2, may explode
         } else if ((roll.getIntValue() <= 2) && !ae.isConventionalInfantry()) {
+            // attack roll was a 2, may explode
             Roll diceRoll = Compute.rollD6(2);
 
             Report r = new Report(3173);
@@ -142,8 +142,8 @@ public class AmmoWeaponHandler extends WeaponHandler {
                 vPhaseReport.addElement(r);
                 return false;
             }
-            // attack roll was not 2, won't explode
         } else {
+            // attack roll was not 2, won't explode
             return false;
         }
 

--- a/megamek/src/megamek/common/weapons/HVACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/HVACWeaponHandler.java
@@ -91,7 +91,7 @@ public class HVACWeaponHandler extends ACWeaponHandler {
             return true;
         }
 
-        if (roll.getIntValue() == 2) {
+        if ((roll.getIntValue() == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report(3162);
             r.subject = subjectId;
             weapon.setJammed(true);

--- a/megamek/src/megamek/common/weapons/PrimitiveACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PrimitiveACWeaponHandler.java
@@ -43,7 +43,7 @@ public class PrimitiveACWeaponHandler extends ACWeaponHandler {
             return true;
         }
         
-        if (roll.getIntValue() == 2) {
+        if ((roll.getIntValue() == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report(3161);
             r.subject = subjectId;
             r.newlines = 0;

--- a/megamek/src/megamek/common/weapons/PrototypeACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeACWeaponHandler.java
@@ -42,8 +42,8 @@ public class PrototypeACWeaponHandler extends ACWeaponHandler {
         if (doAmmoFeedProblemCheck(vPhaseReport)) {
             return true;
         }
-        
-        if (roll.getIntValue() == 2) {
+
+        if ((roll.getIntValue() == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report(3165);
             r.subject = subjectId;
             weapon.setJammed(true);

--- a/megamek/src/megamek/common/weapons/PrototypeCLUltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeCLUltraWeaponHandler.java
@@ -47,6 +47,9 @@ public class PrototypeCLUltraWeaponHandler extends UltraWeaponHandler {
         if (doAmmoFeedProblemCheck(vPhaseReport)) {
             return true;
         }
+        if (ae.isConventionalInfantry()) {
+            return false;
+        }
         
         if ((roll.getIntValue() <= 3) && (howManyShots == 2)) {
             Report r = new Report(3160);

--- a/megamek/src/megamek/common/weapons/PrototypeCLUltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeCLUltraWeaponHandler.java
@@ -46,8 +46,7 @@ public class PrototypeCLUltraWeaponHandler extends UltraWeaponHandler {
     protected boolean doChecks(Vector<Report> vPhaseReport) {
         if (doAmmoFeedProblemCheck(vPhaseReport)) {
             return true;
-        }
-        if (ae.isConventionalInfantry()) {
+        } else if (ae.isConventionalInfantry()) {
             return false;
         }
         

--- a/megamek/src/megamek/common/weapons/PrototypeGaussHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeGaussHandler.java
@@ -53,8 +53,8 @@ public class PrototypeGaussHandler extends GRHandler {
         if (doAmmoFeedProblemCheck(vPhaseReport)) {
             return true;
         }
-        
-        if (roll.getIntValue() == 2) {
+
+        if ((roll.getIntValue() == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report(3165);
             r.subject = subjectId;
             weapon.setJammed(true);

--- a/megamek/src/megamek/common/weapons/PrototypeISUltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeISUltraWeaponHandler.java
@@ -47,6 +47,8 @@ public class PrototypeISUltraWeaponHandler extends UltraWeaponHandler {
     protected boolean doChecks(Vector<Report> vPhaseReport) {
         if (doAmmoFeedProblemCheck(vPhaseReport)) {
             return true;
+        } else if (ae.isConventionalInfantry()) {
+            return false;
         }
         
         if (((roll.getIntValue() <= 4) && (howManyShots == 2))

--- a/megamek/src/megamek/common/weapons/PrototypeLBXHandler.java
+++ b/megamek/src/megamek/common/weapons/PrototypeLBXHandler.java
@@ -84,7 +84,7 @@ public class PrototypeLBXHandler extends LBXHandler {
             return true;
         }
         
-        if (roll.getIntValue() == 2) {
+        if ((roll.getIntValue() == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report(3165);
             r.subject = subjectId;
             weapon.setJammed(true);

--- a/megamek/src/megamek/common/weapons/RACHandler.java
+++ b/megamek/src/megamek/common/weapons/RACHandler.java
@@ -49,9 +49,7 @@ public class RACHandler extends UltraWeaponHandler {
     protected boolean doChecks(Vector<Report> vPhaseReport) {
         if (doAmmoFeedProblemCheck(vPhaseReport)) {
             return true;
-        }
-
-        if (ae instanceof Infantry) {
+        } else if (ae.isConventionalInfantry()) {
             return false;
         }
         boolean jams = false;

--- a/megamek/src/megamek/common/weapons/RapidfireACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RapidfireACWeaponHandler.java
@@ -55,7 +55,7 @@ public class RapidfireACWeaponHandler extends UltraWeaponHandler {
         if (kindRapidFire) {
             jamLevel = 2;
         }
-        if ((roll.getIntValue() <= jamLevel) && (howManyShots == 2) && !(ae instanceof Infantry)) {
+        if ((roll.getIntValue() <= jamLevel) && (howManyShots == 2) && !ae.isConventionalInfantry()) {
             if (roll.getIntValue() > 2 || kindRapidFire) {
                 Report r = new Report(3161);
                 r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/RapidfireHVACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/RapidfireHVACWeaponHandler.java
@@ -77,7 +77,7 @@ public class RapidfireHVACWeaponHandler extends RapidfireACWeaponHandler {
             return true;
         }
 
-        if (roll.getIntValue() == 2) {
+        if ((roll.getIntValue() == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report(3162);
             r.subject = subjectId;
             weapon.setJammed(true);

--- a/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/UltraWeaponHandler.java
@@ -155,7 +155,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
             return true;
         }
 
-        if ((roll.getIntValue() == 2) && (howManyShots == 2) && !(ae instanceof Infantry)) {
+        if ((roll.getIntValue() == 2) && (howManyShots == 2) && !ae.isConventionalInfantry()) {
             Report r = new Report();
             r.subject = subjectId;
             weapon.setJammed(true);


### PR DESCRIPTION
Fixes #5995
I changed some checks from an instanceof to a isConventionalInfantry() as the instanceof check includes BA but the rule is only for field guns, i.e. CI. 