### PR TITLE
#5991  Mix tech mech not showing origin of weapon equipped.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -238,6 +238,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             StringBuilder wn = new StringBuilder(mounted.getDesc());
             wn.append(" [");
             wn.append(en.getLocationAbbr(mounted.getLocation()));
+            //Check if mixedTech and add Clan or IS tag
+            if (en.isMixedTech()) {
+                wn.insert(0, wtype.isClan() ? "(C) " : "(IS) ");
+            }
             if (mounted.isSplit()) {
                 wn.append('/');
                 wn.append(en.getLocationAbbr(mounted.getSecondLocation()));
@@ -1371,7 +1375,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
     /**
      * Selects the first valid weapon in the weapon list.
-     * 
+     *
      * @return The weapon id of the weapon selected
      */
     public int selectFirstWeapon() {
@@ -2794,7 +2798,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
      * Updates the Weapon Panel with the information for the given entity. If the
      * given entity
      * is `null`, this method will do nothing.
-     * 
+     *
      * @param entity - The weapon panel will update info based on the {@link Entity}
      *               provided.
      */


### PR DESCRIPTION
  mixedtech check and add appropriate tag
  
![image](https://github.com/user-attachments/assets/c9fb94b1-a3c0-4bd4-a1d5-91cc5a4d272b)

![image](https://github.com/user-attachments/assets/61623d87-4238-4c89-afc7-650ac4976a7e)

only displays if unit is mixedtech.

![image](https://github.com/user-attachments/assets/e8e41d66-1bc8-4350-9aef-4e7e22a70625)

