### PR TITLE
#6061: Restore Altitude Behavior for Princess Deploying Aero

### DIFF
--- a/megamek/src/megamek/common/AllowedDeploymentHelper.java
+++ b/megamek/src/megamek/common/AllowedDeploymentHelper.java
@@ -18,6 +18,8 @@
  */
 package megamek.common;
 
+import megamek.common.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -27,16 +29,28 @@ import static megamek.common.DeploymentElevationType.*;
 public record AllowedDeploymentHelper(Entity entity, Coords coords, Board board, Hex hex, Game game) {
 
     /**
-     * Returns a list of elevations/altitudes that the given entity can deploy to at the given coords. This
-     * can be anything from the seafloor, swimming, ice, water surface, ground, up to elevations and
-     * altitudes. For VTOLs, elevations up to 10 are always included individually if available. Above that
-     * and above all terrain features of the hex, only a single elevation is reported using the
-     * ELEVATIONS_ABOVE marker, meaning that any elevation above the reported value is also available.
-     * Altitudes are always reported individually (0 to 10).
+     * Returns a list of elevations/altitudes that the given entity can deploy to at the given coords. This can be anything from the
+     * seafloor, swimming, ice, water surface, ground, up to elevations and altitudes. For VTOLs, elevations up to 10 are always included
+     * individually if available. Above that and above all terrain features of the hex, only a single elevation is reported using the
+     * ELEVATIONS_ABOVE marker, meaning that any elevation above the reported value is also available. Altitudes are always reported
+     * individually (0 to 10).
      *
      * @return All legal deployment elevations/altitudes
      */
     public List<ElevationOption> findAllowedElevations() {
+        return findAllowedElevations(null);
+    }
+
+    /**
+     * Returns a list of elevations/altitudes that the given entity can deploy to at the given coords that are of the given type. This can
+     * be anything from the seafloor, swimming, ice, water surface, ground, up to elevations and altitudes. For VTOLs, elevations up to 10
+     * are always included individually if available. Above that and above all terrain features of the hex, only a single elevation is
+     * reported using the ELEVATIONS_ABOVE marker, meaning that any elevation above the reported value is also available. Altitudes are
+     * always reported individually (0 to 10).
+     *
+     * @return All legal deployment elevations/altitudes of the given type
+     */
+    public List<ElevationOption> findAllowedElevations(@Nullable DeploymentElevationType limitToType) {
         if (board.inSpace()) {
             throw new IllegalStateException("Cannot find allowed deployment elevations in space!");
         }
@@ -52,6 +66,10 @@ public record AllowedDeploymentHelper(Entity entity, Coords coords, Board board,
 
         if (entity.getMovementMode().isWiGE()) {
             addAirborneWigeOptions(result);
+        }
+
+        if (limitToType != null) {
+            result.removeIf(o -> o.type() != limitToType);
         }
 
         Collections.sort(result);

--- a/megamek/src/megamek/common/ElevationOption.java
+++ b/megamek/src/megamek/common/ElevationOption.java
@@ -21,12 +21,12 @@ package megamek.common;
 import java.util.Objects;
 
 /**
- * This is a data record for a possible deployment elevation together with a DeploymentElevationType that
- * signals if the elevation is, e.g., on the ground, on a bridge or submerged. Note that two such records are
- * equal when their elevation and type are equal.
+ * This is a data record for a possible deployment elevation together with a DeploymentElevationType that signals if the elevation is, e.g.,
+ * on the ground, on a bridge or submerged. Note that two such records are equal when their elevation and type are equal. ElevationOptions
+ * are comparable, with the natural ordering being by their elevation only.
  *
  * @param elevation The elevation or altitude in the hex
- * @param type the DeploymentElevationType (on the ground, on a bridge, ...)
+ * @param type      the DeploymentElevationType (on the ground, on a bridge, ...)
  */
 public record ElevationOption(int elevation, DeploymentElevationType type) implements Comparable<ElevationOption> {
 


### PR DESCRIPTION
Fixes #6061 
With the updated deployment options (for human players), some code in GameManager that simply set the altitude of deployed aeros to 5 was removed. Therefore some Princess code is required. Princess can deploy DS grounded, when the altitude is set to 0 in the lobby.