### PR TITLE
#6027: Disregard torso twists when no weapon is fired together with it

### DIFF
--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -826,6 +826,11 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             }
         }
 
+        // If the only action is a torso/turret twist, discard it as it would have no effect for the unit but prevent twisting later
+        if ((attacks.size() == 1) && (attacks.firstElement() instanceof TorsoTwistAction)) {
+            attacks.clear();
+        }
+
         // remove temporary attacks from game & board
         removeTempAttacks();
 

--- a/megamek/src/megamek/client/ui/swing/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/FiringDisplay.java
@@ -826,11 +826,6 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             }
         }
 
-        // If the only action is a torso/turret twist, discard it as it would have no effect for the unit but prevent twisting later
-        if ((attacks.size() == 1) && (attacks.firstElement() instanceof TorsoTwistAction)) {
-            attacks.clear();
-        }
-
         // remove temporary attacks from game & board
         removeTempAttacks();
 

--- a/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/TargetingPhaseDisplay.java
@@ -557,6 +557,11 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
         // remove temporary attacks from game & board
         removeTempAttacks();
 
+        // If the only action is a torso/turret twist, discard it as it would have no effect for the unit but prevent twisting later
+        if ((attacks.size() == 1) && (attacks.firstElement() instanceof TorsoTwistAction)) {
+            attacks.clear();
+        }
+
         // send out attacks
         clientgui.getClient().sendAttackData(currentEntity, attacks.toVector());
 


### PR DESCRIPTION
The actual issue here was that torso twists got locked in even when no weapon was fired together with them (clicking a twist and then "Skip Firing").

Fixes #6027
Patch note: Torso twists will now only prevent further twisting in a later phase of the same round when a weapon (including TAG) is fired along with the twist.

Update: twists without firing anything are only disregarded in the TAG-firing phase (because the player can just as well twist later, in the weapon firing phase). In the weapon firing phase, twists can now be setup for physical attacks without weapon fire as before.


