### PR TITLE
Save patchwork armor with right tech level

### DIFF
--- a/megamek/src/megamek/common/Mek.java
+++ b/megamek/src/megamek/common/Mek.java
@@ -4258,7 +4258,6 @@ public abstract class Mek extends Entity {
     /**
      * Get an '.mtf' file representation of the Mek. This string can be
      * directly written to disk as a file and later loaded by the MtfFile class.
-     * Known missing level 3 features: mixed tech, laser heatsinks
      */
     public String getMtf() {
         StringBuilder sb = new StringBuilder();
@@ -4450,7 +4449,7 @@ public abstract class Mek extends Entity {
             }
             sb.append(getLocationAbbr(element)).append(" ").append(MtfFile.ARMOR);
             if (hasPatchworkArmor()) {
-                sb.append(EquipmentType.getArmorTypeName(getArmorType(element), isClan()))
+                sb.append(EquipmentType.getArmorTypeName(getArmorType(element), TechConstants.isClan(getArmorTechLevel(element))))
                         .append('(').append(TechConstants.getTechName(getArmorTechLevel(element)))
                         .append("):");
             }


### PR DESCRIPTION
Saving a mixed-tech unit with patchwork armor often results in nonsense in the MTF file like "Clan Heavy Ferro-Fibrous (Inner Sphere)". This armor fails to load and falls back to Standard Armor.

This PR fixes the code to save the tech level of the armor, not of the mech. 

See also MegaMek/megameklab#1634, which fixes a different bug in MML that causes the same problem through an unrelated mistake.