### PR TITLE
Enhance `wordWrap` with HTML Tags for Line Breaks

### DIFF
--- a/megamek/src/megamek/client/ui/WrapLayout.java
+++ b/megamek/src/megamek/client/ui/WrapLayout.java
@@ -211,6 +211,7 @@ public class WrapLayout extends FlowLayout {
     public static String wordWrap(String input, int maximumCharacters) {
         StringTokenizer token = new StringTokenizer(input, " ");
         StringBuilder output = new StringBuilder(input.length());
+        output.append("<html>");
 
         int lineLen = 0;
 
@@ -218,13 +219,14 @@ public class WrapLayout extends FlowLayout {
             String word = token.nextToken();
 
             if (lineLen + word.length() > maximumCharacters) {
-                output.append('\n');
+                output.append("<br>");
                 lineLen = 0;
             }
             output.append(word).append(' ');
             lineLen += word.length();
         }
 
+        output.append("</html>");
         return output.toString();
     }
 }


### PR DESCRIPTION
Added HTML tags to the `wordWrap` method to ensure proper line breaks using `<br>` instead of newline characters. This change improves the rendering of wrapped text in HTML contexts by enclosing the output in `<html>` tags.

This resolves a bug with tooltips used in the updated MekHQ `DateChooser`.