### PR TITLE
Replace Manual GUI scaling with FlatLaf Scaling

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/ASConversionInfoDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/ASConversionInfoDialog.java
@@ -76,7 +76,6 @@ public class ASConversionInfoDialog extends AbstractDialog {
     @Override
     protected void finalizeInitialization() throws Exception {
         super.finalizeInitialization();
-        adaptToGUIScale();
         if (!StringUtility.isNullOrBlank(unitName)) {
             setTitle(getTitle() + " (" + unitName + ")");
         }
@@ -118,10 +117,6 @@ public class ASConversionInfoDialog extends AbstractDialog {
     private void copyToClipboard(String reportString) {
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(reportString), null);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }
 

--- a/megamek/src/megamek/client/ui/dialogs/ASStatsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/ASStatsDialog.java
@@ -72,7 +72,6 @@ public class ASStatsDialog extends AbstractDialog {
         super(frame, "AlphaStrikeStatsDialog", "AlphaStrikeStatsDialog.title");
         this.entities = new ArrayList<>(entities);
         initialize();
-        adaptToGUIScale();
     }
 
     @Override
@@ -105,7 +104,6 @@ public class ASStatsDialog extends AbstractDialog {
         tablePanel = new ASStatsTablePanel(getFrame()).add(entities, "Selected Units");
         scrollPane.setViewportView(tablePanel.getPanel());
         centerPanel.add(scrollPane);
-        adaptToGUIScale();
     }
 
     private void copyToClipboard() {
@@ -195,10 +193,6 @@ public class ASStatsDialog extends AbstractDialog {
             JOptionPane.showMessageDialog(getParent(), "The MMU file could not be written. "
                     + e.getMessage());
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 
     private void printCards() {

--- a/megamek/src/megamek/client/ui/dialogs/BVDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BVDisplayDialog.java
@@ -48,7 +48,6 @@ public class BVDisplayDialog extends AbstractDialog {
     protected void finalizeInitialization() throws Exception {
         super.finalizeInitialization();
         setTitle(getTitle() + " (" + entity.getShortName() + ")");
-        adaptToGUIScale();
         pack();
         Dimension screenSize = UIUtil.getScaledScreenSize(this);
         setSize(new Dimension(getSize().width, Math.min(getHeight(), (int) (screenSize.getHeight() * 0.8))));
@@ -87,9 +86,5 @@ public class BVDisplayDialog extends AbstractDialog {
     private void copyToClipboard(String reportString) {
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(reportString), null);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
@@ -173,7 +173,6 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
         updatePresets();
         initialize();
         updateDialogFields();
-        adaptToGUIScale();
     }
 
     @Override
@@ -917,9 +916,5 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
     @Override
     public void stateChanged(ChangeEvent e) {
         updateEnabledStates();
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigTargetHexDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigTargetHexDialog.java
@@ -45,7 +45,7 @@ import static megamek.common.Terrains.*;
 public class BotConfigTargetHexDialog extends AbstractButtonDialog {
 
     private static final String OK_ACTION = "Ok_Action";
-    
+
     private final TipTextField coordsField = new TipTextField("", 5, "x, y");
     private final JLabel coordsLabel = new JLabel(Messages.getString("BotConfigDialog.hexCoordsLabel"));
     private final JLabel listLabel = new JLabel(Messages.getString("BotConfigDialog.hexListLabel"));
@@ -85,15 +85,14 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
                 coordsField.requestFocus();
             }
         });
-        adaptToGUIScale();
     }
-    
+
     @Override
     protected Container createCenterPane() {
         JPanel result = new JPanel();
         result.setLayout(new BoxLayout(result, BoxLayout.PAGE_AXIS));
         result.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        
+
         var coordsFieldPanel = new UIUtil.FixedYPanel();
         coordsFieldPanel.setAlignmentX(JComponent.CENTER_ALIGNMENT);
         coordsField.setToolTipText(Messages.getString("BotConfigDialog.hexCoordsTip"));
@@ -102,21 +101,21 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
         coordsFieldPanel.add(coordsLabel);
         coordsFieldPanel.add(coordsField);
 
-        var listLabelPanel = new UIUtil.FixedYPanel(); 
+        var listLabelPanel = new UIUtil.FixedYPanel();
         listLabel.setLabelFor(coordsList);
         listLabel.setDisplayedMnemonic(KeyEvent.VK_S);
         listLabelPanel.add(listLabel);
-        
+
         coordsList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         coordsList.setLayoutOrientation(JList.VERTICAL);
         coordsList.setCellRenderer(new BuildingHexRenderer());
         coordsList.setFont(UIUtil.getScaledFont());
         coordsList.setVisibleRowCount(6);
         coordsList.setPrototypeCellValue(new Coords(-21, 22));
-        
+
         if (clientGui == null) {
             listLabel.setEnabled(false);
-            coordsList.setEnabled(false);   
+            coordsList.setEnabled(false);
         } else {
             board.getBuildingsVector().stream().map(Building::getCoordsList).forEach(coordsListModel::addAll);
         }
@@ -127,10 +126,10 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
         result.add(listLabelPanel);
         result.add(Box.createVerticalStrut(25));
         result.add(new JScrollPane(coordsList));
-        
+
         return result;
     }
-    
+
     public List<Coords> getSelectedCoords() {
         List<Coords> result = new ArrayList<>();
         // Parse the Coords text field
@@ -144,11 +143,11 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
         } catch (Exception ignored) {
             // No coords if it cannot be parsed
         }
-        // Add the marked list entries 
+        // Add the marked list entries
         result.addAll(coordsList.getSelectedValuesList());
         return result;
     }
-    
+
     /** Shows building info for the hexes in the list model. */
     private class BuildingHexRenderer extends DefaultListCellRenderer {
 
@@ -158,13 +157,13 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
             Coords coords = (Coords) value;
             String content = Messages.getString("BotConfigDialog.hexListIntro", coords.getX() + 1, coords.getY() + 1);
             if (board != null && board.getHex(coords) != null) {
-                final Hex hex = board.getHex(coords); 
+                final Hex hex = board.getHex(coords);
                 final Building bldg = board.getBuildingAt(coords);
                 if (hex.containsTerrain(BUILDING)) {
                     content += Messages.getString("BotConfigDialog.hexListBldg", Building.typeName(bldg.getType()),
                             Building.className(bldg.getBldgClass()), hex.terrainLevel(BLDG_ELEV), hex.terrainLevel(BLDG_CF));
                 } else if (hex.containsTerrain(FUEL_TANK)) {
-                    content += Messages.getString("BotConfigDialog.hexListFuel", 
+                    content += Messages.getString("BotConfigDialog.hexListFuel",
                             hex.terrainLevel(FUEL_TANK_CF), hex.terrainLevel(FUEL_TANK_MAGN));
                 } else {
                     content += Messages.getString("BotConfigDialog.hexListBrdg", Building.typeName(bldg.getType()),
@@ -173,9 +172,5 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
             }
             return super.getListCellRendererComponent(list, content, index, isSelected, cellHasFocus);
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigTargetUnitDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigTargetUnitDialog.java
@@ -30,11 +30,11 @@ import megamek.client.ui.baseComponents.AbstractButtonDialog;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.util.UIUtil.TipTextField;
 
-/** A dialog for entering one or more entity IDs that are to be used as strategic targets by Princess. */ 
+/** A dialog for entering one or more entity IDs that are to be used as strategic targets by Princess. */
 public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
-    
+
     private static final String OK_ACTION = "Ok_Action";
-    
+
     private final TipTextField unitIDField = new TipTextField(5, "..., ...");
     private final JLabel unitIDLabel = new JLabel(Messages.getString("BotConfigDialog.unitIdLabel"));
     private final JLabel noteLabel = new JLabel("<HTML><CENTER>" + Messages.getString("BotConfigDialog.noteLabel"));
@@ -42,7 +42,7 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
     protected BotConfigTargetUnitDialog(JFrame frame) {
         super(frame, "BotConfigTargetUnitDialog", "BotConfigDialog.bctudTitle");
         initialize();
-        // Catch the Enter key as "OK" 
+        // Catch the Enter key as "OK"
         final KeyStroke enter = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
         getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(enter, OK_ACTION);
         getRootPane().getInputMap(JComponent.WHEN_FOCUSED).put(enter, OK_ACTION);
@@ -58,7 +58,6 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
                 unitIDField.requestFocus();
             }
         });
-        adaptToGUIScale();
     }
 
     @Override
@@ -66,14 +65,14 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
         JPanel result = new JPanel();
         result.setLayout(new BoxLayout(result, BoxLayout.PAGE_AXIS));
         result.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
-        
+
         JPanel unitIDPanel = new UIUtil.FixedYPanel();
         unitIDField.setToolTipText(Messages.getString("BotConfigDialog.unitIdTip"));
         unitIDLabel.setLabelFor(unitIDField);
         unitIDLabel.setDisplayedMnemonic(KeyEvent.VK_I);
         unitIDPanel.add(unitIDLabel);
         unitIDPanel.add(unitIDField);
-        
+
         noteLabel.setBorder(new EmptyBorder(0, 20, 0, 20));
         noteLabel.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 
@@ -83,7 +82,7 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
         result.add(noteLabel);
         return result;
     }
-    
+
     /** Returns a list of entered entity IDs. The list may be empty but not null. */
     public Set<Integer> getSelectedIDs() {
         Set<Integer> result = new HashSet<>();
@@ -96,9 +95,5 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
             }
         }
         return result;
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/CamoChooserDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/CamoChooserDialog.java
@@ -170,16 +170,6 @@ public class CamoChooserDialog extends AbstractIconChooserDialog {
     }
 
     @Override
-    protected void finalizeInitialization() throws Exception {
-        super.finalizeInitialization();
-        adaptToGUIScale();
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
-    }
-
-    @Override
     public void setVisible(boolean b) {
         if ((originalCamo != null) && b) {
             rotationSlider.setValue(originalCamo.getRotationAngle());

--- a/megamek/src/megamek/client/ui/dialogs/CamoChooserDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/CamoChooserDialog.java
@@ -102,12 +102,12 @@ public class CamoChooserDialog extends AbstractIconChooserDialog {
         entityImage = new EntityImagePanel(null, null);
 
         JPanel rotationPanel = new JPanel();
-        rotationPanel.add(UIUtil.scaledHorizontalSpacer(20));
+        rotationPanel.add(Box.createHorizontalStrut(20));
         rotationPanel.add(new JLabel(Messages.getString("CamoChoiceDialog.rotation") + ":"));
         rotationPanel.add(rotationSlider);
 
         JPanel scalePanel = new JPanel();
-        scalePanel.add(UIUtil.scaledHorizontalSpacer(30));
+        scalePanel.add(Box.createHorizontalStrut(30));
         scalePanel.add(new JLabel(Messages.getString("CamoChoiceDialog.scale") + ":"));
         scalePanel.add(scaleSlider);
 
@@ -142,7 +142,7 @@ public class CamoChooserDialog extends AbstractIconChooserDialog {
         buttonPanel.setName("buttonPanel");
         buttonPanel.add(parentCamoButton);
         buttonPanel.add(refreshButton);
-        buttonPanel.add(UIUtil.scaledHorizontalSpacer(30));
+        buttonPanel.add(Box.createHorizontalStrut(30));
         buttonPanel.add(okButton);
         buttonPanel.add(cancelButton);
 

--- a/megamek/src/megamek/client/ui/dialogs/CostDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/CostDisplayDialog.java
@@ -115,7 +115,6 @@ public class CostDisplayDialog extends AbstractDialog {
 
     /** Does gui-scaling, packs the dialog and reduces the height if its too big. */
     private void updateDialogSize() {
-        adaptToGUIScale();
         pack();
         Dimension screenSize = UIUtil.getScaledScreenSize(this);
         setSize(new Dimension(getSize().width, Math.min(getHeight(), (int) (screenSize.getHeight() * 0.8))));
@@ -124,9 +123,5 @@ public class CostDisplayDialog extends AbstractDialog {
     private void copyToClipboard(String reportString) {
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(reportString), null);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/EntityReadoutDialog.java
@@ -25,7 +25,6 @@ import megamek.client.ui.baseComponents.AbstractDialog;
 import megamek.client.ui.panes.EntityViewPane;
 import megamek.client.ui.preferences.JTabbedPanePreference;
 import megamek.client.ui.preferences.PreferencesNode;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 
 /**
@@ -37,7 +36,7 @@ public class EntityReadoutDialog extends AbstractDialog {
     private final Entity entity;
     private EntityViewPane entityView;
 
-    /** Constructs a non-modal dialog showing the readout (TRO) of the given entity. */ 
+    /** Constructs a non-modal dialog showing the readout (TRO) of the given entity. */
     public EntityReadoutDialog(final JFrame frame, final Entity entity) {
         this(frame, false, entity);
     }
@@ -55,19 +54,10 @@ public class EntityReadoutDialog extends AbstractDialog {
         entityView = new EntityViewPane(getFrame(), entity);
         return entityView;
     }
-    
+
     @Override
     protected void setCustomPreferences(final PreferencesNode preferences) throws Exception {
         super.setCustomPreferences(preferences);
         preferences.manage(new JTabbedPanePreference(entityView));
-    }
-
-    @Override
-    public void setVisible(boolean visible) {
-        if (visible) {
-            UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-        }
-
-        super.setVisible(visible);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/MMNarrativeStoryDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/MMNarrativeStoryDialog.java
@@ -18,7 +18,9 @@
  */
 package megamek.client.ui.dialogs;
 
+import megamek.client.ui.swing.util.FlatLafStyleBuilder;
 import megamek.client.ui.swing.util.FontHandler;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.server.scriptedevent.NarrativeDisplayProvider;
 
 import javax.swing.*;
@@ -50,7 +52,7 @@ public class MMNarrativeStoryDialog extends MMStoryDialog {
         gbc.weightx = 1.0;
         gbc.fill = GridBagConstraints.BOTH;
         JTextPane txtDesc = new JTextPane();
-        txtDesc.setFont(FontHandler.notoFont());
+        new FlatLafStyleBuilder(FontHandler.notoFont()).apply(txtDesc);
         txtDesc.setEditable(false);
         txtDesc.setContentType("text/html");
         txtDesc.setText(getStoryPoint().text());
@@ -59,7 +61,7 @@ public class MMNarrativeStoryDialog extends MMStoryDialog {
         JScrollPane scrollPane = new JScrollPane(txtDesc) {
             @Override
             public Dimension getPreferredSize() {
-                return new Dimension(400, super.getPreferredSize().height);
+                return new Dimension(UIUtil.scaleForGUI(400), super.getPreferredSize().height);
             }
         };
         scrollPane.setBorder(null);

--- a/megamek/src/megamek/client/ui/dialogs/MMStoryDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/MMStoryDialog.java
@@ -20,10 +20,10 @@ package megamek.client.ui.dialogs;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.dialog.DialogButton;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.server.scriptedevent.NarrativeDisplayProvider;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -77,7 +77,7 @@ public abstract class MMStoryDialog extends JDialog {
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.LINE_AXIS));
         buttonPanel.setBorder(BorderFactory.createCompoundBorder(
                 new MatteBorder(1, 0, 0, 0, UIManager.getColor("Separator.foreground")),
-                new UIUtil.ScaledEmptyBorder(10, 0, 10, 0)));
+                new EmptyBorder(10, 0, 10, 0)));
 
         Box verticalBox = Box.createVerticalBox();
         verticalBox.add(Box.createVerticalGlue());

--- a/megamek/src/megamek/client/ui/dialogs/MMStoryDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/MMStoryDialog.java
@@ -19,7 +19,10 @@
 package megamek.client.ui.dialogs;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.dialog.DialogButton;
+import megamek.client.ui.swing.util.UIUtil;
+import megamek.common.util.ImageUtil;
 import megamek.server.scriptedevent.NarrativeDisplayProvider;
 
 import javax.swing.*;
@@ -28,6 +31,7 @@ import javax.swing.border.MatteBorder;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
 
 /**
  * This is the base class for MM dialogs that have a similar look to Story Arc dialogs. Instead of the
@@ -116,9 +120,16 @@ public abstract class MMStoryDialog extends JDialog {
         }
 
         if (null != img) {
+
             ImageIcon icon = new ImageIcon(img);
             imgWidth = icon.getIconWidth();
             imgHeight = icon.getIconHeight();
+            if (GUIPreferences.getInstance().getGUIScale() != 1) {
+                imgWidth = UIUtil.scaleForGUI(imgWidth);
+                imgHeight = UIUtil.scaleForGUI(imgHeight);
+                BufferedImage image = ImageUtil.getScaledImage(img, imgWidth, imgHeight);
+                icon = new ImageIcon(image);
+            }
             JLabel imgLbl = new JLabel();
             imgLbl.setIcon(icon);
             imagePanel.add(imgLbl, BorderLayout.CENTER);

--- a/megamek/src/megamek/client/ui/dialogs/WeightDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/WeightDisplayDialog.java
@@ -52,7 +52,6 @@ public class WeightDisplayDialog extends AbstractDialog {
     protected void finalizeInitialization() throws Exception {
         super.finalizeInitialization();
         setTitle(getTitle() + " (" + entity.getShortName() + ")");
-        adaptToGUIScale();
         pack();
         Dimension screenSize = UIUtil.getScaledScreenSize(this);
         setSize(new Dimension(getSize().width, Math.min(getHeight(), (int) (screenSize.getHeight() * 0.8))));
@@ -101,9 +100,5 @@ public class WeightDisplayDialog extends AbstractDialog {
     private void copyToClipboard(String reportString) {
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(reportString), null);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/helpDialogs/AbstractHelpDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/helpDialogs/AbstractHelpDialog.java
@@ -27,7 +27,6 @@ import javax.swing.JScrollPane;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.AbstractDialog;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.logging.MMLogger;
 
 /**
@@ -79,15 +78,5 @@ public abstract class AbstractHelpDialog extends AbstractDialog {
         }
 
         return new JScrollPane(pane);
-    }
-
-    @Override
-    protected void finalizeInitialization() throws Exception {
-        super.finalizeInitialization();
-        adaptToGUIScale();
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
@@ -78,7 +78,7 @@ public abstract class AbstractPhaseDisplay extends SkinnedJPanel implements
         setBorder(new MegaMekBorder(panelSkin));
 
         butDone = new MegaMekButton("DONE", buttonSkin);
-        String f = UIUtil.colorHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE)+ "</FONT>";
+        String f = UIUtil.fontHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE)+ "</FONT>";
         butDone.setToolTipText("<html><body>" + f + "</body></html>");
         butDone.addActionListener(e -> done());
 

--- a/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/AbstractPhaseDisplay.java
@@ -19,8 +19,6 @@
  */
 package megamek.client.ui.swing;
 
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-
 import java.util.Objects;
 
 import megamek.client.event.BoardViewEvent;
@@ -80,7 +78,7 @@ public abstract class AbstractPhaseDisplay extends SkinnedJPanel implements
         setBorder(new MegaMekBorder(panelSkin));
 
         butDone = new MegaMekButton("DONE", buttonSkin);
-        String f = guiScaledFontHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE)+ "</FONT>";
+        String f = UIUtil.colorHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE)+ "</FONT>";
         butDone.setToolTipText("<html><body>" + f + "</body></html>");
         butDone.addActionListener(e -> done());
 

--- a/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
@@ -18,8 +18,6 @@
  */
 package megamek.client.ui.swing;
 
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.util.List;
@@ -56,7 +54,7 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
         var donePanel = super.setupDonePanel();
         butSkipTurn = new MegaMekButton("SKIP", SkinSpecification.UIComponents.PhaseDisplayDoneButton.getComp());
         butSkipTurn.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
-        String f = guiScaledFontHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
+        String f = UIUtil.colorHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
         butSkipTurn.setToolTipText("<html><body>" + f + "</body></html>");
         addToDonePanel(donePanel, butSkipTurn);
 

--- a/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/ActionPhaseDisplay.java
@@ -54,7 +54,7 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
         var donePanel = super.setupDonePanel();
         butSkipTurn = new MegaMekButton("SKIP", SkinSpecification.UIComponents.PhaseDisplayDoneButton.getComp());
         butSkipTurn.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
-        String f = UIUtil.colorHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
+        String f = UIUtil.fontHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
         butSkipTurn.setToolTipText("<html><body>" + f + "</body></html>");
         addToDonePanel(donePanel, butSkipTurn);
 

--- a/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
+++ b/megamek/src/megamek/client/ui/swing/AdvancedSearchDialog.java
@@ -14,7 +14,6 @@
 package megamek.client.ui.swing;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
@@ -47,7 +46,6 @@ import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.table.MegaMekTable;
 import megamek.client.ui.swing.unitSelector.TWAdvancedSearchPanel;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.EquipmentType;
 import megamek.common.Mek;
 import megamek.common.MekSearchFilter;
@@ -545,14 +543,6 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
                 (frame.getLocation().y + (frame.getSize().height / 2)) -
                         (getSize().height / 2));
         setLocation(x, y);
-    }
-
-    @Override
-    public void setVisible(boolean show) {
-        if (show) {
-            adaptToGUIScale();
-        }
-        super.setVisible(show);
     }
 
     /**
@@ -1349,7 +1339,7 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
 
     /**
      * Base class for different tokens that can be in a filter expression.
-     * 
+     *
      * @author Arlith
      */
     public class FilterTokens {
@@ -1358,7 +1348,7 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
 
     /**
      * FilterTokens subclass that represents parenthesis.
-     * 
+     *
      * @author Arlith
      */
     public class ParensFT extends FilterTokens {
@@ -1376,7 +1366,7 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
 
     /**
      * FilterTokens subclass that represents equipment.
-     * 
+     *
      * @author Arlith
      */
     public class EquipmentFT extends FilterTokens {
@@ -1402,7 +1392,7 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
 
     /**
      * FilterTokens subclass that represents a boolean operation.
-     * 
+     *
      * @author Arlith
      *
      */
@@ -1423,13 +1413,5 @@ public class AdvancedSearchDialog extends JDialog implements ActionListener, Ite
                 return "";
             }
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-        scrTableWeapons.setMinimumSize(new Dimension(UIUtil.scaleForGUI(850), UIUtil.scaleForGUI(150)));
-        scrTableWeapons.setPreferredSize(new Dimension(UIUtil.scaleForGUI(850), UIUtil.scaleForGUI(150)));
-        scrTableEquipment.setMinimumSize(new Dimension(UIUtil.scaleForGUI(850), UIUtil.scaleForGUI(150)));
-        scrTableEquipment.setPreferredSize(new Dimension(UIUtil.scaleForGUI(850), UIUtil.scaleForGUI(150)));
     }
 }

--- a/megamek/src/megamek/client/ui/swing/AnalyzeFormationDialog.java
+++ b/megamek/src/megamek/client/ui/swing/AnalyzeFormationDialog.java
@@ -38,7 +38,6 @@ import megamek.client.ratgenerator.ModelRecord;
 import megamek.client.ratgenerator.RATGenerator;
 import megamek.client.ratgenerator.UnitTable;
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.EntityWeightClass;
 import megamek.common.MekSummary;
 import megamek.common.UnitRole;
@@ -229,8 +228,6 @@ public class AnalyzeFormationDialog extends JDialog {
         btnOk.addActionListener(ev -> setVisible(false));
         getContentPane().add(btnOk, BorderLayout.SOUTH);
 
-        adaptToGUIScale();
-
         pack();
     }
 
@@ -357,9 +354,5 @@ public class AnalyzeFormationDialog extends JDialog {
                     return metric == null ? "?" : metric.apply(ms);
             }
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -205,8 +205,6 @@ public class BoardEditor extends JPanel implements ItemListener, ListSelectionLi
         public Component getListCellRendererComponent(final JList<?> list, final Object value,
                 final int index, final boolean isSelected,
                 final boolean cellHasFocus) {
-            JComponent comp = (JComponent) super.getListCellRendererComponent(list, value, index,
-                    isSelected, cellHasFocus);
             if ((-1 < index) && (value != null)) {
                 if (terrainTypes != null) {
                     list.setToolTipText(terrainTypes.get(index).getTooltip());
@@ -214,7 +212,7 @@ public class BoardEditor extends JPanel implements ItemListener, ListSelectionLi
                     list.setToolTipText(terrains[index].getTerrainTooltip());
                 }
             }
-            return comp;
+            return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
         }
 
         public void setTerrains(TerrainHelper... terrains) {
@@ -969,7 +967,6 @@ public class BoardEditor extends JPanel implements ItemListener, ListSelectionLi
                 }
             }
         });
-        choTerrainType.setFont(fontComboTerr);
         butAddTerrain = new JButton(Messages.getString("BoardEditor.butAddTerrain"));
         butTerrUp = prepareButton("ButtonTLUP", "Increase Terrain Level", null, BASE_ARROWBUTTON_ICON_WIDTH);
         butTerrDown = prepareButton("ButtonTLDN", "Decrease Terrain Level", null, BASE_ARROWBUTTON_ICON_WIDTH);

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -84,8 +84,6 @@ import megamek.common.MapSettings;
 import megamek.common.Terrain;
 import megamek.common.Terrains;
 import megamek.common.annotations.Nullable;
-import megamek.common.preference.IPreferenceChangeListener;
-import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.util.BoardUtilities;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
@@ -99,9 +97,8 @@ import megamek.logging.MMLogger;
 // TODO: sluggish hex drawing?
 // TODO: the board validation after a board load seems to be influenced by the former board...
 // TODO: copy/paste hexes
-public class BoardEditor extends JPanel
-        implements ItemListener, ListSelectionListener, ActionListener,
-        DocumentListener, IMapSettingsObserver, IPreferenceChangeListener {
+public class BoardEditor extends JPanel implements ItemListener, ListSelectionListener, ActionListener,
+        DocumentListener, IMapSettingsObserver {
     private final static MMLogger logger = MMLogger.create(BoardEditor.class);
 
     /**
@@ -509,9 +506,6 @@ public class BoardEditor extends JPanel
                 showHelp();
             }
         }
-
-        adaptToGUIScale();
-        GUIPreferences.getInstance().addPreferenceChangeListener(this);
     }
 
     /**
@@ -547,11 +541,6 @@ public class BoardEditor extends JPanel
                     controller.boardEditor = null;
                 }
                 frame.dispose();
-            }
-
-            @Override
-            public void windowClosed(WindowEvent e) {
-                GUIPreferences.getInstance().removePreferenceChangeListener(BoardEditor.this);
             }
         });
     }
@@ -2356,59 +2345,6 @@ public class BoardEditor extends JPanel
         if (event.getSource().equals(lisTerrain) && !noTextFieldUpdate) {
             refreshTerrainFromList();
         }
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        }
-    }
-
-    /** Adapts the whole Board Editor UI to the current guiScale. */
-    private void adaptToGUIScale() {
-        Font scaledFont = UIUtil.getScaledFont();
-
-        butAddTerrain.setFont(scaledFont);
-        butBoardNew.setFont(scaledFont);
-        butBoardOpen.setFont(scaledFont);
-        butBoardSave.setFont(scaledFont);
-        butBoardSaveAs.setFont(scaledFont);
-        butBoardSaveAsImage.setFont(scaledFont);
-        butBoardValidate.setFont(scaledFont);
-        butExpandMap.setFont(scaledFont);
-        butSourceFile.setFont(scaledFont);
-
-        choTerrainType.setFont(scaledFont);
-        choTheme.setFont(scaledFont);
-        cheRoadsAutoExit.setFont(scaledFont);
-        cheTerrExitSpecified.setFont(scaledFont);
-        lisTerrain.setFont(scaledFont);
-        texTerrExits.setFont(scaledFont);
-        texElev.setFont(scaledFont);
-        texTerrainLevel.setFont(scaledFont);
-        copyButton.setFont(scaledFont);
-        pasteButton.setFont(scaledFont);
-
-        labHelp1.setFont(scaledFont);
-        labHelp2.setFont(scaledFont);
-        labTheme.setFont(scaledFont);
-
-        ((TitledBorder) panelBoardSettings.getBorder()).setTitleFont(scaledFont);
-        ((TitledBorder) panelHexSettings.getBorder()).setTitleFont(scaledFont);
-        ((TitledBorder) panelTerrSettings.getBorder()).setTitleFont(scaledFont);
-
-        terrainButtons.forEach(ScalingIconButton::rescale);
-        undoButtons.forEach(ScalingIconButton::rescale);
-        brushButtons.forEach(ScalingIconToggleButton::rescale);
-        butTerrDown.rescale();
-        butTerrUp.rescale();
-        butElevDown.rescale();
-        butElevUp.rescale();
-        butExitDown.rescale();
-        butExitUp.rescale();
-        butTerrExits.rescale();
-        butDelTerrain.rescale();
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/BoardViewsContainer.java
+++ b/megamek/src/megamek/client/ui/swing/BoardViewsContainer.java
@@ -100,7 +100,7 @@ public class BoardViewsContainer {
 //            tooltip += "<BR>Located at " + enclosingBoard.embeddedBoardPosition(boardId).getBoardNum() +
 //                    " in " + enclosingBoard;
 //        }
-        return "<HTML><BODY>" + UIUtil.guiScaledFontHTML() + board(boardId).getMapName() + "</HTML>";
+        return board(boardId).getMapName();
     }
 
     private Board board(int id) {

--- a/megamek/src/megamek/client/ui/swing/ChatterBox.java
+++ b/megamek/src/megamek/client/ui/swing/ChatterBox.java
@@ -18,8 +18,6 @@ import megamek.client.commands.ClientCommand;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.event.*;
-import megamek.common.preference.IPreferenceChangeListener;
-import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 
 import javax.swing.*;
@@ -34,7 +32,7 @@ import java.util.LinkedList;
  * ChatterBox keeps track of a player list and a (chat) message buffer. Although
  * it is not an AWT component, it keeps one that it will gladly supply.
  */
-public class ChatterBox implements KeyListener, IPreferenceChangeListener {
+public class ChatterBox implements KeyListener {
     public static final int MAX_HISTORY = 10;
     Client client;
     private final ClientGUI clientGUI;
@@ -180,9 +178,6 @@ public class ChatterBox implements KeyListener, IPreferenceChangeListener {
         butDone.setPreferredSize(butDone.getSize());
         butDone.setMinimumSize(butDone.getSize());
         chatPanel.setMinimumSize(chatPanel.getPreferredSize());
-
-        adaptToGUIScale();
-        GUIP.addPreferenceChangeListener(this);
     }
 
     /**
@@ -288,20 +283,5 @@ public class ChatterBox implements KeyListener, IPreferenceChangeListener {
 
     public void setChatterBox2(ChatterBox2 cb2) {
         this.cb2 = cb2;
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(chatPanel, UIUtil.FONT_SCALE1);
-        UIUtil.adjustContainer(butDone, UIUtil.FONT_SCALE1);
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        switch (e.getName()) {
-            case GUIPreferences.GUI_SCALE:
-                adaptToGUIScale();
-                break;
-
-        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/ClientDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ClientDialog.java
@@ -15,17 +15,12 @@
 package megamek.client.ui.swing;
 
 import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
 import java.awt.GridBagConstraints;
 
-import javax.swing.Box;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import megamek.client.ui.swing.util.UIUtil;
 
 /**
  * A MegaMek Dialog box.
@@ -33,166 +28,49 @@ import megamek.client.ui.swing.util.UIUtil;
 public class ClientDialog extends JDialog {
 
     private static final long serialVersionUID = 6154951760485853883L;
-    
-    private static final double TASKBAR_SIZE = .05;
-    private static final int CONTAINER_BUFFER = 10;
 
     protected JFrame owner = null;
-    private boolean isScaling = false;
 
-    /** 
-     * Creates a basic ClientDialog.
-     * @see JDialog#JDialog(java.awt.Frame, String) 
-     */
-    public ClientDialog(JFrame owner, String title) {
-        super(owner, title);
-        this.owner = owner;
-    }
-
-    /** 
+    /**
      * Creates a ClientDialog with modality as given by modal.
-     * @see JDialog#JDialog(java.awt.Frame, String, boolean) 
+     * @see JDialog#JDialog(java.awt.Frame, String, boolean)
      */
     public ClientDialog(JFrame owner, String title, boolean modal) {
         super(owner, title, modal);
         this.owner = owner;
     }
-    
-    /** 
-     * Creates a ClientDialog with modality as given by modal. This dialog
-     * will automatically scale with the current GUI scaling value. Results of
-     * this may vary with the complexity of the dialog; manual scaling will
-     * often be better.
-     * @see JDialog#JDialog(java.awt.Frame, String, boolean) 
-     */
-    public ClientDialog(JFrame owner, String title, boolean modal, boolean scale) {
-        super(owner, title, modal);
-        this.owner = owner;
-        isScaling = scale;
-    }
 
-    /**
-     * Set the size and location to something sane (always within the screen).
-     * We try to fit the dialog in the middle of its owner, if it is smaller,
-     * but allow it to eclipse the parent if it is larger, still keeping all on
-     * the screen.
-     * 
-     * @param desiredX the desired width of this dialog (you might not get it)
-     * @param desiredY the desired height of this dialog (you might not get it)
-     */
-    public void setLocationAndSize(int desiredX, int desiredY) {
-        setLocationAndSize(new Dimension(desiredX, desiredY));
-    }
-
-    /**
-     * Set the size and location to something sane (always within the screen).
-     * We try to fit the dialog in the middle of its owner, if it is smaller,
-     * but allow it to eclipse the parent if it is larger, still keeping all on
-     * the screen.
-     * 
-     * @param desiredDimension the desired dimension of this dialog (you might
-     *            not get it)
-     */
-    public void setLocationAndSize(Dimension desiredDimension) {
-        int height, width;
-
-        GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
-        Dimension screenSize = new Dimension(gd.getDisplayMode().getWidth(), gd.getDisplayMode().getHeight());
-
-        width = Math.min(desiredDimension.width + CONTAINER_BUFFER,
-                screenSize.width);
-        height = Math.min(desiredDimension.height + CONTAINER_BUFFER,
-                screenSize.height);
-
-        // Shrink the dialog if it will go bigger than page:
-        // A border is used to account for things like the windows taskbar.
-        // Sadly, the true size of the taskbar cannot be found without making
-        // a native call, so 5% is just a guess. It should probably be
-        // a configuration setting so people can modify it according to
-        // their OS setup.
-        int screenBorder = Math.max((int) (screenSize.width * TASKBAR_SIZE),
-                (int) (screenSize.height * TASKBAR_SIZE));
-        if (height == screenSize.height) {
-            height = screenSize.height - 2 * screenBorder;
-        }
-
-        if (width == screenSize.width) {
-            width = screenSize.width - 2 * screenBorder;
-        }
-
-        setSize(width, height);
-        setLocationRelativeTo(owner);
-    }
-    
     /** Center the dialog within the owner frame.  */
     public void center() {
         if (owner == null) {
             return;
         }
-        
-        setLocation(owner.getLocation().x + (owner.getSize().width / 2) 
+
+        setLocation(owner.getLocation().x + (owner.getSize().width / 2)
               - (getSize().width / 2),
-              owner.getLocation().y + (owner.getSize().height / 2) 
+              owner.getLocation().y + (owner.getSize().height / 2)
               - (getSize().height / 2));
     }
-    
-    /** 
+
+    /**
      * Adds a row (line) with the two JComponents <code>label, secondC</code>
      * to the given <code>panel</code>, using constraints c. The label will be
-     * right-aligned, the secondC left-aligned to bring them close together. 
+     * right-aligned, the secondC left-aligned to bring them close together.
      * Only useful for simple panels with GridBagLayout.
      */
     public void addOptionRow(JPanel targetP, GridBagConstraints c, JLabel label, Component secondC) {
         int oldGridW = c.gridwidth;
         int oldAnchor = c.anchor;
-        
+
         c.gridwidth = 1;
         c.anchor = GridBagConstraints.EAST;
         targetP.add(label, c);
-        
+
         c.gridwidth = GridBagConstraints.REMAINDER;
         c.anchor = GridBagConstraints.WEST;
         targetP.add(secondC, c);
-        
+
         c.gridwidth = oldGridW;
         c.anchor = oldAnchor;
     }
-    
-    /** 
-     * Adds a spacer row (line) to the given <code>panel</code>, 
-     * using constraints c. Only useful for simple panels with GridBagLayout.
-     */
-    public void addSpacerRow(JPanel targetP, GridBagConstraints c, int vGap) {
-        int oldGridW = c.gridwidth;
-        
-        c.gridwidth = GridBagConstraints.REMAINDER;
-        targetP.add(Box.createVerticalStrut(vGap), c);
-        
-        c.gridwidth = oldGridW;
-    }
-    
-    @Override
-    public void setVisible(boolean b) {
-        if (isScaling && b) {
-            guiScale();
-            super.setVisible(true);
-        } else {
-            super.setVisible(b);
-        }
-    }
-    
-    /** 
-     * Applies the GUI Scaling on the event thread as demanded
-     * by {@link java.awt.Container#getComponent(int)}. 
-     */
-    public void guiScale() {
-        adaptToGUIScale();
-        pack();
-        center();
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
-    }
-
 }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1238,7 +1238,6 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
                 break;
             case STARTING_SCENARIO:
                 component = new StartingScenarioPanel();
-                UIUtil.scaleComp(component, UIUtil.FONT_SCALE1);
                 main = CG_STARTINGSCENARIO;
                 component.setName(main);
                 panMain.add(component, main);
@@ -1246,7 +1245,6 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
             case EXCHANGE:
                 chatlounge.killPreviewBV();
                 component = new ReceivingGameDataPanel();
-                UIUtil.scaleComp(component, UIUtil.FONT_SCALE1);
                 main = CG_EXCHANGE;
                 component.setName(main);
                 panMain.add(component, main);
@@ -1814,7 +1812,6 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
         JScrollPane scrollPane = new JScrollPane(textArea,
                 ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-        UIUtil.adjustContainer(scrollPane, UIUtil.FONT_SCALE1);
         textArea.setText("<pre>" + message + "</pre>");
         scrollPane.setPreferredSize(new Dimension(
                 (int) (clientGuiPanel.getSize().getWidth() / 1.5), (int) (clientGuiPanel.getSize().getHeight() / 1.5)));

--- a/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
@@ -25,6 +25,7 @@ import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
@@ -74,12 +75,12 @@ public class CommonAboutDialog extends JDialog {
         copyButton.addActionListener(e -> copySystemData());
 
         JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 20, 0));
-        buttonPanel.setBorder(new UIUtil.ScaledEmptyBorder(25, 20, 10, 10));
+        buttonPanel.setBorder(new EmptyBorder(25, 20, 10, 10));
         buttonPanel.add(closeButton);
         buttonPanel.add(copyButton);
 
         Box contentPanel = Box.createVerticalBox();
-        contentPanel.setBorder(new UIUtil.ScaledEmptyBorder(35, 50, 0, 50));
+        contentPanel.setBorder(new EmptyBorder(35, 50, 0, 50));
         titleImageLabel.setAlignmentX(0.5f);
         contentPanel.add(titleImageLabel);
         contentPanel.add(UIUtil.scaledVerticalSpacer(35), BorderLayout.PAGE_START);

--- a/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
@@ -83,11 +83,11 @@ public class CommonAboutDialog extends JDialog {
         contentPanel.setBorder(new EmptyBorder(35, 50, 0, 50));
         titleImageLabel.setAlignmentX(0.5f);
         contentPanel.add(titleImageLabel);
-        contentPanel.add(UIUtil.scaledVerticalSpacer(35), BorderLayout.PAGE_START);
+        contentPanel.add(Box.createVerticalStrut(35));
         contentPanel.add(lblVersion);
-        contentPanel.add(UIUtil.scaledVerticalSpacer(15), BorderLayout.PAGE_START);
+        contentPanel.add(Box.createVerticalStrut(15));
         contentPanel.add(lblCopyright);
-        contentPanel.add(UIUtil.scaledVerticalSpacer(15), BorderLayout.PAGE_START);
+        contentPanel.add(Box.createVerticalStrut(15));
         contentPanel.add(lblAbout);
 
         add(contentPanel, BorderLayout.CENTER);

--- a/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonAboutDialog.java
@@ -94,7 +94,6 @@ public class CommonAboutDialog extends JDialog {
 
         // Size and center
         getRootPane().setDefaultButton(closeButton);
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
         pack();
         setLocationRelativeTo(parentFrame);
         setResizable(false);

--- a/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
+++ b/megamek/src/megamek/client/ui/swing/CommonMenuBar.java
@@ -366,7 +366,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         menu.addSeparator();
         initMenuItem(helpAbout, menu, HELP_ABOUT);
 
-        adaptToGUIScale();
         setKeyBinds();
         GUIP.addPreferenceChangeListener(this);
         KeyBindParser.addPreferenceChangeListener(this);
@@ -595,8 +594,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
             viewTurnDetailsOverlay.setSelected((Boolean) e.getNewValue());
         } else if (e.getName().equals(GUIPreferences.SHOW_UNIT_OVERVIEW)) {
             viewUnitOverview.setSelected((Boolean) e.getNewValue());
-        } else if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
         } else if (e.getName().equals(GUIPreferences.MINI_MAP_ENABLED)) {
             viewMinimap.setSelected(GUIP.getMinimapEnabled());
         } else if (e.getName().equals(GUIPreferences.SHOW_COORDS)) {
@@ -614,11 +611,6 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
         } else if (e.getName().equals(RecentBoardList.RECENT_BOARDS_UPDATED)) {
             initializeRecentBoardsMenu();
         }
-    }
-
-    /** Adapts the menu (the font size) to the current GUI scale. */
-    private void adaptToGUIScale() {
-        UIUtil.scaleMenu(this);
     }
 
     /** Removes this as listener. */
@@ -652,6 +644,5 @@ public class CommonMenuBar extends JMenuBar implements ActionListener, IPreferen
             initMenuItem(item, boardRecent, BOARD_RECENT + "|" + recentBoard);
         }
         boardRecent.setEnabled(!recentBoards.isEmpty());
-        adaptToGUIScale();
     }
 }

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -61,7 +61,6 @@ import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.client.ui.swing.util.FontHandler;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.PlayerColour;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.common.Configuration;
 import megamek.common.KeyBindParser;
@@ -565,8 +564,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         panTabs.add(Messages.getString("CommonSettingsDialog.buttonOrder"), getButtonOrderPanel());
         panTabs.add(Messages.getString("CommonSettingsDialog.autoDisplay"), autoDisplayPane);
         panTabs.add(Messages.getString("CommonSettingsDialog.advanced"), advancedSettingsPane);
-
-        adaptToGUIScale();
 
         return panTabs;
     }
@@ -2081,8 +2078,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             }
 
             markDuplicateBinds();
-
-            adaptToGUIScale();
         }
 
         super.setVisible(visible);
@@ -3439,10 +3434,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             logger.warn(e, "Error while reading " + fileEnding + " files from " + path);
             return new ArrayList<>();
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/ConfirmDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ConfirmDialog.java
@@ -37,7 +37,6 @@ import javax.swing.JTextArea;
 import javax.swing.KeyStroke;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 
 /**
  * A simple yes/no confirmation dialog.
@@ -127,7 +126,6 @@ public class ConfirmDialog extends JDialog{
             defaultButton = butYes;
         }
 
-        adaptToGUIScale();
         finishSetup(p);
     }
 
@@ -268,9 +266,5 @@ public class ConfirmDialog extends JDialog{
             return true;
         }
         return !botherCheckbox.isSelected();
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/CustomMekDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMekDialog.java
@@ -306,7 +306,6 @@ public class CustomMekDialog extends AbstractButtonDialog implements ActionListe
             }
         }
 
-        adaptToGUIScale();
         validate();
     }
 
@@ -1085,10 +1084,6 @@ public class CustomMekDialog extends AbstractButtonDialog implements ActionListe
         panEquip.add(m_equip, GBC.std());
     }
 
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-    }
-
     private void setStealth(Entity e, boolean stealthed) {
         int newStealth = (stealthed) ? 1 : 0;
         EquipmentMode newMode = (stealthed) ? EquipmentMode.getMode("On") : EquipmentMode.getMode("Off");
@@ -1408,7 +1403,6 @@ public class CustomMekDialog extends AbstractButtonDialog implements ActionListe
             m_equip.initialize();
         }
 
-        adaptToGUIScale();
         setResizable(true);
         return mainPanel;
     }

--- a/megamek/src/megamek/client/ui/swing/DeployElevationChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/DeployElevationChoiceDialog.java
@@ -24,6 +24,7 @@ import megamek.common.DeploymentElevationType;
 import megamek.common.ElevationOption;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import java.util.List;
 
@@ -62,7 +63,7 @@ public class DeployElevationChoiceDialog extends AbstractChoiceDialog<ElevationO
         JPanel buttonPanel = new JPanel();
         buttonPanel.setBorder(BorderFactory.createCompoundBorder(
                 new MatteBorder(1, 0, 0, 0, UIManager.getColor("Separator.foreground")),
-                new UIUtil.ScaledEmptyBorder(10, 0, 10, 0)));
+                new EmptyBorder(10, 0, 10, 0)));
         buttonPanel.add(new ButtonEsc(new CloseAction(this)));
         return buttonPanel;
     }

--- a/megamek/src/megamek/client/ui/swing/DeployElevationChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/DeployElevationChoiceDialog.java
@@ -78,15 +78,6 @@ public class DeployElevationChoiceDialog extends AbstractChoiceDialog<ElevationO
                 + "</div></BODY></HTML>";
     }
 
-    @Override
-    public void setVisible(boolean visible) {
-        if (visible) {
-            UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-            pack();
-        }
-        super.setVisible(visible);
-    }
-
     public static String styles() {
         int descriptionSize = UIUtil.scaleForGUI(UIUtil.FONT_SCALE1);
         int elevationSize = (int) (0.8 * UIUtil.scaleForGUI(UIUtil.FONT_SCALE1));

--- a/megamek/src/megamek/client/ui/swing/EditBotsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/EditBotsDialog.java
@@ -99,7 +99,6 @@ public class EditBotsDialog extends AbstractButtonDialog {
     @Override
     protected void initialize() {
         super.initialize();
-        adaptToGUIScale();
         try {
             finalizeInitialization();
         } catch (Exception ex) {
@@ -375,9 +374,5 @@ public class EditBotsDialog extends AbstractButtonDialog {
             }
         }
         return result;
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGenerationOptionsPanel.java
@@ -38,7 +38,6 @@ import megamek.client.ratgenerator.RATGenerator;
 import megamek.client.ratgenerator.UnitTable;
 import megamek.client.ratgenerator.UnitTable.Parameters;
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.EntityMovementMode;
 import megamek.common.EntityWeightClass;
 import megamek.common.MekSummary;
@@ -250,8 +249,6 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
         c.weightx = 0.0;
         c.weighty = 0.5;
         add(panUnitTypeOptions, c);
-
-        adaptToGUIScale();
 
         if (!RATGenerator.getInstance().isInitialized()) {
             RATGenerator.getInstance().registerListener(this);
@@ -1218,9 +1215,5 @@ class ForceGenerationOptionsPanel extends JPanel implements ActionListener, Focu
             generatedUnits = list;
             txtNoFormation.setVisible(list == null || list.isEmpty());
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
@@ -377,7 +377,6 @@ public class ForceGeneratorViewUi implements ActionListener {
                     item = new JMenuItem("Export as MUL");
                     item.addActionListener(ev -> panControls.exportMUL(fd));
                     menu.add(item);
-                    UIUtil.scaleMenu(menu);
                     menu.show(evt.getComponent(), evt.getX(), evt.getY());
                 }
             }
@@ -422,7 +421,6 @@ public class ForceGeneratorViewUi implements ActionListener {
                     menu.add(UIUtil.menuItem(msg_viewcost, FGV_COST + eIds, true, ForceGeneratorViewUi.this,
                             Integer.MIN_VALUE));
 
-                    UIUtil.scaleMenu(menu);
                     menu.show(evt.getComponent(), evt.getX(), evt.getY());
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
@@ -225,8 +225,6 @@ public class ForceGeneratorViewUi implements ActionListener {
         leftPanel.setLayout(new BoxLayout(leftPanel, BoxLayout.Y_AXIS));
         leftPanel.add(panControls);
         leftPanel.add(scroll);
-
-        adaptToGUIScale();
     }
 
     public Component getLeftPanel() {
@@ -705,10 +703,5 @@ public class ForceGeneratorViewUi implements ActionListener {
 
             return ms;
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(leftPanel, UIUtil.FONT_SCALE1);
-        UIUtil.adjustContainer(rightPanel, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -32,9 +32,6 @@ import javax.swing.filechooser.FileFilter;
 import javax.xml.parsers.DocumentBuilder;
 
 import megamek.client.ui.baseComponents.AbstractButtonDialog;
-import megamek.client.ui.swing.util.UIUtil;
-import megamek.common.preference.IPreferenceChangeListener;
-import megamek.common.preference.PreferenceChangeEvent;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
@@ -48,7 +45,7 @@ import static megamek.client.ui.swing.util.UIUtil.*;
 import static megamek.client.ui.Messages.*;
 
 /** Responsible for displaying the current game options and allowing the user to change them. */
-public class GameOptionsDialog extends AbstractButtonDialog implements ActionListener, DialogOptionListener, IPreferenceChangeListener {
+public class GameOptionsDialog extends AbstractButtonDialog implements ActionListener, DialogOptionListener {
 
     private ClientGUI clientGui;
     private JFrame frame;
@@ -140,10 +137,6 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
         mainPanel.add(panPassword);
         mainPanel.add(Box.createVerticalStrut(5));
         mainPanel.add(panButtons);
-
-        adaptToGUIScale();
-        GUIPreferences.getInstance().addPreferenceChangeListener(this);
-
         return mainPanel;
     }
 
@@ -165,8 +158,6 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
         panButtons.add(butDefaults);
         panButtons.add(butSave);
         panButtons.add(butLoad);
-
-        adaptToGUIScale();
 
         return panButtons;
     }
@@ -536,8 +527,6 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
         }
         List<DialogOptionComponent> comps = optionComps.computeIfAbsent(option.getName(), k -> new ArrayList<>());
         comps.add(optionComp);
-
-        UIUtil.adjustContainer(optionComp, UIUtil.FONT_SCALE1);
     }
 
     // Gets called when one of the option checkboxes is clicked.
@@ -918,17 +907,5 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
      */
     public boolean isEditable() {
         return editable;
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/HelpDialog.java
+++ b/megamek/src/megamek/client/ui/swing/HelpDialog.java
@@ -31,7 +31,6 @@ import javax.swing.KeyStroke;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.HyperlinkEvent;
 
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.logging.MMLogger;
 
 /**
@@ -77,7 +76,6 @@ public class HelpDialog extends JDialog {
         scrollPane.getVerticalScrollBar().setUnitIncrement(16);
         scrollPane.setBorder(new EmptyBorder(10, 10, 10, 10));
         add(scrollPane);
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
 
         // Escape keypress
         final KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);

--- a/megamek/src/megamek/client/ui/swing/MapDimensionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/MapDimensionsDialog.java
@@ -14,7 +14,6 @@
 package megamek.client.ui.swing;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.MapSettings;
 
 import javax.swing.*;
@@ -24,7 +23,7 @@ import java.awt.event.ActionListener;
 
 /**
  * Display a small dialog with adjustable settings for the dimensions of the playing board
- * 
+ *
  * @author Taharqa
  * @since February 12, 2010
  */
@@ -33,7 +32,7 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
 
     private ClientGUI clientGUI;
     private MapSettings mapSettings;
-    
+
     private JPanel panMapSize = new JPanel();
     private JLabel labBoardSize = new JLabel(Messages.getString("BoardSelectionDialog.BoardSize"),
             SwingConstants.RIGHT);
@@ -46,19 +45,19 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
     private JLabel labMapDivider = new JLabel("x", SwingConstants.CENTER);
     private JSpinner spnMapWidth = new JSpinner();
     private JSpinner spnMapHeight = new JSpinner();
-    
+
     private JPanel panButtons = new JPanel();
     private JButton butOkay = new JButton(Messages.getString("Okay"));
     private JButton butCancel = new JButton(Messages.getString("Cancel"));
-    
+
     public MapDimensionsDialog(ClientGUI clientGUI, MapSettings mapSettings) {
         super(clientGUI.frame, Messages.getString("MapDimensionsDialog.MapDimensions"), true);
         this.clientGUI = clientGUI;
         this.mapSettings = MapSettings.getInstance(mapSettings);
-     
+
         setupMapSize();
         setupButtons();
-        
+
         // layout
         GridBagLayout gridbag = new GridBagLayout();
         GridBagConstraints c = new GridBagConstraints();
@@ -74,7 +73,7 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridheight = 1;
         gridbag.setConstraints(panMapSize, c);
         add(panMapSize);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.weightx = 0.0;
         c.weighty = 0.0;
@@ -84,7 +83,7 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridheight = 1;
         gridbag.setConstraints(panButtons, c);
         add(panButtons);
-        
+
         pack();
         setResizable(false);
         setLocation(clientGUI.frame.getLocation().x
@@ -93,9 +92,9 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
                         + clientGUI.frame.getSize().height / 2
                         - getSize().height / 2);
     }
-    
+
     private void setupMapSize() {
-        
+
         SpinnerModel boardHeightModel = new SpinnerNumberModel(mapSettings.getMapHeight(), 1, 15, 1);
         SpinnerModel boardWidthModel = new SpinnerNumberModel(mapSettings.getMapWidth(), 1, 15, 1);
         spnMapHeight = new JSpinner(boardHeightModel);
@@ -104,12 +103,12 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         texBoardHeight.setText(Integer.toString(mapSettings.getBoardHeight()));
         texBoardWidth.addActionListener(this);
         texBoardHeight.addActionListener(this);
-        
+
         if (mapSettings.getMedium() == MapSettings.MEDIUM_SPACE) {
             spnMapHeight.setEnabled(false);
             spnMapWidth.setEnabled(false);
         }
-        
+
         GridBagLayout gridbag = new GridBagLayout();
         GridBagConstraints c = new GridBagConstraints();
         panMapSize.setLayout(gridbag);
@@ -121,11 +120,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 0;
         c.gridy = 0;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.WEST;
         gridbag.setConstraints(labMapSize, c);
         panMapSize.add(labBoardSize);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -133,11 +132,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 1;
         c.gridy = 0;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.NORTHWEST;
         gridbag.setConstraints(texBoardWidth, c);
         panMapSize.add(texBoardWidth);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -145,11 +144,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 2;
         c.gridy = 0;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.WEST;
         gridbag.setConstraints(labBoardDivider, c);
         panMapSize.add(labBoardDivider);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -157,11 +156,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 3;
         c.gridy = 0;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.NORTHWEST;
         gridbag.setConstraints(texBoardHeight, c);
         panMapSize.add(texBoardHeight);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -169,11 +168,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 0;
         c.gridy = 1;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.WEST;
         gridbag.setConstraints(labMapSize, c);
         panMapSize.add(labMapSize);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -181,11 +180,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 1;
         c.gridy = 1;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.NORTHWEST;
         gridbag.setConstraints(spnMapHeight, c);
         panMapSize.add(spnMapHeight);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -193,11 +192,11 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 2;
         c.gridy = 1;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.WEST;
         gridbag.setConstraints(labMapDivider, c);
         panMapSize.add(labMapDivider);
-        
+
         c.fill = GridBagConstraints.HORIZONTAL;
         c.insets = new Insets(1, 1, 1, 1);
         c.weightx = 0.0;
@@ -205,17 +204,17 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridx = 3;
         c.gridy = 1;
         c.gridwidth = 1;
-        c.gridheight = 1; 
+        c.gridheight = 1;
         c.anchor = GridBagConstraints.NORTHWEST;
         gridbag.setConstraints(spnMapWidth, c);
         panMapSize.add(spnMapWidth);
     }
-    
+
     private void setupButtons() {
-        
+
         butOkay.addActionListener(this);
         butCancel.addActionListener(this);
-        
+
         GridBagLayout gridbag = new GridBagLayout();
         GridBagConstraints c = new GridBagConstraints();
         panButtons.setLayout(gridbag);
@@ -241,7 +240,7 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         c.gridheight = 1;
         gridbag.setConstraints(butCancel, c);
         panButtons.add(butCancel);
-        
+
     }
 
     /**
@@ -257,7 +256,7 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         // read map size settings
         try {
             boardWidth = Integer.parseInt(texBoardWidth.getText());
-            boardHeight = Integer.parseInt(texBoardHeight.getText());         
+            boardHeight = Integer.parseInt(texBoardHeight.getText());
             mapWidth = (Integer) spnMapWidth.getModel().getValue();
             mapHeight = (Integer) spnMapHeight.getModel().getValue();
         } catch (NumberFormatException ex) {
@@ -282,8 +281,8 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
         mapSettings.setMapSize(mapWidth, mapHeight);
         clientGUI.getClient().sendMapDimensions(mapSettings);
     }
-    
-    
+
+
     @Override
     public void actionPerformed(ActionEvent e) {
         if (e.getSource().equals(butOkay)) {
@@ -291,19 +290,6 @@ public class MapDimensionsDialog extends JDialog implements ActionListener {
             setVisible(false);
         } else if (e.getSource().equals(butCancel)) {
             setVisible(false);
-        }   
-    }
-    
-    @Override
-    public void setVisible(boolean b) {
-        if (b) {
-            adaptToGUIScale();;
-            pack();
         }
-        super.setVisible(b);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -135,6 +135,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         // implementing it in
         // TODO : SuiteOptions
         try {
+            System.setProperty("flatlaf.uiScale", "1.4");
             UIManager.setLookAndFeel(GUIPreferences.getInstance().getUITheme());
         } catch (Exception ex) {
             logger.error(ex, "Failed to set look and feel!");

--- a/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MiniReportDisplay.java
@@ -1,14 +1,14 @@
 /*
  * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * 
- * This program is free software; you can redistribute it and/or modify it 
- * under the terms of the GNU General Public License as published by the Free 
- * Software Foundation; either version 2 of the License, or (at your option) 
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
  * any later version.
- * 
- * This program is distributed in the hope that it will be useful, but 
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * for more details.
  */
 package megamek.client.ui.swing;
@@ -44,9 +44,9 @@ import java.util.List;
 /**
  * Shows reports, with an Okay JButton
  */
-public class MiniReportDisplay extends JPanel implements ActionListener, HyperlinkListener, IPreferenceChangeListener {
+public class MiniReportDisplay extends JPanel implements ActionListener, HyperlinkListener {
     private JButton butSwitchLocation;
-    private JTabbedPane tabs;  
+    private JTabbedPane tabs;
     private JButton butPlayerSearchUp;
     private JButton butPlayerSearchDown;
     private JButton butEntitySearchUp;
@@ -114,10 +114,6 @@ public class MiniReportDisplay extends JPanel implements ActionListener, Hyperli
         add(panelMain, BorderLayout.CENTER);
 
         doLayout();
-        adaptToGUIScale();
-
-        GUIP.addPreferenceChangeListener(this);
-        CP.addPreferenceChangeListener(this);
     }
 
     private void searchTextPane(String searchPattern, Boolean searchDown) {
@@ -381,42 +377,4 @@ public class MiniReportDisplay extends JPanel implements ActionListener, Hyperli
             }
         }
     };
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(this, UIUtil.FONT_SCALE1);
-
-        for (int i = 0; i < tabs.getTabCount(); i++) {
-            Component cp = tabs.getComponentAt(i);
-            if (cp instanceof JScrollPane) {
-                Component pane = ((JScrollPane) cp).getViewport().getView();
-                if (pane instanceof JTextPane) {
-                    JTextPane tp = (JTextPane) pane;
-                    Report.setupStylesheet(tp);
-                    tp.setText(tp.getText());
-                }
-            }
-        }
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(ClientPreferences.REPORT_KEYWORDS)) {
-            updateQuickChoice();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_LINK)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_SUCCESS)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_MISS)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_INFO)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.WARNING_COLOR)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_FONT_TYPE)) {
-            adaptToGUIScale();
-        }
-    }
 }

--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -19,8 +19,6 @@
  */
 package megamek.client.ui.swing;
 
-import static megamek.client.ui.swing.util.UIUtil.scaleForGUI;
-
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.FlowLayout;
@@ -38,6 +36,7 @@ import javax.swing.border.EmptyBorder;
 
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.dialog.DialogButton;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.util.UIUtil.Content;
 import megamek.client.ui.swing.util.UIUtil.FixedYPanel;
 import megamek.client.ui.swing.util.UIUtil.OptionPanel;
@@ -168,10 +167,10 @@ public class PlanetaryConditionsDialog extends ClientDialog {
         result.setAlignmentX(Component.LEFT_ALIGNMENT);
         File iconFile = new MegaMekFile(Configuration.widgetsDir(), "Planetary.png").getFile();
         Image image = ImageUtil.loadImageFromFile(iconFile.toString());
-        Icon planetIcon = new ImageIcon(image.getScaledInstance(scaleForGUI(40), -1, Image.SCALE_SMOOTH));
+        Icon planetIcon = new ImageIcon(image.getScaledInstance(UIUtil.scaleForGUI(40), -1, Image.SCALE_SMOOTH));
         JLabel planetLabel = new JLabel(Messages.getString("PlanetaryConditionsDialog.title"),
                 planetIcon, SwingConstants.CENTER);
-        planetLabel.setIconTextGap(scaleForGUI(12));
+        planetLabel.setIconTextGap(12);
         planetLabel.setBorder(new EmptyBorder(15, 0, 10, 0));
         result.add(planetLabel);
         return result;

--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -68,7 +68,7 @@ public class PlanetaryConditionsDialog extends ClientDialog {
 
     /** Creates new PlanetaryConditionsDialog and takes the conditions from the client's Game. */
     public PlanetaryConditionsDialog(ClientGUI cl) {
-        super(cl.frame, Messages.getString("PlanetaryConditionsDialog.title"), true, true);
+        super(cl.frame, Messages.getString("PlanetaryConditionsDialog.title"), true);
         client = cl;
         setupDialog();
         update(client.getClient().getGame().getPlanetaryConditions());
@@ -76,7 +76,7 @@ public class PlanetaryConditionsDialog extends ClientDialog {
 
     /** Creates new PlanetaryConditionsDialog and sets the given conditions. Used for scenarios. */
     public PlanetaryConditionsDialog(JFrame frame, PlanetaryConditions conditions) {
-        super(frame, Messages.getString("PlanetaryConditionsDialog.title"), true, true);
+        super(frame, Messages.getString("PlanetaryConditionsDialog.title"), true);
         setupDialog();
         update(conditions);
     }

--- a/megamek/src/megamek/client/ui/swing/PlayerListDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlayerListDialog.java
@@ -1,6 +1,6 @@
 /*
  * MegaMek - Copyright (C) 2000-2003 Ben Mazur (bmazur@sev.org)
- * MegaMek - Copyright (C) 2020 - The MegaMek Team  
+ * MegaMek - Copyright (C) 2020 - The MegaMek Team
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -16,12 +16,9 @@ package megamek.client.ui.swing;
 
 import megamek.client.Client;
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.IGame;
 import megamek.common.Player;
 import megamek.common.Team;
-import megamek.common.preference.IPreferenceChangeListener;
-import megamek.common.preference.PreferenceChangeEvent;
 
 import javax.swing.*;
 import java.awt.*;
@@ -33,7 +30,7 @@ import java.text.MessageFormat;
 import java.util.Comparator;
 import java.util.List;
 
-public class PlayerListDialog extends JDialog implements ActionListener, IPreferenceChangeListener {
+public class PlayerListDialog extends JDialog implements ActionListener {
 
     private static final long serialVersionUID = 7270469195373150106L;
 
@@ -69,10 +66,6 @@ public class PlayerListDialog extends JDialog implements ActionListener, IPrefer
 
         refreshPlayerList();
         setMinimumSize(new Dimension(300, 260));
-
-        adaptToGUIScale();
-        GUIP.addPreferenceChangeListener(this);
-
         pack();
         setResizable(false);
 
@@ -195,19 +188,6 @@ public class PlayerListDialog extends JDialog implements ActionListener, IPrefer
             if (!modal) {
                 saveSettings();
             }
-        }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-        setMinimumSize(new Dimension(UIUtil.scaleForGUI(300), UIUtil.scaleForGUI(260)));
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
         }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -267,8 +267,6 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
         setSize(GUIP.getRndArmySizeWidth(), GUIP.getRndArmySizeHeight());
         setLocation(GUIP.getRndArmyPosX(), GUIP.getRndArmyPosY());
 
-        adaptToGUIScale();
-
         String closeAction = "closeAction";
         final KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0);
         getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, closeAction);
@@ -1145,7 +1143,6 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
             updateRATs();
         }
 
-        adaptToGUIScale();
         m_chPlayer.grabFocus();
         super.setVisible(show);
     }
@@ -1451,9 +1448,5 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
             }
             return null;
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomMapDialog.java
@@ -502,8 +502,6 @@ public class RandomMapDialog extends JDialog implements ActionListener {
     @Override
     public void setVisible(boolean b) {
         if (b) {
-            adaptToGUIScale();
-            pack();
             loadWindowSettings();
         } else {
             saveWindowSettings();
@@ -535,9 +533,5 @@ public class RandomMapDialog extends JDialog implements ActionListener {
             switchView(false, false);
             basicButton.setSelected(true);
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/RandomNameDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomNameDialog.java
@@ -252,13 +252,6 @@ public class RandomNameDialog extends JDialog implements ActionListener {
         panMain.add(comboHistoricalEthnicity, c);
 
         getContentPane().add(panMain, java.awt.BorderLayout.PAGE_START);
-
-        adaptToGUIScale();
-
         pack();
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/Ruler.java
+++ b/megamek/src/megamek/client/ui/swing/Ruler.java
@@ -53,7 +53,7 @@ import megamek.logging.MMLogger;
 /**
  * @author Ken Nguyen (kenn)
  */
-public class Ruler extends JDialog implements BoardViewListener, IPreferenceChangeListener {
+public class Ruler extends JDialog implements BoardViewListener {
     private static final MMLogger logger = MMLogger.create(Ruler.class);
 
     private static final long serialVersionUID = -4820402626782115601L;
@@ -268,10 +268,6 @@ public class Ruler extends JDialog implements BoardViewListener, IPreferenceChan
         add(sp);
 
         validate();
-
-        adaptToGUIScale();
-        GUIPreferences.getInstance().addPreferenceChangeListener(this);
-
         setVisible(false);
     }
 
@@ -496,16 +492,5 @@ public class Ruler extends JDialog implements BoardViewListener, IPreferenceChan
     @Override
     public void unitSelected(BoardViewEvent b) {
         // ignored
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/SelectArtyAutoHitHexDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/SelectArtyAutoHitHexDisplay.java
@@ -13,7 +13,6 @@
  */
 package megamek.client.ui.swing;
 
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 import static megamek.client.ui.swing.util.UIUtil.uiLightViolet;
 
 import java.awt.event.ActionEvent;
@@ -26,6 +25,7 @@ import java.util.Map;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.util.KeyCommandBind;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.widget.MegaMekButton;
 import megamek.client.ui.swing.widget.SkinSpecification;
 import megamek.common.Board;
@@ -148,12 +148,12 @@ public class SelectArtyAutoHitHexDisplay extends StatusBarPhaseDisplay {
             String tt = cmd.getHotKeyDesc();
             if (!tt.isEmpty()) {
                 String title = Messages.getString("SelectArtyAutoHitHexDisplay." + cmd.getCmd());
-                tt = guiScaledFontHTML(uiLightViolet()) + title + ": " + tt + "</FONT>";
+                tt = UIUtil.colorHTML(uiLightViolet()) + title + ": " + tt + "</FONT>";
                 tt += "<BR>";
             }
             if (Messages.keyExists(ttKey)) {
                 String msg_key = Messages.getString(ttKey);
-                tt += guiScaledFontHTML() + msg_key + "</FONT>";
+                tt += msg_key;
             }
             if (!tt.isEmpty()) {
                 String b = "<BODY>" + tt + "</BODY>";

--- a/megamek/src/megamek/client/ui/swing/SelectArtyAutoHitHexDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/SelectArtyAutoHitHexDisplay.java
@@ -148,7 +148,7 @@ public class SelectArtyAutoHitHexDisplay extends StatusBarPhaseDisplay {
             String tt = cmd.getHotKeyDesc();
             if (!tt.isEmpty()) {
                 String title = Messages.getString("SelectArtyAutoHitHexDisplay." + cmd.getCmd());
-                tt = UIUtil.colorHTML(uiLightViolet()) + title + ": " + tt + "</FONT>";
+                tt = UIUtil.fontHTML(uiLightViolet()) + title + ": " + tt + "</FONT>";
                 tt += "<BR>";
             }
             if (Messages.keyExists(ttKey)) {

--- a/megamek/src/megamek/client/ui/swing/SkillGenerationDialog.java
+++ b/megamek/src/megamek/client/ui/swing/SkillGenerationDialog.java
@@ -25,7 +25,6 @@ import megamek.client.ui.baseComponents.MMButton;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.panels.SkillGenerationOptionsPanel;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import megamek.common.Player;
 
@@ -126,11 +125,6 @@ public class SkillGenerationDialog extends AbstractButtonDialog {
     }
     //endregion Initialization
 
-    @Override
-    protected void finalizeInitialization() throws Exception {
-        super.finalizeInitialization();
-        adaptToGUIScale();
-    }
 
     //region Button Actions
     @Override
@@ -141,8 +135,4 @@ public class SkillGenerationDialog extends AbstractButtonDialog {
         clientGUI.getClient().sendServerChat(Player.PLAYER_NONE, msg);
     }
     //endregion Button Actions
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-    }
 }

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -246,7 +246,6 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
 
         panButtons.add(buttonsPanel);
         panButtons.add(donePanel);
-        adaptToGUIScale();
         panButtons.validate();
         panButtons.repaint();
     }
@@ -286,12 +285,6 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         labStatus.setText(text);
     }
 
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(panButtons, UIUtil.FONT_SCALE1);
-        UIUtil.adjustContainer(panStatus, UIUtil.FONT_SCALE2);
-        donePanel.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
-    }
-
     @Override
     public void preferenceChange(PreferenceChangeEvent e) {
         if (e.getName().equals(GUIPreferences.BUTTONS_PER_ROW)) {
@@ -301,8 +294,6 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         } else if (e.getName().equals(KeyBindParser.KEYBINDS_CHANGED)) {
             setButtonsTooltips();
         }
-
-        adaptToGUIScale();
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -184,7 +184,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         String toolTip = hotKeyDesc;
         if (!toolTip.isEmpty()) {
             String title = Messages.getString(keyPrefix + cmd);
-            toolTip = UIUtil.colorHTML(uiLightViolet()) + title + ": " + toolTip + "</FONT>";
+            toolTip = UIUtil.fontHTML(uiLightViolet()) + title + ": " + toolTip + "</FONT>";
             toolTip += "<BR>";
         }
         if (Messages.keyExists(ttKey)) {

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -19,7 +19,6 @@
  */
 package megamek.client.ui.swing;
 
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 import static megamek.client.ui.swing.util.UIUtil.uiLightViolet;
 
 import java.awt.Color;
@@ -185,12 +184,12 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         String toolTip = hotKeyDesc;
         if (!toolTip.isEmpty()) {
             String title = Messages.getString(keyPrefix + cmd);
-            toolTip = guiScaledFontHTML(uiLightViolet()) + title + ": " + toolTip + "</FONT>";
+            toolTip = UIUtil.colorHTML(uiLightViolet()) + title + ": " + toolTip + "</FONT>";
             toolTip += "<BR>";
         }
         if (Messages.keyExists(ttKey)) {
             String msg_key = Messages.getString(ttKey);
-            toolTip += guiScaledFontHTML() + msg_key + "</FONT>";
+            toolTip += msg_key;
         }
         if (!toolTip.isEmpty()) {
             String b = "<BODY>" + toolTip + "</BODY>";

--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -30,7 +30,6 @@ import java.util.function.BiConsumer;
 import javax.swing.*;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.options.OptionsConstants;
 
@@ -161,7 +160,6 @@ public class UnitEditorDialog extends JDialog {
         getRootPane().getInputMap(JComponent.WHEN_FOCUSED).put(escape, closeAction);
         getRootPane().getActionMap().put(closeAction, new CloseAction(this));
 
-        adaptToGUIScale();
         pack();
     }
 
@@ -1599,9 +1597,5 @@ public class UnitEditorDialog extends JDialog {
             }
 
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
@@ -245,7 +245,7 @@ class AttackSprite extends Sprite {
         String sAttacherDesc = "";
 
         sAttacherDesc = attackerDesc + "<BR>&nbsp;&nbsp;" + Messages.getString("BoardView1.on") + " " + targetDesc;
-        result = UIUtil.colorHTML(attackColor) + sAttacherDesc + "</FONT>";
+        result = UIUtil.fontHTML(attackColor) + sAttacherDesc + "</FONT>";
         String sAttacks = "";
         if ((phase.isFiring()) || (phase.isPhysical())) {
             for (String wpD : attacks.getDescriptions()) {

--- a/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/AttackSprite.java
@@ -11,11 +11,10 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.tileset.HexTileset;
 import megamek.client.ui.swing.tooltip.EntityActionLog;
 import megamek.client.ui.swing.util.StraightArrowPolygon;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.actions.*;
 import megamek.common.enums.GamePhase;
-
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 
 /**
  * Sprite and info for an attack. Does not actually use the image buffer as
@@ -246,7 +245,7 @@ class AttackSprite extends Sprite {
         String sAttacherDesc = "";
 
         sAttacherDesc = attackerDesc + "<BR>&nbsp;&nbsp;" + Messages.getString("BoardView1.on") + " " + targetDesc;
-        result = guiScaledFontHTML(attackColor) + sAttacherDesc + "</FONT>";
+        result = UIUtil.colorHTML(attackColor) + sAttacherDesc + "</FONT>";
         String sAttacks = "";
         if ((phase.isFiring()) || (phase.isPhysical())) {
             for (String wpD : attacks.getDescriptions()) {

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardEditorTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardEditorTooltip.java
@@ -75,7 +75,7 @@ public class BoardEditorTooltip implements BoardViewTooltipProvider {
         int padding = UIUtil.scaleForGUI(BASE_PADDING);
 
         StringBuilder result = new StringBuilder();
-        result.append(UIUtil.colorHTML(GUIP.getUnitToolTipTerrainFGColor()));
+        result.append(UIUtil.fontHTML(GUIP.getUnitToolTipTerrainFGColor()));
         result.append("<FONT FACE=" + FontHandler.notoFont().getName() + ">");
 
         // Coordinates and level
@@ -124,7 +124,7 @@ public class BoardEditorTooltip implements BoardViewTooltipProvider {
         List<String> errors = new ArrayList<>();
         if (!hex.isValid(errors)) {
             result.append(paragraphHTMLOpen(padding))
-                    .append(UIUtil.colorHTML(GUIP.getWarningColor())).append(UIUtil.WARNING_SIGN).append("</FONT>")
+                    .append(UIUtil.fontHTML(GUIP.getWarningColor())).append(UIUtil.WARNING_SIGN).append("</FONT>")
                     .append(Messages.getString("BoardView1.invalidHex")).append("<BR>")
                     .append(String.join("<BR>", errors))
                     .append("</p>");

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardEditorTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardEditorTooltip.java
@@ -30,8 +30,7 @@ import java.awt.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static megamek.client.ui.swing.util.UIUtil.DOT_SPACER;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+import static megamek.client.ui.swing.util.UIUtil.*;
 
 /**
  * This class is a {@link megamek.client.ui.swing.boardview.BoardViewTooltipProvider} that is tailored
@@ -76,7 +75,7 @@ public class BoardEditorTooltip implements BoardViewTooltipProvider {
         int padding = UIUtil.scaleForGUI(BASE_PADDING);
 
         StringBuilder result = new StringBuilder();
-        result.append(guiScaledFontHTML(GUIP.getUnitToolTipTerrainFGColor()));
+        result.append(UIUtil.colorHTML(GUIP.getUnitToolTipTerrainFGColor()));
         result.append("<FONT FACE=" + FontHandler.notoFont().getName() + ">");
 
         // Coordinates and level
@@ -125,7 +124,7 @@ public class BoardEditorTooltip implements BoardViewTooltipProvider {
         List<String> errors = new ArrayList<>();
         if (!hex.isValid(errors)) {
             result.append(paragraphHTMLOpen(padding))
-                    .append(guiScaledFontHTML(GUIP.getWarningColor())).append(UIUtil.WARNING_SIGN).append("</FONT>")
+                    .append(UIUtil.colorHTML(GUIP.getWarningColor())).append(UIUtil.WARNING_SIGN).append("</FONT>")
                     .append(Messages.getString("BoardView1.invalidHex")).append("<BR>")
                     .append(String.join("<BR>", errors))
                     .append("</p>");

--- a/megamek/src/megamek/client/ui/swing/boardview/TWBoardViewTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TWBoardViewTooltip.java
@@ -18,7 +18,6 @@
  */
 package megamek.client.ui.swing.boardview;
 
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 import static megamek.client.ui.swing.util.UIUtil.uiWhite;
 
 import java.awt.Point;
@@ -102,7 +101,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     } else {
                         sTerrain += Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange1");
                         String tmp = Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange2");
-                        sTerrain += guiScaledFontHTML(GUIP.getWarningColor()) + tmp + "<FONT>";
+                        sTerrain += UIUtil.colorHTML(GUIP.getWarningColor()) + tmp + "<FONT>";
                         sTerrain += Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange3");
                     }
                 }
@@ -120,7 +119,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                 }
             }
 
-            sTerrain = guiScaledFontHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
+            sTerrain = UIUtil.colorHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
             String col = "<TD>" + sTerrain + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipTerrainBGColor())
@@ -137,7 +136,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     String sInvalidHex = Messages.getString("BoardView1.invalidHex");
                     sInvalidHex += "<BR>";
                     sInvalidHex += String.join("<BR>", errors);
-                    sInvalidHex = guiScaledFontHTML(GUIP.getUnitToolTipFGColor()) + sInvalidHex + "</FONT>";
+                    sInvalidHex = UIUtil.colorHTML(GUIP.getUnitToolTipFGColor()) + sInvalidHex + "</FONT>";
                     result += "<BR>" + sInvalidHex;
                 }
             }
@@ -157,7 +156,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     }
 
                     String sName = "&nbsp;&nbsp;" + player.getName();
-                    sName = guiScaledFontHTML(player.getColour().getColour()) + sName + "</FONT>";
+                    sName = UIUtil.colorHTML(player.getColour().getColour()) + sName + "</FONT>";
                     sAttilleryAutoHix += "<B>" + sName + "</B>";
                     sAttilleryAutoHix += "<BR>";
                 }
@@ -173,7 +172,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
             msg_artyautohit += Messages.getString("BoardView1.Tooltip.ArtyAutoHint3", keybindText);
             sAttilleryAutoHix += "<I>" + msg_artyautohit + "</I>";
 
-            sAttilleryAutoHix = guiScaledFontHTML(uiWhite()) + sAttilleryAutoHix + "</FONT>";
+            sAttilleryAutoHix = UIUtil.colorHTML(uiWhite()) + sAttilleryAutoHix + "</FONT>";
 
             String col = "<TD>" + sAttilleryAutoHix + "</TD>";
             String row = "<TR>" + col + "</TR>";
@@ -193,7 +192,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
         for (var wSprite : wreckList) {
             if (wSprite.getPosition().equals(coords)) {
                 String sWreck = wSprite.getTooltip().toString();
-                sWreck = guiScaledFontHTML(GUIP.getUnitToolTipAltFGColor()) + sWreck + "</FONT>";
+                sWreck = UIUtil.colorHTML(GUIP.getUnitToolTipAltFGColor()) + sWreck + "</FONT>";
                 String col = "<TD>" + sWreck + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String rows = row;
@@ -243,7 +242,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
             }
             sUnitsInfo += " in this hex...";
 
-            sUnitsInfo = guiScaledFontHTML(GUIP.getUnitToolTipBlockFGColor()) + sUnitsInfo + "</FONT>";
+            sUnitsInfo = UIUtil.colorHTML(GUIP.getUnitToolTipBlockFGColor()) + sUnitsInfo + "</FONT>";
             String col = "<TD>" + sUnitsInfo + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBlockBGColor())
@@ -255,7 +254,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
         for (AttackSprite aSprite : bv.getAttackSprites()) {
             if (aSprite.isInside(coords)) {
                 String sAttackSprite = aSprite.getTooltip().toString();
-                sAttackSprite = guiScaledFontHTML(GUIP.getUnitToolTipAltFGColor()) + sAttackSprite + "</FONT>";
+                sAttackSprite = UIUtil.colorHTML(GUIP.getUnitToolTipAltFGColor()) + sAttackSprite + "</FONT>";
                 String col = "<TD>" + sAttackSprite + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipAltBGColor())
@@ -294,7 +293,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                 msg_artilleryatack += Messages.getString("BoardView1.Tooltip.ArtilleryAttackN2", ammoName);
             }
 
-            msg_artilleryatack = guiScaledFontHTML(GUIP.getUnitToolTipBlockFGColor()) + msg_artilleryatack + "</FONT>";
+            msg_artilleryatack = UIUtil.colorHTML(GUIP.getUnitToolTipBlockFGColor()) + msg_artilleryatack + "</FONT>";
             String col = "<TD>" + msg_artilleryatack + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBlockBGColor())
@@ -321,7 +320,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
             } else {
                 msg_artilleryautohit = Messages.getString("BoardView1.ArtilleryAdjustment", amod);
             }
-            msg_artilleryautohit = guiScaledFontHTML(UIUtil.uiWhite()) + msg_artilleryautohit + "</FONT>";
+            msg_artilleryautohit = UIUtil.colorHTML(UIUtil.uiWhite()) + msg_artilleryautohit + "</FONT>";
             result += msg_artilleryautohit + "<BR>";
         }
 
@@ -350,7 +349,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     String buf = shd.getInfo();
                     buf = buf.replaceAll("\\n", "<BR>");
                     sSpecialHex += buf;
-                    sSpecialHex = guiScaledFontHTML(UIUtil.uiWhite()) + sSpecialHex + "</FONT>";
+                    sSpecialHex = UIUtil.colorHTML(UIUtil.uiWhite()) + sSpecialHex + "</FONT>";
                     sSpecialHex += "<BR>";
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/boardview/TWBoardViewTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TWBoardViewTooltip.java
@@ -101,7 +101,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     } else {
                         sTerrain += Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange1");
                         String tmp = Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange2");
-                        sTerrain += UIUtil.colorHTML(GUIP.getWarningColor()) + tmp + "<FONT>";
+                        sTerrain += UIUtil.fontHTML(GUIP.getWarningColor()) + tmp + "<FONT>";
                         sTerrain += Messages.getString("BoardView1.Tooltip.SensorsHexNotInRange3");
                     }
                 }
@@ -119,7 +119,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                 }
             }
 
-            sTerrain = UIUtil.colorHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
+            sTerrain = UIUtil.fontHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
             String col = "<TD>" + sTerrain + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipTerrainBGColor())
@@ -136,7 +136,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     String sInvalidHex = Messages.getString("BoardView1.invalidHex");
                     sInvalidHex += "<BR>";
                     sInvalidHex += String.join("<BR>", errors);
-                    sInvalidHex = UIUtil.colorHTML(GUIP.getUnitToolTipFGColor()) + sInvalidHex + "</FONT>";
+                    sInvalidHex = UIUtil.fontHTML(GUIP.getUnitToolTipFGColor()) + sInvalidHex + "</FONT>";
                     result += "<BR>" + sInvalidHex;
                 }
             }
@@ -156,7 +156,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     }
 
                     String sName = "&nbsp;&nbsp;" + player.getName();
-                    sName = UIUtil.colorHTML(player.getColour().getColour()) + sName + "</FONT>";
+                    sName = UIUtil.fontHTML(player.getColour().getColour()) + sName + "</FONT>";
                     sAttilleryAutoHix += "<B>" + sName + "</B>";
                     sAttilleryAutoHix += "<BR>";
                 }
@@ -172,7 +172,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
             msg_artyautohit += Messages.getString("BoardView1.Tooltip.ArtyAutoHint3", keybindText);
             sAttilleryAutoHix += "<I>" + msg_artyautohit + "</I>";
 
-            sAttilleryAutoHix = UIUtil.colorHTML(uiWhite()) + sAttilleryAutoHix + "</FONT>";
+            sAttilleryAutoHix = UIUtil.fontHTML(uiWhite()) + sAttilleryAutoHix + "</FONT>";
 
             String col = "<TD>" + sAttilleryAutoHix + "</TD>";
             String row = "<TR>" + col + "</TR>";
@@ -192,7 +192,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
         for (var wSprite : wreckList) {
             if (wSprite.getPosition().equals(coords)) {
                 String sWreck = wSprite.getTooltip().toString();
-                sWreck = UIUtil.colorHTML(GUIP.getUnitToolTipAltFGColor()) + sWreck + "</FONT>";
+                sWreck = UIUtil.fontHTML(GUIP.getUnitToolTipAltFGColor()) + sWreck + "</FONT>";
                 String col = "<TD>" + sWreck + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String rows = row;
@@ -242,7 +242,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
             }
             sUnitsInfo += " in this hex...";
 
-            sUnitsInfo = UIUtil.colorHTML(GUIP.getUnitToolTipBlockFGColor()) + sUnitsInfo + "</FONT>";
+            sUnitsInfo = UIUtil.fontHTML(GUIP.getUnitToolTipBlockFGColor()) + sUnitsInfo + "</FONT>";
             String col = "<TD>" + sUnitsInfo + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBlockBGColor())
@@ -254,7 +254,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
         for (AttackSprite aSprite : bv.getAttackSprites()) {
             if (aSprite.isInside(coords)) {
                 String sAttackSprite = aSprite.getTooltip().toString();
-                sAttackSprite = UIUtil.colorHTML(GUIP.getUnitToolTipAltFGColor()) + sAttackSprite + "</FONT>";
+                sAttackSprite = UIUtil.fontHTML(GUIP.getUnitToolTipAltFGColor()) + sAttackSprite + "</FONT>";
                 String col = "<TD>" + sAttackSprite + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipAltBGColor())
@@ -293,7 +293,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                 msg_artilleryatack += Messages.getString("BoardView1.Tooltip.ArtilleryAttackN2", ammoName);
             }
 
-            msg_artilleryatack = UIUtil.colorHTML(GUIP.getUnitToolTipBlockFGColor()) + msg_artilleryatack + "</FONT>";
+            msg_artilleryatack = UIUtil.fontHTML(GUIP.getUnitToolTipBlockFGColor()) + msg_artilleryatack + "</FONT>";
             String col = "<TD>" + msg_artilleryatack + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBlockBGColor())
@@ -320,7 +320,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
             } else {
                 msg_artilleryautohit = Messages.getString("BoardView1.ArtilleryAdjustment", amod);
             }
-            msg_artilleryautohit = UIUtil.colorHTML(UIUtil.uiWhite()) + msg_artilleryautohit + "</FONT>";
+            msg_artilleryautohit = UIUtil.fontHTML(UIUtil.uiWhite()) + msg_artilleryautohit + "</FONT>";
             result += msg_artilleryautohit + "<BR>";
         }
 
@@ -349,7 +349,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                     String buf = shd.getInfo();
                     buf = buf.replaceAll("\\n", "<BR>");
                     sSpecialHex += buf;
-                    sSpecialHex = UIUtil.colorHTML(UIUtil.uiWhite()) + sSpecialHex + "</FONT>";
+                    sSpecialHex = UIUtil.fontHTML(UIUtil.uiWhite()) + sSpecialHex + "</FONT>";
                     sSpecialHex += "<BR>";
                 }
             }

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -33,13 +33,10 @@ import java.util.regex.PatternSyntaxException;
 
 import javax.swing.*;
 import javax.swing.RowSorter.SortKey;
-import javax.swing.event.ChangeEvent;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.event.TableColumnModelEvent;
-import javax.swing.event.TableColumnModelListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
@@ -52,7 +49,6 @@ import megamek.client.ui.models.XTableColumnModel;
 import megamek.client.ui.panes.EntityViewPane;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import megamek.common.EntityWeightClass;
 import megamek.common.MekFileParser;
@@ -260,10 +256,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
         scrollTableUnits = new JScrollPane(tableUnits);
         scrollTableUnits.setName("scrollTableUnits");
-
-        unitModel.addTableModelListener((e) -> UIUtil.updateRowHeightsForEqualHeights(tableUnits));
-        sorter.addRowSorterListener((e) -> UIUtil.updateRowHeightsForEqualHeights(tableUnits));
-        unitColumnModel.addColumnModelListener(columnModelListener);
 
         gridBagConstraints.insets = new Insets(5, 0, 0, 0);
         gridBagConstraints.gridx = 0;
@@ -782,10 +774,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         buttonResetSearch.setEnabled(false);
         filterUnits();
 
-        if (visible) {
-            adaptToGUIScale();
-        }
-
         validate();
         repaint();
         super.setVisible(visible);
@@ -1146,40 +1134,4 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
             }
         }
     }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-        setMinimumSize(UIUtil.scaleForGUI(new Dimension(700, 500)));
-        textFilter.setMinimumSize(UIUtil.scaleForGUI(new Dimension(200, 28)));
-        textFilter.setPreferredSize(UIUtil.scaleForGUI(new Dimension(200, 28)));
-        techLevelScroll.setMinimumSize(UIUtil.scaleForGUI(new Dimension(300, 100)));
-        techLevelScroll.setPreferredSize(UIUtil.scaleForGUI(new Dimension(300, 100)));
-    }
-
-    TableColumnModelListener columnModelListener = new TableColumnModelListener() {
-
-        @Override
-        public void columnAdded(TableColumnModelEvent e) {
-        }
-
-        @Override
-        public void columnRemoved(TableColumnModelEvent e) {
-        }
-
-        @Override
-        public void columnMoved(TableColumnModelEvent e) {
-            UIUtil.updateRowHeightsForEqualHeights(tableUnits);
-        }
-
-        @Override
-        public void columnMarginChanged(ChangeEvent e) {
-            UIUtil.updateRowHeightsForEqualHeights(tableUnits);
-        }
-
-        @Override
-        public void columnSelectionChanged(ListSelectionEvent e) {
-            if (!e.getValueIsAdjusting())
-                UIUtil.updateRowHeightsForEqualHeights(tableUnits);
-        }
-    };
 }

--- a/megamek/src/megamek/client/ui/swing/dialog/AdvancedSearchDialog2.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AdvancedSearchDialog2.java
@@ -51,9 +51,6 @@ public class AdvancedSearchDialog2 extends AbstractButtonDialog {
     @Override
     public void setVisible(boolean b) {
         alphaStrikeTab.saveValues();
-        if (b) {
-            adaptToGUIScale();
-        }
         super.setVisible(b);
     }
 
@@ -95,10 +92,5 @@ public class AdvancedSearchDialog2 extends AbstractButtonDialog {
 
     public TWAdvancedSearchPanel getTWAdvancedSearch() {
         return totalWarTab;
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-        totalWarTab.adaptToGUIScale();
     }
 }

--- a/megamek/src/megamek/client/ui/swing/dialog/FloodDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/FloodDialog.java
@@ -31,7 +31,7 @@ import static megamek.client.ui.Messages.*;
 public final class FloodDialog extends AbstractButtonDialog {
 
     private BoardEditor.EditorTextField txtLevelChange = new BoardEditor.EditorTextField("0", 5, -5, 15);
-    private MMToggleButton butRemove = new MMToggleButton(scaleStringForGUI(getString("FloodDialog.removeButton")));
+    private MMToggleButton butRemove = new MMToggleButton(getString("FloodDialog.removeButton"));
 
     /** Constructs a modal LevelChangeDialog with frame as parent. */
     public FloodDialog(JFrame frame) {
@@ -47,17 +47,15 @@ public final class FloodDialog extends AbstractButtonDialog {
 
         JPanel textFieldPanel = new FixedYPanel();
         textFieldPanel.add(txtLevelChange);
-        
+
         JPanel toggleButtonPanel = new FixedYPanel();
         toggleButtonPanel.add(butRemove);
-        
-        JLabel labInfo = new JLabel(scaleStringForGUI("<CENTER>" + getString("FloodDialog.info")), 
-                SwingConstants.CENTER);
+
+        JLabel labInfo = new JLabel("<CENTER>" + getString("FloodDialog.info"), SwingConstants.CENTER);
         labInfo.setAlignmentX(CENTER_ALIGNMENT);
-        JLabel labRemoveInfo = new JLabel(scaleStringForGUI("<CENTER>" + getString("FloodDialog.removeInfo")), 
-                SwingConstants.CENTER);
+        JLabel labRemoveInfo = new JLabel("<CENTER>" + getString("FloodDialog.removeInfo"), SwingConstants.CENTER);
         labRemoveInfo.setAlignmentX(CENTER_ALIGNMENT);
-        
+
         result.add(Box.createVerticalGlue());
         result.add(labInfo);
         result.add(Box.createVerticalStrut(5));
@@ -67,10 +65,10 @@ public final class FloodDialog extends AbstractButtonDialog {
         result.add(Box.createVerticalStrut(5));
         result.add(toggleButtonPanel);
         result.add(Box.createVerticalGlue());
-        
+
         return result;
     }
-    
+
     /** Returns the level change entered by the user or 0, if it cannot be parsed. */
     public int getLevelChange() {
         try {
@@ -79,7 +77,7 @@ public final class FloodDialog extends AbstractButtonDialog {
             return 0;
         }
     }
-    
+
     /** Returns if all newly submerged hexes should have their terrain removed. */
     public boolean getRemoveTerrain() {
         return butRemove.isSelected();

--- a/megamek/src/megamek/client/ui/swing/dialog/LevelChangeDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/LevelChangeDialog.java
@@ -28,12 +28,12 @@ import megamek.client.ui.swing.BoardEditor;
 import static megamek.client.ui.swing.util.UIUtil.*;
 import static megamek.client.ui.Messages.*;
 
-/** 
+/**
  * A Board Editor dialog asking the user for a desired level change for the board.
- * {@link #getLevelChange()} reports the result of the dialog. 
- */ 
+ * {@link #getLevelChange()} reports the result of the dialog.
+ */
 public final class LevelChangeDialog extends AbstractButtonDialog {
-    
+
     private BoardEditor.EditorTextField txtLevelChange = new BoardEditor.EditorTextField("1", 5, -10, 15);
 
     /** Constructs a modal LevelChangeDialog with frame as parent. */
@@ -50,20 +50,19 @@ public final class LevelChangeDialog extends AbstractButtonDialog {
 
         JPanel textFieldPanel = new FixedYPanel();
         textFieldPanel.add(txtLevelChange);
-        
-        JLabel labInfo = new JLabel(scaleStringForGUI("<CENTER>" + getString("LCDialog.info")), 
-                SwingConstants.CENTER);
+
+        JLabel labInfo = new JLabel("<CENTER>" + getString("LCDialog.info"), SwingConstants.CENTER);
         labInfo.setAlignmentX(CENTER_ALIGNMENT);
-        
+
         result.add(Box.createVerticalGlue());
         result.add(labInfo);
         result.add(Box.createVerticalStrut(5));
         result.add(textFieldPanel);
         result.add(Box.createVerticalGlue());
-        
+
         return result;
     }
-    
+
     /** Returns the level change entered by the user or 0, if it cannot be parsed. */
     public int getLevelChange() {
         try {

--- a/megamek/src/megamek/client/ui/swing/dialog/MMConfirmDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MMConfirmDialog.java
@@ -1,16 +1,16 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
-*/ 
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
+*/
 package megamek.client.ui.swing.dialog;
 
 import java.awt.BorderLayout;
@@ -27,25 +27,25 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientDialog;
 import megamek.client.ui.swing.util.UIUtil;
 
-/** 
+/**
  * A simple modal confirmation dialog showing a single question and YES
- * and NO buttons. This dialog will scale with the gui scaling (and I 
+ * and NO buttons. This dialog will scale with the gui scaling (and I
  * found no way to do this for JOptionDialog)
- *  
+ *
  * @author Juliez
  */
 public class MMConfirmDialog {
-    
-    private final static Dimension MINIMUM_SIZE = new Dimension(400, 180); 
+
+    private final static Dimension MINIMUM_SIZE = new Dimension(400, 180);
     private final static int BASE_WIDTH = 400;
 
     /** Shows a modal confirmation dialog with a YES and a NO button. The String title
      * is shown as the window title. The given message is shown as the question to be confirmed
      * in the center of the dialog.
-     * 
+     *
      * <BR><BR>Returns Response.YES when the user pressed ENTER or selected YES,
      * Response.NO otherwise.
-     * 
+     *
      * <BR><BR>The dialog scales itself with the current GUI scale. It closes when ESC is pressed.
      */
     public static boolean confirm(JFrame owner, String title, String message) {
@@ -54,21 +54,21 @@ public class MMConfirmDialog {
         dialog.setVisible(true);
         return dialog.userResponse;
     }
-    
+
     // PRIVATE
-    
+
     private static class ConfirmDialog extends ClientDialog {
-        
+
         private static final long serialVersionUID = -2877691301521648979L;
 
         private boolean userResponse = false;
-        
+
         private JPanel panButtons = new JPanel(new FlowLayout(FlowLayout.CENTER, 20, 10));
         private JButton butYes = new DialogButton(Messages.getString("Yes"));
         private JButton butNo = new DialogButton(Messages.getString("No"));
-        
+
         public ConfirmDialog(JFrame owner, String title, String message) {
-            super(owner, title, true, true);
+            super(owner, title, true);
             addWindowListener(new WindowAdapter() {
                 @Override
                 public void windowClosed(WindowEvent e) {
@@ -104,13 +104,13 @@ public class MMConfirmDialog {
         private void respondNo() {
             setVisible(false);
         }
-        
+
         private void respondYes() {
             userResponse = true;
             setVisible(false);
         }
 
-        KeyListener k = new KeyAdapter() { 
+        KeyListener k = new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
                 if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {

--- a/megamek/src/megamek/client/ui/swing/dialog/MMConfirmDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MMConfirmDialog.java
@@ -86,7 +86,7 @@ public class MMConfirmDialog {
             lblMain.setHorizontalAlignment(JLabel.CENTER);
             lblMain.setBorder(new EmptyBorder(0, 20, 0, 20));
             add(lblMain, BorderLayout.CENTER);
-            setMinimumSize(UIUtil.scaleForGUI(MINIMUM_SIZE));
+            setMinimumSize(MINIMUM_SIZE);
             center();
             // Make the dialog take ENTER as Yes and ESC as No
             getRootPane().setDefaultButton(butYes);

--- a/megamek/src/megamek/client/ui/swing/dialog/MultiIntSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MultiIntSelectorDialog.java
@@ -20,7 +20,6 @@
 package megamek.client.ui.swing.dialog;
 
 import static megamek.client.ui.Messages.getString;
-import static megamek.client.ui.swing.util.UIUtil.scaleStringForGUI;
 
 import java.awt.Container;
 import java.util.List;
@@ -77,8 +76,7 @@ public class MultiIntSelectorDialog extends AbstractButtonDialog {
         JPanel listFieldPanel = new FixedYPanel();
         listFieldPanel.add(list);
 
-        JLabel labInfo = new JLabel(scaleStringForGUI("<CENTER>" + description),
-                SwingConstants.CENTER);
+        JLabel labInfo = new JLabel("<CENTER>" + description, SwingConstants.CENTER);
         labInfo.setAlignmentX(CENTER_ALIGNMENT);
 
         result.add(Box.createVerticalGlue());

--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
@@ -81,13 +81,13 @@ class ForceDisplayMekCellFormatter {
             }
 
             uType = DOT_SPACER + uType + DOT_SPACER;
-            value += guiScaledFontHTML() + uType + "</FONT>";;
+            value += uType;
             return UnitToolTip.wrapWithHTML(value);
         } else if (showAsUnknown) {
             return "";
         }
 
-        StringBuilder result = new StringBuilder("<NOBR>&nbsp;&nbsp;" + guiScaledFontHTML());
+        StringBuilder result = new StringBuilder("<NOBR>&nbsp;&nbsp;");
         boolean isCarried = entity.getTransportId() != Entity.NONE;
 
         Color color = GUIP.getEnemyUnitColor();
@@ -98,11 +98,11 @@ class ForceDisplayMekCellFormatter {
         }
 
         if (entity.getForceId() == Force.NO_FORCE) {
-            result.append(guiScaledFontHTML(color) + "\u25AD" + "</FONT>");
+            result.append(colorHTML(color) + "\u25AD" + "</FONT>");
         }
 
         String id = MessageFormat.format("[{0}] ", entity.getId());
-        result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + id + "</FONT>");
+        result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + id + "</FONT>");
 
         // Done
         if (!game.getPhase().isReport()) {
@@ -112,26 +112,25 @@ class ForceDisplayMekCellFormatter {
             } else {
                 done = "\u2611 ";
             }
-            result.append(guiScaledFontHTML(color) + done + "</FONT>");
+            result.append(colorHTML(color) + done + "</FONT>");
         }
 
         // Unit name
         // Gray out if the unit is a fighter in a squadron
         if (entity.isPartOfFighterSquadron()) {
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + entity.getShortNameRaw() + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + entity.getShortNameRaw() + "</FONT>");
         } else {
             result.append(entity.getShortNameRaw());
         }
 
         // Pilot
         Crew pilot = entity.getCrew();
-        result.append(guiScaledFontHTML());
         result.append(DOT_SPACER);
 
         if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
             result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
         } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + "<B>'");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + "<B>'");
             result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
             if (!pilot.getStatusDesc(0).isEmpty()) {
                 result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -151,7 +150,7 @@ class ForceDisplayMekCellFormatter {
         NumberFormat formatter = NumberFormat.getNumberInstance(MegaMek.getMMOptions().getLocale());
         String tonnage = formatter.format(entity.getWeight());
         tonnage += Messages.getString("ChatLounge.Tons");
-        result.append(guiScaledFontHTML() + tonnage + "</FONT>");
+        result.append(tonnage);
 
         // Alpha Strike Unit Role
         if (!entity.isUnitGroup()) {
@@ -165,7 +164,7 @@ class ForceDisplayMekCellFormatter {
         if (pilot.countOptions() > 0) {
             firstEntry = dotSpacerOnlyFirst(result, firstEntry);
             String quirks = Messages.getString("ChatLounge.abilities");
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipQuirkColor()) + quirks + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipQuirkColor()) + quirks + "</FONT>");
         }
 
         // ECM
@@ -193,7 +192,7 @@ class ForceDisplayMekCellFormatter {
             } else {
                 c3Name += CONNECTED_SIGN + entity.getC3NetId();
             }
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + c3Name + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + c3Name + "</FONT>");
         }
 
         if (entity.hasC3()) {
@@ -222,7 +221,7 @@ class ForceDisplayMekCellFormatter {
                 c3 += entity.getC3Master().getChassis();
             }
 
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + c3 + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + c3 + "</FONT>");
         }
 
         // Loaded onto another unit
@@ -231,12 +230,12 @@ class ForceDisplayMekCellFormatter {
             result.append(DOT_SPACER);
             String carried = "(" + loader.getChassis() + " [" + entity.getTransportId() + "])";
             carried = "<I>" + carried + "</I>";
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + carried + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + carried + "</FONT>");
         }
 
         if (entity.countPartialRepairs() > 0) {
             result.append(DOT_SPACER);
-            result.append(guiScaledFontHTML(GUIP.getWarningColor()) + "Partial Repairs" + "</FONT>");
+            result.append(colorHTML(GUIP.getWarningColor()) + "Partial Repairs" + "</FONT>");
         }
 
         // Offboard deployment
@@ -244,7 +243,7 @@ class ForceDisplayMekCellFormatter {
             result.append(DOT_SPACER);
             String msg_offboard = Messages.getString("ChatLounge.compact.deploysOffBoard");
             msg_offboard = "<I>" + msg_offboard + "</I>";
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_offboard + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_offboard + "</FONT>");
         } else if (!entity.isDeployed()) {
             result.append(DOT_SPACER);
             String msg_deploy = Messages.getString("ChatLounge.compact.deployRound", entity.getDeployRound());
@@ -254,7 +253,7 @@ class ForceDisplayMekCellFormatter {
                         IStartingPositions.START_LOCATION_NAMES[entity.getStartingPos(false)]);
             }
             msg_deploy = "<I>" + msg_deploy + msg_zone + "</I>";
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_deploy + "</FONT>");
+            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_deploy + "</FONT>");
         }
 
         // Starting values for Altitude / Velocity / Elevation
@@ -275,13 +274,13 @@ class ForceDisplayMekCellFormatter {
                     msg_fuel += aero.getCurrentFuel();
                 }
                 msg_vel = "<I>" + msg_vel + msg_alt + msg_fuel + "</I>";
-                result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_vel + "</FONT>");
+                result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_vel + "</FONT>");
             } else if (entity.getPosition() != null && ((entity.getElevation() != 0) || (entity instanceof VTOL))) {
                 result.append(DOT_SPACER);
                 String msg_ele = Messages.getString("ChatLounge.compact.elevation") + ": ";
                 msg_ele += entity.getElevation();
                 msg_ele = "<I>" + msg_ele + "</I>;";
-                result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_ele + "</FONT>");
+                result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_ele + "</FONT>");
             }
         }
 
@@ -289,7 +288,7 @@ class ForceDisplayMekCellFormatter {
         if (!localPlayer.equals(owner)) {
             result.append(DOT_SPACER);
             String player = entity.getOwner().getName() + " \u2691 ";
-            result.append(guiScaledFontHTML(color) + player + "</FONT>");
+            result.append(colorHTML(color) + player + "</FONT>");
         }
 
         return UnitToolTip.wrapWithHTML(result.toString());

--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekCellFormatter.java
@@ -24,6 +24,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.force.Force;
 import megamek.common.options.GameOptions;
@@ -98,11 +99,11 @@ class ForceDisplayMekCellFormatter {
         }
 
         if (entity.getForceId() == Force.NO_FORCE) {
-            result.append(colorHTML(color) + "\u25AD" + "</FONT>");
+            result.append(UIUtil.fontHTML(color) + "\u25AD" + "</FONT>");
         }
 
         String id = MessageFormat.format("[{0}] ", entity.getId());
-        result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + id + "</FONT>");
+        result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + id + "</FONT>");
 
         // Done
         if (!game.getPhase().isReport()) {
@@ -112,13 +113,13 @@ class ForceDisplayMekCellFormatter {
             } else {
                 done = "\u2611 ";
             }
-            result.append(colorHTML(color) + done + "</FONT>");
+            result.append(UIUtil.fontHTML(color) + done + "</FONT>");
         }
 
         // Unit name
         // Gray out if the unit is a fighter in a squadron
         if (entity.isPartOfFighterSquadron()) {
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + entity.getShortNameRaw() + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + entity.getShortNameRaw() + "</FONT>");
         } else {
             result.append(entity.getShortNameRaw());
         }
@@ -130,7 +131,7 @@ class ForceDisplayMekCellFormatter {
         if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
             result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
         } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + "<B>'");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + "<B>'");
             result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
             if (!pilot.getStatusDesc(0).isEmpty()) {
                 result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -164,20 +165,20 @@ class ForceDisplayMekCellFormatter {
         if (pilot.countOptions() > 0) {
             firstEntry = dotSpacerOnlyFirst(result, firstEntry);
             String quirks = Messages.getString("ChatLounge.abilities");
-            result.append(colorHTML(GUIP.getUnitToolTipQuirkColor()) + quirks + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipQuirkColor()) + quirks + "</FONT>");
         }
 
         // ECM
         if (entity.hasActiveECM()) {
             firstEntry = dotSpacerOnlyFirst(result, firstEntry);
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor(), 0.2f) + ECM_SIGN + "</FONT>");
+            result.append(fontHTML(GUIP.getUnitToolTipHighlightColor(), 0.2f) + ECM_SIGN + "</FONT>");
         }
 
         // Quirk Count
         int quirkCount = entity.countQuirks() + entity.countWeaponQuirks();
         if (quirkCount > 0) {
             firstEntry = dotSpacerOnlyFirst(result, firstEntry);
-            result.append(guiScaledFontHTML(GUIP.getUnitToolTipQuirkColor(), 0.2f) + QUIRKS_SIGN + "</FONT>");
+            result.append(fontHTML(GUIP.getUnitToolTipQuirkColor(), 0.2f) + QUIRKS_SIGN + "</FONT>");
         }
 
         // C3 ...
@@ -192,7 +193,7 @@ class ForceDisplayMekCellFormatter {
             } else {
                 c3Name += CONNECTED_SIGN + entity.getC3NetId();
             }
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + c3Name + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + c3Name + "</FONT>");
         }
 
         if (entity.hasC3()) {
@@ -221,7 +222,7 @@ class ForceDisplayMekCellFormatter {
                 c3 += entity.getC3Master().getChassis();
             }
 
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + c3 + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + c3 + "</FONT>");
         }
 
         // Loaded onto another unit
@@ -230,12 +231,12 @@ class ForceDisplayMekCellFormatter {
             result.append(DOT_SPACER);
             String carried = "(" + loader.getChassis() + " [" + entity.getTransportId() + "])";
             carried = "<I>" + carried + "</I>";
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + carried + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + carried + "</FONT>");
         }
 
         if (entity.countPartialRepairs() > 0) {
             result.append(DOT_SPACER);
-            result.append(colorHTML(GUIP.getWarningColor()) + "Partial Repairs" + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getWarningColor()) + "Partial Repairs" + "</FONT>");
         }
 
         // Offboard deployment
@@ -243,7 +244,7 @@ class ForceDisplayMekCellFormatter {
             result.append(DOT_SPACER);
             String msg_offboard = Messages.getString("ChatLounge.compact.deploysOffBoard");
             msg_offboard = "<I>" + msg_offboard + "</I>";
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_offboard + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_offboard + "</FONT>");
         } else if (!entity.isDeployed()) {
             result.append(DOT_SPACER);
             String msg_deploy = Messages.getString("ChatLounge.compact.deployRound", entity.getDeployRound());
@@ -253,7 +254,7 @@ class ForceDisplayMekCellFormatter {
                         IStartingPositions.START_LOCATION_NAMES[entity.getStartingPos(false)]);
             }
             msg_deploy = "<I>" + msg_deploy + msg_zone + "</I>";
-            result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_deploy + "</FONT>");
+            result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_deploy + "</FONT>");
         }
 
         // Starting values for Altitude / Velocity / Elevation
@@ -274,13 +275,13 @@ class ForceDisplayMekCellFormatter {
                     msg_fuel += aero.getCurrentFuel();
                 }
                 msg_vel = "<I>" + msg_vel + msg_alt + msg_fuel + "</I>";
-                result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_vel + "</FONT>");
+                result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_vel + "</FONT>");
             } else if (entity.getPosition() != null && ((entity.getElevation() != 0) || (entity instanceof VTOL))) {
                 result.append(DOT_SPACER);
                 String msg_ele = Messages.getString("ChatLounge.compact.elevation") + ": ";
                 msg_ele += entity.getElevation();
                 msg_ele = "<I>" + msg_ele + "</I>;";
-                result.append(colorHTML(GUIP.getUnitToolTipHighlightColor()) + msg_ele + "</FONT>");
+                result.append(UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + msg_ele + "</FONT>");
             }
         }
 
@@ -288,7 +289,7 @@ class ForceDisplayMekCellFormatter {
         if (!localPlayer.equals(owner)) {
             result.append(DOT_SPACER);
             String player = entity.getOwner().getName() + " \u2691 ";
-            result.append(colorHTML(color) + player + "</FONT>");
+            result.append(UIUtil.fontHTML(color) + player + "</FONT>");
         }
 
         return UnitToolTip.wrapWithHTML(result.toString());
@@ -326,22 +327,22 @@ class ForceDisplayMekCellFormatter {
         } else {
             fLevel = "\u25E5&nbsp;&nbsp; ";
         }
-        result.append(guiScaledFontHTML(color, size) + fLevel +  "</FONT>");
+        result.append(fontHTML(color, size) + fLevel +  "</FONT>");
 
         // Name
         String fName = force.getName();
         fName = "<B>" + fName + "</B>";
-        result.append(guiScaledFontHTML(color, size) + fName +  "</FONT>");
+        result.append(fontHTML(color, size) + fName +  "</FONT>");
 
         // ID
         String id = " [" + force.getId() + "]";
-        result.append(guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor(), size) + id + "</FONT>");
+        result.append(fontHTML(GUIP.getUnitToolTipHighlightColor(), size) + id + "</FONT>");
 
         // Display force owner
         if ((ownerId != client.getLocalPlayerNumber()) && (owner != null)) {
             result.append(DOT_SPACER);
             String oName = "\u2691 " + owner.getName();
-            result.append(guiScaledFontHTML(color, size) + oName + "</FONT>");
+            result.append(fontHTML(color, size) + oName + "</FONT>");
         }
 
         // BV
@@ -352,7 +353,7 @@ class ForceDisplayMekCellFormatter {
         if (totalBv > 0) {
             String msg_bvplain = Messages.getString("ChatLounge.BVplain");
             msg_bvplain =  msg_bvplain + " " + String.format("%,d", totalBv);
-            result.append(guiScaledFontHTML(color, size) + msg_bvplain  + "</FONT>");
+            result.append(fontHTML(color, size) + msg_bvplain  + "</FONT>");
 
             // Unit Type
             long unittypes = fullEntities.stream().map(e -> Entity.getEntityMajorTypeName(e.getEntityType())).distinct().count();
@@ -360,15 +361,15 @@ class ForceDisplayMekCellFormatter {
 
             if (unittypes > 1) {
                 String msg_mixed = Messages.getString("ChatLounge.Mixed");
-                result.append(guiScaledFontHTML(color, size) + msg_mixed + "</FONT>");
+                result.append(fontHTML(color, size) + msg_mixed + "</FONT>");
             } else if (unittypes == 1) {
                 Entity entity = CollectionUtil.anyOneElement(fullEntities);
                 String eType = UnitType.getTypeName(entity.getUnitType());
-                result.append(guiScaledFontHTML(color, size) + eType + "</FONT>");
+                result.append(fontHTML(color, size) + eType + "</FONT>");
             }
 
         } else {
-            result.append(guiScaledFontHTML(color, size) + "Empty" + "</FONT>");
+            result.append(fontHTML(color, size) + "Empty" + "</FONT>");
         }
 
         return UnitToolTip.wrapWithHTML(result.toString());

--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayPanel.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayPanel.java
@@ -33,7 +33,6 @@ import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.lobby.LobbyUtility;
 import megamek.client.ui.swing.util.ScalingPopup;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
 import megamek.common.Game;
 import megamek.common.event.*;
@@ -73,8 +72,6 @@ public class ForceDisplayPanel extends JPanel implements GameListener, IPreferen
         forceTree.addMouseListener(mekForceTreeMouseListener);
         clientgui.getClient().getGame().addGameListener(this);
         GUIP.addPreferenceChangeListener(this);
-
-        adaptToGUIScale();
     }
 
     private void setupForce() {
@@ -338,16 +335,8 @@ public class ForceDisplayPanel extends JPanel implements GameListener, IPreferen
         // noaction default
     }
 
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(this, UIUtil.FONT_SCALE1);
-    }
-
     @Override
     public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        }
         if (e.getName().equals(GUIPreferences.FORCE_DISPLAY_ENABLED)) {
             refreshTree();
         }

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/ConnectDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/ConnectDialog.java
@@ -26,7 +26,6 @@ import java.awt.event.ActionEvent;
 import javax.swing.*;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.server.Server;
 
 /** The Connect to game (as Bot or Player) dialog */
@@ -56,7 +55,7 @@ public class ConnectDialog extends AbstractGameConnectionDialog {
         serverAddressField.addActionListener(this);
         setPortField(new JTextField(getClientPreferences().getLastConnectPort() + "", 4));
         getPortField().addActionListener(this);
-        
+
         JPanel middlePanel = new JPanel(new GridBagLayout());
         GridBagConstraints c = new GridBagConstraints();
         c.fill = GridBagConstraints.NONE;
@@ -64,7 +63,7 @@ public class ConnectDialog extends AbstractGameConnectionDialog {
         c.weighty = 0.0;
         c.insets = new Insets(5, 5, 5, 5);
         c.gridwidth = 1;
-        
+
         addOptionRow(middlePanel, c, yourNameL, getPlayerNameField());
         addOptionRow(middlePanel, c, serverAddrL, serverAddressField);
         addOptionRow(middlePanel, c, portL, getPortField());
@@ -106,18 +105,5 @@ public class ConnectDialog extends AbstractGameConnectionDialog {
         // update settings
         getClientPreferences().setLastConnectAddr(getServerAddress());
         setVisible(false);
-    }
-    
-    @Override
-    public void setVisible(boolean b) {
-        if (b) {
-            adaptToGUIScale();
-            pack();
-        }
-        super.setVisible(b);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/HostDialog.java
@@ -27,7 +27,6 @@ import java.util.Vector;
 import javax.swing.*;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.server.Server;
 
 /**
@@ -35,7 +34,7 @@ import megamek.server.Server;
  */
 public class HostDialog extends AbstractGameConnectionDialog {
     private static final long serialVersionUID = -103094006944170081L;
-    
+
     // Some fields are accessed for the results of the dialog
     private String serverPass;
     private boolean register;
@@ -173,18 +172,5 @@ public class HostDialog extends AbstractGameConnectionDialog {
         getClientPreferences().setLastServerPass(getServerPass());
         getClientPreferences().setValue("megamek.megamek.metaservername", getMetaserver());
         setVisible(false);
-    }
-    
-    @Override
-    public void setVisible(boolean b) {
-        if (b) {
-            adaptToGUIScale();
-            pack();
-        }
-        super.setVisible(b);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this,  UIUtil.FONT_SCALE1);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -63,7 +63,6 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
-import javax.swing.border.TitledBorder;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.event.ListSelectionEvent;
@@ -129,7 +128,6 @@ import megamek.common.util.CrewSkillSummaryUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.logging.MMLogger;
 import megamek.server.ServerBoardHelper;
-import megamek.utilities.BoardsTagger;
 
 public class ChatLounge extends AbstractPhaseDisplay implements
         ListSelectionListener, IMapSettingsObserver, IPreferenceChangeListener {
@@ -323,7 +321,6 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         setupUnitsPanel();
         setupMapPanel();
         refreshLabels();
-        adaptToGUIScale();
         setupListeners();
     }
 
@@ -3016,9 +3013,6 @@ public class ChatLounge extends AbstractPhaseDisplay implements
     @Override
     public void preferenceChange(PreferenceChangeEvent e) {
         switch (e.getName()) {
-            case GUIPreferences.GUI_SCALE:
-                adaptToGUIScale();
-                break;
             case ClientPreferences.SHOW_UNIT_ID:
                 setButUnitIDState();
                 mekModel.refreshCells();
@@ -3109,79 +3103,6 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             return;
         }
         column.setPreferredWidth(GUIP.getInt(key));
-    }
-
-    /** Adapts the whole Lobby UI (both panels) to the current guiScale. */
-    private void adaptToGUIScale() {
-        updateTableHeaders();
-        refreshLabels();
-        refreshCamoButton();
-        refreshMapButtons();
-        mekModel.refreshCells();
-
-        Font scaledFont = UIUtil.getScaledFont();
-
-        UIUtil.adjustContainer(splitPaneMain, UIUtil.FONT_SCALE1);
-        UIUtil.scaleComp(butDone, UIUtil.FONT_SCALE2);
-        UIUtil.scaleComp(butOptions, UIUtil.FONT_SCALE2);
-        UIUtil.scaleComp(butAdd, UIUtil.FONT_SCALE2);
-        UIUtil.scaleComp(butArmy, UIUtil.FONT_SCALE2);
-
-        setTableRowHeights();
-
-        String searchTip = Messages.getString("ChatLounge.map.searchTip") + "<BR>";
-        searchTip += autoTagHTMLTable();
-        fldSearch.setToolTipText(UIUtil.scaleStringForGUI(searchTip));
-
-        ((TitledBorder) panUnitInfo.getBorder()).setTitleFont(scaledFont);
-        ((TitledBorder) panPlayerInfo.getBorder()).setTitleFont(scaledFont);
-
-        int scaledBorder = UIUtil.scaleForGUI(TEAMOVERVIEW_BORDER);
-        panTeam.setBorder(new EmptyBorder(scaledBorder, scaledBorder, scaledBorder, scaledBorder));
-
-        butBoardPreview
-                .setToolTipText(scaleStringForGUI(Messages.getString("BoardSelectionDialog.ViewGameBoardTooltip")));
-        butSaveMapSetup.setToolTipText(scaleStringForGUI(Messages.getString("ChatLounge.map.saveMapSetupTip")));
-
-        Font scaledHelpFont = new Font(SuiteConstants.FONT_DIALOG, Font.PLAIN,
-                UIUtil.scaleForGUI(UIUtil.FONT_SCALE1 + 33));
-        butHelp.setFont(scaledHelpFont);
-
-        // Makes a new tooltip appear immediately (rescaled and possibly for a different
-        // unit)
-        ToolTipManager manager = ToolTipManager.sharedInstance();
-        long time = System.currentTimeMillis() - manager.getInitialDelay() + 1;
-        Point locationOnScreen = MouseInfo.getPointerInfo().getLocation();
-        Point locationOnComponent = new Point(locationOnScreen);
-        SwingUtilities.convertPointFromScreen(locationOnComponent, mekTable);
-        MouseEvent event = new MouseEvent(mekTable, -1, time, 0,
-                locationOnComponent.x, locationOnComponent.y, 0, 0, 1, false, 0);
-        manager.mouseMoved(event);
-    }
-
-    private String autoTagHTMLTable() {
-        String result = "<TABLE><TR>" + UIUtil.guiScaledFontHTML();
-        int colCount = 0;
-        var autoTags = BoardsTagger.Tags.values();
-        for (BoardsTagger.Tags tag : autoTags) {
-            if (colCount == 0) {
-                result += "<TR>";
-            }
-
-            result += "<TD>" + tag.getName() + "</TD>";
-            colCount++;
-
-            if (colCount == 3) {
-                colCount = 0;
-                result += "</TR>";
-            }
-        }
-
-        if (colCount != 0) {
-            result += "</TR>";
-        }
-        result += "</TABLE>";
-        return result;
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2467,7 +2467,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             if (tablePlayers.getSelectedRowCount() == 0) {
                 return;
             }
-            ScalingPopup popup = PlayerTablePopup.playerTablePopup(clientgui,
+            JPopupMenu popup = PlayerTablePopup.playerTablePopup(clientgui,
                     playerTableActionListener,
                     getSelectedPlayers(),
                     ServerBoardHelper.getPossibleGameBoard(mapSettings, true));
@@ -3046,7 +3046,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             String headerText = mekModel.getColumnName(i);
             // Add info about the current sorting
             if (activeSorter.getColumnIndex() == i) {
-                headerText += "&nbsp;&nbsp;&nbsp;" + colorHTML(uiGray());
+                headerText += "&nbsp;&nbsp;&nbsp;" + UIUtil.fontHTML(uiGray());
                 if (activeSorter.getSortingDirection() == MekTableSorter.Sorting.ASCENDING) {
                     headerText += "\u25B4 ";
                 } else {

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -32,7 +32,6 @@ import static megamek.client.ui.swing.lobby.LobbyUtility.isValidStartPos;
 import static megamek.client.ui.swing.lobby.LobbyUtility.mekReadoutAction;
 import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 import static megamek.client.ui.swing.util.UIUtil.scaleForGUI;
-import static megamek.client.ui.swing.util.UIUtil.scaleStringForGUI;
 import static megamek.client.ui.swing.util.UIUtil.setHighQualityRendering;
 import static megamek.client.ui.swing.util.UIUtil.uiGray;
 import static megamek.common.util.CollectionUtil.theElement;
@@ -1873,7 +1872,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             } else if (ev.getSource() == butHelp) {
                 File helpfile = new File(CL_KEY_FILEPATH_MAPASSEMBLYHELP);
                 final JDialog dialog = new ClientDialog(clientgui.getFrame(),
-                        Messages.getString("ChatLounge.map.title.mapAssemblyHelp"), true, true);
+                        Messages.getString("ChatLounge.map.title.mapAssemblyHelp"), true);
                 final int height = 600;
                 final int width = 600;
 
@@ -2143,7 +2142,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         String txt = Messages.getString("ChatLounge.GameYear");
         txt += opts.intOption(OptionsConstants.ALLOWED_YEAR);
         lblGameYear.setText(txt);
-        lblGameYear.setToolTipText(scaleStringForGUI(Messages.getString("ChatLounge.tooltip.techYear")));
+        lblGameYear.setToolTipText(Messages.getString("ChatLounge.tooltip.techYear"));
 
         String tlString = TechConstants.getLevelDisplayableName(TechConstants.T_TECH_UNKNOWN);
         IOption tlOpt = opts.getOption(OptionsConstants.ALLOWED_TECHLEVEL);
@@ -2151,7 +2150,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             tlString = tlOpt.stringValue();
         }
         lblTechLevel.setText(Messages.getString("ChatLounge.TechLevel") + tlString);
-        lblTechLevel.setToolTipText(scaleStringForGUI(Messages.getString("ChatLounge.tooltip.techYear")));
+        lblTechLevel.setToolTipText(Messages.getString("ChatLounge.tooltip.techYear"));
 
         txt = Messages.getString("ChatLounge.MapSummary");
         txt += (mapSettings.getBoardWidth() * mapSettings.getMapWidth()) + " x "
@@ -2176,7 +2175,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             }
             selectedMaps.append("<br>");
         }
-        lblMapSummary.setToolTipText(scaleStringForGUI(selectedMaps.toString()));
+        lblMapSummary.setToolTipText(selectedMaps.toString());
     }
 
     @Override
@@ -3043,7 +3042,6 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         mekTable.setRowHeight(UIUtil.scaleForGUI(rowbaseHeight));
         rowbaseHeight = butCompact.isSelected() ? MEKTABLE_ROWHEIGHT_COMPACT : MEKTREE_ROWHEIGHT_FULL;
         mekForceTree.setRowHeight(UIUtil.scaleForGUI(rowbaseHeight));
-        tablePlayers.rescale();
     }
 
     /** Refreshes the table headers of the MekTable and PlayerTable. */
@@ -3403,7 +3401,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             // Found or created an icon; finish the panel
             setText("");
             if (lisBoardsAvailable.isEnabled()) {
-                setToolTipText(scaleStringForGUI(createBoardTooltip(board)));
+                setToolTipText(createBoardTooltip(board));
             } else {
                 setToolTipText(null);
             }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -30,10 +30,7 @@ import static megamek.client.ui.swing.lobby.LobbyUtility.invalidBoardTip;
 import static megamek.client.ui.swing.lobby.LobbyUtility.isBoardFile;
 import static megamek.client.ui.swing.lobby.LobbyUtility.isValidStartPos;
 import static megamek.client.ui.swing.lobby.LobbyUtility.mekReadoutAction;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-import static megamek.client.ui.swing.util.UIUtil.scaleForGUI;
-import static megamek.client.ui.swing.util.UIUtil.setHighQualityRendering;
-import static megamek.client.ui.swing.util.UIUtil.uiGray;
+import static megamek.client.ui.swing.util.UIUtil.*;
 import static megamek.common.util.CollectionUtil.theElement;
 import static megamek.common.util.CollectionUtil.union;
 
@@ -62,11 +59,7 @@ import java.util.stream.Collectors;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.event.ListSelectionEvent;
-import javax.swing.event.ListSelectionListener;
-import javax.swing.event.MouseInputAdapter;
+import javax.swing.event.*;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumn;
@@ -169,7 +162,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
     private JButton butSaveList = new JButton(Messages.getString("ChatLounge.butSaveList"));
 
     /* Unit Table */
-    private JTable mekTable;
+    private MekTable mekTable;
     public JScrollPane scrMekTable;
     private MMToggleButton butCompact = new MMToggleButton(Messages.getString("ChatLounge.butCompact"));
     private MMToggleButton butShowUnitID = new MMToggleButton(Messages.getString("ChatLounge.butShowUnitID"));
@@ -3038,9 +3031,8 @@ public class ChatLounge extends AbstractPhaseDisplay implements
      * Sets the row height of the MekTable according to compact mode and GUI scale
      */
     private void setTableRowHeights() {
-        int rowbaseHeight = butCompact.isSelected() ? MEKTABLE_ROWHEIGHT_COMPACT : MEKTABLE_ROWHEIGHT_FULL;
-        mekTable.setRowHeight(UIUtil.scaleForGUI(rowbaseHeight));
-        rowbaseHeight = butCompact.isSelected() ? MEKTABLE_ROWHEIGHT_COMPACT : MEKTREE_ROWHEIGHT_FULL;
+        mekTable.setRowHeights();
+        int rowbaseHeight = butCompact.isSelected() ? MEKTABLE_ROWHEIGHT_COMPACT : MEKTREE_ROWHEIGHT_FULL;
         mekForceTree.setRowHeight(UIUtil.scaleForGUI(rowbaseHeight));
     }
 
@@ -3054,7 +3046,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
             String headerText = mekModel.getColumnName(i);
             // Add info about the current sorting
             if (activeSorter.getColumnIndex() == i) {
-                headerText += "&nbsp;&nbsp;&nbsp;" + guiScaledFontHTML(uiGray());
+                headerText += "&nbsp;&nbsp;&nbsp;" + colorHTML(uiGray());
                 if (activeSorter.getSortingDirection() == MekTableSorter.Sorting.ASCENDING) {
                     headerText += "\u25B4 ";
                 } else {
@@ -3419,10 +3411,22 @@ public class ChatLounge extends AbstractPhaseDisplay implements
     }
 
     private class MekTable extends JTable {
-        private static final long serialVersionUID = -4054214297803021212L;
 
         public MekTable(MekTableModel mekModel) {
             super(mekModel);
+            mekModel.addTableModelListener(e -> setRowHeights());
+            setRowHeights();
+        }
+
+        @Override
+        public void columnMarginChanged(ChangeEvent e) {
+            setRowHeights();
+            super.columnMarginChanged(e);
+        }
+
+        private void setRowHeights() {
+            int rowbaseHeight = butCompact.isSelected() ? MEKTABLE_ROWHEIGHT_COMPACT : MEKTABLE_ROWHEIGHT_FULL;
+            setRowHeight(UIUtil.scaleForGUI(rowbaseHeight));
         }
 
         /**

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -34,6 +34,7 @@ import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.util.PlayerColour;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
 import megamek.common.alphaStrike.AlphaStrikeElement;
 import megamek.common.force.Force;
@@ -81,7 +82,7 @@ class LobbyMekCellFormatter {
      * When blindDrop is true, the unit details are not given.
      */
     static String formatUnitFull(Entity entity, ChatLounge lobby, boolean forceView) {
-        StringBuilder result = new StringBuilder("<HTML><NOBR>" + guiScaledFontHTML());
+        StringBuilder result = new StringBuilder("<HTML><NOBR>" + fontHTML());
 
         Client client = lobby.getClientgui().getClient();
         Game game = client.getGame();
@@ -121,7 +122,7 @@ class LobbyMekCellFormatter {
 
         // First line
         if (LobbyUtility.hasYellowWarning(entity)) {
-            result.append(colorHTML(uiYellow()));
+            result.append(UIUtil.fontHTML(uiYellow()));
             result.append(WARNING_SIGN + "</FONT>");
             hasWarning = true;
         }
@@ -132,24 +133,24 @@ class LobbyMekCellFormatter {
                 || (entity.doomedOnGround() && mapType == MapSettings.MEDIUM_GROUND)
                 || (entity.doomedInSpace() && mapType == MapSettings.MEDIUM_SPACE)
                 || (!entity.isDesignValid())) {
-            result.append(colorHTML(GUIP.getWarningColor()));
+            result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
             result.append(WARNING_SIGN + "</FONT>");
             hasCritical = true;
         }
 
         // Unit Name
         if (hasCritical) {
-            result.append(colorHTML(GUIP.getWarningColor()));
+            result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
         } else if (hasWarning) {
-            result.append(colorHTML(uiYellow()));
+            result.append(UIUtil.fontHTML(uiYellow()));
         } else {
-            result.append(guiScaledFontHTML());
+            result.append(fontHTML());
         }
         result.append("<B>" + entity.getShortNameRaw() + "</B></FONT>");
 
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(colorHTML(uiGray()));
+            result.append(UIUtil.fontHTML(uiGray()));
             result.append(" [ID: " + entity.getId() + "]</FONT>");
         }
         if (!forceView) {
@@ -157,7 +158,7 @@ class LobbyMekCellFormatter {
         }
 
         // Tonnage
-        result.append(guiScaledFontHTML());
+        result.append(fontHTML());
         if (forceView) {
             result.append(DOT_SPACER);
         }
@@ -176,7 +177,7 @@ class LobbyMekCellFormatter {
         if (!forceView) {
             if (!entity.isDesignValid()) {
                 result.append(DOT_SPACER);
-                result.append(colorHTML(GUIP.getWarningColor()));
+                result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
                 result.append("\u26D4 ").append(Messages.getString("ChatLounge.invalidDesign"));
                 result.append("</FONT>");
             }
@@ -186,7 +187,7 @@ class LobbyMekCellFormatter {
         if (!forceView) {
             if (entity.isShutDown()) {
                 result.append(DOT_SPACER);
-                result.append(colorHTML(GUIP.getWarningColor()));
+                result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
                 result.append(WARNING_SIGN).append(Messages.getString("ChatLounge.shutdown"));
                 result.append("</FONT>");
             }
@@ -194,7 +195,7 @@ class LobbyMekCellFormatter {
 
         // ECM
         if (entity.hasActiveECM()) {
-            result.append(DOT_SPACER + colorHTML(uiC3Color()));
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiC3Color()));
             result.append(ECM_SIGN + " ");
             result.append(Messages.getString("BoardView1.ecmSource"));
             result.append("</FONT>");
@@ -204,7 +205,7 @@ class LobbyMekCellFormatter {
         int quirkCount = entity.countQuirks() + entity.countWeaponQuirks();
         if (quirkCount > 0) {
             result.append(DOT_SPACER);
-            result.append(colorHTML(uiQuirksColor()));
+            result.append(UIUtil.fontHTML(uiQuirksColor()));
             result.append(QUIRKS_SIGN);
             result.append(Messages.getString("ChatLounge.Quirks"));
             result.append("</FONT>");
@@ -213,13 +214,13 @@ class LobbyMekCellFormatter {
         // Pilot
         if (forceView) {
             Crew pilot = entity.getCrew();
-            result.append(guiScaledFontHTML());
+            result.append(fontHTML());
             result.append(DOT_SPACER);
 
             if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
                 result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
             } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-                result.append(colorHTML(uiNickColor()) + "<B>'");
+                result.append(UIUtil.fontHTML(uiNickColor()) + "<B>'");
                 result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
                 if (!pilot.getStatusDesc(0).isEmpty()) {
                     result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -231,7 +232,7 @@ class LobbyMekCellFormatter {
             final boolean rpgSkills = options.booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
             result.append(" (" + pilot.getSkillsAsString(rpgSkills) + ")");
             if (pilot.countOptions() > 0) {
-                result.append(DOT_SPACER + colorHTML(uiQuirksColor()));
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiQuirksColor()));
                 result.append(Messages.getString("ChatLounge.abilities"));
                 result.append("</FONT>");
             }
@@ -239,13 +240,13 @@ class LobbyMekCellFormatter {
             // Owner
             if (!localPlayer.equals(owner)) {
                 result.append(DOT_SPACER);
-                result.append(colorHTML(owner.getColour().getColour()));
+                result.append(UIUtil.fontHTML(owner.getColour().getColour()));
                 result.append("\u2691 ");
                 result.append(entity.getOwner().getName()).append("</FONT>");
             }
 
             // Info sign (i)
-            result.append(colorHTML(uiGreen()));
+            result.append(UIUtil.fontHTML(uiGreen()));
             result.append("&nbsp;  \u24D8</FONT>");
         }
 
@@ -262,7 +263,7 @@ class LobbyMekCellFormatter {
                 && (sp >= 0)) {
             firstEntry = dotSpacer(result, firstEntry);
             if (spe != Board.START_NONE) {
-                result.append(colorHTML(uiLightGreen()));
+                result.append(UIUtil.fontHTML(uiLightGreen()));
             }
             String msg_start = Messages.getString("ChatLounge.Start");
             result.append(" " + msg_start + ": ");
@@ -298,7 +299,7 @@ class LobbyMekCellFormatter {
         if (forceView) {
             if (!entity.isDesignValid()) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(GUIP.getWarningColor()));
+                result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
                 result.append("\u26D4 </FONT>").append(Messages.getString("ChatLounge.invalidDesign"));
             }
         }
@@ -306,7 +307,7 @@ class LobbyMekCellFormatter {
         // C3 ...
         if (entity.hasC3i()) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(colorHTML(uiC3Color()));
+            result.append(UIUtil.fontHTML(uiC3Color()));
             if (entity.calculateFreeC3Nodes() >= 5) {
                 result.append("C3i" + UNCONNECTED_SIGN);
             } else {
@@ -320,7 +321,7 @@ class LobbyMekCellFormatter {
 
         if (entity.hasNavalC3()) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(colorHTML(uiC3Color()));
+            result.append(UIUtil.fontHTML(uiC3Color()));
             if (entity.calculateFreeC3Nodes() >= 5) {
                 result.append("NC3" + UNCONNECTED_SIGN);
             } else {
@@ -337,13 +338,13 @@ class LobbyMekCellFormatter {
                 if (entity.hasC3S()) {
                     firstEntry = dotSpacer(result, firstEntry);
                     result.append(
-                            colorHTML(uiC3Color()) + Messages.getString("ChatLounge.C3S") + UNCONNECTED_SIGN);
+                            UIUtil.fontHTML(uiC3Color()) + Messages.getString("ChatLounge.C3S") + UNCONNECTED_SIGN);
                     result.append("</FONT>");
                 }
 
                 if (entity.hasC3M()) {
                     firstEntry = dotSpacer(result, firstEntry);
-                    result.append(colorHTML(uiC3Color()) + Messages.getString("ChatLounge.C3Master"));
+                    result.append(UIUtil.fontHTML(uiC3Color()) + Messages.getString("ChatLounge.C3Master"));
                     int freeS = entity.calculateFreeC3Nodes();
                     if (freeS == 0) {
                         result.append(" (full)");
@@ -354,7 +355,7 @@ class LobbyMekCellFormatter {
                 }
             } else if (entity.C3MasterIs(entity)) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(uiC3Color()) + Messages.getString("ChatLounge.C3CC"));
+                result.append(UIUtil.fontHTML(uiC3Color()) + Messages.getString("ChatLounge.C3CC"));
                 if (entity.hasC3MM()) {
                     String msg_freec3mnodes = Messages.getString("ChatLounge.FreeC3MNodes");
                     result.append(MessageFormat.format(" " + msg_freec3mnodes,
@@ -365,7 +366,7 @@ class LobbyMekCellFormatter {
                 result.append("</FONT>");
             } else {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(uiC3Color()));
+                result.append(UIUtil.fontHTML(uiC3Color()));
                 if (entity.hasC3S()) {
                     result.append(getString("ChatLounge.C3S") + CONNECTED_SIGN);
                 } else {
@@ -384,11 +385,11 @@ class LobbyMekCellFormatter {
         }
 
         // Loaded onto transport
-        result.append(colorHTML(uiGreen()));
+        result.append(UIUtil.fontHTML(uiGreen()));
         if (isCarried) {
             firstEntry = dotSpacer(result, firstEntry);
             Entity loader = entity.getGame().getEntity(entity.getTransportId());
-            result.append(colorHTML(uiGreen()) + LOADED_SIGN);
+            result.append(UIUtil.fontHTML(uiGreen()) + LOADED_SIGN);
             result.append("<I> " + Messages.getString("ChatLounge.aboard") + " " + loader.getChassis());
             if (PreferenceManager.getClientPreferences().getShowUnitId()) {
                 result.append(" [" + entity.getTransportId() + "]");
@@ -428,7 +429,7 @@ class LobbyMekCellFormatter {
         // Starting heat
         if (entity.getHeat() != 0 && entity.tracksHeat()) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(colorHTML(uiLightRed()));
+            result.append(UIUtil.fontHTML(uiLightRed()));
             result.append(entity.getHeat()).append(" Heat").append("</FONT>");
         }
 
@@ -436,7 +437,7 @@ class LobbyMekCellFormatter {
         int partRepCount = entity.countPartialRepairs();
         if ((partRepCount > 0)) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(colorHTML(uiLightRed()));
+            result.append(UIUtil.fontHTML(uiLightRed()));
             result.append(Messages.getString("ChatLounge.PartialRepairs"));
             result.append("</FONT>");
         }
@@ -446,7 +447,7 @@ class LobbyMekCellFormatter {
             if (entity.isAero()) {
                 IAero aero = (IAero) entity;
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(uiGreen()) + "<I>");
+                result.append(UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.velocity") + ": ");
                 result.append(aero.getCurrentVelocity());
                 if (mapType != MapSettings.MEDIUM_SPACE) {
@@ -460,7 +461,7 @@ class LobbyMekCellFormatter {
                 result.append("</I></FONT>");
             } else if ((entity.getElevation() != 0) || (entity instanceof VTOL)) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(uiGreen()) + "<I>");
+                result.append(UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.elevation") + ": ");
                 result.append(entity.getElevation() + "</I></FONT>");
             }
@@ -472,7 +473,7 @@ class LobbyMekCellFormatter {
             Mek mek = ((Mek) entity);
             if ((mek.hasEjectSeat()) && (!mek.isAutoEject())) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(uiYellow()));
+                result.append(UIUtil.fontHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF<I>");
                 result.append(msg_autoejectdisabled);
                 result.append("</I></FONT>");
@@ -485,7 +486,7 @@ class LobbyMekCellFormatter {
             if ((aero.hasEjectSeat())
                     && (!aero.isAutoEject())) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(colorHTML(uiYellow()));
+                result.append(UIUtil.fontHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF<I>");
                 result.append(msg_autoejectdisabled);
                 result.append("</I></FONT>");
@@ -513,7 +514,7 @@ class LobbyMekCellFormatter {
         if (hideEntity) {
             String value = "<HTML><NOBR>&nbsp;&nbsp;";
             if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-                value += colorHTML(uiGray());
+                value += UIUtil.fontHTML(uiGray());
                 value += MessageFormat.format("[{0}] </FONT>", entity.getId());
             }
             String uType = "";
@@ -534,10 +535,10 @@ class LobbyMekCellFormatter {
             } else {
                 uType = entity.getWeightClassName();
             }
-            return value + guiScaledFontHTML() + DOT_SPACER + uType + DOT_SPACER;
+            return value + fontHTML() + DOT_SPACER + uType + DOT_SPACER;
         }
 
-        StringBuilder result = new StringBuilder("<HTML><NOBR>&nbsp;&nbsp;" + guiScaledFontHTML());
+        StringBuilder result = new StringBuilder("<HTML><NOBR>&nbsp;&nbsp;" + fontHTML());
         boolean isCarried = entity.getTransportId() != Entity.NONE;
         int mapType = lobby.mapSettings.getMedium();
 
@@ -550,14 +551,14 @@ class LobbyMekCellFormatter {
         color = addGray(color, 128).brighter();
 
         if (entity.getForceId() == Force.NO_FORCE && forceView) {
-            result.append(colorHTML(color));
+            result.append(UIUtil.fontHTML(color));
             result.append("\u25AD </FONT>");
         }
 
         // Signs before the unit name
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(colorHTML(uiGray()));
+            result.append(UIUtil.fontHTML(uiGray()));
             result.append(MessageFormat.format("[{0}] </FONT>", entity.getId()));
         }
 
@@ -567,25 +568,25 @@ class LobbyMekCellFormatter {
                 || (entity.doomedOnGround() && mapType == MapSettings.MEDIUM_GROUND)
                 || (entity.doomedInSpace() && mapType == MapSettings.MEDIUM_SPACE)
                 || (!entity.isDesignValid())) {
-            result.append(colorHTML(GUIP.getWarningColor()));
+            result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
             result.append(WARNING_SIGN + "</FONT>");
         }
 
         // General (Yellow) Warnings
         if (LobbyUtility.hasYellowWarning(entity)) {
-            result.append(colorHTML(uiYellow()));
+            result.append(UIUtil.fontHTML(uiYellow()));
             result.append(WARNING_SIGN + "</FONT>");
         }
 
         // Loaded unit
         if (isCarried) {
-            result.append(colorHTML(uiGreen()) + LOADED_SIGN + "</FONT>");
+            result.append(UIUtil.fontHTML(uiGreen()) + LOADED_SIGN + "</FONT>");
         }
 
         // Unit name
         // Gray out if the unit is a fighter in a squadron
         if (entity.isPartOfFighterSquadron()) {
-            result.append(colorHTML(uiGray()));
+            result.append(UIUtil.fontHTML(uiGray()));
             result.append(entity.getShortNameRaw()).append("</FONT>");
         } else {
             result.append(entity.getShortNameRaw());
@@ -594,13 +595,13 @@ class LobbyMekCellFormatter {
         // Pilot
         if (forceView) {
             Crew pilot = entity.getCrew();
-            result.append(guiScaledFontHTML());
+            result.append(fontHTML());
             result.append(DOT_SPACER);
 
             if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
                 result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
             } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-                result.append(colorHTML(uiNickColor()) + "<B>'");
+                result.append(UIUtil.fontHTML(uiNickColor()) + "<B>'");
                 result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
                 if (!pilot.getStatusDesc(0).isEmpty()) {
                     result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -612,14 +613,14 @@ class LobbyMekCellFormatter {
             final boolean rpgSkills = options.booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
             result.append(" (" + pilot.getSkillsAsString(rpgSkills) + ")");
             if (pilot.countOptions() > 0) {
-                result.append(DOT_SPACER + colorHTML(uiQuirksColor()));
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiQuirksColor()));
                 result.append(Messages.getString("ChatLounge.abilities"));
             }
 
             // Owner
             if (!localPlayer.equals(owner)) {
                 result.append(DOT_SPACER);
-                result.append(colorHTML(owner.getColour().getColour()));
+                result.append(UIUtil.fontHTML(owner.getColour().getColour()));
                 result.append("\u2691 ");
                 result.append(entity.getOwner().getName()).append("</FONT>");
             }
@@ -628,13 +629,13 @@ class LobbyMekCellFormatter {
         // Invalid unit design
         if (!entity.isDesignValid()) {
             result.append(DOT_SPACER);
-            result.append(colorHTML(GUIP.getWarningColor()));
+            result.append(UIUtil.fontHTML(GUIP.getWarningColor()));
             result.append("\u26D4 </FONT>").append(Messages.getString("ChatLounge.invalidDesign"));
         }
 
         // ECM
         if (entity.hasActiveECM()) {
-            result.append(guiScaledFontHTML(uiC3Color(), 0.2f));
+            result.append(fontHTML(uiC3Color(), 0.2f));
             result.append(ECM_SIGN);
             result.append("</FONT>");
         }
@@ -642,14 +643,14 @@ class LobbyMekCellFormatter {
         // Quirk Count
         int quirkCount = entity.countQuirks() + entity.countWeaponQuirks();
         if (quirkCount > 0) {
-            result.append(guiScaledFontHTML(uiQuirksColor(), 0.2f));
+            result.append(fontHTML(uiQuirksColor(), 0.2f));
             result.append(QUIRKS_SIGN);
             result.append("</FONT>");
         }
 
         // C3 ...
         if (entity.hasC3i() || entity.hasNavalC3()) {
-            result.append(DOT_SPACER + colorHTML(uiC3Color()));
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiC3Color()));
             String msg_c3i = Messages.getString("ChatLounge.C3i");
             String msg_nc3 = Messages.getString("ChatLounge.NC3");
 
@@ -667,7 +668,7 @@ class LobbyMekCellFormatter {
             String msg_c3m = Messages.getString("ChatLounge.C3M");
             String msg_c3mcc = Messages.getString("ChatLounge.C3MCC");
 
-            result.append(DOT_SPACER + colorHTML(uiC3Color()));
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiC3Color()));
             if (entity.getC3Master() == null) {
                 if (entity.hasC3S()) {
                     result.append(msg_c3sabrv + UNCONNECTED_SIGN);
@@ -691,7 +692,7 @@ class LobbyMekCellFormatter {
         // Loaded onto another unit
         if (isCarried) {
             Entity loader = entity.getGame().getEntity(entity.getTransportId());
-            result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>(");
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>(");
             result.append(loader.getChassis());
             if (PreferenceManager.getClientPreferences().getShowUnitId()) {
                 result.append(" [" + entity.getTransportId() + "]");
@@ -702,32 +703,32 @@ class LobbyMekCellFormatter {
         // Deployment info, doesn't matter when the unit is carried
         if (!isCarried) {
             if (entity.isHidden()) {
-                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.hidden") + "</I></FONT>");
             }
 
             if (entity.isHullDown()) {
-                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.hulldown") + "</I></FONT>");
             }
 
             if (entity.isProne()) {
-                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.prone") + "</I></FONT>");
             }
         }
 
         if (entity.countPartialRepairs() > 0) {
-            result.append(DOT_SPACER + colorHTML(uiLightRed()));
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiLightRed()));
             result.append("Partial Repairs</FONT>");
         }
 
         // Offboard deployment
         if (entity.isOffBoard()) {
-            result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
             result.append(Messages.getString("ChatLounge.compact.deploysOffBoard") + "</I></FONT>");
         } else if (entity.getDeployRound() > 0) {
-            result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
             result.append(Messages.getString("ChatLounge.compact.deployRound", entity.getDeployRound()));
             if (entity.getStartingPos(false) != Board.START_NONE) {
                 result.append(Messages.getString("ChatLounge.compact.deployZone",
@@ -740,7 +741,7 @@ class LobbyMekCellFormatter {
         if (!isCarried) {
             if (entity.isAero()) {
                 IAero aero = (IAero) entity;
-                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.velocity") + ": ");
                 result.append(aero.getCurrentVelocity());
                 if (mapType != MapSettings.MEDIUM_SPACE) {
@@ -753,7 +754,7 @@ class LobbyMekCellFormatter {
                 }
                 result.append("</I></FONT>");
             } else if ((entity.getElevation() != 0) || (entity instanceof VTOL)) {
-                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.elevation") + ": ");
                 result.append(entity.getElevation() + "</I></FONT>");
             }
@@ -761,7 +762,7 @@ class LobbyMekCellFormatter {
 
         // Starting heat
         if (entity.getHeat() != 0 && entity.tracksHeat()) {
-            result.append(DOT_SPACER + colorHTML(uiGreen()));
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()));
             result.append("<I>Heat: ").append(entity.getHeat()).append(" </I></FONT>");
         }
 
@@ -769,7 +770,7 @@ class LobbyMekCellFormatter {
 
         // Info tooltip sign
         if (forceView) {
-            result.append(guiScaledFontHTML(uiGreen(), 0.3f));
+            result.append(fontHTML(uiGreen(), 0.3f));
             result.append("&nbsp;  \u24D8");
         }
 
@@ -777,8 +778,8 @@ class LobbyMekCellFormatter {
         if (entity instanceof Mek) {
             Mek mek = ((Mek) entity);
             if ((mek.hasEjectSeat()) && (!mek.isAutoEject())) {
-                result.append(DOT_SPACER + colorHTML(uiGreen()));
-                result.append(colorHTML(uiYellow()));
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()));
+                result.append(UIUtil.fontHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF</FONT>");
             }
         }
@@ -788,8 +789,8 @@ class LobbyMekCellFormatter {
             Aero aero = ((Aero) entity);
             if ((aero.hasEjectSeat())
                     && (!aero.isAutoEject())) {
-                result.append(DOT_SPACER + colorHTML(uiGreen()));
-                result.append(colorHTML(uiYellow()));
+                result.append(DOT_SPACER + UIUtil.fontHTML(uiGreen()));
+                result.append(UIUtil.fontHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF</FONT>");
             }
         }
@@ -834,7 +835,7 @@ class LobbyMekCellFormatter {
         color = addGray(color, 128).brighter();
 
         StringBuilder result = new StringBuilder("<HTML><NOBR>");
-        result.append(guiScaledFontHTML(color, size));
+        result.append(fontHTML(color, size));
 
         // A top-level / subforce special char
         if (force.isTopLevel()) {
@@ -848,24 +849,24 @@ class LobbyMekCellFormatter {
 
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(guiScaledFontHTML(uiGray(), size));
+            result.append(fontHTML(uiGray(), size));
             result.append(" [").append(force.getId()).append("]</FONT>");
         }
 
         // Display force owner
         if ((ownerId != client.getLocalPlayerNumber()) && (owner != null)) {
-            result.append(guiScaledFontHTML(size));
+            result.append(fontHTML(size));
             result.append(DOT_SPACER).append("</FONT>");
 
             PlayerColour ownerColour = (owner.getColour() == null) ? PlayerColour.FIRE_BRICK : owner.getColour();
-            result.append(guiScaledFontHTML(ownerColour.getColour(), size));
+            result.append(fontHTML(ownerColour.getColour(), size));
             result.append("\u2691 ");
             result.append(owner.getName()).append("</FONT>");
         }
 
         // BV
         List<Entity> fullEntities = ForceAssignable.filterToEntityList(lobby.game().getForces().getFullEntities(force));
-        result.append(guiScaledFontHTML(color, size));
+        result.append(fontHTML(color, size));
         result.append(DOT_SPACER);
         int totalBv = fullEntities.stream().filter(e -> !e.isPartOfFighterSquadron())
                 .mapToInt(Entity::calculateBattleValue).sum();
@@ -875,7 +876,7 @@ class LobbyMekCellFormatter {
             // Unit Type
             long unittypes = fullEntities.stream().map(e -> Entity.getEntityMajorTypeName(e.getEntityType())).distinct()
                     .count();
-            result.append(guiScaledFontHTML(color, size));
+            result.append(fontHTML(color, size));
             result.append(DOT_SPACER);
             if (unittypes > 1) {
                 String msg_mixed = Messages.getString("ChatLounge.Mixed");
@@ -901,7 +902,7 @@ class LobbyMekCellFormatter {
     static String formatPilotCompact(Entity entity, boolean blindDrop, boolean rpgSkills) {
         Crew pilot = entity.getCrew();
         StringBuilder result = new StringBuilder("<HTML><NOBR>");
-        result.append(guiScaledFontHTML());
+        result.append(fontHTML());
 
         if (blindDrop) {
             result.append(Messages.getString("ChatLounge.Unknown"));
@@ -911,7 +912,7 @@ class LobbyMekCellFormatter {
         if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
             result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
         } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-            result.append(colorHTML(uiNickColor()) + "<B>'");
+            result.append(UIUtil.fontHTML(uiNickColor()) + "<B>'");
             result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
             if (!pilot.getStatusDesc(0).isEmpty()) {
                 result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -922,7 +923,7 @@ class LobbyMekCellFormatter {
 
         result.append(" (" + pilot.getSkillsAsString(rpgSkills) + ")");
         if (pilot.countOptions() > 0) {
-            result.append(DOT_SPACER + colorHTML(uiQuirksColor()));
+            result.append(DOT_SPACER + UIUtil.fontHTML(uiQuirksColor()));
             result.append(Messages.getString("ChatLounge.abilities"));
         }
 
@@ -944,7 +945,7 @@ class LobbyMekCellFormatter {
         final boolean rpgSkills = options.booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
         final float overallScale = 0f;
 
-        result.append(guiScaledFontHTML(overallScale));
+        result.append(fontHTML(overallScale));
 
         if (blindDrop) {
             result.append("<B>" + Messages.getString("ChatLounge.Unknown") + "</B>");
@@ -956,7 +957,7 @@ class LobbyMekCellFormatter {
                 result.append("<B>No " + crew.getCrewType().getRoleName(0) + "</B>");
             } else {
                 if ((crew.getNickname(0) != null) && !crew.getNickname(0).isEmpty()) {
-                    result.append(guiScaledFontHTML(uiNickColor(), overallScale));
+                    result.append(fontHTML(uiNickColor(), overallScale));
                     result.append("<B>'" + crew.getNickname(0).toUpperCase() + "'</B></FONT>");
                 } else {
                     result.append("<B>" + crew.getDesc(0) + "</B>");
@@ -972,7 +973,7 @@ class LobbyMekCellFormatter {
 
         // Advantages, MD, Edge
         if ((crew.countOptions(LVL3_ADVANTAGES) > 0) || (crew.countOptions(MD_ADVANTAGES) > 0)) {
-            result.append(guiScaledFontHTML(uiQuirksColor(), overallScale));
+            result.append(fontHTML(uiQuirksColor(), overallScale));
             result.append(Messages.getString("ChatLounge.abilities"));
             result.append("</FONT>");
         }

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekCellFormatter.java
@@ -121,7 +121,7 @@ class LobbyMekCellFormatter {
 
         // First line
         if (LobbyUtility.hasYellowWarning(entity)) {
-            result.append(guiScaledFontHTML(uiYellow()));
+            result.append(colorHTML(uiYellow()));
             result.append(WARNING_SIGN + "</FONT>");
             hasWarning = true;
         }
@@ -132,16 +132,16 @@ class LobbyMekCellFormatter {
                 || (entity.doomedOnGround() && mapType == MapSettings.MEDIUM_GROUND)
                 || (entity.doomedInSpace() && mapType == MapSettings.MEDIUM_SPACE)
                 || (!entity.isDesignValid())) {
-            result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+            result.append(colorHTML(GUIP.getWarningColor()));
             result.append(WARNING_SIGN + "</FONT>");
             hasCritical = true;
         }
 
         // Unit Name
         if (hasCritical) {
-            result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+            result.append(colorHTML(GUIP.getWarningColor()));
         } else if (hasWarning) {
-            result.append(guiScaledFontHTML(uiYellow()));
+            result.append(colorHTML(uiYellow()));
         } else {
             result.append(guiScaledFontHTML());
         }
@@ -149,7 +149,7 @@ class LobbyMekCellFormatter {
 
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(guiScaledFontHTML(uiGray()));
+            result.append(colorHTML(uiGray()));
             result.append(" [ID: " + entity.getId() + "]</FONT>");
         }
         if (!forceView) {
@@ -176,7 +176,7 @@ class LobbyMekCellFormatter {
         if (!forceView) {
             if (!entity.isDesignValid()) {
                 result.append(DOT_SPACER);
-                result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+                result.append(colorHTML(GUIP.getWarningColor()));
                 result.append("\u26D4 ").append(Messages.getString("ChatLounge.invalidDesign"));
                 result.append("</FONT>");
             }
@@ -186,7 +186,7 @@ class LobbyMekCellFormatter {
         if (!forceView) {
             if (entity.isShutDown()) {
                 result.append(DOT_SPACER);
-                result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+                result.append(colorHTML(GUIP.getWarningColor()));
                 result.append(WARNING_SIGN).append(Messages.getString("ChatLounge.shutdown"));
                 result.append("</FONT>");
             }
@@ -194,7 +194,7 @@ class LobbyMekCellFormatter {
 
         // ECM
         if (entity.hasActiveECM()) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiC3Color()));
+            result.append(DOT_SPACER + colorHTML(uiC3Color()));
             result.append(ECM_SIGN + " ");
             result.append(Messages.getString("BoardView1.ecmSource"));
             result.append("</FONT>");
@@ -204,7 +204,7 @@ class LobbyMekCellFormatter {
         int quirkCount = entity.countQuirks() + entity.countWeaponQuirks();
         if (quirkCount > 0) {
             result.append(DOT_SPACER);
-            result.append(guiScaledFontHTML(uiQuirksColor()));
+            result.append(colorHTML(uiQuirksColor()));
             result.append(QUIRKS_SIGN);
             result.append(Messages.getString("ChatLounge.Quirks"));
             result.append("</FONT>");
@@ -219,7 +219,7 @@ class LobbyMekCellFormatter {
             if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
                 result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
             } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-                result.append(guiScaledFontHTML(uiNickColor()) + "<B>'");
+                result.append(colorHTML(uiNickColor()) + "<B>'");
                 result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
                 if (!pilot.getStatusDesc(0).isEmpty()) {
                     result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -231,7 +231,7 @@ class LobbyMekCellFormatter {
             final boolean rpgSkills = options.booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
             result.append(" (" + pilot.getSkillsAsString(rpgSkills) + ")");
             if (pilot.countOptions() > 0) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiQuirksColor()));
+                result.append(DOT_SPACER + colorHTML(uiQuirksColor()));
                 result.append(Messages.getString("ChatLounge.abilities"));
                 result.append("</FONT>");
             }
@@ -239,13 +239,13 @@ class LobbyMekCellFormatter {
             // Owner
             if (!localPlayer.equals(owner)) {
                 result.append(DOT_SPACER);
-                result.append(guiScaledFontHTML(owner.getColour().getColour()));
+                result.append(colorHTML(owner.getColour().getColour()));
                 result.append("\u2691 ");
                 result.append(entity.getOwner().getName()).append("</FONT>");
             }
 
             // Info sign (i)
-            result.append(guiScaledFontHTML(uiGreen()));
+            result.append(colorHTML(uiGreen()));
             result.append("&nbsp;  \u24D8</FONT>");
         }
 
@@ -262,7 +262,7 @@ class LobbyMekCellFormatter {
                 && (sp >= 0)) {
             firstEntry = dotSpacer(result, firstEntry);
             if (spe != Board.START_NONE) {
-                result.append(guiScaledFontHTML(uiLightGreen()));
+                result.append(colorHTML(uiLightGreen()));
             }
             String msg_start = Messages.getString("ChatLounge.Start");
             result.append(" " + msg_start + ": ");
@@ -298,7 +298,7 @@ class LobbyMekCellFormatter {
         if (forceView) {
             if (!entity.isDesignValid()) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+                result.append(colorHTML(GUIP.getWarningColor()));
                 result.append("\u26D4 </FONT>").append(Messages.getString("ChatLounge.invalidDesign"));
             }
         }
@@ -306,7 +306,7 @@ class LobbyMekCellFormatter {
         // C3 ...
         if (entity.hasC3i()) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(guiScaledFontHTML(uiC3Color()));
+            result.append(colorHTML(uiC3Color()));
             if (entity.calculateFreeC3Nodes() >= 5) {
                 result.append("C3i" + UNCONNECTED_SIGN);
             } else {
@@ -320,7 +320,7 @@ class LobbyMekCellFormatter {
 
         if (entity.hasNavalC3()) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(guiScaledFontHTML(uiC3Color()));
+            result.append(colorHTML(uiC3Color()));
             if (entity.calculateFreeC3Nodes() >= 5) {
                 result.append("NC3" + UNCONNECTED_SIGN);
             } else {
@@ -337,13 +337,13 @@ class LobbyMekCellFormatter {
                 if (entity.hasC3S()) {
                     firstEntry = dotSpacer(result, firstEntry);
                     result.append(
-                            guiScaledFontHTML(uiC3Color()) + Messages.getString("ChatLounge.C3S") + UNCONNECTED_SIGN);
+                            colorHTML(uiC3Color()) + Messages.getString("ChatLounge.C3S") + UNCONNECTED_SIGN);
                     result.append("</FONT>");
                 }
 
                 if (entity.hasC3M()) {
                     firstEntry = dotSpacer(result, firstEntry);
-                    result.append(guiScaledFontHTML(uiC3Color()) + Messages.getString("ChatLounge.C3Master"));
+                    result.append(colorHTML(uiC3Color()) + Messages.getString("ChatLounge.C3Master"));
                     int freeS = entity.calculateFreeC3Nodes();
                     if (freeS == 0) {
                         result.append(" (full)");
@@ -354,7 +354,7 @@ class LobbyMekCellFormatter {
                 }
             } else if (entity.C3MasterIs(entity)) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(uiC3Color()) + Messages.getString("ChatLounge.C3CC"));
+                result.append(colorHTML(uiC3Color()) + Messages.getString("ChatLounge.C3CC"));
                 if (entity.hasC3MM()) {
                     String msg_freec3mnodes = Messages.getString("ChatLounge.FreeC3MNodes");
                     result.append(MessageFormat.format(" " + msg_freec3mnodes,
@@ -365,7 +365,7 @@ class LobbyMekCellFormatter {
                 result.append("</FONT>");
             } else {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(uiC3Color()));
+                result.append(colorHTML(uiC3Color()));
                 if (entity.hasC3S()) {
                     result.append(getString("ChatLounge.C3S") + CONNECTED_SIGN);
                 } else {
@@ -384,11 +384,11 @@ class LobbyMekCellFormatter {
         }
 
         // Loaded onto transport
-        result.append(guiScaledFontHTML(uiGreen()));
+        result.append(colorHTML(uiGreen()));
         if (isCarried) {
             firstEntry = dotSpacer(result, firstEntry);
             Entity loader = entity.getGame().getEntity(entity.getTransportId());
-            result.append(guiScaledFontHTML(uiGreen()) + LOADED_SIGN);
+            result.append(colorHTML(uiGreen()) + LOADED_SIGN);
             result.append("<I> " + Messages.getString("ChatLounge.aboard") + " " + loader.getChassis());
             if (PreferenceManager.getClientPreferences().getShowUnitId()) {
                 result.append(" [" + entity.getTransportId() + "]");
@@ -428,7 +428,7 @@ class LobbyMekCellFormatter {
         // Starting heat
         if (entity.getHeat() != 0 && entity.tracksHeat()) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(guiScaledFontHTML(uiLightRed()));
+            result.append(colorHTML(uiLightRed()));
             result.append(entity.getHeat()).append(" Heat").append("</FONT>");
         }
 
@@ -436,7 +436,7 @@ class LobbyMekCellFormatter {
         int partRepCount = entity.countPartialRepairs();
         if ((partRepCount > 0)) {
             firstEntry = dotSpacer(result, firstEntry);
-            result.append(guiScaledFontHTML(uiLightRed()));
+            result.append(colorHTML(uiLightRed()));
             result.append(Messages.getString("ChatLounge.PartialRepairs"));
             result.append("</FONT>");
         }
@@ -446,7 +446,7 @@ class LobbyMekCellFormatter {
             if (entity.isAero()) {
                 IAero aero = (IAero) entity;
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.velocity") + ": ");
                 result.append(aero.getCurrentVelocity());
                 if (mapType != MapSettings.MEDIUM_SPACE) {
@@ -460,7 +460,7 @@ class LobbyMekCellFormatter {
                 result.append("</I></FONT>");
             } else if ((entity.getElevation() != 0) || (entity instanceof VTOL)) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.elevation") + ": ");
                 result.append(entity.getElevation() + "</I></FONT>");
             }
@@ -472,7 +472,7 @@ class LobbyMekCellFormatter {
             Mek mek = ((Mek) entity);
             if ((mek.hasEjectSeat()) && (!mek.isAutoEject())) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(uiYellow()));
+                result.append(colorHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF<I>");
                 result.append(msg_autoejectdisabled);
                 result.append("</I></FONT>");
@@ -485,7 +485,7 @@ class LobbyMekCellFormatter {
             if ((aero.hasEjectSeat())
                     && (!aero.isAutoEject())) {
                 firstEntry = dotSpacer(result, firstEntry);
-                result.append(guiScaledFontHTML(uiYellow()));
+                result.append(colorHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF<I>");
                 result.append(msg_autoejectdisabled);
                 result.append("</I></FONT>");
@@ -513,7 +513,7 @@ class LobbyMekCellFormatter {
         if (hideEntity) {
             String value = "<HTML><NOBR>&nbsp;&nbsp;";
             if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-                value += guiScaledFontHTML(uiGray());
+                value += colorHTML(uiGray());
                 value += MessageFormat.format("[{0}] </FONT>", entity.getId());
             }
             String uType = "";
@@ -550,14 +550,14 @@ class LobbyMekCellFormatter {
         color = addGray(color, 128).brighter();
 
         if (entity.getForceId() == Force.NO_FORCE && forceView) {
-            result.append(guiScaledFontHTML(color));
+            result.append(colorHTML(color));
             result.append("\u25AD </FONT>");
         }
 
         // Signs before the unit name
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(guiScaledFontHTML(uiGray()));
+            result.append(colorHTML(uiGray()));
             result.append(MessageFormat.format("[{0}] </FONT>", entity.getId()));
         }
 
@@ -567,25 +567,25 @@ class LobbyMekCellFormatter {
                 || (entity.doomedOnGround() && mapType == MapSettings.MEDIUM_GROUND)
                 || (entity.doomedInSpace() && mapType == MapSettings.MEDIUM_SPACE)
                 || (!entity.isDesignValid())) {
-            result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+            result.append(colorHTML(GUIP.getWarningColor()));
             result.append(WARNING_SIGN + "</FONT>");
         }
 
         // General (Yellow) Warnings
         if (LobbyUtility.hasYellowWarning(entity)) {
-            result.append(guiScaledFontHTML(uiYellow()));
+            result.append(colorHTML(uiYellow()));
             result.append(WARNING_SIGN + "</FONT>");
         }
 
         // Loaded unit
         if (isCarried) {
-            result.append(guiScaledFontHTML(uiGreen()) + LOADED_SIGN + "</FONT>");
+            result.append(colorHTML(uiGreen()) + LOADED_SIGN + "</FONT>");
         }
 
         // Unit name
         // Gray out if the unit is a fighter in a squadron
         if (entity.isPartOfFighterSquadron()) {
-            result.append(guiScaledFontHTML(uiGray()));
+            result.append(colorHTML(uiGray()));
             result.append(entity.getShortNameRaw()).append("</FONT>");
         } else {
             result.append(entity.getShortNameRaw());
@@ -600,7 +600,7 @@ class LobbyMekCellFormatter {
             if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
                 result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
             } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-                result.append(guiScaledFontHTML(uiNickColor()) + "<B>'");
+                result.append(colorHTML(uiNickColor()) + "<B>'");
                 result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
                 if (!pilot.getStatusDesc(0).isEmpty()) {
                     result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -612,14 +612,14 @@ class LobbyMekCellFormatter {
             final boolean rpgSkills = options.booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
             result.append(" (" + pilot.getSkillsAsString(rpgSkills) + ")");
             if (pilot.countOptions() > 0) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiQuirksColor()));
+                result.append(DOT_SPACER + colorHTML(uiQuirksColor()));
                 result.append(Messages.getString("ChatLounge.abilities"));
             }
 
             // Owner
             if (!localPlayer.equals(owner)) {
                 result.append(DOT_SPACER);
-                result.append(guiScaledFontHTML(owner.getColour().getColour()));
+                result.append(colorHTML(owner.getColour().getColour()));
                 result.append("\u2691 ");
                 result.append(entity.getOwner().getName()).append("</FONT>");
             }
@@ -628,7 +628,7 @@ class LobbyMekCellFormatter {
         // Invalid unit design
         if (!entity.isDesignValid()) {
             result.append(DOT_SPACER);
-            result.append(guiScaledFontHTML(GUIP.getWarningColor()));
+            result.append(colorHTML(GUIP.getWarningColor()));
             result.append("\u26D4 </FONT>").append(Messages.getString("ChatLounge.invalidDesign"));
         }
 
@@ -649,7 +649,7 @@ class LobbyMekCellFormatter {
 
         // C3 ...
         if (entity.hasC3i() || entity.hasNavalC3()) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiC3Color()));
+            result.append(DOT_SPACER + colorHTML(uiC3Color()));
             String msg_c3i = Messages.getString("ChatLounge.C3i");
             String msg_nc3 = Messages.getString("ChatLounge.NC3");
 
@@ -667,7 +667,7 @@ class LobbyMekCellFormatter {
             String msg_c3m = Messages.getString("ChatLounge.C3M");
             String msg_c3mcc = Messages.getString("ChatLounge.C3MCC");
 
-            result.append(DOT_SPACER + guiScaledFontHTML(uiC3Color()));
+            result.append(DOT_SPACER + colorHTML(uiC3Color()));
             if (entity.getC3Master() == null) {
                 if (entity.hasC3S()) {
                     result.append(msg_c3sabrv + UNCONNECTED_SIGN);
@@ -691,7 +691,7 @@ class LobbyMekCellFormatter {
         // Loaded onto another unit
         if (isCarried) {
             Entity loader = entity.getGame().getEntity(entity.getTransportId());
-            result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>(");
+            result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>(");
             result.append(loader.getChassis());
             if (PreferenceManager.getClientPreferences().getShowUnitId()) {
                 result.append(" [" + entity.getTransportId() + "]");
@@ -702,32 +702,32 @@ class LobbyMekCellFormatter {
         // Deployment info, doesn't matter when the unit is carried
         if (!isCarried) {
             if (entity.isHidden()) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.hidden") + "</I></FONT>");
             }
 
             if (entity.isHullDown()) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.hulldown") + "</I></FONT>");
             }
 
             if (entity.isProne()) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.prone") + "</I></FONT>");
             }
         }
 
         if (entity.countPartialRepairs() > 0) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiLightRed()));
+            result.append(DOT_SPACER + colorHTML(uiLightRed()));
             result.append("Partial Repairs</FONT>");
         }
 
         // Offboard deployment
         if (entity.isOffBoard()) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+            result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
             result.append(Messages.getString("ChatLounge.compact.deploysOffBoard") + "</I></FONT>");
         } else if (entity.getDeployRound() > 0) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+            result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
             result.append(Messages.getString("ChatLounge.compact.deployRound", entity.getDeployRound()));
             if (entity.getStartingPos(false) != Board.START_NONE) {
                 result.append(Messages.getString("ChatLounge.compact.deployZone",
@@ -740,7 +740,7 @@ class LobbyMekCellFormatter {
         if (!isCarried) {
             if (entity.isAero()) {
                 IAero aero = (IAero) entity;
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.velocity") + ": ");
                 result.append(aero.getCurrentVelocity());
                 if (mapType != MapSettings.MEDIUM_SPACE) {
@@ -753,7 +753,7 @@ class LobbyMekCellFormatter {
                 }
                 result.append("</I></FONT>");
             } else if ((entity.getElevation() != 0) || (entity instanceof VTOL)) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()) + "<I>");
+                result.append(DOT_SPACER + colorHTML(uiGreen()) + "<I>");
                 result.append(Messages.getString("ChatLounge.compact.elevation") + ": ");
                 result.append(entity.getElevation() + "</I></FONT>");
             }
@@ -761,7 +761,7 @@ class LobbyMekCellFormatter {
 
         // Starting heat
         if (entity.getHeat() != 0 && entity.tracksHeat()) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()));
+            result.append(DOT_SPACER + colorHTML(uiGreen()));
             result.append("<I>Heat: ").append(entity.getHeat()).append(" </I></FONT>");
         }
 
@@ -777,8 +777,8 @@ class LobbyMekCellFormatter {
         if (entity instanceof Mek) {
             Mek mek = ((Mek) entity);
             if ((mek.hasEjectSeat()) && (!mek.isAutoEject())) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()));
-                result.append(guiScaledFontHTML(uiYellow()));
+                result.append(DOT_SPACER + colorHTML(uiGreen()));
+                result.append(colorHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF</FONT>");
             }
         }
@@ -788,8 +788,8 @@ class LobbyMekCellFormatter {
             Aero aero = ((Aero) entity);
             if ((aero.hasEjectSeat())
                     && (!aero.isAutoEject())) {
-                result.append(DOT_SPACER + guiScaledFontHTML(uiGreen()));
-                result.append(guiScaledFontHTML(uiYellow()));
+                result.append(DOT_SPACER + colorHTML(uiGreen()));
+                result.append(colorHTML(uiYellow()));
                 result.append(WARNING_SIGN + "\u23CF</FONT>");
             }
         }
@@ -911,7 +911,7 @@ class LobbyMekCellFormatter {
         if (pilot.getSlotCount() > 1 || entity instanceof FighterSquadron) {
             result.append("<I>" + Messages.getString("ChatLounge.multipleCrew") + "</I>");
         } else if ((pilot.getNickname(0) != null) && !pilot.getNickname(0).isEmpty()) {
-            result.append(guiScaledFontHTML(uiNickColor()) + "<B>'");
+            result.append(colorHTML(uiNickColor()) + "<B>'");
             result.append(pilot.getNickname(0).toUpperCase() + "'</B></FONT>");
             if (!pilot.getStatusDesc(0).isEmpty()) {
                 result.append(" (" + pilot.getStatusDesc(0) + ")");
@@ -922,7 +922,7 @@ class LobbyMekCellFormatter {
 
         result.append(" (" + pilot.getSkillsAsString(rpgSkills) + ")");
         if (pilot.countOptions() > 0) {
-            result.append(DOT_SPACER + guiScaledFontHTML(uiQuirksColor()));
+            result.append(DOT_SPACER + colorHTML(uiQuirksColor()));
             result.append(Messages.getString("ChatLounge.abilities"));
         }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
@@ -176,7 +176,7 @@ public class LobbyUtility {
      * invalid.
      */
     static String invalidBoardTip() {
-        return UIUtil.colorHTML(GUIPreferences.getInstance().getWarningColor())
+        return UIUtil.fontHTML(GUIPreferences.getInstance().getWarningColor())
                 + Messages.getString("ChatLounge.map.invalidTip") + "</FONT>";
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyUtility.java
@@ -176,7 +176,7 @@ public class LobbyUtility {
      * invalid.
      */
     static String invalidBoardTip() {
-        return UIUtil.guiScaledFontHTML(GUIPreferences.getInstance().getWarningColor())
+        return UIUtil.colorHTML(GUIPreferences.getInstance().getWarningColor())
                 + Messages.getString("ChatLounge.map.invalidTip") + "</FONT>";
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/MapPreviewButton.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MapPreviewButton.java
@@ -20,7 +20,6 @@ package megamek.client.ui.swing.lobby;
 
 import static megamek.client.ui.swing.lobby.LobbyUtility.cleanBoardName;
 import static megamek.client.ui.swing.lobby.LobbyUtility.drawMinimapLabel;
-import static megamek.client.ui.swing.util.UIUtil.scaleStringForGUI;
 
 import java.awt.Color;
 import java.awt.Component;
@@ -124,7 +123,7 @@ public class MapPreviewButton extends JButton {
     }
 
     private void generateTooltip() {
-        setToolTipText(scaleStringForGUI(lobby.createBoardTooltip(boardName)));
+        setToolTipText(lobby.createBoardTooltip(boardName));
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableASUnitEntry.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableASUnitEntry.java
@@ -40,7 +40,7 @@ public class MekTableASUnitEntry {
      * When blindDrop is true, the unit details are not given.
      */
     static String fullEntry(AlphaStrikeElement element, ChatLounge lobby, boolean forceView, boolean compactView) {
-        StringBuilder result = new StringBuilder("<HTML><NOBR>" + guiScaledFontHTML());
+        StringBuilder result = new StringBuilder("<HTML><NOBR>");
 
         Client client = lobby.getClientgui().getClient();
         Game game = client.getGame();
@@ -72,12 +72,12 @@ public class MekTableASUnitEntry {
         // First line
 
         // Unit Name
-        result.append(guiScaledFontHTML(uiLightGreen()));
+        result.append(colorHTML(uiLightGreen()));
         result.append("<B>").append(element.getName()).append("</B></FONT>");
 
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(guiScaledFontHTML(uiGray()));
+            result.append(colorHTML(uiGray()));
             result.append(" [ID: ").append(element.getId()).append("]</FONT>");
         }
         if (!forceView && !compactView) {
@@ -87,7 +87,6 @@ public class MekTableASUnitEntry {
         }
 
         // Tonnage
-        result.append(guiScaledFontHTML());
         if (forceView) {
             result.append(DOT_SPACER);
         }
@@ -116,7 +115,7 @@ public class MekTableASUnitEntry {
 
         // ECM
         if (element.hasAnySUAOf(ECM, LECM, AECM)) {
-            result.append(DOT_SPACER).append(guiScaledFontHTML(uiC3Color()));
+            result.append(DOT_SPACER).append(colorHTML(uiC3Color()));
             result.append(ECM_SIGN + " ");
             result.append(Messages.getString("BoardView1.ecmSource"));
             result.append("</FONT>");

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableASUnitEntry.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableASUnitEntry.java
@@ -72,12 +72,12 @@ public class MekTableASUnitEntry {
         // First line
 
         // Unit Name
-        result.append(colorHTML(uiLightGreen()));
+        result.append(UIUtil.fontHTML(uiLightGreen()));
         result.append("<B>").append(element.getName()).append("</B></FONT>");
 
         // ID
         if (PreferenceManager.getClientPreferences().getShowUnitId()) {
-            result.append(colorHTML(uiGray()));
+            result.append(UIUtil.fontHTML(uiGray()));
             result.append(" [ID: ").append(element.getId()).append("]</FONT>");
         }
         if (!forceView && !compactView) {
@@ -115,7 +115,7 @@ public class MekTableASUnitEntry {
 
         // ECM
         if (element.hasAnySUAOf(ECM, LECM, AECM)) {
-            result.append(DOT_SPACER).append(colorHTML(uiC3Color()));
+            result.append(DOT_SPACER).append(UIUtil.fontHTML(uiC3Color()));
             result.append(ECM_SIGN + " ");
             result.append(Messages.getString("BoardView1.ecmSource"));
             result.append("</FONT>");

--- a/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/MekTableModel.java
@@ -19,7 +19,7 @@
 package megamek.client.ui.swing.lobby;
 
 import static megamek.client.ui.swing.util.UIUtil.alternateTableBGColor;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+import static megamek.client.ui.swing.util.UIUtil.fontHTML;
 import static megamek.client.ui.swing.util.UIUtil.uiGreen;
 
 import java.awt.Color;
@@ -127,7 +127,7 @@ public class MekTableModel extends AbstractTableModel {
             boolean localGM = clientGui.getClient().getLocalPlayer().isGameMaster();
             boolean hideEntity = !localGM && isEnemy && isBlindDrop;
             float size = chatLounge.isCompact() ? 0 : 0.2f;
-            return hideEntity ? "" : guiScaledFontHTML(size) + NumberFormat.getIntegerInstance().format(bv.get(row));
+            return hideEntity ? "" : fontHTML(size) + NumberFormat.getIntegerInstance().format(bv.get(row));
 
         } else if (col == COLS.PLAYER.ordinal()) {
             return playerCells.get(row);
@@ -240,7 +240,7 @@ public class MekTableModel extends AbstractTableModel {
      */
     @Override
     public String getColumnName(int column) {
-        String result = "<HTML>" + UIUtil.guiScaledFontHTML(0.2f);
+        String result = "<HTML>" + UIUtil.fontHTML(0.2f);
         if (column == COLS.PILOT.ordinal()) {
             return result + Messages.getString("ChatLounge.colPilot");
         } else if (column == COLS.UNIT.ordinal()) {
@@ -275,9 +275,9 @@ public class MekTableModel extends AbstractTableModel {
         boolean isEnemy = clientGui.getClient().getLocalPlayer().isEnemyOf(owner);
         float size = chatLounge.isCompact() ? 0 : 0.2f;
         String sep = chatLounge.isCompact() ? DOT_SPACER : "<BR>";
-        result.append(guiScaledFontHTML(owner.getColour().getColour(), size)).append(owner.getName())
-                .append("</FONT>").append(guiScaledFontHTML(size)).append(sep).append("</FONT>")
-                .append(guiScaledFontHTML(isEnemy ? Color.RED : uiGreen(), size))
+        result.append(UIUtil.fontHTML(owner.getColour().getColour(), size)).append(owner.getName())
+                .append("</FONT>").append(fontHTML(size)).append(sep).append("</FONT>")
+                .append(UIUtil.fontHTML(isEnemy ? Color.RED : uiGreen(), size))
                 .append(Player.TEAM_NAMES[owner.getTeam()]);
         return result.toString();
     }

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -160,12 +160,6 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
     };
 
     @Override
-    protected void finalizeInitialization() throws Exception {
-        adaptToGUIScale();
-        super.finalizeInitialization();
-    }
-
-    @Override
     protected void okAction() {
         apply();
     }
@@ -977,10 +971,6 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         } catch (NumberFormatException ex) {
             return 0;
         }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
     }
 
     public FactionRecord getFaction() {

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -796,10 +796,8 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         for (int i : butStartPos.keySet()) {
             butText.get(i).append("<HTML><P ALIGN=CENTER>");
             if (!isValidStartPos(client.getGame(), client.getLocalPlayer(), i)) {
-                butText.get(i).append(guiScaledFontHTML(uiYellow()));
+                butText.get(i).append(UIUtil.colorHTML(uiYellow()));
                 butTT.get(i).append(Messages.getString("PlayerSettingsDialog.invalidStartPosTT"));
-            } else {
-                butText.get(i).append(guiScaledFontHTML());
             }
 
             if (i <= Board.NUM_ZONES) {
@@ -813,7 +811,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         for (Player listedPlayer : client.getGame().getPlayersList()) {
             int pos = listedPlayer.getStartingPos();
             if (!listedPlayer.equals(client.getLocalPlayer()) && (pos != Board.START_ANY)) {
-                butText.get(pos).append(guiScaledFontHTML(teamColor(listedPlayer, client.getLocalPlayer())));
+                butText.get(pos).append(UIUtil.colorHTML(teamColor(listedPlayer, client.getLocalPlayer())));
                 butText.get(pos).append("\u25A0</FONT>");
                 if (!hasPlayer.containsKey(pos)) {
                     if (butTT.get(pos).length() > 0) {
@@ -826,7 +824,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
             }
         }
 
-        butText.get(currentPlayerStartPos).append(guiScaledFontHTML(GUIPreferences.getInstance().getMyUnitColor()));
+        butText.get(currentPlayerStartPos).append(UIUtil.colorHTML(GUIPreferences.getInstance().getMyUnitColor()));
         butText.get(currentPlayerStartPos).append("\u2B24</FONT>");
 
         for (int i : butStartPos.keySet()) {

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -22,7 +22,7 @@ package megamek.client.ui.swing.lobby;
 import static megamek.client.ui.Messages.getString;
 import static megamek.client.ui.swing.lobby.LobbyMekPopupActions.resetBombChoices;
 import static megamek.client.ui.swing.lobby.LobbyUtility.isValidStartPos;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+import static megamek.client.ui.swing.util.UIUtil.fontHTML;
 import static megamek.client.ui.swing.util.UIUtil.teamColor;
 import static megamek.client.ui.swing.util.UIUtil.uiYellow;
 
@@ -796,7 +796,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         for (int i : butStartPos.keySet()) {
             butText.get(i).append("<HTML><P ALIGN=CENTER>");
             if (!isValidStartPos(client.getGame(), client.getLocalPlayer(), i)) {
-                butText.get(i).append(UIUtil.colorHTML(uiYellow()));
+                butText.get(i).append(UIUtil.fontHTML(uiYellow()));
                 butTT.get(i).append(Messages.getString("PlayerSettingsDialog.invalidStartPosTT"));
             }
 
@@ -811,7 +811,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         for (Player listedPlayer : client.getGame().getPlayersList()) {
             int pos = listedPlayer.getStartingPos();
             if (!listedPlayer.equals(client.getLocalPlayer()) && (pos != Board.START_ANY)) {
-                butText.get(pos).append(UIUtil.colorHTML(teamColor(listedPlayer, client.getLocalPlayer())));
+                butText.get(pos).append(UIUtil.fontHTML(teamColor(listedPlayer, client.getLocalPlayer())));
                 butText.get(pos).append("\u25A0</FONT>");
                 if (!hasPlayer.containsKey(pos)) {
                     if (butTT.get(pos).length() > 0) {
@@ -824,7 +824,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
             }
         }
 
-        butText.get(currentPlayerStartPos).append(UIUtil.colorHTML(GUIPreferences.getInstance().getMyUnitColor()));
+        butText.get(currentPlayerStartPos).append(UIUtil.fontHTML(GUIPreferences.getInstance().getMyUnitColor()));
         butText.get(currentPlayerStartPos).append("\u2B24</FONT>");
 
         for (int i : butStartPos.keySet()) {

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
@@ -18,12 +18,7 @@
  */
 package megamek.client.ui.swing.lobby;
 
-import static megamek.client.ui.swing.util.UIUtil.WARNING_SIGN;
-import static megamek.client.ui.swing.util.UIUtil.alternateTableBGColor;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-import static megamek.client.ui.swing.util.UIUtil.scaleForGUI;
-import static megamek.client.ui.swing.util.UIUtil.uiGreen;
-import static megamek.client.ui.swing.util.UIUtil.uiYellow;
+import static megamek.client.ui.swing.util.UIUtil.*;
 
 import java.awt.Color;
 import java.awt.Component;
@@ -40,6 +35,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.UIManager;
+import javax.swing.event.*;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
@@ -56,7 +52,6 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 
 class PlayerTable extends JTable {
-    private static final long serialVersionUID = 6252953920509362407L;
 
     private static final int PLAYERTABLE_ROWHEIGHT = 45;
 
@@ -71,12 +66,19 @@ class PlayerTable extends JTable {
         getTableHeader().setReorderingAllowed(false);
         setDefaultRenderer(Player.class, new PlayerRenderer());
         TableColumn column = getColumnModel().getColumn(0);
-        String msg_players = Messages.getString("ChatLounge.Players");
-        column.setHeaderValue(msg_players);
+        column.setHeaderValue(Messages.getString("ChatLounge.Players"));
+        setColumnHeights();
+        pm.addTableModelListener(e -> setColumnHeights());
     }
 
-    void rescale() {
+    void setColumnHeights() {
         setRowHeight(UIUtil.scaleForGUI(PLAYERTABLE_ROWHEIGHT));
+    }
+
+    @Override
+    public void columnMarginChanged(ChangeEvent e) {
+        setColumnHeights();
+        super.columnMarginChanged(e);
     }
 
     @Override
@@ -87,11 +89,11 @@ class PlayerTable extends JTable {
             return null;
         }
 
-        StringBuilder result = new StringBuilder("<HTML>");
-        result.append(guiScaledFontHTML(player.getColour().getColour()));
-        result.append(player.getName() + "</FONT>");
+        StringBuilder result = new StringBuilder("<HTML><BODY>");
+        result.append("<FONT").append(UIUtil.colorString(player.getColour().getColour())).append(">");
+        result.append(player.getName());
+        result.append("</FONT>");
 
-        result.append(guiScaledFontHTML());
         if ((lobby.client() instanceof BotClient) && player.equals(lobby.localPlayer())) {
             String msg_thisbot = Messages.getString("ChatLounge.ThisBot");
             result.append(" (" + UIUtil.BOT_MARKER + " " + msg_thisbot + ")");
@@ -122,8 +124,6 @@ class PlayerTable extends JTable {
     }
 
     public static class PlayerTableModel extends AbstractTableModel {
-
-        private static final long serialVersionUID = -1372393680232901923L;
 
         static final int COL_PLAYER = 0;
         static final int N_COL = 1;
@@ -172,7 +172,6 @@ class PlayerTable extends JTable {
     }
 
     class PlayerRenderer extends DefaultTableCellRenderer {
-        private static final long serialVersionUID = 4947299735765324311L;
 
         public PlayerRenderer() {
             setLayout(new GridLayout(1, 1, 5, 0));
@@ -201,13 +200,12 @@ class PlayerTable extends JTable {
             // Second Line - Team
             boolean isEnemy = lobby.localPlayer().isEnemyOf(player);
             Color color = isEnemy ? GUIPreferences.getInstance().getWarningColor() : uiGreen();
-            result.append(guiScaledFontHTML(color));
+            result.append("<FONT").append(UIUtil.colorString(color)).append(">");
             result.append(Player.TEAM_NAMES[player.getTeam()]);
             result.append("</FONT>");
 
             // Deployment Position
             result.append(UIUtil.DOT_SPACER);
-            result.append(guiScaledFontHTML());
 
             String msg_start = Messages.getString("ChatLounge.Start");
 
@@ -241,43 +239,39 @@ class PlayerTable extends JTable {
             } else if (player.getStartingPos() > IStartingPositions.START_LOCATION_NAMES.length) {
                 result.append(msg_start + ": " + "Zone " + Board.decodeCustomDeploymentZoneID(player.getStartingPos()));
             }
-            result.append("</FONT>");
 
             if (!LobbyUtility.isValidStartPos(lobby.game(), player)) {
-                result.append(guiScaledFontHTML(uiYellow()));
-                result.append(WARNING_SIGN + "</FONT>");
+                result.append("<FONT").append(UIUtil.colorString(uiYellow())).append(">");
+                result.append(WARNING_SIGN);
+                result.append("</FONT>");
             }
 
             // Player BV
             result.append(UIUtil.DOT_SPACER);
-            result.append(guiScaledFontHTML());
             String msg_bvplain = Messages.getString("ChatLounge.BVplain");
             result.append(msg_bvplain + ": ");
             NumberFormat formatter = NumberFormat.getIntegerInstance(MegaMek.getMMOptions().getLocale());
             result.append((player.getBV() != 0) ? formatter.format(player.getBV()) : "--");
-            result.append("</FONT>");
 
             // Initiative Mod
             if (player.getConstantInitBonus() != 0) {
                 result.append(UIUtil.DOT_SPACER);
-                result.append(guiScaledFontHTML());
                 String sign = (player.getConstantInitBonus() > 0) ? "+" : "";
                 String msg_init = Messages.getString("ChatLounge.Init");
                 result.append(msg_init + ": ").append(sign);
                 result.append(player.getConstantInitBonus());
-                result.append("</FONT>");
             }
 
             if (player.getSingleBlind()) {
                 result.append(UIUtil.DOT_SPACER);
-                result.append(guiScaledFontHTML(uiGreen()));
+                result.append("<FONT").append(UIUtil.colorString(uiGreen())).append(">");
                 result.append("\uD83D\uDC41");
                 result.append("</FONT>");
             }
 
             if (player.getGameMaster()) {
                 result.append(UIUtil.DOT_SPACER);
-                result.append(guiScaledFontHTML(uiGreen()));
+                result.append("<FONT").append(UIUtil.colorString(uiGreen())).append(">");
                 result.append("\uD83D\uDD2E  GM");
                 result.append("</FONT>");
             }

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
@@ -152,7 +152,7 @@ class PlayerTable extends JTable {
 
         @Override
         public String getColumnName(int column) {
-            return "<HTML>" + UIUtil.guiScaledFontHTML() + Messages.getString("ChatLounge.colPlayer");
+            return Messages.getString("ChatLounge.colPlayer");
         }
 
         @Override
@@ -163,7 +163,6 @@ class PlayerTable extends JTable {
         @Override
         public Object getValueAt(int row, int col) {
             return getPlayerAt(row);
-
         }
 
         Player getPlayerAt(int row) {
@@ -188,7 +187,7 @@ class PlayerTable extends JTable {
 
             Player player = (Player) value;
 
-            StringBuilder result = new StringBuilder("<HTML><NOBR>" + UIUtil.guiScaledFontHTML());
+            StringBuilder result = new StringBuilder("<HTML><NOBR>");
             // First Line - Player Name
             if ((lobby.client() instanceof BotClient) && player.equals(lobby.localPlayer())
                     || lobby.client().getBots().containsKey(player.getName())) {
@@ -278,7 +277,7 @@ class PlayerTable extends JTable {
 
             setText(result.toString());
 
-            setIconTextGap(scaleForGUI(10));
+            setIconTextGap(10);
             Image camo = player.getCamouflage().getImage();
             int size = scaleForGUI(PLAYERTABLE_ROWHEIGHT) / 2;
             setImage(camo.getScaledInstance(-1, size, Image.SCALE_SMOOTH));

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTable.java
@@ -67,17 +67,17 @@ class PlayerTable extends JTable {
         setDefaultRenderer(Player.class, new PlayerRenderer());
         TableColumn column = getColumnModel().getColumn(0);
         column.setHeaderValue(Messages.getString("ChatLounge.Players"));
-        setColumnHeights();
-        pm.addTableModelListener(e -> setColumnHeights());
+        setRowHeights();
+        pm.addTableModelListener(e -> setRowHeights());
     }
 
-    void setColumnHeights() {
+    void setRowHeights() {
         setRowHeight(UIUtil.scaleForGUI(PLAYERTABLE_ROWHEIGHT));
     }
 
     @Override
     public void columnMarginChanged(ChangeEvent e) {
-        setColumnHeights();
+        setRowHeights();
         super.columnMarginChanged(e);
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerTablePopup.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerTablePopup.java
@@ -21,8 +21,7 @@ package megamek.client.ui.swing.lobby;
 import java.awt.event.ActionListener;
 import java.util.Collection;
 
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
+import javax.swing.*;
 
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.util.ScalingPopup;
@@ -46,10 +45,10 @@ class PlayerTablePopup {
     static final String PTP_DEPLOY = "DEPLOY";
     static final String PTP_REPLACE = "REPLACE";
 
-    static ScalingPopup playerTablePopup(ClientGUI clientGui, ActionListener listener,
-            Collection<Player> players, Board currentBoard) {
+    static JPopupMenu playerTablePopup(ClientGUI clientGui, ActionListener listener,
+                                       Collection<Player> players, Board currentBoard) {
 
-        ScalingPopup popup = new ScalingPopup();
+        JPopupMenu popup = new ScalingPopup();
 
         var cl = clientGui.getClient();
         var isOnePlayer = players.size() == 1;
@@ -90,12 +89,12 @@ class PlayerTablePopup {
             JMenuItem item = menuItem(IStartingPositions.START_LOCATION_NAMES[i], PTP_DEPLOY + "|" + i, enabled, listener);
             menu.add(item);
         }
-        
+
         for (int i : currentBoard.getCustomDeploymentZones()) {
             JMenuItem item = menuItem("Zone " + i, PTP_DEPLOY + "|" + Board.encodeCustomDeploymentZoneID(i), enabled, listener);
             menu.add(item);
         }
-        
+
         menu.setEnabled(enabled);
         return menu;
     }

--- a/megamek/src/megamek/client/ui/swing/lobby/TeamOverviewPanel.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/TeamOverviewPanel.java
@@ -20,8 +20,7 @@ package megamek.client.ui.swing.lobby;
 
 import static megamek.client.ui.swing.util.UIUtil.FONT_SCALE1;
 import static megamek.client.ui.swing.util.UIUtil.criticalSign;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-import static megamek.client.ui.swing.util.UIUtil.scaleForGUI;
+import static megamek.client.ui.swing.util.UIUtil.fontHTML;
 import static megamek.client.ui.swing.util.UIUtil.warningSign;
 
 import java.awt.Color;
@@ -314,7 +313,7 @@ public class TeamOverviewPanel extends JPanel {
                 }
             }
             // Add a little margin to the rows
-            teamOverviewTable.setRowHeight(rowHeight + scaleForGUI(20));
+            teamOverviewTable.setRowHeight(rowHeight + 20);
         }
 
         @Override
@@ -322,7 +321,7 @@ public class TeamOverviewPanel extends JPanel {
             column += (isDetached && column > 1) ? 2 : 0;
             String text = Messages.getString("ChatLounge.teamOverview.COL" + TOMCOLS.values()[column]);
             float textSizeDelta = isDetached ? 0f : 0.3f;
-            return "<HTML><NOBR>" + UIUtil.guiScaledFontHTML(textSizeDelta) + text;
+            return "<HTML><NOBR>" + UIUtil.fontHTML(textSizeDelta) + text;
         }
 
         @Override
@@ -340,12 +339,12 @@ public class TeamOverviewPanel extends JPanel {
                     boolean isEnemy = !teams.get(row).players().contains(clientGui.getClient().getLocalPlayer());
                     Color color = isEnemy ? GUIPreferences.getInstance().getEnemyUnitColor()
                             : GUIPreferences.getInstance().getMyUnitColor();
-                    result.append(guiScaledFontHTML(color, textSizeDelta) + "&nbsp;");
+                    result.append(UIUtil.fontHTML(color, textSizeDelta) + "&nbsp;");
                     result.append(teamNames.get(row) + "</FONT>");
                     break;
 
                 case TONNAGE:
-                    result.append(guiScaledFontHTML(textSizeDelta) + "<CENTER>");
+                    result.append(fontHTML(textSizeDelta) + "<CENTER>");
                     double ton = (double) tons.get(row) / 1000;
                     if (ton < 10) {
                         result.append(String.format("%.2f", ton) + " Tons");
@@ -356,7 +355,7 @@ public class TeamOverviewPanel extends JPanel {
                     break;
 
                 case COST:
-                    result.append(guiScaledFontHTML(textSizeDelta) + "<CENTER>");
+                    result.append(fontHTML(textSizeDelta) + "<CENTER>");
                     if (costs.get(row) < 10_000_000) {
                         result.append(String.format("%,d", costs.get(row)) + " C-Bills");
                     } else {
@@ -369,21 +368,21 @@ public class TeamOverviewPanel extends JPanel {
                     return teams.get(row).players();
 
                 case BV:
-                    result.append(guiScaledFontHTML(textSizeDelta) + "<CENTER>");
+                    result.append(fontHTML(textSizeDelta) + "<CENTER>");
                     result.append(NumberFormat.getIntegerInstance().format(bvs.get(row)));
                     result.append(relativeValue(bvs, row));
                     break;
 
                 case UNITS:
                     if (!seeTeam(row)) {
-                        return "<HTML>" + guiScaledFontHTML(UIUtil.uiGray(), textSizeDelta - 0.1f) + "Unavailable";
+                        return "<HTML>" + UIUtil.fontHTML(UIUtil.uiGray(), textSizeDelta - 0.1f) + "Unavailable";
                     }
-                    result.append(guiScaledFontHTML(textSizeDelta - 0.1f));
+                    result.append(fontHTML(textSizeDelta - 0.1f));
                     result.append(units.get(row));
                     break;
 
                 case HIDDEN:
-                    result.append(guiScaledFontHTML(textSizeDelta) + "<CENTER>");
+                    result.append(fontHTML(textSizeDelta) + "<CENTER>");
                     var percentage = hidden.get(row);
                     result.append(percentage == 0 ? "--" : NumberFormat.getPercentInstance().format(percentage));
 
@@ -417,10 +416,10 @@ public class TeamOverviewPanel extends JPanel {
                     String selectedTeam = teamNames.get(selectedRow);
                     long percentage = 100 * values.get(row) / baseValue;
                     if (isDetached) {
-                        return "<BR>" + UIUtil.guiScaledFontHTML(UIUtil.uiGray(), -0.1f)
+                        return "<BR>" + UIUtil.fontHTML(UIUtil.uiGray(), -0.1f)
                                 + String.format("(%d %%)", percentage);
                     } else {
-                        return "<BR>" + UIUtil.guiScaledFontHTML(UIUtil.uiGray(), -0.1f)
+                        return "<BR>" + UIUtil.fontHTML(UIUtil.uiGray(), -0.1f)
                                 + String.format("(%d %% of %s)", percentage, selectedTeam);
                     }
                 }
@@ -450,8 +449,8 @@ public class TeamOverviewPanel extends JPanel {
             add(Box.createVerticalGlue());
             List<?> playerList = (List<?>) value;
             int baseSize = FONT_SCALE1 - (isDetached ? 2 : 0);
-            int size = scaleForGUI(2 * baseSize);
-            Font font = new Font(MMConstants.FONT_DIALOG, Font.PLAIN, scaleForGUI(baseSize));
+            int size = 2 * baseSize;
+            Font font = new Font(MMConstants.FONT_DIALOG, Font.PLAIN, baseSize);
             for (Object obj : playerList) {
                 if (!(obj instanceof Player)) {
                     continue;
@@ -460,7 +459,7 @@ public class TeamOverviewPanel extends JPanel {
                 JLabel lblPlayer = new JLabel(player.getName());
                 lblPlayer.setBorder(new EmptyBorder(3, 3, 3, 3));
                 lblPlayer.setFont(font);
-                lblPlayer.setIconTextGap(scaleForGUI(5));
+                lblPlayer.setIconTextGap(5);
                 Image camo = player.getCamouflage().getImage();
                 lblPlayer.setIcon(new ImageIcon(camo.getScaledInstance(-1, size, Image.SCALE_SMOOTH)));
                 add(lblPlayer);

--- a/megamek/src/megamek/client/ui/swing/sbf/SBFActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/sbf/SBFActionPhaseDisplay.java
@@ -18,8 +18,6 @@
  */
 package megamek.client.ui.swing.sbf;
 
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
-
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.util.List;
@@ -61,7 +59,7 @@ public abstract class SBFActionPhaseDisplay extends StatusBarPhaseDisplay {
         var donePanel = super.setupDonePanel();
         butSkipTurn = new MegaMekButton("SKIP", SkinSpecification.UIComponents.PhaseDisplayDoneButton.getComp());
         butSkipTurn.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
-        String f = guiScaledFontHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
+        String f = UIUtil.colorHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
         butSkipTurn.setToolTipText("<html><body>" + f + "</body></html>");
         addToDonePanel(donePanel, butSkipTurn);
 

--- a/megamek/src/megamek/client/ui/swing/sbf/SBFActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/sbf/SBFActionPhaseDisplay.java
@@ -59,7 +59,7 @@ public abstract class SBFActionPhaseDisplay extends StatusBarPhaseDisplay {
         var donePanel = super.setupDonePanel();
         butSkipTurn = new MegaMekButton("SKIP", SkinSpecification.UIComponents.PhaseDisplayDoneButton.getComp());
         butSkipTurn.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
-        String f = UIUtil.colorHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
+        String f = UIUtil.fontHTML(UIUtil.uiLightViolet()) +  KeyCommandBind.getDesc(KeyCommandBind.DONE_NO_ACTION)+ "</FONT>";
         butSkipTurn.setToolTipText("<html><body>" + f + "</body></html>");
         addToDonePanel(donePanel, butSkipTurn);
 

--- a/megamek/src/megamek/client/ui/swing/sbf/SBFJumpChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/sbf/SBFJumpChoiceDialog.java
@@ -76,15 +76,6 @@ public class SBFJumpChoiceDialog extends AbstractChoiceDialog<Integer> {
                 + "</div></BODY></HTML>";
     }
 
-    @Override
-    public void setVisible(boolean visible) {
-        if (visible) {
-            UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-            pack();
-        }
-        super.setVisible(visible);
-    }
-
     public static String styles() {
         float labelSize = UIUtil.scaleForGUI(UIUtil.FONT_SCALE2);
         int padding = UIUtil.scaleForGUI(BASE_PADDING);

--- a/megamek/src/megamek/client/ui/swing/sbf/SBFJumpChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/sbf/SBFJumpChoiceDialog.java
@@ -24,6 +24,7 @@ import megamek.client.ui.swing.CloseAction;
 import megamek.client.ui.swing.util.UIUtil;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import java.util.List;
 
@@ -58,7 +59,7 @@ public class SBFJumpChoiceDialog extends AbstractChoiceDialog<Integer> {
         JPanel buttonPanel = new JPanel();
         buttonPanel.setBorder(BorderFactory.createCompoundBorder(
                 new MatteBorder(1, 0, 0, 0, UIManager.getColor("Separator.foreground")),
-                new UIUtil.ScaledEmptyBorder(10, 0, 10, 0)));
+                new EmptyBorder(10, 0, 10, 0)));
         buttonPanel.add(new ButtonEsc(new CloseAction(this)));
         return buttonPanel;
     }

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioChooser.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioChooser.java
@@ -39,6 +39,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.UIManager;
+import javax.swing.border.EmptyBorder;
 import javax.swing.border.MatteBorder;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
@@ -123,7 +124,7 @@ public class ScenarioChooser extends AbstractButtonDialog {
         buttonPanel.setLayout(new BoxLayout(buttonPanel, BoxLayout.LINE_AXIS));
         buttonPanel.setBorder(BorderFactory.createCompoundBorder(
                 new MatteBorder(1, 0, 0, 0, UIManager.getColor("Separator.foreground")),
-                new UIUtil.ScaledEmptyBorder(10, 0, 10, 0)));
+                new EmptyBorder(10, 0, 10, 0)));
 
         Box verticalBox = Box.createVerticalBox();
         verticalBox.add(Box.createVerticalGlue());

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioChooser.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioChooser.java
@@ -18,9 +18,7 @@
  */
 package megamek.client.ui.swing.scenario;
 
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.FlowLayout;
+import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.nio.file.Path;
@@ -81,7 +79,7 @@ public class ScenarioChooser extends AbstractButtonDialog {
         super(parentFrame, "ScenarioChooser", "ScenarioChooser.title");
         initialize();
         setMinimumSize(
-                UIUtil.scaleForGUI(ScenarioInfoPanel.BASE_MINIMUM_WIDTH, ScenarioInfoPanel.BASE_MINIMUM_HEIGHT * 3));
+                new Dimension(ScenarioInfoPanel.BASE_MINIMUM_WIDTH, ScenarioInfoPanel.BASE_MINIMUM_HEIGHT * 3));
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioChooser.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioChooser.java
@@ -191,14 +191,6 @@ public class ScenarioChooser extends AbstractButtonDialog {
         return scenarioInfos.stream().collect(Collectors.groupingBy(this::getSubDirectory, Collectors.toList()));
     }
 
-    @Override
-    public void setVisible(boolean b) {
-        if (b) {
-            UIUtil.adjustDialog(this, UIUtil.FONT_SCALE1);
-        }
-        super.setVisible(b);
-    }
-
     private void selectFromFile(MouseEvent event) {
         JFileChooser fc = new JFileChooser(Configuration.scenariosDir());
         fc.setFileFilter(new FileNameExtensionFilter("Scenario files", "mms"));

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
@@ -25,6 +25,7 @@ import megamek.common.scenario.ScenarioV1;
 import megamek.common.scenario.Scenario;
 
 import javax.swing.*;
+import javax.swing.border.EmptyBorder;
 import java.awt.*;
 
 /**
@@ -58,7 +59,7 @@ public class ScenarioInfoPanel extends JPanel {
         textDescription2.setFont(new Font("Noto Sans", Font.PLAIN, UIUtil.FONT_SCALE1));
         textDescription2.setAlignmentX(0.5f);
         textDescription2.setVerticalAlignment(SwingConstants.TOP);
-        textDescription2.setBorder(new UIUtil.ScaledEmptyBorder(0, 10, 0, 10));
+        textDescription2.setBorder(new EmptyBorder(0, 10, 0, 10));
         add(textDescription2);
     }
 

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
@@ -48,13 +48,13 @@ public class ScenarioInfoPanel extends JPanel {
         lblTitle.setName("lblTitle");
         lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
         lblTitle.setForeground(UIUtil.uiLightGreen());
-        new FlatLafStyleBuilder(lblTitle).font("Exo 2").bold().size(1.4).set();
+        new FlatLafStyleBuilder().font("Exo 2").bold().size(1.4).apply(lblTitle);
         add(lblTitle);
         add(Box.createVerticalStrut(10));
         add(new DashedSeparator(UIUtil.uiLightGreen(), 0.9f, 2f));
         add(Box.createVerticalStrut(10));
 
-        new FlatLafStyleBuilder(textDescription2).font(FontHandler.notoFont()).set();
+        new FlatLafStyleBuilder().font(FontHandler.notoFont()).apply(textDescription2);
         textDescription2.setAlignmentX(0.5f);
         textDescription2.setVerticalAlignment(SwingConstants.TOP);
         textDescription2.setBorder(new EmptyBorder(0, 10, 0, 10));

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
@@ -18,9 +18,7 @@
  */
 package megamek.client.ui.swing.scenario;
 
-import megamek.client.ui.swing.util.DashedSeparator;
-import megamek.client.ui.swing.util.LocationBorder;
-import megamek.client.ui.swing.util.UIUtil;
+import megamek.client.ui.swing.util.*;
 import megamek.common.scenario.ScenarioV1;
 import megamek.common.scenario.Scenario;
 
@@ -37,7 +35,7 @@ public class ScenarioInfoPanel extends JPanel {
     static final int BASE_MINIMUM_WIDTH = 600;
     static final int BASE_MINIMUM_HEIGHT = 100;
 
-    private final JLabel lblTitle = new HeaderLabel();
+    private final JLabel lblTitle = new JLabel();
     private final DescriptionLabel textDescription2 = new DescriptionLabel();
 
     public ScenarioInfoPanel() {
@@ -50,13 +48,13 @@ public class ScenarioInfoPanel extends JPanel {
         lblTitle.setName("lblTitle");
         lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
         lblTitle.setForeground(UIUtil.uiLightGreen());
-        lblTitle.setFont(new Font("Exo 2", Font.BOLD, UIUtil.FONT_SCALE1));
+        new FlatLafStyleBuilder(lblTitle).font("Exo 2").bold().size(1.4).set();
         add(lblTitle);
-        add(UIUtil.scaledVerticalSpacer(10));
+        add(Box.createVerticalStrut(10));
         add(new DashedSeparator(UIUtil.uiLightGreen(), 0.9f, 2f));
-        add(UIUtil.scaledVerticalSpacer(10));
+        add(Box.createVerticalStrut(10));
 
-        textDescription2.setFont(new Font("Noto Sans", Font.PLAIN, UIUtil.FONT_SCALE1));
+        new FlatLafStyleBuilder(textDescription2).font(FontHandler.notoFont()).set();
         textDescription2.setAlignmentX(0.5f);
         textDescription2.setVerticalAlignment(SwingConstants.TOP);
         textDescription2.setBorder(new EmptyBorder(0, 10, 0, 10));
@@ -71,21 +69,13 @@ public class ScenarioInfoPanel extends JPanel {
     private static class DescriptionLabel extends JLabel {
         @Override
         public Dimension getMaximumSize() {
-            return UIUtil.scaleForGUI(BASE_MINIMUM_WIDTH, BASE_MINIMUM_HEIGHT);
+            // Fixed sizes do not get scaled by FlatLaf
+            return new Dimension(UIUtil.scaleForGUI(BASE_MINIMUM_WIDTH), UIUtil.scaleForGUI(BASE_MINIMUM_HEIGHT));
         }
 
         @Override
         public Dimension getPreferredSize() {
-            return UIUtil.scaleForGUI(BASE_MINIMUM_WIDTH, BASE_MINIMUM_HEIGHT);
-        }
-    }
-
-    private static class HeaderLabel extends JLabel {
-        @Override
-        public void setFont(Font font) {
-            // Keep a higher font size; UIUtil.adjustDialog sets everything to the same absolute font size
-            font = font.deriveFont(1.4f * font.getSize());
-            super.setFont(font);
+            return getMaximumSize();
         }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/tooltip/HexTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/HexTooltip.java
@@ -14,7 +14,6 @@
 package megamek.client.ui.swing.tooltip;
 
 import static megamek.client.ui.swing.util.UIUtil.DOT_SPACER;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
 
 import java.util.List;
 import java.util.Vector;
@@ -58,7 +57,7 @@ public final class HexTooltip {
                         bldg.getMagnitude());
             }
 
-            sFuelTank = guiScaledFontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sFuelTank + "</FONT>";
+            sFuelTank = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sFuelTank + "</FONT>";
             String col = "<TD>" + sFuelTank + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -78,7 +77,7 @@ public final class HexTooltip {
                         mhex.terrainLevel(Terrains.BLDG_CF),
                         Math.max(mhex.terrainLevel(Terrains.BLDG_ARMOR), 0),
                         BasementType.getType(mhex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).toString());
-                sBuilding = guiScaledFontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
+                sBuilding = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
                 String col = "<TD>" + sBuilding + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -96,7 +95,7 @@ public final class HexTooltip {
                 if (bldg.getBasementCollapsed(mcoords)) {
                     sBuilding += Messages.getString("BoardView1.Tooltip.BldgBasementCollapsed");
                 }
-                sBuilding = guiScaledFontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
+                sBuilding = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
                 String col = "<TD>" + sBuilding + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -122,7 +121,7 @@ public final class HexTooltip {
                         bldg.toString(),
                         bldg.getCurrentCF(mcoords));
             }
-            sBridge = guiScaledFontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBridge + "</FONT>";
+            sBridge = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBridge + "</FONT>";
             String col = "<TD>" + sBridge + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -156,7 +155,7 @@ public final class HexTooltip {
                         break;
                 }
 
-                sMinefield = guiScaledFontHTML(UIUtil.uiWhite()) + sMinefield + "</FONT>";
+                sMinefield = UIUtil.colorHTML(UIUtil.uiWhite()) + sMinefield + "</FONT>";
                 result.append(sMinefield);
                 result.append("<BR>");
             }
@@ -165,7 +164,7 @@ public final class HexTooltip {
         if ((game != null) && game.getGroundObjects(mcoords).size() > 0) {
         	for (ICarryable groundObject : game.getGroundObjects(mcoords)) {
         		result.append("&nbsp");
-        		result.append(guiScaledFontHTML(UIUtil.uiWhite()));
+        		result.append(UIUtil.colorHTML(UIUtil.uiWhite()));
         		result.append(groundObject.specificName());
         		result.append("</font>");
         		result.append("<br/>");
@@ -187,7 +186,7 @@ public final class HexTooltip {
         if (bldg.getBasementCollapsed(mcoords)) {
             sBuilding += Messages.getString("BoardView1.Tooltip.BldgBasementCollapsed");
         }
-        sBuilding = guiScaledFontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
+        sBuilding = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
         String col = "<TD>" + sBuilding + "</TD>";
         String row = "<TR>" + col + "</TR>";
         String table = "<TABLE BORDER=0 BGCOLOR=" + GUIP.hexColor(GUIP.getUnitToolTipBuildingBGColor()) + " width=100%>" + row + "</TABLE>";
@@ -208,7 +207,7 @@ public final class HexTooltip {
         boolean inAtmosphere = game.getBoard().inAtmosphere();
         Coords mcoords = mhex.getCoords();
         String indicator = IlluminationLevel.determineIlluminationLevel(game, mcoords).getIndicator();
-        String illuminated = DOT_SPACER + guiScaledFontHTML(GUIP.getCautionColor()) + " " + indicator + "</FONT>";
+        String illuminated = DOT_SPACER + UIUtil.colorHTML(GUIP.getCautionColor()) + " " + indicator + "</FONT>";
         String result = "";
         StringBuilder sTerrain = new StringBuilder(
                 Messages.getString(
@@ -238,7 +237,7 @@ public final class HexTooltip {
             }
         }
 
-        result += guiScaledFontHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
+        result += UIUtil.colorHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
         return result;
     }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/HexTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/HexTooltip.java
@@ -57,7 +57,7 @@ public final class HexTooltip {
                         bldg.getMagnitude());
             }
 
-            sFuelTank = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sFuelTank + "</FONT>";
+            sFuelTank = UIUtil.fontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sFuelTank + "</FONT>";
             String col = "<TD>" + sFuelTank + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -77,7 +77,7 @@ public final class HexTooltip {
                         mhex.terrainLevel(Terrains.BLDG_CF),
                         Math.max(mhex.terrainLevel(Terrains.BLDG_ARMOR), 0),
                         BasementType.getType(mhex.terrainLevel(Terrains.BLDG_BASEMENT_TYPE)).toString());
-                sBuilding = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
+                sBuilding = UIUtil.fontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
                 String col = "<TD>" + sBuilding + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -95,7 +95,7 @@ public final class HexTooltip {
                 if (bldg.getBasementCollapsed(mcoords)) {
                     sBuilding += Messages.getString("BoardView1.Tooltip.BldgBasementCollapsed");
                 }
-                sBuilding = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
+                sBuilding = UIUtil.fontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
                 String col = "<TD>" + sBuilding + "</TD>";
                 String row = "<TR>" + col + "</TR>";
                 String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -121,7 +121,7 @@ public final class HexTooltip {
                         bldg.toString(),
                         bldg.getCurrentCF(mcoords));
             }
-            sBridge = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBridge + "</FONT>";
+            sBridge = UIUtil.fontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBridge + "</FONT>";
             String col = "<TD>" + sBridge + "</TD>";
             String row = "<TR>" + col + "</TR>";
             String table = "<TABLE BORDER=0 BGCOLOR=" + GUIPreferences.hexColor(GUIP.getUnitToolTipBuildingBGColor())
@@ -155,7 +155,7 @@ public final class HexTooltip {
                         break;
                 }
 
-                sMinefield = UIUtil.colorHTML(UIUtil.uiWhite()) + sMinefield + "</FONT>";
+                sMinefield = UIUtil.fontHTML(UIUtil.uiWhite()) + sMinefield + "</FONT>";
                 result.append(sMinefield);
                 result.append("<BR>");
             }
@@ -164,7 +164,7 @@ public final class HexTooltip {
         if ((game != null) && game.getGroundObjects(mcoords).size() > 0) {
         	for (ICarryable groundObject : game.getGroundObjects(mcoords)) {
         		result.append("&nbsp");
-        		result.append(UIUtil.colorHTML(UIUtil.uiWhite()));
+        		result.append(UIUtil.fontHTML(UIUtil.uiWhite()));
         		result.append(groundObject.specificName());
         		result.append("</font>");
         		result.append("<br/>");
@@ -186,7 +186,7 @@ public final class HexTooltip {
         if (bldg.getBasementCollapsed(mcoords)) {
             sBuilding += Messages.getString("BoardView1.Tooltip.BldgBasementCollapsed");
         }
-        sBuilding = UIUtil.colorHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
+        sBuilding = UIUtil.fontHTML(GUIP.getUnitToolTipBuildingFGColor()) + sBuilding + "</FONT>";
         String col = "<TD>" + sBuilding + "</TD>";
         String row = "<TR>" + col + "</TR>";
         String table = "<TABLE BORDER=0 BGCOLOR=" + GUIP.hexColor(GUIP.getUnitToolTipBuildingBGColor()) + " width=100%>" + row + "</TABLE>";
@@ -207,7 +207,7 @@ public final class HexTooltip {
         boolean inAtmosphere = game.getBoard().inAtmosphere();
         Coords mcoords = mhex.getCoords();
         String indicator = IlluminationLevel.determineIlluminationLevel(game, mcoords).getIndicator();
-        String illuminated = DOT_SPACER + UIUtil.colorHTML(GUIP.getCautionColor()) + " " + indicator + "</FONT>";
+        String illuminated = DOT_SPACER + UIUtil.fontHTML(GUIP.getCautionColor()) + " " + indicator + "</FONT>";
         String result = "";
         StringBuilder sTerrain = new StringBuilder(
                 Messages.getString(
@@ -237,7 +237,7 @@ public final class HexTooltip {
             }
         }
 
-        result += UIUtil.colorHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
+        result += UIUtil.fontHTML(GUIP.getUnitToolTipTerrainFGColor()) + sTerrain + "</FONT>";
         return result;
     }
 

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -127,7 +127,6 @@ public final class PilotToolTip {
         // Effective entity skill for the whole crew
         boolean rpg_skills = game.getOptions().booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
         result += CrewSkillSummaryUtil.getSkillNames(entity) + ": " + crew.getSkillsAsString(rpg_skills);
-        result = UIUtil.guiScaledFontHTML() + result + "</FONT>";
         return new StringBuilder(result);
     }
 
@@ -146,7 +145,7 @@ public final class PilotToolTip {
 
             if ((crew.getNickname(i) != null) && !crew.getNickname(i).isBlank()) {
                 String sNickName = "<B>'" + crew.getNickname(i).toUpperCase() + "'</B>";
-                sCrew += guiScaledFontHTML(UIUtil.uiNickColor()) + sNickName + "</FONT>";
+                sCrew += UIUtil.colorHTML(UIUtil.uiNickColor()) + sNickName + "</FONT>";
             } else if ((crew.getName(i) != null) && !crew.getName(i).isBlank()) {
                 sCrew += crew.getName(i);
             } else {
@@ -158,7 +157,7 @@ public final class PilotToolTip {
             }
 
             if (!crew.getStatusDesc(i).isEmpty()) {
-                sCrew += guiScaledFontHTML(GUIP.getWarningColor()) + " (" + crew.getStatusDesc(i) + ")</FONT>";
+                sCrew += UIUtil.colorHTML(GUIP.getWarningColor()) + " (" + crew.getStatusDesc(i) + ")</FONT>";
             }
             result += sCrew + "<BR>";
         }
@@ -166,7 +165,6 @@ public final class PilotToolTip {
         // Effective entity skill for the whole crew
         boolean rpg_skills = game.getOptions().booleanOption(OptionsConstants.RPG_RPG_GUNNERY);
         result += CrewSkillSummaryUtil.getSkillNames(entity) + ": " + crew.getSkillsAsString(rpg_skills);
-        result = guiScaledFontHTML() + result + "</FONT>";
         String col = "<TD align=\"left\">" + result + "</TD>";
 
         return new StringBuilder().append(col);
@@ -185,7 +183,7 @@ public final class PilotToolTip {
         String col = "";
 
         if (!pickedUp.isEmpty()) {
-            pickedUp = guiScaledFontHTML(GUIP.getCautionColor()) + Messages.getString("BoardView1.Tooltip.PickedUp")
+            pickedUp = UIUtil.colorHTML(GUIP.getCautionColor()) + Messages.getString("BoardView1.Tooltip.PickedUp")
                     + pickedUp + "</FONT>";
             col = "<TD>" + pickedUp + "</TD>";
         }

--- a/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/PilotToolTip.java
@@ -14,8 +14,8 @@
 package megamek.client.ui.swing.tooltip;
 
 import static megamek.client.ui.swing.tooltip.TipUtil.getOptionList;
-import static megamek.client.ui.swing.tooltip.TipUtil.scaledHTMLSpacer;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+import static megamek.client.ui.swing.tooltip.TipUtil.htmlSpacer;
+import static megamek.client.ui.swing.util.UIUtil.fontHTML;
 import static megamek.client.ui.swing.util.UIUtil.uiQuirksColor;
 
 import java.awt.Image;
@@ -106,7 +106,7 @@ public final class PilotToolTip {
         if (!detailed) {
             result += "<HR STYLE=WIDTH:90% />";
         } else {
-            result += scaledHTMLSpacer(3);
+            result += htmlSpacer(3);
         }
 
         return new StringBuilder().append(result);
@@ -115,7 +115,7 @@ public final class PilotToolTip {
     /** The crew advantages and MD */
     public static StringBuilder getCrewAdvs(Entity entity, boolean detailed) {
         String sCrewAdvs = crewAdvs(entity, detailed).toString();
-        String result = scaledHTMLSpacer(3) + sCrewAdvs + "</FONT>";
+        String result = htmlSpacer(3) + sCrewAdvs + "</FONT>";
 
         return new StringBuilder().append(result);
     }
@@ -145,7 +145,7 @@ public final class PilotToolTip {
 
             if ((crew.getNickname(i) != null) && !crew.getNickname(i).isBlank()) {
                 String sNickName = "<B>'" + crew.getNickname(i).toUpperCase() + "'</B>";
-                sCrew += UIUtil.colorHTML(UIUtil.uiNickColor()) + sNickName + "</FONT>";
+                sCrew += UIUtil.fontHTML(UIUtil.uiNickColor()) + sNickName + "</FONT>";
             } else if ((crew.getName(i) != null) && !crew.getName(i).isBlank()) {
                 sCrew += crew.getName(i);
             } else {
@@ -157,7 +157,7 @@ public final class PilotToolTip {
             }
 
             if (!crew.getStatusDesc(i).isEmpty()) {
-                sCrew += UIUtil.colorHTML(GUIP.getWarningColor()) + " (" + crew.getStatusDesc(i) + ")</FONT>";
+                sCrew += UIUtil.fontHTML(GUIP.getWarningColor()) + " (" + crew.getStatusDesc(i) + ")</FONT>";
             }
             result += sCrew + "<BR>";
         }
@@ -183,7 +183,7 @@ public final class PilotToolTip {
         String col = "";
 
         if (!pickedUp.isEmpty()) {
-            pickedUp = UIUtil.colorHTML(GUIP.getCautionColor()) + Messages.getString("BoardView1.Tooltip.PickedUp")
+            pickedUp = UIUtil.fontHTML(GUIP.getCautionColor()) + Messages.getString("BoardView1.Tooltip.PickedUp")
                     + pickedUp + "</FONT>";
             col = "<TD>" + pickedUp + "</TD>";
         }
@@ -246,7 +246,7 @@ public final class PilotToolTip {
         String sOptionList = "";
         Crew crew = entity.getCrew();
         sOptionList = getOptionList(crew.getOptions().getGroups(), crew::countOptions, detailed);
-        result = guiScaledFontHTML(uiQuirksColor(), UnitToolTip.TT_SMALLFONT_DELTA) + sOptionList + "</FONT>";
+        result = UIUtil.fontHTML(uiQuirksColor(), UnitToolTip.TT_SMALLFONT_DELTA) + sOptionList + "</FONT>";
 
         return new StringBuilder().append(result);
     }

--- a/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/TipUtil.java
@@ -1,16 +1,16 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
-*/ 
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
+*/
 package megamek.client.ui.swing.tooltip;
 
 import java.util.ArrayList;
@@ -26,21 +26,21 @@ import megamek.common.options.IOptionGroup;
 
 /** Provides static helper functions for creating entity and crew tooltips. */
 public final class TipUtil {
-    
+
     final static boolean BR = true;
     final static boolean NOBR = false;
 
     /**
-     * Returns a List wherein each element consists of an option group of the given 
+     * Returns a List wherein each element consists of an option group of the given
      * optGroups, which is e.g. crew.getOptions().getGroups() or entity.getQuirks().getGroups()
      * as well as the count of active options within that group, e.g. "Manei Domini (2)".
      * A counter function for the options of a group must be supplied, in the form of
      * e.g. e -&gt; crew.countOptions(e) or e -&gt; entity.countQuirks(e).
      * A namer function for the group names must be supplied, e.g. (e) -&gt; weapon.getDesc().
      */
-    public static List<String> getOptionListArray(Enumeration<IOptionGroup> optGroups, 
+    public static List<String> getOptionListArray(Enumeration<IOptionGroup> optGroups,
             Function<String, Integer> counter, Function<IOptionGroup, String> namer) {
-        
+
         List<String> result = new ArrayList<>();
         while (optGroups.hasMoreElements()) {
             IOptionGroup advGroup = optGroups.nextElement();
@@ -52,7 +52,7 @@ public final class TipUtil {
         return result;
     }
 
-    /** 
+    /**
      * Returns an HTML String listing the options given as optGroups, which
      * is e.g. crew.getOptions().getGroups() or entity.getQuirks().getGroups().
      * A counter function for the options of a group must be supplied, in the form of
@@ -61,7 +61,7 @@ public final class TipUtil {
      * The group names are italicized.
      * The list is 40 characters wide with \u2B1D as option separator.
      */
-    public static String getOptionList(Enumeration<IOptionGroup> optGroups, Function<String, Integer> counter, 
+    public static String getOptionList(Enumeration<IOptionGroup> optGroups, Function<String, Integer> counter,
             Function<IOptionGroup, String> namer, boolean detailed) {
         if (detailed) {
             return optionListFull(optGroups, counter, namer);
@@ -69,8 +69,8 @@ public final class TipUtil {
             return optionListShort(optGroups, counter, namer);
         }
     }
-    
-    /** 
+
+    /**
      * Returns an HTML String listing the options given as optGroups, which
      * is e.g. crew.getOptions().getGroups() or entity.getQuirks().getGroups().
      * A counter function for the options of a group must be supplied, in the form of
@@ -86,24 +86,23 @@ public final class TipUtil {
         }
     }
 
-    static String scaledHTMLSpacer(final int unscaledSize) {
-        int scaledSize = (int) (GUIPreferences.getInstance().getGUIScale() * unscaledSize);  
+    static String htmlSpacer(int unscaledSize) {
         return "<P><IMG SRC=FILE:" + Configuration.widgetsDir() + "/Tooltip/TT_Spacer.png "
-                + "WIDTH=" + scaledSize + " HEIGHT=" + scaledSize + "></P>";
+                + "WIDTH=" + unscaledSize + " HEIGHT=" + unscaledSize + "></P>";
     }
-        
+
     // PRIVATE
-    
-    private static String optionListFull(Enumeration<IOptionGroup> advGroups, 
+
+    private static String optionListFull(Enumeration<IOptionGroup> advGroups,
             Function<String, Integer> counter, Function<IOptionGroup, String> namer) {
         StringBuilder result = new StringBuilder();
-        
+
         while (advGroups.hasMoreElements()) {
             IOptionGroup advGroup = advGroups.nextElement();
             if (counter.apply(advGroup.getKey()) > 0) {
                 // Group title
                 result.append("<I>" + namer.apply(advGroup) + ":</I><BR>");
-                
+
                 // Gather the group options
                 List<String> origList = new ArrayList<>();
                 for (Enumeration<IOption> advs = advGroup.getOptions(); advs.hasMoreElements();) {
@@ -112,7 +111,7 @@ public final class TipUtil {
                         origList.add(adv.getDisplayableNameWithValue());
                     }
                 }
-                
+
                 // Arrange the options in lines according to length
                 List<String> advLines = UIUtil.arrangeInLines(origList, 40, " \u2B1D ", false);
                 for (String line: advLines) {
@@ -122,11 +121,11 @@ public final class TipUtil {
         }
         return result.toString();
     }
-    
-    private static String optionListShort(Enumeration<IOptionGroup> advGroups, 
+
+    private static String optionListShort(Enumeration<IOptionGroup> advGroups,
             Function<String, Integer> counter, Function<IOptionGroup, String> namer) {
         StringBuilder result = new StringBuilder();
-        
+
         // Gather the option groups and option count per group
         List<String> origList = new ArrayList<>();
         while (advGroups.hasMoreElements()) {
@@ -136,7 +135,7 @@ public final class TipUtil {
                 origList.add(namer.apply(advGroup) + " (" + numOpts + ")");
             }
         }
-        
+
         // Arrange the option groups in lines according to length
         for (String line: UIUtil.arrangeInLines(origList, 40, "; ", true)) {
             result.append(line + "<BR>");

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -19,7 +19,7 @@ import static megamek.client.ui.swing.tooltip.TipUtil.getOptionList;
 import static megamek.client.ui.swing.util.UIUtil.DOT_SPACER;
 import static megamek.client.ui.swing.util.UIUtil.ECM_SIGN;
 import static megamek.client.ui.swing.util.UIUtil.addGray;
-import static megamek.client.ui.swing.util.UIUtil.guiScaledFontHTML;
+import static megamek.client.ui.swing.util.UIUtil.fontHTML;
 import static megamek.client.ui.swing.util.UIUtil.repeat;
 
 import java.awt.Color;
@@ -244,8 +244,8 @@ public final class UnitToolTip {
             result += "&nbsp;&nbsp;" + entity.getEntityTypeName(entity.getEntityType());
             result += "<BR>" + ownerName;
             String msg_id = MessageFormat.format(" [ID: {0}]", entity.getId());
-            result += UIUtil.colorHTML(GUIP.getUnitToolTipFGColor()) + msg_id + "</FONT>";
-            result = UIUtil.colorHTML(ownerColor) + result + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getUnitToolTipFGColor()) + msg_id + "</FONT>";
+            result = UIUtil.fontHTML(ownerColor) + result + "</FONT>";
         }
 
         return result;
@@ -280,7 +280,7 @@ public final class UnitToolTip {
                 }
             }
 
-            return guiScaledFontHTML(GUIP.getUnitToolTipQuirkColor(), TT_SMALLFONT_DELTA) + sQuirks + "</FONT>";
+            return UIUtil.fontHTML(GUIP.getUnitToolTipQuirkColor(), TT_SMALLFONT_DELTA) + sQuirks + "</FONT>";
         }
 
         return "";
@@ -292,7 +292,7 @@ public final class UnitToolTip {
                 grp -> entity.countPartialRepairs(), details);
 
         if (!partialList.isEmpty()) {
-            result += guiScaledFontHTML(GUIP.getPrecautionColor(), TT_SMALLFONT_DELTA) + partialList + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getPrecautionColor(), TT_SMALLFONT_DELTA) + partialList + "</FONT>";
         }
 
         return result;
@@ -319,7 +319,7 @@ public final class UnitToolTip {
 
         if ((good + hits) > 0) {
             locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-            result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+            result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
             result += systemBar(good, hits, bad);
         }
 
@@ -334,7 +334,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -348,7 +348,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -362,7 +362,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -376,7 +376,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -390,7 +390,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -404,7 +404,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -418,7 +418,7 @@ public final class UnitToolTip {
         boolean bad = hits > 0;
 
         locAbbr = "&nbsp;&nbsp;" + locAbbr + ":&nbsp;";
-        result = guiScaledFontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
+        result = fontHTML(TT_SMALLFONT_DELTA) + locAbbr + "</FONT>";
         result += systemBar(good, hits, bad);
 
         return new StringBuilder().append(result);
@@ -474,24 +474,24 @@ public final class UnitToolTip {
                 // Destroyed location
                 col1 = "";
                 String sLocHeader = "&nbsp;&nbsp;" + locationHeader(entity, loc) + ":&nbsp;";
-                col2 = guiScaledFontHTML(TT_SMALLFONT_DELTA) + sLocHeader + "</FONT>";
+                col2 = fontHTML(TT_SMALLFONT_DELTA) + sLocHeader + "</FONT>";
                 col2 += destroyedLocBar(entity.getOArmor(loc, true)).toString();
             } else {
                 // Rear armor
                 if (entity.hasRearArmor(loc)) {
                     String msg_abbr_rear = Messages.getString("BoardView1.Tooltip.AbbreviationRear");
                     String sLocHeader = "&nbsp;&nbsp;" + locationHeader(entity, loc) + msg_abbr_rear + "&nbsp;";
-                    col1 = guiScaledFontHTML(TT_SMALLFONT_DELTA) + sLocHeader + "</FONT>";
+                    col1 = fontHTML(TT_SMALLFONT_DELTA) + sLocHeader + "</FONT>";
                     col1 += intactLocBar(entity.getOArmor(loc, true), entity.getArmor(loc, true), armorChar).toString();
                 } else {
                     // No rear armor: empty table cells instead
                     // At small font sizes, writing one character at the correct font size is
                     // necessary to prevent the table rows from being spaced non-beautifully
-                    col1 = guiScaledFontHTML(TT_SMALLFONT_DELTA) + "&nbsp;" + "</FONT>";
+                    col1 = fontHTML(TT_SMALLFONT_DELTA) + "&nbsp;" + "</FONT>";
                 }
                 // Front armor
                 String sLocHeader = "&nbsp;&nbsp;" + locationHeader(entity, loc) + ":&nbsp;";
-                col2 = guiScaledFontHTML(TT_SMALLFONT_DELTA) + sLocHeader + "</FONT>";
+                col2 = fontHTML(TT_SMALLFONT_DELTA) + sLocHeader + "</FONT>";
                 col2 += intactLocBar(entity.getOInternal(loc), entity.getInternal(loc), internalChar).toString();
                 col2 += intactLocBar(entity.getOArmor(loc), entity.getArmor(loc), armorChar).toString();
             }
@@ -711,15 +711,15 @@ public final class UnitToolTip {
                 String msg_x = Messages.getString("BoardView1.Tooltip.X");
                 String sIntact = dChar + msg_x + tensIntact * 10;
                 sIntact += repeat(dChar, numIntact - 10 * tensIntact);
-                result += guiScaledFontHTML(colorIntact, TT_SMALLFONT_DELTA) + sIntact + "</FONT>";
+                result += UIUtil.fontHTML(colorIntact, TT_SMALLFONT_DELTA) + sIntact + "</FONT>";
             } else {
                 String sIntact = repeat(dChar, numIntact);
-                result += guiScaledFontHTML(colorIntact, TT_SMALLFONT_DELTA) + sIntact + "</FONT>";
+                result += UIUtil.fontHTML(colorIntact, TT_SMALLFONT_DELTA) + sIntact + "</FONT>";
             }
         }
         if (numPartial > 0) {
             String sPartial = repeat(dChar, numPartial);
-            result += guiScaledFontHTML(colorPartialDmg, TT_SMALLFONT_DELTA) + sPartial + "</FONT>";
+            result += UIUtil.fontHTML(colorPartialDmg, TT_SMALLFONT_DELTA) + sPartial + "</FONT>";
         }
         if (numDmgd > 0) {
             if (numDmgd > 15 && numIntact + numDmgd > 30) {
@@ -727,10 +727,10 @@ public final class UnitToolTip {
                 String msg_x = Messages.getString("BoardView1.Tooltip.X");
                 String sDamage = dChar + msg_x + tensDmgd * 10;
                 sDamage += repeat(dChar, numDmgd - 10 * tensDmgd);
-                result += guiScaledFontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";
+                result += UIUtil.fontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";
             } else {
                 String sDamage = repeat(dChar, numDmgd);
-                result += guiScaledFontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";
+                result += UIUtil.fontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sDamage + "</FONT>";
             }
         }
         return new StringBuilder().append(result);
@@ -751,15 +751,15 @@ public final class UnitToolTip {
         if (good > 0) {
             if (!destroyed) {
                 String sGood = repeat(iChar, good);
-                result = guiScaledFontHTML(colorIntact, TT_SMALLFONT_DELTA) + sGood + "</FONT>";
+                result = UIUtil.fontHTML(colorIntact, TT_SMALLFONT_DELTA) + sGood + "</FONT>";
             } else {
                 String sGood = repeat(iChar, good);
-                result = guiScaledFontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sGood + "</FONT>";
+                result = UIUtil.fontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sGood + "</FONT>";
             }
         }
         if (bad > 0) {
             String sBad = repeat(dChar, bad);
-            result += guiScaledFontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sBad + "</FONT>";
+            result += UIUtil.fontHTML(colorDamaged, TT_SMALLFONT_DELTA) + sBad + "</FONT>";
         }
         return new StringBuilder().append(result);
     }
@@ -1052,9 +1052,9 @@ public final class UnitToolTip {
                 }
                 ;
 
-                col1 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
+                col1 = UIUtil.fontHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
                 col1 = "<TD>" + col1 + "</TD>";
-                col2 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
+                col2 = UIUtil.fontHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
                 col2 = "<TD>" + col2 + "</TD>";
                 row = "<TR>" + col1 + col2 + "</TR>";
             }
@@ -1092,11 +1092,11 @@ public final class UnitToolTip {
                     col2 = "&nbsp;x&nbsp;";
                     col3 = BombType.getBombName(i);
 
-                    col1 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
+                    col1 = UIUtil.fontHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
                     col1 = "<TD>" + col1 + "</TD>";
-                    col2 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
+                    col2 = UIUtil.fontHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
                     col2 = "<TD>" + col2 + "</TD>";
-                    col3 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col3 + "</FONT>";
+                    col3 = UIUtil.fontHTML(GUIP.getUnitToolTipWeaponColor()) + col3 + "</FONT>";
                     col3 = "<TD>" + col3 + "</TD>";
                     row = "<TR>" + col1 + col2 + col3 + "</TR>";
                 } else {
@@ -1141,7 +1141,7 @@ public final class UnitToolTip {
             String msg_outofammo = Messages.getString("BoardView1.Tooltip.OutOfAmmo");
             col2 = "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;" + msg_outofammo;
             col1 = "<TD>" + col1 + "</TD>";
-            col2 = guiScaledFontHTML(GUIP.getCautionColor(), -0.2f) + col2 + "</FONT>";
+            col2 = UIUtil.fontHTML(GUIP.getCautionColor(), -0.2f) + col2 + "</FONT>";
             col2 = "<TD>" + col2 + "</TD>";
             row = "<TR>" + col1 + col2 + "</TR>";
             rows += row;
@@ -1169,7 +1169,7 @@ public final class UnitToolTip {
                 }
 
                 col1 = "<TD>" + col1 + "</TD>";
-                col2 = guiScaledFontHTML(GUIP.getCautionColor(), -0.2f) + col2 + "</FONT>";
+                col2 = UIUtil.fontHTML(GUIP.getCautionColor(), -0.2f) + col2 + "</FONT>";
                 col2 = "<TD>" + col2 + "</TD>";
                 row = "<TR>" + col1 + col2 + "</TR>";
                 rows += row;
@@ -1192,8 +1192,8 @@ public final class UnitToolTip {
             sECMInfo += ECM_SIGN + " " + msg_eccmsource;
         }
 
-        result = guiScaledFontHTML() + sECMInfo + "</FONT>";
-        result = guiScaledFontHTML() + result + "</FONT>";
+        result = UIUtil.fontHTML() + sECMInfo + "</FONT>";
+        result = UIUtil.fontHTML() + result + "</FONT>";
 
         return new StringBuilder().append(result);
     }
@@ -1263,13 +1263,13 @@ public final class UnitToolTip {
         result += ' ' + getDamageLevelDesc(entity, true);
 
         if (!isGunEmplacement && entity.isImmobile()) {
-            result += ' ' + UIUtil.colorHTML(GUIP.getWarningColor())
+            result += ' ' + UIUtil.fontHTML(GUIP.getWarningColor())
                     + Messages.getString("BoardView1.Tooltip.Immobile") + "</FONT>";
         }
 
         // Unit Prone
         if (!isGunEmplacement && entity.isProne()) {
-            result += ' ' + UIUtil.colorHTML(GUIP.getWarningColor()) + Messages.getString("BoardView1.Tooltip.Prone")
+            result += ' ' + UIUtil.fontHTML(GUIP.getWarningColor()) + Messages.getString("BoardView1.Tooltip.Prone")
                     + "</FONT>";
         }
 
@@ -1298,17 +1298,17 @@ public final class UnitToolTip {
 
         if (entity.isDoomed() || entity.isDestroyed()) {
             String msg_destroyed = Messages.getString("BoardView1.Tooltip.Destroyed");
-            return useHtml ? UIUtil.colorHTML(GUIP.getWarningColor()) + msg_destroyed + "</FONT>" : msg_destroyed;
+            return useHtml ? UIUtil.fontHTML(GUIP.getWarningColor()) + msg_destroyed + "</FONT>" : msg_destroyed;
         }
 
         switch (entity.getDamageLevel()) {
             case Entity.DMG_CRIPPLED:
                 String msg_crippled = Messages.getString("BoardView1.Tooltip.Crippled");
-                result = useHtml ? UIUtil.colorHTML(GUIP.getWarningColor()) + msg_crippled + "</FONT>" : msg_crippled;
+                result = useHtml ? UIUtil.fontHTML(GUIP.getWarningColor()) + msg_crippled + "</FONT>" : msg_crippled;
                 break;
             case Entity.DMG_HEAVY:
                 String msg_heavydmg = Messages.getString("BoardView1.Tooltip.HeavyDmg");
-                result = useHtml ? UIUtil.colorHTML(GUIP.getWarningColor()) + msg_heavydmg + "</FONT>" : msg_heavydmg;
+                result = useHtml ? UIUtil.fontHTML(GUIP.getWarningColor()) + msg_heavydmg + "</FONT>" : msg_heavydmg;
                 break;
             case Entity.DMG_MODERATE:
                 String msg_moderatedmg = Messages.getString("BoardView1.Tooltip.ModerateDmg");
@@ -1363,7 +1363,7 @@ public final class UnitToolTip {
             if (!entity.isDone() && game.getPhase().isMovement()) {
                 String sNotYetMoved = addToTT("NotYetMoved", BR).toString();
                 sNotYetMoved = "<I>" + sNotYetMoved + "</I>";
-                result += UIUtil.colorHTML(GUIP.getColorForMovement(entity.moved)) + sNotYetMoved + "</FONT>";
+                result += UIUtil.fontHTML(GUIP.getColorForMovement(entity.moved)) + sNotYetMoved + "</FONT>";
             } else if ((entity.isDone() && game.getPhase().isMovement())
                     || (game.getPhase().isMovementReport())
                     || (game.getPhase().isFiring())
@@ -1386,14 +1386,14 @@ public final class UnitToolTip {
                 if (entity.isEvading()) {
                     String sSpecialMove = addToTT("Evade", BR).toString();
                     sSpecialMove = "<I>" + sSpecialMove + "</I>";
-                    sSpecialMove = UIUtil.colorHTML(GUIP.getPrecautionColor()) + sSpecialMove + "</FONT>";
+                    sSpecialMove = UIUtil.fontHTML(GUIP.getPrecautionColor()) + sSpecialMove + "</FONT>";
                     sMove += sSpecialMove;
                 }
 
                 if ((entity instanceof Infantry) && ((Infantry) entity).isTakingCover()) {
                     String sTakingCover = addToTT("TakingCover", BR).toString();
                     sTakingCover = "<I>" + sTakingCover + "</I>";
-                    sTakingCover = UIUtil.colorHTML(GUIP.getPrecautionColor()) + sTakingCover + "</FONT>";
+                    sTakingCover = UIUtil.fontHTML(GUIP.getPrecautionColor()) + sTakingCover + "</FONT>";
                     sMove += sTakingCover;
                 }
 
@@ -1404,7 +1404,7 @@ public final class UnitToolTip {
                 if (entity.isMakingDfa()) {
                     String sDFA = addToTT("DFA", BR).toString();
                     sDFA = "<I>" + sDFA + "</I>";
-                    sDFA = UIUtil.colorHTML(GUIP.getWarningColor()) + sDFA + "</FONT>";
+                    sDFA = UIUtil.fontHTML(GUIP.getWarningColor()) + sDFA + "</FONT>";
                     sMove += sDFA;
                 }
 
@@ -1419,7 +1419,7 @@ public final class UnitToolTip {
                     sMove += sUnJamming;
                 }
 
-                result += UIUtil.colorHTML(GUIP.getColorForMovement(entity.moved)) + sMove + "</FONT>";
+                result += UIUtil.fontHTML(GUIP.getColorForMovement(entity.moved)) + sMove + "</FONT>";
             }
         }
 
@@ -1429,7 +1429,7 @@ public final class UnitToolTip {
                 String uw = "<br/>"
                         + addToTT("InfUWDuration", NOBR, mount.getUWEndurance() - entity.underwaterRounds).toString();
                 if (entity.underwaterRounds >= mount.getUWEndurance()) {
-                    uw = UIUtil.colorHTML(GUIP.getWarningColor()) + uw + "</font>";
+                    uw = UIUtil.fontHTML(GUIP.getWarningColor()) + uw + "</font>";
                 }
                 result += uw;
             }
@@ -1447,7 +1447,7 @@ public final class UnitToolTip {
             sAeroInfo = addToTT("Elev", BR, entity.getElevation()).toString();
         }
         sAeroInfo = "<I>" + sAeroInfo + "</I>";
-        result += UIUtil.colorHTML(GUIP.getUnitToolTipHighlightColor()) + sAeroInfo + "</FONT>";
+        result += UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + sAeroInfo + "</FONT>";
 
         result += "<BR>";
         String msg_facing = Messages.getString("BoardView1.Tooltip.Facing");
@@ -1456,7 +1456,7 @@ public final class UnitToolTip {
             String msg_twist = Messages.getString("BoardView1.Tooltip.Twist");
             sFacingTwist += "&nbsp;&nbsp;" + msg_twist + ":&nbsp;" + entity.getFacingName(entity.getSecondaryFacing());
         }
-        result += guiScaledFontHTML() + sFacingTwist + "</FONT>";
+        result += UIUtil.fontHTML() + sFacingTwist + "</FONT>";
 
         // Heat, not shown for units with 999 heat sinks (vehicles)
         if (entity.getHeatCapacity() != 999) {
@@ -1469,25 +1469,25 @@ public final class UnitToolTip {
             }
             HeatDisplayHelper hdh = getHeatCapacityForDisplay(entity);
             sHeat += " / " + hdh.heatCapacityStr;
-            result += UIUtil.colorHTML(GUIP.getColorForHeat(heat, GUIP.getUnitToolTipFGColor())) + sHeat + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getColorForHeat(heat, GUIP.getUnitToolTipFGColor())) + sHeat + "</FONT>";
 
             if (entity instanceof Mek && ((Mek) entity).hasActiveTSM()) {
                 result += DOT_SPACER;
                 String sTSM = "TSM";
-                result += UIUtil.colorHTML(GUIP.getPrecautionColor()) + sTSM + "</FONT>";
+                result += UIUtil.fontHTML(GUIP.getPrecautionColor()) + sTSM + "</FONT>";
             }
         }
 
         String illuminated = entity.isIlluminated() ? DOT_SPACER + "\uD83D\uDCA1" : "";
-        result += UIUtil.colorHTML(GUIP.getCautionColor()) + illuminated + "</FONT>";
+        result += UIUtil.fontHTML(GUIP.getCautionColor()) + illuminated + "</FONT>";
 
         if (entity.hasSearchlight()) {
             String searchLight = entity.isUsingSearchlight() ? DOT_SPACER + "\uD83D\uDD26" : "";
             searchLight += entity.usedSearchlight() ? " \u2580\u2580" : "";
-            result += UIUtil.colorHTML(GUIP.getCautionColor()) + searchLight + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getCautionColor()) + searchLight + "</FONT>";
         } else {
             String searchLight = "\uD83D\uDD26";
-            result += UIUtil.colorHTML(GUIP.getWarningColor()) + DOT_SPACER + searchLight + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getWarningColor()) + DOT_SPACER + searchLight + "</FONT>";
         }
 
         // Gun Emplacement Status
@@ -1496,20 +1496,20 @@ public final class UnitToolTip {
             if (emp.isTurret() && emp.isTurretLocked(emp.getLocTurret())) {
                 String sTurretLocked = addToTT("TurretLocked", BR).toString();
                 sTurretLocked = "<I>" + sTurretLocked + "</I>";
-                result += UIUtil.colorHTML(GUIP.getWarningColor()) + sTurretLocked + "</FONT>";
+                result += UIUtil.fontHTML(GUIP.getWarningColor()) + sTurretLocked + "</FONT>";
             }
         }
 
         // Unit Immobile
         if (!isGunEmplacement && entity.isImmobile()) {
             String sImmobile = addToTT("Immobile", BR).toString();
-            result += UIUtil.colorHTML(GUIP.getWarningColor()) + sImmobile + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getWarningColor()) + sImmobile + "</FONT>";
         }
 
         // Unit Prone
         if (!isGunEmplacement && entity.isProne()) {
             String sUnitProne = addToTT("Prone", BR).toString();
-            result += UIUtil.colorHTML(GUIP.getCautionColor()) + sUnitProne + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getCautionColor()) + sUnitProne + "</FONT>";
         }
 
         if (!entity.getHiddenActivationPhase().isUnknown()) {
@@ -1534,14 +1534,14 @@ public final class UnitToolTip {
             String msg_error = Messages.getString("ERROR");
             String sa = (swarmAttacker == null) ? msg_error : swarmAttacker.getDisplayName();
             String sSwarmed = addToTT("Swarmed", BR, sa).toString();
-            result += UIUtil.colorHTML(GUIP.getWarningColor()) + sSwarmed + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getWarningColor()) + sSwarmed + "</FONT>";
         }
 
         // Spotting
         if (entity.isSpotting() && game.hasEntity(entity.getSpotTargetId())) {
             String sSpotting = addToTT("Spotting", BR, game.getEntity(entity.getSpotTargetId()).getDisplayName())
                     .toString();
-            result += guiScaledFontHTML() + sSpotting + "</FONT>";
+            result += UIUtil.fontHTML() + sSpotting + "</FONT>";
         }
 
         if (showSeenBy) {
@@ -1583,7 +1583,7 @@ public final class UnitToolTip {
                 if (tempList.length() > 1) {
                     tempList.delete(tempList.length() - 2, tempList.length());
                     String sSeenBy = addToTT("SeenBy", BR, tempList.toString()).toString();
-                    result += guiScaledFontHTML() + sSeenBy + "</FONT>";
+                    result += UIUtil.fontHTML() + sSeenBy + "</FONT>";
                 }
             }
         }
@@ -1612,7 +1612,7 @@ public final class UnitToolTip {
 
         if (entity.hasAnyTypeNarcPodsAttached()) {
             String sNarced = addToTT(entity.hasNarcPodsAttached() ? "Narced" : "INarced", BR).toString();
-            result += UIUtil.colorHTML(GUIP.getPrecautionColor()) + sNarced + "</FONT>";
+            result += UIUtil.fontHTML(GUIP.getPrecautionColor()) + sNarced + "</FONT>";
         }
 
         // Towing
@@ -1626,7 +1626,7 @@ public final class UnitToolTip {
         }
 
         // Coloring to make these transient entries stand out
-        result = UIUtil.colorHTML(GUIP.getUnitToolTipHighlightColor()) + result + "</FONT>";
+        result = UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor()) + result + "</FONT>";
 
         return new StringBuilder().append(result);
     }
@@ -1745,14 +1745,14 @@ public final class UnitToolTip {
                 if (entity.getGame().getPlanetaryConditions().getGravity() != 1.0) {
                     sMove += DOT_SPACER;
                     String sGravity = entity.getGame().getPlanetaryConditions().getGravity() + "g";
-                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sGravity + "</FONT>";
+                    sMove += UIUtil.fontHTML(GUIP.getWarningColor()) + sGravity + "</FONT>";
                 }
                 int walkMPNoHeat = entity.getWalkMP(MPCalculationSetting.NO_HEAT);
                 int runMPNoHeat = entity.getRunMP(MPCalculationSetting.NO_HEAT);
                 if ((walkMPNoHeat != walkMPModified) || (runMPNoHeat != runMPModified)) {
                     sMove += DOT_SPACER;
                     String sHeat = "\uD83D\uDD25";
-                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sHeat + "</FONT>";
+                    sMove += UIUtil.fontHTML(GUIP.getWarningColor()) + sHeat + "</FONT>";
                 }
             }
 
@@ -1762,7 +1762,7 @@ public final class UnitToolTip {
                 if (bombMod != walkMP) {
                     sMove += DOT_SPACER;
                     String sBomb = "\uD83D\uDCA3";
-                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sBomb + "</FONT>";
+                    sMove += UIUtil.fontHTML(GUIP.getWarningColor()) + sBomb + "</FONT>";
                 }
             }
 
@@ -1771,7 +1771,7 @@ public final class UnitToolTip {
             if ((weatherMod != 0) || (partialWingWeaterMod != 0)) {
                 sMove += DOT_SPACER;
                 String sWeather = "\u2602";
-                sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sWeather + "</FONT>";
+                sMove += UIUtil.fontHTML(GUIP.getWarningColor()) + sWeather + "</FONT>";
             }
 
             if ((legsDestroyed > 0) || (hipHits > 0) || (actuatorHits > 0) || (jumpJetDistroyed > 0)
@@ -1779,7 +1779,7 @@ public final class UnitToolTip {
                     || (jumpBoosterDistroyed > 0) || (entity.isImmobile()) || (entity.isGyroDestroyed())) {
                 sMove += DOT_SPACER;
                 String sDamage = "\uD83D\uDD27";
-                sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sDamage + "</FONT>";
+                sMove += UIUtil.fontHTML(GUIP.getWarningColor()) + sDamage + "</FONT>";
             }
 
             if ((entity instanceof BipedMek) || (entity instanceof TripodMek)) {
@@ -1792,14 +1792,14 @@ public final class UnitToolTip {
                 if (shieldMod != 0) {
                     sMove += DOT_SPACER;
                     String sShield = "\u26E8";
-                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sShield + "</FONT>";
+                    sMove += UIUtil.fontHTML(GUIP.getWarningColor()) + sShield + "</FONT>";
                 }
             }
 
             if (entity.hasModularArmor()) {
                 sMove += DOT_SPACER;
                 String sArmor = "\u27EC\u25AE";
-                sMove += DOT_SPACER + UIUtil.colorHTML(GUIP.getWarningColor()) + sArmor + "</FONT>";
+                sMove += DOT_SPACER + UIUtil.fontHTML(GUIP.getWarningColor()) + sArmor + "</FONT>";
             }
 
             l1 = "<Li style=\"list-style-type: none; list-style-image: none; margin: 0; padding: 0; width: 300px;\">"
@@ -1840,7 +1840,7 @@ public final class UnitToolTip {
 
         String ul = "<UL style=\"list-style-type: none; list-style-image: none; margin: 0; padding: 0;\">" + l1 + l2
                 + l3 + "</UL>";
-        result = guiScaledFontHTML() + ul + "</FONT>";
+        result = UIUtil.fontHTML() + ul + "</FONT>";
 
         return new StringBuilder().append(result);
     }
@@ -1874,7 +1874,7 @@ public final class UnitToolTip {
 
         String ul = "<UL style=\"list-style-type: none; list-style-image: none; margin: 0; padding: 0;\">" + l1
                 + "</UL>";
-        result = guiScaledFontHTML() + ul + "</FONT>";
+        result = UIUtil.fontHTML() + ul + "</FONT>";
 
         return new StringBuilder().append(result);
     }
@@ -1906,7 +1906,7 @@ public final class UnitToolTip {
             String msg_cannotsurvivespace = Messages.getString("BoardView1.Tooltip.CannotSurviveSpace");
             sWarnings += "<BR>" + msg_cannotsurvivespace;
         }
-        result += UIUtil.colorHTML(GUIP.getWarningColor()) + sWarnings + "</FONT>";
+        result += UIUtil.fontHTML(GUIP.getWarningColor()) + sWarnings + "</FONT>";
 
         String sNoncritial = "";
         // Non-critical (yellow) warnings
@@ -1923,7 +1923,7 @@ public final class UnitToolTip {
             sNoncritial += "<BR>" + msg_fightersquadronempty;
         }
 
-        result += UIUtil.colorHTML(GUIP.getCautionColor()) + sNoncritial + "</FONT>" + "<BR>";
+        result += UIUtil.fontHTML(GUIP.getCautionColor()) + sNoncritial + "</FONT>" + "<BR>";
 
         return new StringBuilder().append(result);
     }
@@ -1949,7 +1949,7 @@ public final class UnitToolTip {
                 }
             }
 
-            result = guiScaledFontHTML() + sCarriedUnits + "</FONT>";
+            result = UIUtil.fontHTML() + sCarriedUnits + "</FONT>";
         }
 
         return new StringBuilder().append(result);
@@ -1960,7 +1960,7 @@ public final class UnitToolTip {
         List<ICarryable> cargoList = entity.getDistinctCarriedObjects();
 
         if (!cargoList.isEmpty()) {
-            sb.append(guiScaledFontHTML());
+            sb.append(UIUtil.fontHTML());
             sb.append(Messages.getString("MissionRole.cargo"));
             sb.append(":<br/>&nbsp;&nbsp;");
 
@@ -1994,7 +1994,7 @@ public final class UnitToolTip {
                 sForceEntry += forceChain.get(i).getName();
                 sForceEntry += i != 0 ? ", " : "";
             }
-            result = UIUtil.colorHTML(color) + sForceEntry + "</FONT>";
+            result = UIUtil.fontHTML(color) + sForceEntry + "</FONT>";
         }
 
         return new StringBuilder().append(result);
@@ -2025,7 +2025,7 @@ public final class UnitToolTip {
                 sC3Info += "<BR>";
             }
 
-            result = guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor(), -0.2f) + sC3Info + "</FONT>";
+            result = UIUtil.fontHTML(GUIP.getUnitToolTipHighlightColor(), -0.2f) + sC3Info + "</FONT>";
 
         }
 
@@ -2047,13 +2047,13 @@ public final class UnitToolTip {
         }
 
         sC3UnitName += "<I>" + msg_c3 + "</I>";
-        result += guiScaledFontHTML(GUIP.getUnitToolTipFGColor(), -0.2f) + sC3UnitName + "</FONT>";
+        result += UIUtil.fontHTML(GUIP.getUnitToolTipFGColor(), -0.2f) + sC3UnitName + "</FONT>";
         result += c3member.getShortNameRaw();
 
         String msg_thisunit = " (" + Messages.getString("BoardView1.Tooltip.ThisUnit") + ")";
         tmp = "<I>" + msg_thisunit + "</I>";
         String sC3Member = c3member.equals(entity) ? tmp : "";
-        result += guiScaledFontHTML(GUIP.getUnitToolTipFGColor(), -0.2f) + sC3Member + "</FONT>";
+        result += UIUtil.fontHTML(GUIP.getUnitToolTipFGColor(), -0.2f) + sC3Member + "</FONT>";
 
         return result;
     }

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -46,7 +46,6 @@ import megamek.common.planetaryconditions.PlanetaryConditions;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.templates.TROView;
 import megamek.common.weapons.*;
-import megamek.common.weapons.infantry.InfantryArchaicAxeWeapon;
 import megamek.logging.MMLogger;
 
 public final class UnitToolTip {
@@ -245,8 +244,8 @@ public final class UnitToolTip {
             result += "&nbsp;&nbsp;" + entity.getEntityTypeName(entity.getEntityType());
             result += "<BR>" + ownerName;
             String msg_id = MessageFormat.format(" [ID: {0}]", entity.getId());
-            result += UIUtil.guiScaledFontHTML(GUIP.getUnitToolTipFGColor()) + msg_id + "</FONT>";
-            result = guiScaledFontHTML(ownerColor) + result + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getUnitToolTipFGColor()) + msg_id + "</FONT>";
+            result = UIUtil.colorHTML(ownerColor) + result + "</FONT>";
         }
 
         return result;
@@ -1053,9 +1052,9 @@ public final class UnitToolTip {
                 }
                 ;
 
-                col1 = guiScaledFontHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
+                col1 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
                 col1 = "<TD>" + col1 + "</TD>";
-                col2 = guiScaledFontHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
+                col2 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
                 col2 = "<TD>" + col2 + "</TD>";
                 row = "<TR>" + col1 + col2 + "</TR>";
             }
@@ -1065,8 +1064,6 @@ public final class UnitToolTip {
 
         String tbody = "<TBODY>" + rows + "</TBODY>";
         String table = "<TABLE CELLSPACING=0 CELLPADDING=0>" + tbody + "</TABLE>";
-        table = guiScaledFontHTML() + table + "</FONT>";
-
         return new StringBuilder().append(table);
     }
 
@@ -1095,11 +1092,11 @@ public final class UnitToolTip {
                     col2 = "&nbsp;x&nbsp;";
                     col3 = BombType.getBombName(i);
 
-                    col1 = guiScaledFontHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
+                    col1 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col1 + "</FONT>";
                     col1 = "<TD>" + col1 + "</TD>";
-                    col2 = guiScaledFontHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
+                    col2 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col2 + "</FONT>";
                     col2 = "<TD>" + col2 + "</TD>";
-                    col3 = guiScaledFontHTML(GUIP.getUnitToolTipWeaponColor()) + col3 + "</FONT>";
+                    col3 = UIUtil.colorHTML(GUIP.getUnitToolTipWeaponColor()) + col3 + "</FONT>";
                     col3 = "<TD>" + col3 + "</TD>";
                     row = "<TR>" + col1 + col2 + col3 + "</TR>";
                 } else {
@@ -1266,13 +1263,13 @@ public final class UnitToolTip {
         result += ' ' + getDamageLevelDesc(entity, true);
 
         if (!isGunEmplacement && entity.isImmobile()) {
-            result += ' ' + guiScaledFontHTML(GUIP.getWarningColor())
+            result += ' ' + UIUtil.colorHTML(GUIP.getWarningColor())
                     + Messages.getString("BoardView1.Tooltip.Immobile") + "</FONT>";
         }
 
         // Unit Prone
         if (!isGunEmplacement && entity.isProne()) {
-            result += ' ' + guiScaledFontHTML(GUIP.getWarningColor()) + Messages.getString("BoardView1.Tooltip.Prone")
+            result += ' ' + UIUtil.colorHTML(GUIP.getWarningColor()) + Messages.getString("BoardView1.Tooltip.Prone")
                     + "</FONT>";
         }
 
@@ -1301,17 +1298,17 @@ public final class UnitToolTip {
 
         if (entity.isDoomed() || entity.isDestroyed()) {
             String msg_destroyed = Messages.getString("BoardView1.Tooltip.Destroyed");
-            return useHtml ? guiScaledFontHTML(GUIP.getWarningColor()) + msg_destroyed + "</FONT>" : msg_destroyed;
+            return useHtml ? UIUtil.colorHTML(GUIP.getWarningColor()) + msg_destroyed + "</FONT>" : msg_destroyed;
         }
 
         switch (entity.getDamageLevel()) {
             case Entity.DMG_CRIPPLED:
                 String msg_crippled = Messages.getString("BoardView1.Tooltip.Crippled");
-                result = useHtml ? guiScaledFontHTML(GUIP.getWarningColor()) + msg_crippled + "</FONT>" : msg_crippled;
+                result = useHtml ? UIUtil.colorHTML(GUIP.getWarningColor()) + msg_crippled + "</FONT>" : msg_crippled;
                 break;
             case Entity.DMG_HEAVY:
                 String msg_heavydmg = Messages.getString("BoardView1.Tooltip.HeavyDmg");
-                result = useHtml ? guiScaledFontHTML(GUIP.getWarningColor()) + msg_heavydmg + "</FONT>" : msg_heavydmg;
+                result = useHtml ? UIUtil.colorHTML(GUIP.getWarningColor()) + msg_heavydmg + "</FONT>" : msg_heavydmg;
                 break;
             case Entity.DMG_MODERATE:
                 String msg_moderatedmg = Messages.getString("BoardView1.Tooltip.ModerateDmg");
@@ -1366,7 +1363,7 @@ public final class UnitToolTip {
             if (!entity.isDone() && game.getPhase().isMovement()) {
                 String sNotYetMoved = addToTT("NotYetMoved", BR).toString();
                 sNotYetMoved = "<I>" + sNotYetMoved + "</I>";
-                result += guiScaledFontHTML(GUIP.getColorForMovement(entity.moved)) + sNotYetMoved + "</FONT>";
+                result += UIUtil.colorHTML(GUIP.getColorForMovement(entity.moved)) + sNotYetMoved + "</FONT>";
             } else if ((entity.isDone() && game.getPhase().isMovement())
                     || (game.getPhase().isMovementReport())
                     || (game.getPhase().isFiring())
@@ -1389,14 +1386,14 @@ public final class UnitToolTip {
                 if (entity.isEvading()) {
                     String sSpecialMove = addToTT("Evade", BR).toString();
                     sSpecialMove = "<I>" + sSpecialMove + "</I>";
-                    sSpecialMove = guiScaledFontHTML(GUIP.getPrecautionColor()) + sSpecialMove + "</FONT>";
+                    sSpecialMove = UIUtil.colorHTML(GUIP.getPrecautionColor()) + sSpecialMove + "</FONT>";
                     sMove += sSpecialMove;
                 }
 
                 if ((entity instanceof Infantry) && ((Infantry) entity).isTakingCover()) {
                     String sTakingCover = addToTT("TakingCover", BR).toString();
                     sTakingCover = "<I>" + sTakingCover + "</I>";
-                    sTakingCover = guiScaledFontHTML(GUIP.getPrecautionColor()) + sTakingCover + "</FONT>";
+                    sTakingCover = UIUtil.colorHTML(GUIP.getPrecautionColor()) + sTakingCover + "</FONT>";
                     sMove += sTakingCover;
                 }
 
@@ -1407,7 +1404,7 @@ public final class UnitToolTip {
                 if (entity.isMakingDfa()) {
                     String sDFA = addToTT("DFA", BR).toString();
                     sDFA = "<I>" + sDFA + "</I>";
-                    sDFA = guiScaledFontHTML(GUIP.getWarningColor()) + sDFA + "</FONT>";
+                    sDFA = UIUtil.colorHTML(GUIP.getWarningColor()) + sDFA + "</FONT>";
                     sMove += sDFA;
                 }
 
@@ -1422,7 +1419,7 @@ public final class UnitToolTip {
                     sMove += sUnJamming;
                 }
 
-                result += guiScaledFontHTML(GUIP.getColorForMovement(entity.moved)) + sMove + "</FONT>";
+                result += UIUtil.colorHTML(GUIP.getColorForMovement(entity.moved)) + sMove + "</FONT>";
             }
         }
 
@@ -1432,7 +1429,7 @@ public final class UnitToolTip {
                 String uw = "<br/>"
                         + addToTT("InfUWDuration", NOBR, mount.getUWEndurance() - entity.underwaterRounds).toString();
                 if (entity.underwaterRounds >= mount.getUWEndurance()) {
-                    uw = guiScaledFontHTML(GUIP.getWarningColor()) + uw + "</font>";
+                    uw = UIUtil.colorHTML(GUIP.getWarningColor()) + uw + "</font>";
                 }
                 result += uw;
             }
@@ -1450,7 +1447,7 @@ public final class UnitToolTip {
             sAeroInfo = addToTT("Elev", BR, entity.getElevation()).toString();
         }
         sAeroInfo = "<I>" + sAeroInfo + "</I>";
-        result += guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + sAeroInfo + "</FONT>";
+        result += UIUtil.colorHTML(GUIP.getUnitToolTipHighlightColor()) + sAeroInfo + "</FONT>";
 
         result += "<BR>";
         String msg_facing = Messages.getString("BoardView1.Tooltip.Facing");
@@ -1472,25 +1469,25 @@ public final class UnitToolTip {
             }
             HeatDisplayHelper hdh = getHeatCapacityForDisplay(entity);
             sHeat += " / " + hdh.heatCapacityStr;
-            result += guiScaledFontHTML(GUIP.getColorForHeat(heat, GUIP.getUnitToolTipFGColor())) + sHeat + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getColorForHeat(heat, GUIP.getUnitToolTipFGColor())) + sHeat + "</FONT>";
 
             if (entity instanceof Mek && ((Mek) entity).hasActiveTSM()) {
                 result += DOT_SPACER;
                 String sTSM = "TSM";
-                result += guiScaledFontHTML(GUIP.getPrecautionColor()) + sTSM + "</FONT>";
+                result += UIUtil.colorHTML(GUIP.getPrecautionColor()) + sTSM + "</FONT>";
             }
         }
 
         String illuminated = entity.isIlluminated() ? DOT_SPACER + "\uD83D\uDCA1" : "";
-        result += guiScaledFontHTML(GUIP.getCautionColor()) + illuminated + "</FONT>";
+        result += UIUtil.colorHTML(GUIP.getCautionColor()) + illuminated + "</FONT>";
 
         if (entity.hasSearchlight()) {
             String searchLight = entity.isUsingSearchlight() ? DOT_SPACER + "\uD83D\uDD26" : "";
             searchLight += entity.usedSearchlight() ? " \u2580\u2580" : "";
-            result += guiScaledFontHTML(GUIP.getCautionColor()) + searchLight + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getCautionColor()) + searchLight + "</FONT>";
         } else {
             String searchLight = "\uD83D\uDD26";
-            result += guiScaledFontHTML(GUIP.getWarningColor()) + DOT_SPACER + searchLight + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getWarningColor()) + DOT_SPACER + searchLight + "</FONT>";
         }
 
         // Gun Emplacement Status
@@ -1499,20 +1496,20 @@ public final class UnitToolTip {
             if (emp.isTurret() && emp.isTurretLocked(emp.getLocTurret())) {
                 String sTurretLocked = addToTT("TurretLocked", BR).toString();
                 sTurretLocked = "<I>" + sTurretLocked + "</I>";
-                result += guiScaledFontHTML(GUIP.getWarningColor()) + sTurretLocked + "</FONT>";
+                result += UIUtil.colorHTML(GUIP.getWarningColor()) + sTurretLocked + "</FONT>";
             }
         }
 
         // Unit Immobile
         if (!isGunEmplacement && entity.isImmobile()) {
             String sImmobile = addToTT("Immobile", BR).toString();
-            result += guiScaledFontHTML(GUIP.getWarningColor()) + sImmobile + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getWarningColor()) + sImmobile + "</FONT>";
         }
 
         // Unit Prone
         if (!isGunEmplacement && entity.isProne()) {
             String sUnitProne = addToTT("Prone", BR).toString();
-            result += guiScaledFontHTML(GUIP.getCautionColor()) + sUnitProne + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getCautionColor()) + sUnitProne + "</FONT>";
         }
 
         if (!entity.getHiddenActivationPhase().isUnknown()) {
@@ -1537,7 +1534,7 @@ public final class UnitToolTip {
             String msg_error = Messages.getString("ERROR");
             String sa = (swarmAttacker == null) ? msg_error : swarmAttacker.getDisplayName();
             String sSwarmed = addToTT("Swarmed", BR, sa).toString();
-            result += guiScaledFontHTML(GUIP.getWarningColor()) + sSwarmed + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getWarningColor()) + sSwarmed + "</FONT>";
         }
 
         // Spotting
@@ -1615,7 +1612,7 @@ public final class UnitToolTip {
 
         if (entity.hasAnyTypeNarcPodsAttached()) {
             String sNarced = addToTT(entity.hasNarcPodsAttached() ? "Narced" : "INarced", BR).toString();
-            result += guiScaledFontHTML(GUIP.getPrecautionColor()) + sNarced + "</FONT>";
+            result += UIUtil.colorHTML(GUIP.getPrecautionColor()) + sNarced + "</FONT>";
         }
 
         // Towing
@@ -1629,7 +1626,7 @@ public final class UnitToolTip {
         }
 
         // Coloring to make these transient entries stand out
-        result = guiScaledFontHTML(GUIP.getUnitToolTipHighlightColor()) + result + "</FONT>";
+        result = UIUtil.colorHTML(GUIP.getUnitToolTipHighlightColor()) + result + "</FONT>";
 
         return new StringBuilder().append(result);
     }
@@ -1748,14 +1745,14 @@ public final class UnitToolTip {
                 if (entity.getGame().getPlanetaryConditions().getGravity() != 1.0) {
                     sMove += DOT_SPACER;
                     String sGravity = entity.getGame().getPlanetaryConditions().getGravity() + "g";
-                    sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sGravity + "</FONT>";
+                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sGravity + "</FONT>";
                 }
                 int walkMPNoHeat = entity.getWalkMP(MPCalculationSetting.NO_HEAT);
                 int runMPNoHeat = entity.getRunMP(MPCalculationSetting.NO_HEAT);
                 if ((walkMPNoHeat != walkMPModified) || (runMPNoHeat != runMPModified)) {
                     sMove += DOT_SPACER;
                     String sHeat = "\uD83D\uDD25";
-                    sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sHeat + "</FONT>";
+                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sHeat + "</FONT>";
                 }
             }
 
@@ -1765,7 +1762,7 @@ public final class UnitToolTip {
                 if (bombMod != walkMP) {
                     sMove += DOT_SPACER;
                     String sBomb = "\uD83D\uDCA3";
-                    sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sBomb + "</FONT>";
+                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sBomb + "</FONT>";
                 }
             }
 
@@ -1774,7 +1771,7 @@ public final class UnitToolTip {
             if ((weatherMod != 0) || (partialWingWeaterMod != 0)) {
                 sMove += DOT_SPACER;
                 String sWeather = "\u2602";
-                sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sWeather + "</FONT>";
+                sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sWeather + "</FONT>";
             }
 
             if ((legsDestroyed > 0) || (hipHits > 0) || (actuatorHits > 0) || (jumpJetDistroyed > 0)
@@ -1782,7 +1779,7 @@ public final class UnitToolTip {
                     || (jumpBoosterDistroyed > 0) || (entity.isImmobile()) || (entity.isGyroDestroyed())) {
                 sMove += DOT_SPACER;
                 String sDamage = "\uD83D\uDD27";
-                sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sDamage + "</FONT>";
+                sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sDamage + "</FONT>";
             }
 
             if ((entity instanceof BipedMek) || (entity instanceof TripodMek)) {
@@ -1795,14 +1792,14 @@ public final class UnitToolTip {
                 if (shieldMod != 0) {
                     sMove += DOT_SPACER;
                     String sShield = "\u26E8";
-                    sMove += guiScaledFontHTML(GUIP.getWarningColor()) + sShield + "</FONT>";
+                    sMove += UIUtil.colorHTML(GUIP.getWarningColor()) + sShield + "</FONT>";
                 }
             }
 
             if (entity.hasModularArmor()) {
                 sMove += DOT_SPACER;
                 String sArmor = "\u27EC\u25AE";
-                sMove += DOT_SPACER + guiScaledFontHTML(GUIP.getWarningColor()) + sArmor + "</FONT>";
+                sMove += DOT_SPACER + UIUtil.colorHTML(GUIP.getWarningColor()) + sArmor + "</FONT>";
             }
 
             l1 = "<Li style=\"list-style-type: none; list-style-image: none; margin: 0; padding: 0; width: 300px;\">"
@@ -1909,7 +1906,7 @@ public final class UnitToolTip {
             String msg_cannotsurvivespace = Messages.getString("BoardView1.Tooltip.CannotSurviveSpace");
             sWarnings += "<BR>" + msg_cannotsurvivespace;
         }
-        result += guiScaledFontHTML(GUIP.getWarningColor()) + sWarnings + "</FONT>";
+        result += UIUtil.colorHTML(GUIP.getWarningColor()) + sWarnings + "</FONT>";
 
         String sNoncritial = "";
         // Non-critical (yellow) warnings
@@ -1926,7 +1923,7 @@ public final class UnitToolTip {
             sNoncritial += "<BR>" + msg_fightersquadronempty;
         }
 
-        result += guiScaledFontHTML(GUIP.getCautionColor()) + sNoncritial + "</FONT>" + "<BR>";
+        result += UIUtil.colorHTML(GUIP.getCautionColor()) + sNoncritial + "</FONT>" + "<BR>";
 
         return new StringBuilder().append(result);
     }
@@ -1997,7 +1994,7 @@ public final class UnitToolTip {
                 sForceEntry += forceChain.get(i).getName();
                 sForceEntry += i != 0 ? ", " : "";
             }
-            result = guiScaledFontHTML(color) + sForceEntry + "</FONT>";
+            result = UIUtil.colorHTML(color) + sForceEntry + "</FONT>";
         }
 
         return new StringBuilder().append(result);

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/ExtraPanel.java
@@ -52,7 +52,7 @@ import megamek.common.util.fileUtils.MegaMekFile;
 /**
  * This class shows information about a unit that doesn't belong elsewhere.
  */
-class ExtraPanel extends PicMap implements ActionListener, ItemListener, IPreferenceChangeListener {
+class ExtraPanel extends PicMap implements ActionListener, ItemListener {
     private final UnitDisplay unitDisplay;
 
     private JPanel panelMain;
@@ -257,8 +257,6 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener, IPrefer
         c.weighty = 1;
         panelMain.add(new Label(" "), c);
 
-        adaptToGUIScale();
-        GUIPreferences.getInstance().addPreferenceChangeListener(this);
         setLayout(new BorderLayout());
         add(panelMain, BorderLayout.NORTH);
         panelMain.setOpaque(false);
@@ -662,20 +660,6 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener, IPrefer
         } else if (unitReadout.equals(ae.getSource())) {
             Entity entity = clientgui.getClient().getGame().getEntity(myMekId);
             LobbyUtility.mekReadout(entity, 0, false, clientgui.getFrame());
-        }
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(panelMain, UIUtil.FONT_SCALE1);
-        scrollPane.setMinimumSize(new Dimension(200, UIUtil.scaleForGUI(100)));
-        scrollPane.setPreferredSize(new Dimension(200, UIUtil.scaleForGUI(100)));
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
         }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -176,7 +176,7 @@ public class SummaryPanel extends PicMap {
     }
 
     private String padLeft(String html) {
-        int dist = (int) (GUIPreferences.getInstance().getGUIScale() * 5);
+        int dist = 5;
         String col = "";
         String row = "";
         String tbody = "";

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SystemPanel.java
@@ -59,7 +59,7 @@ import megamek.common.util.fileUtils.MegaMekFile;
  * This class shows the critical hits and systems for a mek
  */
 class SystemPanel extends PicMap
-        implements ItemListener, ActionListener, ListSelectionListener, IPreferenceChangeListener {
+        implements ItemListener, ActionListener, ListSelectionListener {
 
     private static int LOC_ALL_EQUIP = 0;
     private static int LOC_ALL_WEAPS = 1;
@@ -217,8 +217,6 @@ class SystemPanel extends PicMap
         gridbag.setConstraints(m_bDumpAmmo, c);
         panelMain.add(m_bDumpAmmo);
 
-        adaptToGUIScale();
-        GUIPreferences.getInstance().addPreferenceChangeListener(this);
         setLayout(new BorderLayout());
         add(panelMain);
         panelMain.setOpaque(false);
@@ -872,19 +870,5 @@ class SystemPanel extends PicMap
 
         m_chMode.removeItemListener(this);
         m_bDumpAmmo.removeActionListener(this);
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(panelMain, UIUtil.FONT_SCALE1);
-        tSlotScroll.setMinimumSize(new Dimension(200, UIUtil.scaleForGUI(100)));
-        tSlotScroll.setPreferredSize(new Dimension(200, UIUtil.scaleForGUI(100)));
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/UnitDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/UnitDisplay.java
@@ -41,7 +41,6 @@ import megamek.client.ui.swing.UnitDisplayOrderPreferences;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.client.ui.swing.util.KeyCommandBind;
 import megamek.client.ui.swing.util.MegaMekController;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.client.ui.swing.widget.BackGroundDrawer;
 import megamek.client.ui.swing.widget.MekPanelTabStrip;
 import megamek.client.ui.swing.widget.PMUtil;
@@ -50,8 +49,6 @@ import megamek.client.ui.swing.widget.UnitDisplaySkinSpecification;
 import megamek.common.Configuration;
 import megamek.common.Entity;
 import megamek.common.annotations.Nullable;
-import megamek.common.preference.IPreferenceChangeListener;
-import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.logging.MMLogger;
 
@@ -59,7 +56,7 @@ import megamek.logging.MMLogger;
  * Displays the info for a mek. This is also a sort of interface for special
  * movement and firing actions.
  */
-public class UnitDisplay extends JPanel implements IPreferenceChangeListener {
+public class UnitDisplay extends JPanel {
     private static final MMLogger logger = MMLogger.create(UnitDisplay.class);
 
     // buttons & gizmos for top level
@@ -278,9 +275,6 @@ public class UnitDisplay extends JPanel implements IPreferenceChangeListener {
         } else {
             setDisplayNonTabbed();
         }
-
-        adaptToGUIScale();
-        GUIP.addPreferenceChangeListener(this);
     }
 
     /**
@@ -565,17 +559,5 @@ public class UnitDisplay extends JPanel implements IPreferenceChangeListener {
     @Nullable
     public ClientGUI getClientGUI() {
         return clientgui;
-    }
-
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(this, UIUtil.FONT_SCALE1);
-    }
-
-    @Override
-    public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -460,7 +460,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         this.add(splitPane);
 
         addListeners();
-        adaptToGUIScale();
         GUIP.addPreferenceChangeListener(this);
 
         setBackGround();
@@ -1371,7 +1370,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
     /**
      * Selects the first valid weapon in the weapon list.
-     * 
+     *
      * @return The weapon id of the weapon selected
      */
     public int selectFirstWeapon() {
@@ -2773,16 +2772,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         this.prevTarget = prevTarget;
     }
 
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(panelMain, UIUtil.FONT_SCALE1);
-    }
-
     @Override
     public void preferenceChange(PreferenceChangeEvent e) {
         // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.UNIT_DISPLAY_WEAPON_LIST_HEIGHT)) {
+        if (e.getName().equals(GUIPreferences.UNIT_DISPLAY_WEAPON_LIST_HEIGHT)) {
             tWeaponScroll.setMinimumSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
             tWeaponScroll.setPreferredSize(new Dimension(500, GUIP.getUnitDisplayWeaponListHeight()));
             tWeaponScroll.revalidate();
@@ -2794,7 +2787,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
      * Updates the Weapon Panel with the information for the given entity. If the
      * given entity
      * is `null`, this method will do nothing.
-     * 
+     *
      * @param entity - The weapon panel will update info based on the {@link Entity}
      *               provided.
      */

--- a/megamek/src/megamek/client/ui/swing/unitSelector/TWAdvancedSearchPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitSelector/TWAdvancedSearchPanel.java
@@ -3134,13 +3134,4 @@ public class TWAdvancedSearchPanel extends JPanel implements ActionListener, Ite
             return false;
         }
     }
-
-    public void adaptToGUIScale() {
-        scrTableWeaponType.setMinimumSize(new Dimension(UIUtil.scaleForGUI(650), UIUtil.scaleForGUI(150)));
-        scrTableWeaponType.setPreferredSize(new Dimension(UIUtil.scaleForGUI(650), UIUtil.scaleForGUI(150)));
-        scrTableWeapons.setMinimumSize(new Dimension(UIUtil.scaleForGUI(650), UIUtil.scaleForGUI(250)));
-        scrTableWeapons.setPreferredSize(new Dimension(UIUtil.scaleForGUI(650), UIUtil.scaleForGUI(250)));
-        scrTableEquipment.setMinimumSize(new Dimension(UIUtil.scaleForGUI(650), UIUtil.scaleForGUI(250)));
-        scrTableEquipment.setPreferredSize(new Dimension(UIUtil.scaleForGUI(650), UIUtil.scaleForGUI(250)));
-    }
 }

--- a/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
+++ b/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.client.ui.swing.util;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * This builder class is used to assign fonts and font styles to JComponents in the Swing GUI using FlatLaf's typography system. When
+ * FlatLaf is not used as look and feel, this simply has no effect.
+ */
+public final class FlatLafStyleBuilder {
+
+    private final JComponent component;
+    private String fontName = "";
+    private double size = 1;
+    private boolean bold = false;
+
+    /**
+     * Creates a style builder for the given component. Add styles by chaining calls to the other methods. Apply the style using the
+     * finalizer method {@link #set()}.
+     */
+    public FlatLafStyleBuilder(JComponent component) {
+        this.component = component;
+    }
+
+    /**
+     * Adds the given font (only the font name, not its style nor size) to the style builder.
+     *
+     * @param font The font to use
+     */
+    public FlatLafStyleBuilder font(Font font) {
+        fontName = font.getFontName();
+        return this;
+    }
+
+    /**
+     * Adds the given font name to the style builder.
+     *
+     * @param fontName The font to use
+     */
+    public FlatLafStyleBuilder font(String fontName) {
+        this.fontName = fontName;
+        return this;
+    }
+
+    /**
+     * Sets the style to use bold text.
+     */
+    public FlatLafStyleBuilder bold() {
+        bold = true;
+        return this;
+    }
+
+    /**
+     * Adds the given relative size to the style builder. The default value is 1, meaning default font size. Values above 1 increase font
+     * size with, for example, 1.2 resulting in a font size of 120% of the default font size. Size values of 0 or less are ignored.
+     *
+     * @param size The relative font size to use
+     */
+    public FlatLafStyleBuilder size(double size) {
+        if (size > 0) {
+            this.size = size;
+        }
+        return this;
+    }
+
+    /**
+     * Sets the JComponent of this style builder to use the given style. Note that when not using a FlatLaf look-and-feel, this method
+     * simply has no effect.
+     */
+    public void set() {
+        String styleText = "font:";
+        if ((size != 1) && (size > 0)) {
+            styleText += " " + (int) (100 * size) + "%";
+        }
+        if (bold) {
+            styleText += " bold";
+        }
+        if (fontName != null && !fontName.isBlank()) {
+            styleText += " \"" + fontName + "\"";
+        }
+        component.putClientProperty("FlatLaf.style", styleText);
+    }
+}

--- a/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
+++ b/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
@@ -18,8 +18,11 @@
  */
 package megamek.client.ui.swing.util;
 
+import megamek.common.annotations.Nullable;
+
 import javax.swing.*;
 import java.awt.*;
+import java.util.Objects;
 
 /**
  * This builder class is used to assign fonts and font styles to JComponents in the Swing GUI using FlatLaf's typography system. When
@@ -27,41 +30,47 @@ import java.awt.*;
  */
 public final class FlatLafStyleBuilder {
 
-    private final JComponent component;
     private String fontName = "";
     private double size = 1;
     private boolean bold = false;
 
     /**
-     * Creates a style builder for the given component. Add styles by chaining calls to the other methods. Apply the style using the
-     * finalizer method {@link #set()}.
+     * Creates an empty style builder. Add styles by chaining calls to the other methods. Apply the style using the finalizer method
+     * {@link #apply(JComponent)}.
      */
-    public FlatLafStyleBuilder(JComponent component) {
-        this.component = component;
+    public FlatLafStyleBuilder() {
     }
 
     /**
-     * Adds the given font (only the font name, not its style nor size) to the style builder.
+     * Creates a style builder, initializing it with the given font. Add styles by chaining calls to the other methods. Apply the style
+     * using the finalizer method {@link #apply(JComponent)}.
+     */
+    public FlatLafStyleBuilder(Font font) {
+        font(font);
+    }
+
+    /**
+     * Adds the given font (only the font name, not its style nor size) to the style builder. Note that multiple calls to this method simply
+     * overwrite previous values.
      *
      * @param font The font to use
      */
-    public FlatLafStyleBuilder font(Font font) {
-        fontName = font.getFontName();
-        return this;
+    public FlatLafStyleBuilder font(@Nullable Font font) {
+        return font((font == null) ? "" : font.getFontName());
     }
 
     /**
-     * Adds the given font name to the style builder.
+     * Adds the given font name to the style builder. Note that multiple calls to this method simply overwrite previous values.
      *
      * @param fontName The font to use
      */
-    public FlatLafStyleBuilder font(String fontName) {
-        this.fontName = fontName;
+    public FlatLafStyleBuilder font(@Nullable String fontName) {
+        this.fontName = Objects.requireNonNullElse(fontName, "");
         return this;
     }
 
     /**
-     * Sets the style to use bold text.
+     * Sets the style to use bold text. Note that multiple calls to this method have no further effect.
      */
     public FlatLafStyleBuilder bold() {
         bold = true;
@@ -70,7 +79,9 @@ public final class FlatLafStyleBuilder {
 
     /**
      * Adds the given relative size to the style builder. The default value is 1, meaning default font size. Values above 1 increase font
-     * size with, for example, 1.2 resulting in a font size of 120% of the default font size. Size values of 0 or less are ignored.
+     * size with, for example, 1.2 resulting in a font size of 120% of the default font size. Size values of 0 or less are ignored. Not that
+     * the resulting font size is affected by GUI scaling automatically, there is no need to scale using this method. Note that multiple
+     * calls to this method simply overwrite previous values.
      *
      * @param size The relative font size to use
      */
@@ -82,10 +93,9 @@ public final class FlatLafStyleBuilder {
     }
 
     /**
-     * Sets the JComponent of this style builder to use the given style. Note that when not using a FlatLaf look-and-feel, this method
-     * simply has no effect.
+     * Sets the given JComponent use the given style. Note that when not using a FlatLaf look-and-feel, this method simply has no effect.
      */
-    public void set() {
+    public void apply(JComponent component) {
         String styleText = "font:";
         if ((size != 1) && (size > 0)) {
             styleText += " " + (int) (100 * size) + "%";
@@ -93,7 +103,7 @@ public final class FlatLafStyleBuilder {
         if (bold) {
             styleText += " bold";
         }
-        if (fontName != null && !fontName.isBlank()) {
+        if ((fontName != null) && !fontName.isBlank()) {
             styleText += " \"" + fontName + "\"";
         }
         component.putClientProperty("FlatLaf.style", styleText);

--- a/megamek/src/megamek/client/ui/swing/util/ScalingPopup.java
+++ b/megamek/src/megamek/client/ui/swing/util/ScalingPopup.java
@@ -1,16 +1,16 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
-*/ 
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
+*/
 package megamek.client.ui.swing.util;
 
 import java.awt.Dimension;
@@ -18,24 +18,13 @@ import java.awt.Dimension;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 
-/** 
- * A JPopupMenu that automatically scales with MegaMek's GUI Scaling value 
+/**
+ * A JPopupMenu that automatically scales with MegaMek's GUI Scaling value
  * obtained from {@link megamek.client.ui.swing.GUIPreferences#getGUIScale()}
  * @author Juliez
  */
 public class ScalingPopup extends JPopupMenu {
 
-    private static final long serialVersionUID = 4466741063088667097L;
-
-    @Override
-    public void setVisible(boolean b) {
-        if (b) {
-            UIUtil.scaleMenu(ScalingPopup.this);
-            pack();
-        } 
-        super.setVisible(b);
-    }
-    
     /** Returns a spacer (empty, small menu item) for a scaling popup menu. */
     public static JMenuItem spacer() {
         JMenuItem result = new JMenuItem() {

--- a/megamek/src/megamek/client/ui/swing/util/ScalingPopup.java
+++ b/megamek/src/megamek/client/ui/swing/util/ScalingPopup.java
@@ -33,7 +33,7 @@ public class ScalingPopup extends JPopupMenu {
             @Override
             public Dimension getPreferredSize() {
                 Dimension s = super.getPreferredSize();
-                return new Dimension(s.width, UIUtil.scaleForGUI(8));
+                return new Dimension(s.width, 8);
             }
         };
         result.setEnabled(false);

--- a/megamek/src/megamek/client/ui/swing/util/TurnTimer.java
+++ b/megamek/src/megamek/client/ui/swing/util/TurnTimer.java
@@ -65,8 +65,6 @@ public class TurnTimer {
         display.add(remaining);
         display.add(progressBar);
 
-        UIUtil.adjustContainer(display, UIUtil.FONT_SCALE1);
-
         BasicGameOptions options = client.getGame().getOptions();
         allowExtension = options.getOption(OptionsConstants.BASE_TURN_TIMER_ALLOW_EXTENSION).booleanValue();
 
@@ -83,8 +81,6 @@ public class TurnTimer {
                 Color c = counter  >= 10 ? GUIP.getCautionColor() : GUIP.getWarningColor();
                 progressBar.setForeground(c);
                 progressBar.setValue(counter);
-
-                UIUtil.adjustContainer(display, UIUtil.FONT_SCALE1);
 
                 if (counter < 2 && extendTimer && allowExtension) {
                     timer.restart();

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -510,77 +510,54 @@ public final class UIUtil {
      * gui scale.
      */
     public static void adjustContainer(Container parentCon, int fontSize) {
-        int sf = scaleForGUI(fontSize);
-        int pad = 3;
-
-        for (Component comp : parentCon.getComponents()) {
-            if ((comp instanceof JButton) || (comp instanceof JLabel)
-                    || (comp instanceof JComboBox<?>) || (comp instanceof JTextField) || (comp instanceof JSlider)
-                    || (comp instanceof JSpinner) || (comp instanceof JTextArea) || (comp instanceof JToggleButton)
-                    || (comp instanceof JTable) || (comp instanceof JList) || (comp instanceof JProgressBar)
-                    || (comp instanceof JEditorPane) || (comp instanceof JTree)) {
-                if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
-                    comp.setFont(comp.getFont().deriveFont((float) sf));
-                }
-            }
-            if (comp instanceof JScrollPane
-                    && ((JScrollPane) comp).getViewport().getView() instanceof JComponent) {
-                JScrollPane scrollPane = (JScrollPane) comp;
-                Border border = scrollPane.getBorder();
-                setTitledBorder(border, sf);
-                adjustContainer(((JScrollPane) comp).getViewport(), fontSize);
-            } else if (comp instanceof JPanel) {
-                JPanel panel = (JPanel) comp;
-                Border border = panel.getBorder();
-                setTitledBorder(border, sf);
-                adjustContainer(panel, fontSize);
-            } else if (comp instanceof JTabbedPane) {
-                if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
-                    comp.setFont(comp.getFont().deriveFont((float) sf));
-                }
-                JTabbedPane tabbedPane = (JTabbedPane) comp;
-                for (int i = 0; i < tabbedPane.getTabCount(); i++) {
-                    Component subComp = tabbedPane.getTabComponentAt(i);
-                    if (subComp instanceof JPanel) {
-                        adjustContainer((JPanel) subComp, fontSize);
-                    }
-                }
-                adjustContainer((JTabbedPane) comp, fontSize);
-            } else if (comp instanceof JTable) {
-                JTable table = (JTable) comp;
-                table.setRowHeight(calRowHeights(table, sf, pad));
-                JTableHeader header = table.getTableHeader();
-                if ((header != null)) {
-                    header.setFont(comp.getFont().deriveFont((float) sf));
-                }
-                adjustContainer((Container) comp, fontSize);
-            } else if (comp instanceof Container) {
-                adjustContainer((Container) comp, fontSize);
-            }
-        }
-    }
-
-    /**
-     * Adapt a JPopupMenu to the GUI scaling. Use after all menu items have been
-     * added.
-     */
-    public static void scaleMenu(final JComponent popup) {
-        for (Component comp : popup.getComponents()) {
-            if ((comp instanceof JMenuItem)) {
-                comp.setFont(getScaledFont());
-                scaleJMenuItem((JMenuItem) comp);
-            }
-        }
-    }
-
-    public static void scaleComp(JComponent comp, int fontSize) {
-        int sf = scaleForGUI(fontSize);
-
-        if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
-            comp.setFont(comp.getFont().deriveFont((float) sf));
-            Border border = comp.getBorder();
-            setTitledBorder(border, sf);
-        }
+//        int sf = scaleForGUI(fontSize);
+//        int pad = 3;
+//
+//        for (Component comp : parentCon.getComponents()) {
+//            if ((comp instanceof JButton) || (comp instanceof JLabel)
+//                    || (comp instanceof JComboBox<?>) || (comp instanceof JTextField) || (comp instanceof JSlider)
+//                    || (comp instanceof JSpinner) || (comp instanceof JTextArea) || (comp instanceof JToggleButton)
+//                    || (comp instanceof JTable) || (comp instanceof JList) || (comp instanceof JProgressBar)
+//                    || (comp instanceof JEditorPane) || (comp instanceof JTree)) {
+//                if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
+//                    comp.setFont(comp.getFont().deriveFont((float) sf));
+//                }
+//            }
+//            if (comp instanceof JScrollPane
+//                    && ((JScrollPane) comp).getViewport().getView() instanceof JComponent) {
+//                JScrollPane scrollPane = (JScrollPane) comp;
+//                Border border = scrollPane.getBorder();
+//                setTitledBorder(border, sf);
+//                adjustContainer(((JScrollPane) comp).getViewport(), fontSize);
+//            } else if (comp instanceof JPanel) {
+//                JPanel panel = (JPanel) comp;
+//                Border border = panel.getBorder();
+//                setTitledBorder(border, sf);
+//                adjustContainer(panel, fontSize);
+//            } else if (comp instanceof JTabbedPane) {
+//                if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
+//                    comp.setFont(comp.getFont().deriveFont((float) sf));
+//                }
+//                JTabbedPane tabbedPane = (JTabbedPane) comp;
+//                for (int i = 0; i < tabbedPane.getTabCount(); i++) {
+//                    Component subComp = tabbedPane.getTabComponentAt(i);
+//                    if (subComp instanceof JPanel) {
+//                        adjustContainer((JPanel) subComp, fontSize);
+//                    }
+//                }
+//                adjustContainer((JTabbedPane) comp, fontSize);
+//            } else if (comp instanceof JTable) {
+//                JTable table = (JTable) comp;
+//                table.setRowHeight(calRowHeights(table, sf, pad));
+//                JTableHeader header = table.getTableHeader();
+//                if ((header != null)) {
+//                    header.setFont(comp.getFont().deriveFont((float) sf));
+//                }
+//                adjustContainer((Container) comp, fontSize);
+//            } else if (comp instanceof Container) {
+//                adjustContainer((Container) comp, fontSize);
+//            }
+//        }
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -87,14 +87,16 @@ public final class UIUtil {
      * and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML() {
-        return "<FONT FACE=Dialog " + sizeString() + ">";
+        return "<FONT>";
+//        return "<FONT FACE=Dialog " + sizeString() + ">";
     }
 
     /**
      * Returns an HTML FONT tag setting the color to the given col,
      * the font face to Dialog and the font size according to GUIScale.
      */
-    public static String guiScaledFontHTML(Color col) {
+    public static String colorHTML(Color col) {
+//        return "<FONT " + colorString(col) + ">";
         return "<FONT FACE=Dialog " + sizeString() + colorString(col) + ">";
     }
 
@@ -103,6 +105,7 @@ public final class UIUtil {
      * and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML(float deltaScale) {
+//        return "<FONT>";
         return "<FONT FACE=Dialog " + sizeString(deltaScale) + ">";
     }
 
@@ -111,17 +114,18 @@ public final class UIUtil {
      * the font face to Dialog and the font size according to GUIScale.
      */
     public static String guiScaledFontHTML(Color col, float deltaScale) {
+//        return colorHTML(col);
         return "<FONT FACE=Dialog " + sizeString(deltaScale) + colorString(col) + ">";
     }
 
     /** Returns the yellow and gui-scaled warning sign. */
     public static String warningSign() {
-        return guiScaledFontHTML(uiYellow()) + WARNING_SIGN + "</FONT>";
+        return colorHTML(uiYellow()) + WARNING_SIGN + "</FONT>";
     }
 
     /** Returns the (usually) red and gui-scaled warning sign. */
     public static String criticalSign() {
-        return guiScaledFontHTML(GUIPreferences.getInstance().getWarningColor()) + WARNING_SIGN + "</FONT>";
+        return colorHTML(GUIPreferences.getInstance().getWarningColor()) + WARNING_SIGN + "</FONT>";
     }
 
     /**
@@ -1145,7 +1149,7 @@ public final class UIUtil {
      * size 14 and scaled with the current gui scaling.
      */
     public static Font getScaledFont() {
-        return new Font(MMConstants.FONT_DIALOG, Font.PLAIN, scaleForGUI(FONT_SCALE1));
+        return new Font(MMConstants.FONT_DIALOG, Font.PLAIN, FONT_SCALE1);
     }
 
     /**
@@ -1205,8 +1209,9 @@ public final class UIUtil {
      * "style=font-size:22").
      */
     private static String sizeString() {
-        int fontSize = (int) (GUIPreferences.getInstance().getGUIScale() * FONT_SCALE1);
-        return " style=font-size:" + fontSize + " ";
+        return "";
+//        int fontSize = (int) (GUIPreferences.getInstance().getGUIScale() * FONT_SCALE1);
+//        return " style=font-size:" + fontSize + " ";
     }
 
     /**
@@ -1217,10 +1222,10 @@ public final class UIUtil {
      * Suitable deltaScale values are usually between -0.4 and +0.4
      */
     private static String sizeString(float deltaScale) {
-        float guiScale = GUIPreferences.getInstance().getGUIScale();
-        float boundedScale = Math.max(ClientGUI.MIN_GUISCALE, guiScale + deltaScale);
-        boundedScale = Math.min(ClientGUI.MAX_GUISCALE, boundedScale);
-        int fontSize = (int) (boundedScale * FONT_SCALE1);
+//        float guiScale = GUIPreferences.getInstance().getGUIScale();
+//        float boundedScale = Math.max(ClientGUI.MIN_GUISCALE, guiScale + deltaScale);
+//        boundedScale = Math.min(ClientGUI.MAX_GUISCALE, boundedScale);
+        int fontSize = (int) ((1 + deltaScale) * FONT_SCALE1);
         return " style=font-size:" + fontSize + " ";
     }
 
@@ -1247,20 +1252,6 @@ public final class UIUtil {
 
     private static int colorBrightness(final Color color) {
         return (color.getRed() + color.getGreen() + color.getBlue()) / 3;
-    }
-
-    /** Internal helper method to adapt items in a JPopupmenu to the GUI scaling. */
-    private static void scaleJMenuItem(final @Nullable JMenuItem menuItem) {
-        Font scaledFont = getScaledFont();
-        if (menuItem instanceof JMenu) {
-            JMenu menu = (JMenu) menuItem;
-            menu.setFont(scaledFont);
-            for (int i = 0; i < menu.getItemCount(); i++) {
-                scaleJMenuItem(menu.getItem(i));
-            }
-        } else if (menuItem != null) {
-            menuItem.setFont(scaledFont);
-        }
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -411,21 +411,45 @@ public final class UIUtil {
         return uiBgBrightness() > 130 ? LIGHTUI_DARKBLUE : DARKUI_DARKBLUE;
     }
 
+    /**
+     * Returns the given value multiplied by the current GUI scaling. Use this to adapt things that the automatic scaling doesn't affect,
+     * e.g. images. Note that the given int value is scaled as a float and then rounded.
+     *
+     * @param value The value to scale up or down according to the current GUI scale
+     */
     public static int scaleForGUI(int value) {
         return Math.round(scaleForGUI((float) value));
     }
 
+    /**
+     * Returns the given value multiplied by the current GUI scaling. Use this to adapt things that the automatic scaling doesn't affect,
+     * e.g. images.
+     *
+     * @param value The value to scale up or down according to the current GUI scale
+     */
     public static float scaleForGUI(float value) {
         return GUIPreferences.getInstance().getGUIScale() * value;
     }
 
+    /**
+     * Returns the given dimension multiplied by the current GUI scaling. Use this to adapt things that the automatic scaling doesn't
+     * affect, e.g. images. Note that the dimension is scaled as float values and then rounded.
+     *
+     * @param dim The dimension to scale up or down according to the current GUI scale
+     */
     public static Dimension scaleForGUI(Dimension dim) {
         return scaleForGUI(dim.width, dim.height);
     }
 
+    /**
+     * Returns the given values multiplied by the current GUI scaling as a Dimension. Use this to adapt things that the automatic scaling
+     * doesn't affect, e.g. images. Note that the dimension is scaled as float values and then rounded.
+     *
+     * @param width The width to scale up or down according to the current GUI scale
+     * @param height The height to scale up or down according to the current GUI scale
+     */
     public static Dimension scaleForGUI(int width, int height) {
-        float scale = GUIPreferences.getInstance().getGUIScale();
-        return new Dimension((int) (scale * width), (int) (scale * height));
+        return new Dimension(scaleForGUI(width), scaleForGUI(height));
     }
 
     /**
@@ -454,110 +478,6 @@ public final class UIUtil {
         int green = (color.getGreen() * (255 - gray) + mid) / 255;
         int blue = (color.getBlue() * (255 - gray) + mid) / 255;
         return new Color(red, green, blue, color.getAlpha());
-    }
-
-    /**
-     * Returns the given String str enclosed in HTML tags and with a font tag
-     * according to the guiScale.
-     */
-    public static String scaleStringForGUI(String str) {
-        return "<HTML>" + UIUtil.guiScaledFontHTML() + str + "</FONT></HTML>";
-    }
-
-    /**
-     * Returns the given String str enclosed in HTML tags and with a font tag
-     * according to the guiScale.
-     */
-    public static String scaleMessageForGUI(String str) {
-        return "<HTML>" + UIUtil.guiScaledFontHTML() + Messages.getString(str) + "</FONT></HTML>";
-    }
-
-    /**
-     * Call this for {@link #adjustContainer(Container, int)} with a dialog as
-     * parameter.
-     */
-    public static void adjustDialog(JDialog dialog, int fontSize) {
-        adjustContainer(dialog.getContentPane(), fontSize);
-    }
-
-    /** calculate the max row height in a table + pad */
-    public static int calRowHeights(JTable table, int sf, int pad) {
-        int rowHeight = sf;
-        for (int row = 0; row < table.getRowCount(); row++) {
-            for (int col = 0; col < table.getColumnCount(); col++) {
-                // Consider the preferred height of the column
-                TableCellRenderer renderer = table.getCellRenderer(row, col);
-                Component comp = table.prepareRenderer(renderer, row, col);
-                rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
-            }
-        }
-        // Add a little margin to the rows
-        return rowHeight + pad;
-    }
-
-    /** set font size for the TitledBorder */
-    public static void setTitledBorder(Border border, int sf) {
-        if ((border instanceof TitledBorder)) {
-            ((TitledBorder) border).setTitleFont(((TitledBorder) border).getTitleFont().deriveFont((float) sf));
-        }
-    }
-
-    /**
-     * Applies the current gui scale to a given Container.
-     * For a dialog, pass getContentPane(). This can work well for simple dialogs,
-     * but it is of course "experimental". Complex dialogs must be hand-adapted to
-     * the
-     * gui scale.
-     */
-    public static void adjustContainer(Container parentCon, int fontSize) {
-//        int sf = scaleForGUI(fontSize);
-//        int pad = 3;
-//
-//        for (Component comp : parentCon.getComponents()) {
-//            if ((comp instanceof JButton) || (comp instanceof JLabel)
-//                    || (comp instanceof JComboBox<?>) || (comp instanceof JTextField) || (comp instanceof JSlider)
-//                    || (comp instanceof JSpinner) || (comp instanceof JTextArea) || (comp instanceof JToggleButton)
-//                    || (comp instanceof JTable) || (comp instanceof JList) || (comp instanceof JProgressBar)
-//                    || (comp instanceof JEditorPane) || (comp instanceof JTree)) {
-//                if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
-//                    comp.setFont(comp.getFont().deriveFont((float) sf));
-//                }
-//            }
-//            if (comp instanceof JScrollPane
-//                    && ((JScrollPane) comp).getViewport().getView() instanceof JComponent) {
-//                JScrollPane scrollPane = (JScrollPane) comp;
-//                Border border = scrollPane.getBorder();
-//                setTitledBorder(border, sf);
-//                adjustContainer(((JScrollPane) comp).getViewport(), fontSize);
-//            } else if (comp instanceof JPanel) {
-//                JPanel panel = (JPanel) comp;
-//                Border border = panel.getBorder();
-//                setTitledBorder(border, sf);
-//                adjustContainer(panel, fontSize);
-//            } else if (comp instanceof JTabbedPane) {
-//                if ((comp.getFont() != null) && (sf != comp.getFont().getSize())) {
-//                    comp.setFont(comp.getFont().deriveFont((float) sf));
-//                }
-//                JTabbedPane tabbedPane = (JTabbedPane) comp;
-//                for (int i = 0; i < tabbedPane.getTabCount(); i++) {
-//                    Component subComp = tabbedPane.getTabComponentAt(i);
-//                    if (subComp instanceof JPanel) {
-//                        adjustContainer((JPanel) subComp, fontSize);
-//                    }
-//                }
-//                adjustContainer((JTabbedPane) comp, fontSize);
-//            } else if (comp instanceof JTable) {
-//                JTable table = (JTable) comp;
-//                table.setRowHeight(calRowHeights(table, sf, pad));
-//                JTableHeader header = table.getTableHeader();
-//                if ((header != null)) {
-//                    header.setFont(comp.getFont().deriveFont((float) sf));
-//                }
-//                adjustContainer((Container) comp, fontSize);
-//            } else if (comp instanceof Container) {
-//                adjustContainer((Container) comp, fontSize);
-//            }
-//        }
     }
 
     /**
@@ -1167,8 +1087,7 @@ public final class UIUtil {
      * its width and adding HTML tags.
      */
     public static String formatSideTooltip(String text) {
-        String result = "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
-        return scaleStringForGUI(result);
+        return "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
     }
 
     /**
@@ -1283,33 +1202,6 @@ public final class UIUtil {
     public static boolean isModalDialogDisplayed() {
         return Stream.of(Window.getWindows())
                 .anyMatch(w -> w.isShowing() && (w instanceof JDialog) && ((JDialog) w).isModal());
-    }
-
-    /**
-     * Automatically determines the correct row heights for each row of the given
-     * JTable and sets it.
-     * Note: Just calling this after a data change or after
-     * {@link #adjustDialog(JDialog, int)} will
-     * typically not work well. Instead, it must be called from a
-     * {@link javax.swing.event.TableModelListener},
-     * a {@link javax.swing.event.TableColumnModelListener} and (if a row sorter is
-     * used) a
-     * {@link javax.swing.event.RowSorterListener} to be effective.
-     * Note: For tables of more than about 200 entries or with slow renderers this
-     * will become noticeably slow
-     * when drag-resizing the table. When the table has uniform row heights, better
-     * use
-     * {@link #updateRowHeightsForEqualHeights(JTable)}.
-     */
-    public static void updateRowHeights(JTable table) {
-        for (int row = 0; row < table.getRowCount(); row++) {
-            int rowHeight = table.getRowHeight();
-            for (int column = 0; column < table.getColumnCount(); column++) {
-                Component comp = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
-                rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
-            }
-            table.setRowHeight(row, rowHeight);
-        }
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -401,6 +401,17 @@ public final class UIUtil {
     }
 
     /**
+     * Returns the given values multiplied by the current GUI scaling as a Dimension. Use this to adapt things that the automatic scaling
+     * doesn't affect, e.g. images.
+     *
+     * @param width  the width of the Dimension
+     * @param height the height of the Dimension
+     */
+    public static Dimension scaleForGUI(int width, int height) {
+        return new Dimension(scaleForGUI(width), scaleForGUI(height));
+    }
+
+    /**
      * Returns the given value multiplied by the current GUI scaling. Use this to adapt things that the automatic scaling doesn't affect,
      * e.g. images. Note that the given int value is scaled as a float and then rounded.
      *
@@ -1120,9 +1131,7 @@ public final class UIUtil {
     }
 
     /**
-     * Returns a Font object using the "Dialog" logic font. The font size is based
-     * on
-     * size 14 and scaled with the current gui scaling.
+     * Returns a Font object using the "Dialog" logic font. The font size 14. legacy from manual gui scaling. This method should eventually be removed
      */
     @Deprecated
     public static Font getScaledFont() {

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -21,18 +21,12 @@ import java.awt.event.MouseEvent;
 import java.awt.image.ImageObserver;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 
 import javax.swing.*;
-import javax.swing.border.Border;
-import javax.swing.border.EmptyBorder;
-import javax.swing.border.TitledBorder;
-import javax.swing.table.JTableHeader;
-import javax.swing.table.TableCellRenderer;
 
 import megamek.MMConstants;
 import megamek.client.ui.Messages;
@@ -236,12 +230,6 @@ public final class UIUtil {
             result.add(newLine);
         }
         return result;
-    }
-
-    public static ArrayList<String> arrangeInLines(int maxLength,
-            String sep, boolean sepAtEnd, String... origList) {
-
-        return arrangeInLines(Arrays.asList(origList), maxLength, sep, sepAtEnd);
     }
 
     /**
@@ -1179,53 +1167,12 @@ public final class UIUtil {
     }
 
     /**
-     * This class is a subclass of EmptyBorder. The given top, left, right, bottom
-     * values are scaled with the
-     * current GUI scale.
-     */
-    public static class ScaledEmptyBorder extends EmptyBorder {
-
-        /**
-         * Creates a version of EmptyBorder where top, left, right, bottom values are
-         * scaled with the current GUI scale.
-         */
-        public ScaledEmptyBorder(int top, int left, int bottom, int right) {
-            super(UIUtil.scaleForGUI(top), UIUtil.scaleForGUI(left), UIUtil.scaleForGUI(bottom),
-                    UIUtil.scaleForGUI(right));
-        }
-    }
-
-    /**
      * Returns true when a modal dialog such as the Camo Chooser or a Load Force
      * dialog is currently shown.
      */
     public static boolean isModalDialogDisplayed() {
         return Stream.of(Window.getWindows())
                 .anyMatch(w -> w.isShowing() && (w instanceof JDialog) && ((JDialog) w).isModal());
-    }
-
-    /**
-     * Automatically determines the correct row height for the given JTable and sets
-     * it, assuming it has a
-     * uniform row height for all rows.
-     * Note: Just calling this after a data change or after
-     * {@link #adjustDialog(JDialog, int)} will
-     * typically not work well. Instead, it must be called from a
-     * {@link javax.swing.event.TableModelListener},
-     * a {@link javax.swing.event.TableColumnModelListener} and (if a row sorter is
-     * used) a
-     * {@link javax.swing.event.RowSorterListener} to be effective.
-     */
-    public static void updateRowHeightsForEqualHeights(JTable table) {
-        if (table.getRowCount() > 0) {
-            int row = 0;
-            int rowHeight = 0;
-            for (int column = 0; column < table.getColumnCount(); column++) {
-                Component comp = table.prepareRenderer(table.getCellRenderer(row, column), row, column);
-                rowHeight = Math.max(rowHeight, comp.getPreferredSize().height);
-            }
-            table.setRowHeight(rowHeight);
-        }
     }
 
     // PRIVATE

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -31,11 +31,9 @@ import javax.swing.*;
 import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.MMComboBox;
-import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.MMToggleButton;
 import megamek.common.Player;
-import megamek.common.annotations.Nullable;
 import megamek.common.util.ImageUtil;
 import megamek.logging.MMLogger;
 
@@ -86,46 +84,45 @@ public final class UIUtil {
      * Returns an HTML FONT tag setting the font face to Dialog
      * and the font size according to GUIScale.
      */
-    public static String guiScaledFontHTML() {
-        return "<FONT>";
-//        return "<FONT FACE=Dialog " + sizeString() + ">";
+    @Deprecated
+    public static String fontHTML() {
+        return "<FONT FACE=Dialog>";
     }
 
     /**
-     * Returns an HTML FONT tag setting the color to the given col,
-     * the font face to Dialog and the font size according to GUIScale.
+     * Returns an HTML FONT tag setting the color to the given col and the font face to Dialog.
      */
-    public static String colorHTML(Color col) {
-//        return "<FONT " + colorString(col) + ">";
-        return "<FONT FACE=Dialog " + sizeString() + colorString(col) + ">";
+    @Deprecated
+    public static String fontHTML(Color col) {
+        return "<FONT FACE=Dialog " + colorString(col) + ">";
     }
 
     /**
-     * Returns an HTML FONT tag setting the font face to Dialog
-     * and the font size according to GUIScale.
+     * Returns an HTML FONT tag setting the font face to Dialog and the font size according to the given scale delta,
+     * where the font size target is standard font size * (1 + deltaScale)
      */
-    public static String guiScaledFontHTML(float deltaScale) {
-//        return "<FONT>";
+    @Deprecated
+    public static String fontHTML(float deltaScale) {
         return "<FONT FACE=Dialog " + sizeString(deltaScale) + ">";
     }
 
     /**
-     * Returns an HTML FONT tag setting the color to the given col,
-     * the font face to Dialog and the font size according to GUIScale.
+     * Returns an HTML FONT tag setting the color to the given col, the font face to Dialog and the font size according to the given scale
+     * delta, where the font size target is standard font size * (1 + deltaScale)
      */
-    public static String guiScaledFontHTML(Color col, float deltaScale) {
-//        return colorHTML(col);
+    @Deprecated
+    public static String fontHTML(Color col, float deltaScale) {
         return "<FONT FACE=Dialog " + sizeString(deltaScale) + colorString(col) + ">";
     }
 
     /** Returns the yellow and gui-scaled warning sign. */
     public static String warningSign() {
-        return colorHTML(uiYellow()) + WARNING_SIGN + "</FONT>";
+        return fontHTML(uiYellow()) + WARNING_SIGN + "</FONT>";
     }
 
     /** Returns the (usually) red and gui-scaled warning sign. */
     public static String criticalSign() {
-        return colorHTML(GUIPreferences.getInstance().getWarningColor()) + WARNING_SIGN + "</FONT>";
+        return fontHTML(GUIPreferences.getInstance().getWarningColor()) + WARNING_SIGN + "</FONT>";
     }
 
     /**
@@ -421,27 +418,6 @@ public final class UIUtil {
      */
     public static float scaleForGUI(float value) {
         return GUIPreferences.getInstance().getGUIScale() * value;
-    }
-
-    /**
-     * Returns the given dimension multiplied by the current GUI scaling. Use this to adapt things that the automatic scaling doesn't
-     * affect, e.g. images. Note that the dimension is scaled as float values and then rounded.
-     *
-     * @param dim The dimension to scale up or down according to the current GUI scale
-     */
-    public static Dimension scaleForGUI(Dimension dim) {
-        return scaleForGUI(dim.width, dim.height);
-    }
-
-    /**
-     * Returns the given values multiplied by the current GUI scaling as a Dimension. Use this to adapt things that the automatic scaling
-     * doesn't affect, e.g. images. Note that the dimension is scaled as float values and then rounded.
-     *
-     * @param width The width to scale up or down according to the current GUI scale
-     * @param height The height to scale up or down according to the current GUI scale
-     */
-    public static Dimension scaleForGUI(int width, int height) {
-        return new Dimension(scaleForGUI(width), scaleForGUI(height));
     }
 
     /**
@@ -1148,26 +1124,9 @@ public final class UIUtil {
      * on
      * size 14 and scaled with the current gui scaling.
      */
+    @Deprecated
     public static Font getScaledFont() {
         return new Font(MMConstants.FONT_DIALOG, Font.PLAIN, FONT_SCALE1);
-    }
-
-    /**
-     * Returns a vertical spacer Swing component
-     * ({@link Box#createVerticalStrut(int)}) with the given height
-     * scaled by the current GUI scaling.
-     */
-    public static Component scaledVerticalSpacer(int unscaledHeight) {
-        return Box.createVerticalStrut(scaleForGUI(unscaledHeight));
-    }
-
-    /**
-     * Returns a horizontal spacer Swing component
-     * ({@link Box#createHorizontalStrut(int)}) with the given width
-     * scaled by the current GUI scaling.
-     */
-    public static Component scaledHorizontalSpacer(int unscaledHeight) {
-        return Box.createHorizontalStrut(scaleForGUI(unscaledHeight));
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/widget/SBFReportPanel.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SBFReportPanel.java
@@ -131,7 +131,6 @@ public class SBFReportPanel extends JPanel implements ActionListener, HyperlinkL
         add(panelMain, BorderLayout.CENTER);
 
         doLayout();
-        adaptToGUIScale();
 
         GUIP.addPreferenceChangeListener(this);
         CP.addPreferenceChangeListener(this);
@@ -406,41 +405,10 @@ public class SBFReportPanel extends JPanel implements ActionListener, HyperlinkL
         }
     };
 
-    private void adaptToGUIScale() {
-        UIUtil.adjustContainer(this, UIUtil.FONT_SCALE1);
-
-        for (int i = 0; i < tabs.getTabCount(); i++) {
-            Component cp = tabs.getComponentAt(i);
-            if (cp instanceof JScrollPane) {
-                Component pane = ((JScrollPane) cp).getViewport().getView();
-                if (pane instanceof JTextPane) {
-                    JTextPane tp = (JTextPane) pane;
-                    Report.setupStylesheet(tp);
-                    tp.setText(tp.getText());
-                }
-            }
-        }
-    }
-
     @Override
     public void preferenceChange(PreferenceChangeEvent e) {
-        // Update the text size when the GUI scaling changes
-        if (e.getName().equals(GUIPreferences.GUI_SCALE)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(ClientPreferences.REPORT_KEYWORDS)) {
+        if (e.getName().equals(ClientPreferences.REPORT_KEYWORDS)) {
             updateQuickChoice();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_LINK)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_SUCCESS)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_MISS)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_COLOR_INFO)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.WARNING_COLOR)) {
-            adaptToGUIScale();
-        } else if (e.getName().equals(GUIPreferences.MINI_REPORT_FONT_TYPE)) {
-            adaptToGUIScale();
         }
     }
 }

--- a/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCardPrinter.java
+++ b/megamek/src/megamek/common/alphaStrike/cardDrawer/ASCardPrinter.java
@@ -43,7 +43,6 @@ import javax.swing.border.EmptyBorder;
 
 import megamek.MMConstants;
 import megamek.client.ui.swing.GUIPreferences;
-import megamek.client.ui.swing.util.UIUtil;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.alphaStrike.ASCardDisplayable;
 
@@ -136,7 +135,6 @@ public class ASCardPrinter implements Printable {
             add(new JLabel("Printing Alpha Strike Cards...", JLabel.CENTER));
             add(progressBar);
 
-            UIUtil.adjustDialog(ProgressPopup.this, UIUtil.FONT_SCALE1);
             setLocationRelativeTo(null);
             pack();
         }


### PR DESCRIPTION
This PR removes most of the code of the old manual GUI scaling and replaces it with Flatlaf's built in scaling. It leaves some of the HTML-related methods in UIUtil and just "de-arms" and renames them as the tooltips make heavy use of them and I think we should rewrite those with CSS anyway. This PR also adds a util class for adding font and style to swing components using flatlaf's clientproperty style. The advantage of this is that it is less hassle than using setFont() and scales effortlessly. 

If anyone reviews this, better turn off whitespace changes. It's still a lot.

Merge together with MHQ #4989