### PR TITLE
Data update - line wrapping and consolidating availability ratings

### DIFF
--- a/megamek/data/forcegenerator/2520.xml
+++ b/megamek/data/forcegenerator/2520.xml
@@ -180,8 +180,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,FWL:4,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,FWL:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:4,Periphery.Deep:4,Periphery:4</availability>
@@ -1087,8 +1086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,TH:4,LA:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,TH:4,LA:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1560,8 +1558,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:5-,OA:5-,LA:5-,FWL:5-,IS:5-,Periphery.Deep:5-,FS:5-,MERC:5-,DC:6-,Periphery:5-</availability>
+			<availability>CC:3-,MOC:5-,OA:5-,LA:5-,FWL:5-,IS:5-,Periphery.Deep:5-,FS:5-,MERC:5-,DC:6-,Periphery:5-</availability>
 			<model name='SB-26'>
 				<availability>DC:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2520.xml
+++ b/megamek/data/forcegenerator/2520.xml
@@ -180,7 +180,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,FWL:4,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,LA:5,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:4,Periphery.Deep:4,Periphery:4</availability>
@@ -245,7 +245,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -812,7 +812,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator' unitType='Mek'>
-			<availability>CC:2,MOC:2,OA:2,LA:2,FWL:2,FS:2,MERC:2,DC:1,TC:2,Periphery:2</availability>
+			<availability>CC:2,LA:2,FWL:2,FS:2,MERC:2,DC:1,Periphery:2</availability>
 			<model name='GLD-2R'>
 				<availability>DC:6</availability>
 			</model>
@@ -845,7 +845,7 @@
 		<chassis name='Griffin' unitType='Mek'>
 			<availability>CC:4,TH:8,LA:4,IS:4,DC:3</availability>
 			<model name='GRF-1A'>
-				<availability>LA:4,IS:4,Periphery.Deep:8,MERC:4,Periphery:8,TC:8</availability>
+				<availability>IS:4,Periphery.Deep:8,MERC:4,Periphery:8</availability>
 			</model>
 			<model name='GRF-1N'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1086,7 +1086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,TH:4,LA:4,FWL:4,DC:4</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1513,7 +1513,7 @@
 			<availability>CC:2,TH:6,IS:2,FWL:2,FS:2</availability>
 			<model name='RFL-1N'>
 				<roles>fire_support</roles>
-				<availability>CC:6,MOC:8,IS:6,FWL:6,Periphery.Deep:8,FS:6,MERC:6,Periphery:8</availability>
+				<availability>MOC:8,IS:6,Periphery.Deep:8,MERC:6,Periphery:8</availability>
 			</model>
 			<model name='RFL-2N'>
 				<roles>fire_support</roles>
@@ -1558,7 +1558,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:5-,OA:5-,LA:5-,FWL:5-,IS:5-,Periphery.Deep:5-,FS:5-,MERC:5-,DC:6-,Periphery:5-</availability>
+			<availability>CC:3-,IS:5-,Periphery.Deep:5-,MERC:5-,DC:6-,Periphery:5-</availability>
 			<model name='SB-26'>
 				<availability>DC:6</availability>
 			</model>
@@ -1567,7 +1567,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:6,OA:4,LA:6,IS:6,FWL:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,DC:6</availability>
+			<availability>MOC:4,OA:4,IS:6,RWR:4,MERC:6,Periphery:6,TC:4</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -1583,13 +1583,13 @@
 			<availability>LA:4,FWL:2,FS:2,MERC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
-				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
+				<availability>General:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
 			<availability>TH:7,LA:2,IS:3</availability>
 			<model name='SHD-1R'>
-				<availability>CC:6,MOC:8,IS:6,FWL:6,Periphery.Deep:8,MERC:6,Periphery:8</availability>
+				<availability>IS:6,Periphery.Deep:8,MERC:6,Periphery:8</availability>
 			</model>
 			<model name='SHD-2H'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -1808,7 +1808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
-			<availability>MOC:1,CC:2,OA:1,LA:1,FWL:1,MERC:1,FS:1,DC:6,TC:1,Periphery:1</availability>
+			<availability>CC:2,LA:1,FWL:1,MERC:1,FS:1,DC:6,Periphery:1</availability>
 			<model name='(2405)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>

--- a/megamek/data/forcegenerator/2571.xml
+++ b/megamek/data/forcegenerator/2571.xml
@@ -239,8 +239,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:5,Periphery.Deep:5,Periphery:5</availability>
@@ -416,8 +415,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:5-,OA:5-,TH:6,LA:7-,Periphery.Deep:4-,RWR:5-,FS:7-,MERC:7-,Periphery:4-,TC:5-,DC:7-</availability>
+			<availability>MOC:5-,OA:5-,TH:6,LA:7-,Periphery.Deep:4-,RWR:5-,FS:7-,MERC:7-,Periphery:4-,TC:5-,DC:7-</availability>
 			<model name='BNC-1E'>
 				<availability>TH:2,Periphery.Deep:4,Periphery:4</availability>
 			</model>
@@ -597,8 +595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:6,Periphery.ME:3,FWL:4,SL.R:6,DC:3</availability>
+			<availability>CC:3,MOC:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:6,Periphery.ME:3,FWL:4,SL.R:6,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1346,8 +1343,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2,IS:4,RWR:2,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:2,IS:4,RWR:2,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:4,DC:4</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1551,8 +1547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2266,8 +2261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-26'>
 				<availability>DC:4</availability>
 			</model>
@@ -2354,8 +2348,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,CC:2,RWR:1,MERC:2,Periphery.OS:1,FS:2,Periphery:1,TC:1,OA:1,TH:5,LA:2,Periphery.HR:1,SL:6,FWL:2,SL.R:6,DC:2</availability>
+			<availability>MOC:1,CC:2,RWR:1,MERC:2,Periphery.OS:1,FS:2,Periphery:1,TC:1,OA:1,TH:5,LA:2,Periphery.HR:1,SL:6,FWL:2,SL.R:6,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -2375,8 +2368,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,LA:4,SL:8,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,LA:4,SL:8,FWL:4,DC:4</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
 			</model>
@@ -2609,8 +2601,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:2,CC:2,IS:2,RWR:2,FS:2,Periphery.OS:2,Periphery:2,TC:2,OA:2,TH:4,LA:2,Periphery.HR:2,SL:6,FWL:2,SL.R:2,DC:2</availability>
+			<availability>MOC:2,CC:2,IS:2,RWR:2,FS:2,Periphery.OS:2,Periphery:2,TC:2,OA:2,TH:4,LA:2,Periphery.HR:2,SL:6,FWL:2,SL.R:2,DC:2</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>

--- a/megamek/data/forcegenerator/2571.xml
+++ b/megamek/data/forcegenerator/2571.xml
@@ -239,7 +239,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,LA:5,SL:3-,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:5,Periphery.Deep:5,Periphery:5</availability>
@@ -333,7 +333,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -541,7 +541,7 @@
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -595,7 +595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:6,Periphery.ME:3,FWL:4,SL.R:6,DC:3</availability>
+			<availability>IS:3,MOC:3,RWR:3,MERC:3,TC:3,OA:3,Periphery.MW:3,SL:6,Periphery.ME:3,FWL:4,SL.R:6</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -609,9 +609,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:1,OA:1,LA:3,SL:6,FWL:3,RWR:1,FS:3,MERC:3,DC:3,Periphery:1,TC:1</availability>
+			<availability>CC:3,LA:3,SL:6,FWL:3,FS:3,MERC:3,DC:3,Periphery:1</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
@@ -695,13 +695,13 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,LA:7,SL:3-,IS:3,FWL:3,SL.R:0,RWR:3,FS:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>LA:7,SL:3-,IS:3,SL.R:0,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:3,MOC:1,OA:1,LA:3,SL:6,FWL:3,IS:3,RWR:1,FS:3,DC:3,TC:1</availability>
+			<availability>MOC:1,OA:1,SL:6,IS:3,RWR:1,TC:1</availability>
 			<model name='(2602)'>
 				<roles>mech_carrier</roles>
 				<availability>General:8</availability>
@@ -1156,7 +1156,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator' unitType='Mek'>
-			<availability>CC:2-,MOC:2-,OA:2-,LA:2-,FWL:2-,FS:2-,MERC:2-,DC:1-,Periphery:2,TC:2-</availability>
+			<availability>IS:2-,MOC:2-,OA:2-,MERC:2-,DC:1-,Periphery:2,TC:2-</availability>
 			<model name='GLD-2R'>
 				<availability>DC:4</availability>
 			</model>
@@ -1168,7 +1168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,FS:6,MERC:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1343,7 +1343,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:4,MOC:2,IS:4,RWR:2,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:4,DC:4</availability>
+			<availability>IS:4,Periphery:2,Periphery.MW:4,SL:5,Periphery.ME:4</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1547,7 +1547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1627,7 +1627,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:3,CC:4,IS:4,RWR:3,FS:5,Periphery:2,TC:3,OA:3,LA:6,SL:5,FWL:9,SL.R:4,DC:4</availability>
+			<availability>MOC:3,IS:4,RWR:3,FS:5,Periphery:2,TC:3,OA:3,LA:6,SL:5,FWL:9,SL.R:4</availability>
 			<model name='LGB-0C'>
 				<availability>FWL:4-,IS:4-,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1647,7 +1647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,Periphery.R:2,OA:1,LA:8,Periphery.MW:2,MERC:3,Periphery:1,TC:1</availability>
+			<availability>Periphery.R:2,LA:8,Periphery.MW:2,MERC:3,Periphery:1</availability>
 			<model name='LCF-R15'>
 				<availability>LA:6,General:6,Periphery.Deep:6,MERC:8,Periphery:6</availability>
 			</model>
@@ -1673,7 +1673,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mackie' unitType='Mek'>
-			<availability>TH:4-,LA:2-,SL:2-,IS:2-,FWL:2-,Periphery.Deep:5,SL.R:0,TH.HM:4-,Periphery:5</availability>
+			<availability>TH:4-,IS:2-,Periphery.Deep:5,SL.R:0,TH.HM:4-,Periphery:5</availability>
 			<model name='MSK-6S'>
 				<availability>General:2,FWL:2</availability>
 			</model>
@@ -1996,7 +1996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>CC:3,MOC:1,OA:1,TH:5,LA:4,SL:6,FWL:3,IS:3,RWR:1,FS:3,DC:3,TC:1</availability>
+			<availability>MOC:1,OA:1,TH:5,LA:4,SL:6,IS:3,RWR:1,TC:1</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2207,7 +2207,7 @@
 			<availability>CC:5,TH:6,SL:7,IS:5,FWL:5,SL.R:7,FS:5,Periphery:3</availability>
 			<model name='RFL-1N'>
 				<roles>fire_support</roles>
-				<availability>CC:4,MOC:6,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6</availability>
+				<availability>IS:4,Periphery.Deep:6,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='RFL-2N'>
 				<roles>fire_support</roles>
@@ -2261,7 +2261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-26'>
 				<availability>DC:4</availability>
 			</model>
@@ -2277,7 +2277,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:6,IS:6,RWR:4,MERC:6,FS:6,Periphery:6,TC:4,OA:4,LA:6,SL:8,FWL:6,DC:6</availability>
+			<availability>MOC:4,IS:6,RWR:4,MERC:6,Periphery:6,TC:4,OA:4,SL:8</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,SL.R:8,DC:8</availability>
@@ -2303,7 +2303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,Periphery.R:3,OA:3,LA:4,FWL:3,FS:3,MERC:3,DC:3,Periphery:3,TC:2</availability>
+			<availability>Periphery.R:3,LA:4,FWL:3,FS:3,MERC:3,DC:3,Periphery:3,TC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -2312,7 +2312,7 @@
 		<chassis name='Shadow Hawk' unitType='Mek'>
 			<availability>TH:7,LA:4,SL:7,IS:5,Periphery:2</availability>
 			<model name='SHD-1R'>
-				<availability>CC:4,MOC:6,IS:4,FWL:4,Periphery.Deep:6,MERC:4,Periphery:6</availability>
+				<availability>MOC:6,IS:4,Periphery.Deep:6,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='SHD-2H'>
 				<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
@@ -2348,7 +2348,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CC:2,RWR:1,MERC:2,Periphery.OS:1,FS:2,Periphery:1,TC:1,OA:1,TH:5,LA:2,Periphery.HR:1,SL:6,FWL:2,SL.R:6,DC:2</availability>
+			<availability>CC:2,MERC:2,Periphery.OS:1,FS:2,Periphery:1,TH:5,LA:2,Periphery.HR:1,SL:6,FWL:2,SL.R:6,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -2368,7 +2368,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:4,MOC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery:4,TC:4,OA:4,LA:4,SL:8,FWL:4,DC:4</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery:4,SL:8</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
 			</model>
@@ -2458,7 +2458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CC:1,MOC:2+,OA:2+,TH:5,SL:6,FWL:2,FS:2,MERC:2,DC:2,Periphery:2+,TC:2+</availability>
+			<availability>CC:1,TH:5,SL:6,FWL:2,FS:2,MERC:2,DC:2,Periphery:2+</availability>
 			<model name='THE-F'>
 				<availability>TH:8,SL:6</availability>
 			</model>
@@ -2479,7 +2479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:5,OA:5,LA:9,SL:7,IS:5,FWL:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,DC:5</availability>
+			<availability>LA:9,SL:7,IS:5,FWL:4,Periphery.Deep:5,FS:5,Periphery:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,SL.R:8</availability>
@@ -2491,7 +2491,7 @@
 				<availability>CC:4,MOC:8,Periphery.Deep:8,TC:8,Periphery:8</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
+				<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Toro' unitType='Mek'>
@@ -2540,7 +2540,7 @@
 			<availability>TH:6,SL:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:4</availability>
+				<availability>General:4</availability>
 			</model>
 			<model name='(Original)'>
 				<roles>apc,urban</roles>
@@ -2601,7 +2601,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:2,CC:2,IS:2,RWR:2,FS:2,Periphery.OS:2,Periphery:2,TC:2,OA:2,TH:4,LA:2,Periphery.HR:2,SL:6,FWL:2,SL.R:2,DC:2</availability>
+			<availability>IS:2,Periphery.OS:2,Periphery:2,TH:4,Periphery.HR:2,SL:6,SL.R:2</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>
@@ -2639,7 +2639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
-			<availability>CC:3,MOC:2,OA:2,LA:2,FWL:2,FS:2,MERC:2,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:3,LA:2,FWL:2,FS:2,MERC:2,DC:4,Periphery:2</availability>
 			<model name='(2405)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>

--- a/megamek/data/forcegenerator/2650.xml
+++ b/megamek/data/forcegenerator/2650.xml
@@ -243,8 +243,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -428,8 +427,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:7-,OA:7-,TH:6,LA:7-,Periphery.Deep:6-,RWR:7-,FS:7-,MERC:7-,Periphery:6-,TC:7-,DC:7-</availability>
+			<availability>MOC:7-,OA:7-,TH:6,LA:7-,Periphery.Deep:6-,RWR:7-,FS:7-,MERC:7-,Periphery:6-,TC:7-,DC:7-</availability>
 			<model name='BNC-1E'>
 				<availability>TH:2,Periphery:2</availability>
 			</model>
@@ -507,8 +505,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,IS:7,Periphery.Deep:7,RWR:9,FS:6,MERC:7,TC:8,Periphery:7,LA:8,FWL:8,SL.R:0,TH.HM:6,DC:9</availability>
+			<availability>CC:9,MOC:8,IS:7,Periphery.Deep:7,RWR:9,FS:6,MERC:7,TC:8,Periphery:7,LA:8,FWL:8,SL.R:0,TH.HM:6,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -637,8 +634,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:2,TC:4,OA:4,LA:4,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,SL.R:4,DC:4</availability>
+			<availability>CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:2,TC:4,OA:4,LA:4,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,SL.R:4,DC:4</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1404,8 +1400,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,LA:5,Periphery.MW:5,SL:6,Periphery.ME:5,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,LA:5,Periphery.MW:5,SL:6,Periphery.ME:5,FWL:5,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1627,8 +1622,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1810,8 +1804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:7,IS:8,Periphery.Deep:7,RWR:8,FS:9,MERC:8,Periphery:7,TC:8,OA:8,LA:10,FWL:8,DC:10</availability>
+			<availability>CC:8,MOC:7,IS:8,Periphery.Deep:7,RWR:8,FS:9,MERC:8,Periphery:7,TC:8,OA:8,LA:10,FWL:8,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2146,8 +2139,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				CC:5,MOC:3,IS:5,RWR:4,FS:5,Periphery:3,TC:3,OA:3,TH:5,LA:5,Periphery.MW:3,SL:8,Periphery.ME:3,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:3,IS:5,RWR:4,FS:5,Periphery:3,TC:3,OA:3,TH:5,LA:5,Periphery.MW:3,SL:8,Periphery.ME:3,FWL:5,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2375,8 +2367,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:6,OA:6,LA:6,SL:7,Periphery.Deep:5,IS:6,RWR:6,FS:6,MERC:5,Periphery:5,TC:6,DC:6</availability>
+			<availability>MOC:6,OA:6,LA:6,SL:7,Periphery.Deep:5,IS:6,RWR:6,FS:6,MERC:5,Periphery:5,TC:6,DC:6</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>
@@ -2463,8 +2454,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:8,SL.R:8</availability>
 			</model>
@@ -2515,8 +2505,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,Periphery.R:4,OA:5,LA:4,FWL:3,Periphery.Deep:4,FS:3,MERC:3,DC:3,Periphery:4,TC:4</availability>
+			<availability>MOC:4,Periphery.R:4,OA:5,LA:4,FWL:3,Periphery.Deep:4,FS:3,MERC:3,DC:3,Periphery:4,TC:4</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -2551,8 +2540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -2569,8 +2557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:3,Periphery:3,TC:2,OA:2,TH:5,LA:3,Periphery.HR:3,SL:6,FWL:3,SL.R:5,DC:3</availability>
+			<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:3,Periphery:3,TC:2,OA:2,TH:5,LA:3,Periphery.HR:3,SL:6,FWL:3,SL.R:5,DC:3</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -2596,8 +2583,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				CC:5,MOC:6,IS:5,Periphery.Deep:6,RWR:6,FS:5,Periphery:6,TC:6,OA:6,LA:5,SL:10,FWL:6,DC:5</availability>
+			<availability>CC:5,MOC:6,IS:5,Periphery.Deep:6,RWR:6,FS:5,Periphery:6,TC:6,OA:6,LA:5,SL:10,FWL:6,DC:5</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
 			</model>
@@ -2662,8 +2648,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,RWR:2,MERC:3,Periphery.OS:2,FS:4,TC:2,Periphery:1,OA:2,LA:4,Periphery.HR:2,SL:8,FWL:3,DC:3</availability>
+			<availability>MOC:2,CC:4,RWR:2,MERC:3,Periphery.OS:2,FS:4,TC:2,Periphery:1,OA:2,LA:4,Periphery.HR:2,SL:8,FWL:3,DC:3</availability>
 			<model name='STU-K5'>
 				<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 			</model>
@@ -2865,8 +2850,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				CC:4-,MOC:2-,OA:2-,LA:3-,SL:4-,IS:3-,FWL:4-,RWR:2-,FS:3-,Periphery:2-,TC:2-,DC:4-</availability>
+			<availability>CC:4-,MOC:2-,OA:2-,LA:3-,SL:4-,IS:3-,FWL:4-,RWR:2-,FS:3-,Periphery:2-,TC:2-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2886,8 +2870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery.OS:4,Periphery:4,TC:4,OA:4,TH:5,LA:4,Periphery.HR:4,SL:8,FWL:4,SL.R:2,DC:4</availability>
+			<availability>MOC:4,CC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery.OS:4,Periphery:4,TC:4,OA:4,TH:5,LA:4,Periphery.HR:4,SL:8,FWL:4,SL.R:2,DC:4</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>

--- a/megamek/data/forcegenerator/2650.xml
+++ b/megamek/data/forcegenerator/2650.xml
@@ -243,7 +243,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,LA:5,SL:3-,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -254,7 +254,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>CC:5,MOC:2,OA:2,LA:5,SL:6,FWL:5,IS:4,RWR:2,FS:5,DC:5,Periphery:2,TC:2</availability>
+			<availability>CC:5,LA:5,SL:6,FWL:5,IS:4,FS:5,DC:5,Periphery:2</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -330,7 +330,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -412,7 +412,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>CC:2,MOC:2,OA:2,LA:2,SL:8,IS:2,FWL:2,RWR:2,FS:2,Periphery:1,TC:2,DC:2</availability>
+			<availability>MOC:2,OA:2,SL:8,IS:2,RWR:2,Periphery:1,TC:2</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -559,14 +559,14 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:4,MOC:2,IS:2,RWR:2,FS:2,MERC:2,TC:2,Periphery:2,TH:6,LA:2,SL:7,FWL:2,DC:2</availability>
+			<availability>CC:4,IS:2,RWR:2,FS:2,MERC:2,Periphery:2,TH:6,SL:7</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SL:4,FWL:4,SL.R:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:6,MERC:8,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,SL.R:6,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
@@ -648,9 +648,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,OA:2,LA:4,SL:8,FWL:4,RWR:2,FS:4,MERC:4,DC:3,Periphery:2,TC:2</availability>
+			<availability>CC:4,LA:4,SL:8,FWL:4,RWR:2,FS:4,MERC:4,DC:3,Periphery:2</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,SL:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
@@ -722,7 +722,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,LA:7,SL:3-,IS:3,FWL:3,SL.R:0,RWR:3,FS:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>LA:7,SL:3-,IS:3,SL.R:0,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -969,7 +969,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:5,MOC:3,OA:3,LA:5,SL:6,FWL:5,FS:5,MERC:5,Periphery:3,TC:3</availability>
+			<availability>CC:5,LA:5,SL:6,FWL:5,FS:5,MERC:5,Periphery:3</availability>
 			<model name='FLC-4N'>
 				<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1160,7 +1160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>CC:4,MOC:4,OA:4,LA:4,SL:4,FWL:4,IS:4,FS:3,DC:3,Periphery:2,TC:4</availability>
+			<availability>MOC:4,OA:4,SL:4,IS:4,FS:3,DC:3,Periphery:2,TC:4</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1190,7 +1190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,RWR:3,FS:6,MERC:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1212,11 +1212,11 @@
 			<availability>MOC:1,OA:1,FWL:2,MERC:2,TC:1,Periphery:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+				<availability>Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,OA:2,LA:2,SL:8,IS:2,FWL:8,RWR:2,FS:2,MERC:2,TC:2,DC:2</availability>
+			<availability>CC:3,MOC:2,OA:2,SL:8,IS:2,FWL:8,RWR:2,MERC:2,TC:2</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:6</availability>
 			</model>
@@ -1400,7 +1400,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,LA:5,Periphery.MW:5,SL:6,Periphery.ME:5,FWL:5,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:4,Periphery:4,Periphery.MW:5,SL:6,Periphery.ME:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1443,7 +1443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:3,MOC:3,LA:3,SL:4,FWL:5,IS:3,RWR:2,FS:3,DC:3,Periphery:3,TC:3</availability>
+			<availability>SL:4,FWL:5,IS:3,RWR:2,Periphery:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1459,7 +1459,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:2,LA:2,SL:7,FWL:2,IS:2,FWL.OH:2,RWR:2,FS:2,DC:2,TC:2</availability>
+			<availability>MOC:2,OA:2,SL:7,IS:2,FWL.OH:2,RWR:2,TC:2</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8</availability>
 			</model>
@@ -1597,7 +1597,7 @@
 			<availability>TH:7,SL:7,IS:5,Periphery.Deep:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>CC:4,MOC:2,OA:2,LA:4,SL:6,IS:4,SL.R:6,RWR:2,MERC:4,DC:4,TC:2</availability>
+			<availability>MOC:2,OA:2,SL:6,IS:4,SL.R:6,RWR:2,MERC:4,TC:2</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>SL:8,IS:8,DC:8</availability>
@@ -1622,7 +1622,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1663,7 +1663,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
+			<availability>CC:8,SL:5,FWL:2,IS:3,Periphery:2</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery.Deep:4,Periphery:4</availability>
 			</model>
@@ -1715,7 +1715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:5,CC:5,IS:6,RWR:5,FS:6,Periphery:3,TC:5,OA:6,LA:7,SL:5,FWL:9,SL.R:4,DC:6</availability>
+			<availability>MOC:5,CC:5,IS:6,RWR:5,Periphery:3,TC:5,OA:6,LA:7,SL:5,FWL:9,SL.R:4</availability>
 			<model name='LGB-0C'>
 				<availability>FWL:2-,IS:2-,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -1735,7 +1735,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
 			</model>
@@ -1764,7 +1764,7 @@
 			<availability>CC:10,LA:10,SL:10,FWL:10,IS:9,FS:10,DC:10,Periphery:8</availability>
 		</chassis>
 		<chassis name='Mackie' unitType='Mek'>
-			<availability>TH:3-,LA:1-,IS:1-,FWL:1-,Periphery.Deep:4,SL.R:0,TH.HM:4-,Periphery:4</availability>
+			<availability>TH:3-,IS:1-,Periphery.Deep:4,SL.R:0,TH.HM:4-,Periphery:4</availability>
 			<model name='MSK-6S'>
 				<availability>General:1,FWL:1</availability>
 			</model>
@@ -1804,7 +1804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:7,IS:8,Periphery.Deep:7,RWR:8,FS:9,MERC:8,Periphery:7,TC:8,OA:8,LA:10,FWL:8,DC:10</availability>
+			<availability>IS:8,Periphery.Deep:7,RWR:8,FS:9,MERC:8,Periphery:7,TC:8,OA:8,LA:10,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -1816,7 +1816,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:4,LA:4,Periphery.MW:4,Periphery.HR:3,Periphery.CM:3,IS:4,Periphery:3</availability>
+			<availability>Periphery.R:4,Periphery.MW:4,Periphery.HR:3,Periphery.CM:3,IS:4,Periphery:3</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -1844,7 +1844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:4,MOC:4,OA:3,LA:5,IS:4,FWL:4,RWR:4,FS:4,MERC:4,Periphery:3,TC:3,DC:4</availability>
+			<availability>MOC:4,LA:5,IS:4,RWR:4,MERC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2139,7 +2139,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>CC:5,MOC:3,IS:5,RWR:4,FS:5,Periphery:3,TC:3,OA:3,TH:5,LA:5,Periphery.MW:3,SL:8,Periphery.ME:3,FWL:5,DC:5</availability>
+			<availability>IS:5,RWR:4,Periphery:3,Periphery.MW:3,SL:8,Periphery.ME:3</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2172,7 +2172,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2,CC:2,OA:2,LA:4,IS:3,FWL:3,RWR:2,FS:4,TH.HM:4,Periphery:3,TC:2,DC:3</availability>
+			<availability>MOC:2,CC:2,OA:2,LA:4,IS:3,RWR:2,FS:4,TH.HM:4,Periphery:3,TC:2</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2367,7 +2367,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:6,OA:6,LA:6,SL:7,Periphery.Deep:5,IS:6,RWR:6,FS:6,MERC:5,Periphery:5,TC:6,DC:6</availability>
+			<availability>MOC:6,OA:6,SL:7,Periphery.Deep:5,IS:6,RWR:6,MERC:5,Periphery:5,TC:6</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>
@@ -2377,10 +2377,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,TH:6,SL:7,IS:6,FWL:6,Periphery.Deep:4,SL.R:6,FS:6,Periphery:4</availability>
+			<availability>SL:7,IS:6,Periphery.Deep:4,SL.R:6,Periphery:4</availability>
 			<model name='RFL-1N'>
 				<roles>fire_support</roles>
-				<availability>CC:2,MOC:5,IS:2,FWL:2,Periphery.Deep:5,FS:2,MERC:2,Periphery:5</availability>
+				<availability>MOC:5,IS:2,Periphery.Deep:5,MERC:2,Periphery:5</availability>
 			</model>
 			<model name='RFL-2N'>
 				<roles>fire_support</roles>
@@ -2413,7 +2413,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rogue' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,OA:2,LA:4,SL:5,FWL:4,IS:3,RWR:2,FS:3,DC:3,TC:2</availability>
+			<availability>CC:4,MOC:2,OA:2,LA:4,SL:5,FWL:4,IS:3,RWR:2,TC:2</availability>
 			<model name='RGU-133E'>
 				<availability>General:8,SL.R:8</availability>
 			</model>
@@ -2454,7 +2454,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>SL:5-,IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:8,SL.R:8</availability>
 			</model>
@@ -2470,7 +2470,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:7,FWL:6,DC:6</availability>
+			<availability>IS:6,RWR:6,MERC:6,Periphery:6,SL:7</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,SL.R:6,DC:8</availability>
@@ -2505,7 +2505,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,Periphery.R:4,OA:5,LA:4,FWL:3,Periphery.Deep:4,FS:3,MERC:3,DC:3,Periphery:4,TC:4</availability>
+			<availability>Periphery.R:4,OA:5,LA:4,FWL:3,Periphery.Deep:4,FS:3,MERC:3,DC:3,Periphery:4</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -2540,7 +2540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,Periphery:2,OA:3,SL:3-,SL.R:0,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -2557,7 +2557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:3,Periphery:3,TC:2,OA:2,TH:5,LA:3,Periphery.HR:3,SL:6,FWL:3,SL.R:5,DC:3</availability>
+			<availability>IS:3,MOC:2,RWR:2,MERC:3,Periphery.OS:3,Periphery:3,TC:2,OA:2,TH:5,Periphery.HR:3,SL:6,SL.R:5</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -2583,7 +2583,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:5,MOC:6,IS:5,Periphery.Deep:6,RWR:6,FS:5,Periphery:6,TC:6,OA:6,LA:5,SL:10,FWL:6,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:6,RWR:6,Periphery:6,SL:10,FWL:6</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:3,Periphery:8</availability>
 			</model>
@@ -2720,19 +2720,19 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:5,OA:5,LA:9,SL:7,IS:5,FWL:5,Periphery.Deep:5,FS:5,Periphery:5,TC:5,DC:5</availability>
+			<availability>LA:9,SL:7,Periphery.Deep:5,Periphery:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,SL.R:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,LA:6,SL:8,IS:5,Periphery.Deep:4,FS:7,MERC:5,DC:6,Periphery:4,TC:4</availability>
+			<availability>CC:8,LA:6,SL:8,IS:5,Periphery.Deep:4,FS:7,MERC:5,DC:6,Periphery:4</availability>
 			<model name='TDR-1C'>
 				<availability>CC:2,MOC:6,Periphery.Deep:6,TC:6,Periphery:6</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>CC:8,LA:8,General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
+				<availability>General:8,Periphery.Deep:8,SL.R:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Titan' unitType='Dropship'>
@@ -2795,7 +2795,7 @@
 			<availability>TH:6,SL:2</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 			<model name='(Original)'>
 				<roles>apc,urban</roles>
@@ -2850,7 +2850,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:4-,MOC:2-,OA:2-,LA:3-,SL:4-,IS:3-,FWL:4-,RWR:2-,FS:3-,Periphery:2-,TC:2-,DC:4-</availability>
+			<availability>CC:4-,SL:4-,IS:3-,FWL:4-,RWR:2-,Periphery:2-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2863,14 +2863,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:3,MOC:2,OA:2,LA:3,FWL:3,IS:2,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
+			<availability>CC:3,LA:3,FWL:3,IS:2,RWR:2,FS:3,DC:3,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:4,IS:4,Periphery.Deep:4,RWR:4,FS:4,Periphery.OS:4,Periphery:4,TC:4,OA:4,TH:5,LA:4,Periphery.HR:4,SL:8,FWL:4,SL.R:2,DC:4</availability>
+			<availability>IS:4,Periphery.Deep:4,Periphery.OS:4,Periphery:4,TH:5,Periphery.HR:4,SL:8,SL.R:2</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>
@@ -2914,7 +2914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
-			<availability>CC:3,MOC:2,OA:2,LA:2,FWL:2,FS:2,MERC:2,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:3,LA:2,FWL:2,FS:2,MERC:2,DC:4,Periphery:2</availability>
 			<model name='(2405)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2996,7 +2996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,LA:5,SL:7,FWL:5,IS:5,Periphery.Deep:4,RWR:4,FS:5,DC:5</availability>
+			<availability>,SL:7,IS:5,Periphery.Deep:4,RWR:4</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2</availability>
 			</model>

--- a/megamek/data/forcegenerator/2700.xml
+++ b/megamek/data/forcegenerator/2700.xml
@@ -269,7 +269,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,LA:5,SL:3-,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -280,7 +280,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>CC:5,MOC:3,OA:3,LA:5,SL:6,IS:5,FWL:5,RWR:3,FS:5,Periphery:3,TC:3,DC:5</availability>
+			<availability>,SL:6,IS:5,RWR:3,Periphery:3</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -373,7 +373,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -455,7 +455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>CC:5,MOC:5,OA:5,LA:5,SL:9,IS:5,FWL:5,RWR:5,FS:5,Periphery:2,TC:5,DC:5</availability>
+			<availability>MOC:5,OA:5,SL:9,IS:5,RWR:5,Periphery:2,TC:5</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -637,14 +637,14 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:4,MOC:2,IS:4,RWR:3,FS:4,MERC:3,TC:2,Periphery:2,TH:6,LA:4,SL:6,FWL:4,DC:4</availability>
+			<availability>IS:4,RWR:3,MERC:3,Periphery:2,TH:6,SL:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SL:4,FWL:4,SL.R:2,RWR:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:4,MERC:8,Periphery:8</availability>
+				<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:4,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
@@ -731,7 +731,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>CC:4,MOC:3,OA:3,LA:4,SL:7,FWL:4,RWR:3,FS:4,MERC:4,DC:4,Periphery:2,TC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>LA:8,SL:6,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>SL.R:6</availability>
@@ -813,7 +813,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,LA:7,SL:3-,IS:3,FWL:3,SL.R:0,RWR:3,FS:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>LA:7,SL:3-,IS:3,SL.R:0,RWR:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1061,7 +1061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:4,OA:3,LA:4,SL:4,IS:4,FWL:8,RWR:3,FS:4,Periphery:3,TC:4,DC:4</availability>
+			<availability>MOC:4,OA:3,IS:4,FWL:8,Periphery:3,TC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:4,FS:4</availability>
@@ -1169,7 +1169,7 @@
 			<availability>IS:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:5,MOC:3,OA:3,LA:6,SL:5,FWL:5,FS:5,MERC:5,Periphery:3,TC:3</availability>
+			<availability>CC:5,LA:6,SL:5,FWL:5,FS:5,MERC:5,Periphery:3</availability>
 			<model name='FLC-4N'>
 				<availability>SL:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1378,7 +1378,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>CC:4,MOC:4,OA:4,LA:4,SL:4,IS:4,FWL:4,FS:3,Periphery:3,TC:4,DC:3</availability>
+			<availability>MOC:4,OA:4,IS:4,FS:3,Periphery:3,TC:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1415,7 +1415,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,FS.CH:7,FS:6,MERC:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1441,7 +1441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
+			<availability>CC:4,MOC:3,IS:3,RWR:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:6</availability>
 			</model>
@@ -1513,7 +1513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:4,OA:4,TH:5,LA:5,SL:7,FWL:5,IS:5,RWR:4,FS:5,DC:5,TC:4</availability>
+			<availability>MOC:4,OA:4,SL:7,IS:5,RWR:4,TC:4</availability>
 			<model name='HMR-HC'>
 				<availability>TH:4,SL:2,IS:8</availability>
 			</model>
@@ -1628,7 +1628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:4-,OA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,MERC:6-,Periphery:4-,TC:4-</availability>
+			<availability>SL:4-,Periphery.Deep:4-,MERC:6-,Periphery:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1680,7 +1680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:6,Periphery.ME:5,FWL:5,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5,Periphery.MW:5,SL:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1726,7 +1726,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,LA:4,SL:4,FWL:5,IS:4,RWR:2,FS:3,DC:3,Periphery:3,TC:3</availability>
+			<availability>MOC:4,FWL:5,IS:4,RWR:2,FS:3,DC:3,Periphery:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1742,7 +1742,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,OA:2,LA:3,SL:7,FWL:3,IS:3,FWL.OH:3,RWR:2,FS:3,DC:3,TC:2</availability>
+			<availability>MOC:2,OA:2,SL:7,IS:3,RWR:2,TC:2</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8</availability>
 			</model>
@@ -1767,7 +1767,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,FWL:4,SL.R:0,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1960,7 +1960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2011,7 +2011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:2,FS:3,DC:3,Periphery:2,TC:2</availability>
+			<availability>CC:8,LA:3,SL:5,FWL:2,IS:3,FS:3,DC:3,Periphery:2</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:3</availability>
 			</model>
@@ -2077,7 +2077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,IS:7,Periphery.Deep:5,RWR:7,FS:8,Periphery:5,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:2,DC:6</availability>
+			<availability>MOC:7,CC:6,IS:7,Periphery.Deep:5,RWR:7,FS:8,Periphery:5,TC:7,OA:7,SL:4,FWL:9,SL.R:2,DC:6</availability>
 			<model name='LGB-0C'>
 				<availability>Periphery.Deep:5,Periphery:5</availability>
 			</model>
@@ -2097,7 +2097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
 			</model>
@@ -2191,7 +2191,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:8,Periphery.Deep:8,RWR:9,FS:9,MERC:8,Periphery:8,TC:9,OA:9,LA:10,FWL:8,DC:10</availability>
+			<availability>IS:8,Periphery.Deep:8,RWR:9,FS:9,MERC:8,Periphery:8,TC:9,OA:9,LA:10,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2213,7 +2213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3,Periphery:3</availability>
+			<availability>Periphery.R:3,IS:3,Periphery:3</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2241,7 +2241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:4,RWR:5,FS:5,MERC:5,Periphery:4,TC:4,OA:4,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:5,IS:5,Periphery.Deep:4,RWR:5,MERC:5,Periphery:4,LA:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2329,7 +2329,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:6,MERC:6,Periphery:6,OA:5,LA:6,SL:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter' unitType='Conventional Fighter'>
 			<availability>TH:5,LA:5-,IS:5,MERC:4,Periphery:4</availability>
@@ -2592,7 +2592,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:7,Periphery.ME:4,FWL:5,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:4,RWR:5,Periphery:4,SL:7</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2605,7 +2605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:6,MOC:2,TH:6,LA:6,SL:6-,IS:6,SL.R:4,RWR:2,DC:7,Periphery:2,TC:2</availability>
+			<availability>TH:6,SL:6-,IS:6,SL.R:4,DC:7,Periphery:2</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:8,MERC:8,Periphery:8</availability>
@@ -2616,7 +2616,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,LA:4,SL:5,FWL:4,IS:4,RWR:2,FS:4,MERC:4,DC:4,Periphery:2</availability>
+			<availability>SL:5,IS:4,RWR:2,MERC:4,Periphery:2</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,SL.R:4</availability>
@@ -2642,7 +2642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:4,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:4,FS.DMM:4,FWL:3,TH.HM:4,DC:3</availability>
+			<availability>MOC:2,CC:2,IS:3,RWR:2,FS:4,Periphery:3,TC:2,OA:2,LA:4,TH.HM:4</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2870,7 +2870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:7,OA:7,LA:7,SL:8,Periphery.Deep:7,IS:7,RWR:7,FS:7,MERC:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>SL:8,Periphery.Deep:7,IS:7,MERC:7,Periphery:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2891,7 +2891,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,TH:6,SL:6-,IS:6,FWL:6,Periphery.Deep:4,SL.R:3,FS:6,Periphery:4</availability>
+			<availability>SL:6-,IS:6,Periphery.Deep:4,SL.R:3,Periphery:4</availability>
 			<model name='RFL-1N'>
 				<roles>fire_support</roles>
 				<availability>MOC:4,Periphery.Deep:4,Periphery:4</availability>
@@ -2986,7 +2986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:8,SL.R:6</availability>
 			</model>
@@ -3008,7 +3008,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
+			<availability>IS:6,MERC:6,Periphery:6</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,SL.R:5,DC:8</availability>
@@ -3052,7 +3052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,Periphery.R:4,OA:4,LA:4,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
+			<availability>MOC:3,LA:4,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3090,7 +3090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,Periphery:2,OA:3,SL:3-,SL.R:0,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3129,7 +3129,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:4,Periphery:3,TC:2,OA:2,TH:6,LA:3,Periphery.HR:3,SL:5-,FWL:3,SL.R:3,DC:3</availability>
+			<availability>MOC:2,CC:3,RWR:2,MERC:3,FS:4,Periphery:3,TC:2,OA:2,TH:6,LA:3,SL:5-,FWL:3,SL.R:3,DC:3</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3155,7 +3155,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,RWR:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:9,FWL:6,DC:6</availability>
+			<availability>IS:6,Periphery.Deep:6,RWR:6,Periphery:6,SL:9</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 			</model>
@@ -3243,7 +3243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,RWR:2,MERC:4,Periphery.OS:2,FS:5,TC:2,Periphery:2,OA:2,LA:5,Periphery.HR:2,SL:8,FWL:4,DC:4</availability>
+			<availability>CC:5,MERC:4,FS:5,Periphery:2,LA:5,SL:8,FWL:4,DC:4</availability>
 			<model name='STU-K10'>
 				<availability>FS.DMM:8</availability>
 			</model>
@@ -3297,7 +3297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CC:2,MOC:4+,OA:4+,TH:4,SL:6,FWL:4,FS:4,MERC:4,DC:4,Periphery:4+,TC:4+</availability>
+			<availability>CC:2,TH:4,SL:6,FWL:4,FS:4,MERC:4,DC:4,Periphery:4+</availability>
 			<model name='THE-F'>
 				<availability>TH:8,SL:2</availability>
 			</model>
@@ -3331,7 +3331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:6,Periphery:6,TC:6,DC:6</availability>
+			<availability>LA:9,SL:5,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,SL.R:6</availability>
@@ -3346,7 +3346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,LA:8,SL:7-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5,TC:5</availability>
+			<availability>CC:8,LA:8,SL:7-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5</availability>
 			<model name='TDR-1C'>
 				<availability>MOC:4,Periphery.Deep:4,TC:4,Periphery:4</availability>
 			</model>
@@ -3459,7 +3459,7 @@
 			<availability>TH:5</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -3517,7 +3517,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:4-,MOC:2-,IS:3-,RWR:2-,FS:3-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
+			<availability>CC:4-,IS:3-,Periphery:2-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3531,14 +3531,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,OA:3,LA:4,FWL:4,IS:3,RWR:3,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,OA:3,LA:4,FWL:4,IS:3,RWR:3,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery.OS:5,Periphery:5,TC:5,OA:5,TH:5,LA:5,Periphery.HR:5,SL:7,FWL:5,SL.R:1,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5,SL:7,SL.R:1</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>
@@ -3771,7 +3771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zero' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,OA:2,LA:3,SL:4,FWL:3,IS:3,RWR:2,FS:3,DC:4,Periphery:2,TC:2</availability>
+			<availability>SL:4,IS:3,RWR:2,DC:4,Periphery:2</availability>
 			<model name='ZRO-114'>
 				<availability>General:8,SL.R:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2700.xml
+++ b/megamek/data/forcegenerator/2700.xml
@@ -269,8 +269,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -471,8 +470,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,OA:10-,TH:5,LA:7-,Periphery.Deep:8-,RWR:10-,FS:7-,MERC:7-,TC:10-,Periphery:8-,DC:7-</availability>
+			<availability>MOC:10-,OA:10-,TH:5,LA:7-,Periphery.Deep:8-,RWR:10-,FS:7-,MERC:7-,TC:10-,Periphery:8-,DC:7-</availability>
 			<model name='BNC-1E'>
 				<availability>TH:1,Periphery:1</availability>
 			</model>
@@ -592,8 +590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,IS:7,Periphery.Deep:7,RWR:9,FS:6,MERC:7,TC:8,Periphery:7,LA:8,FWL:8,SL.R:0,TH.HM:6,DC:9</availability>
+			<availability>CC:9,MOC:8,IS:7,Periphery.Deep:7,RWR:9,FS:6,MERC:7,TC:8,Periphery:7,LA:8,FWL:8,SL.R:0,TH.HM:6,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -718,8 +715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:3,TC:4,OA:4,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
+			<availability>CC:4,MOC:4,RWR:4,FS:4,MERC:4,Periphery:3,TC:4,OA:4,LA:4,Periphery.MW:4,SL:5,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1445,8 +1441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
+			<availability>CC:4,MOC:3,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:2,SL:9,Periphery.ME:2,FWL:9,DC:3</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:6</availability>
 			</model>
@@ -1685,8 +1680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:6,Periphery.ME:5,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:6,Periphery.ME:5,FWL:5,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1773,8 +1767,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1967,8 +1960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2085,8 +2077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,IS:7,Periphery.Deep:5,RWR:7,FS:8,Periphery:5,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:2,DC:6</availability>
+			<availability>MOC:7,CC:6,IS:7,Periphery.Deep:5,RWR:7,FS:8,Periphery:5,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:2,DC:6</availability>
 			<model name='LGB-0C'>
 				<availability>Periphery.Deep:5,Periphery:5</availability>
 			</model>
@@ -2200,8 +2191,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:8,Periphery.Deep:8,RWR:9,FS:9,MERC:8,Periphery:8,TC:9,OA:9,LA:10,FWL:8,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:8,Periphery.Deep:8,RWR:9,FS:9,MERC:8,Periphery:8,TC:9,OA:9,LA:10,FWL:8,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2251,8 +2241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:5,MOC:5,IS:5,Periphery.Deep:4,RWR:5,FS:5,MERC:5,Periphery:4,TC:4,OA:4,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:4,RWR:5,FS:5,MERC:5,Periphery:4,TC:4,OA:4,LA:6,FWL:5,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2340,8 +2329,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
+			<availability>CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter' unitType='Conventional Fighter'>
 			<availability>TH:5,LA:5-,IS:5,MERC:4,Periphery:4</availability>
@@ -2604,8 +2592,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:7,Periphery.ME:4,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:7,Periphery.ME:4,FWL:5,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2655,8 +2642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:4,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:4,FS.DMM:4,FWL:3,TH.HM:4,DC:3</availability>
+			<availability>MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:4,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:4,FS.DMM:4,FWL:3,TH.HM:4,DC:3</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2884,8 +2870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,OA:7,LA:7,SL:8,Periphery.Deep:7,IS:7,RWR:7,FS:7,MERC:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>MOC:7,OA:7,LA:7,SL:8,Periphery.Deep:7,IS:7,RWR:7,FS:7,MERC:7,Periphery:7,TC:7,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3001,8 +2986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:8,SL.R:6</availability>
 			</model>
@@ -3068,8 +3052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,Periphery.R:4,OA:4,LA:4,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
+			<availability>MOC:3,Periphery.R:4,OA:4,LA:4,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3107,8 +3090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3147,8 +3129,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:4,Periphery:3,TC:2,OA:2,TH:6,LA:3,Periphery.HR:3,SL:5-,FWL:3,SL.R:3,DC:3</availability>
+			<availability>MOC:2,CC:3,RWR:2,MERC:3,Periphery.OS:3,FS:4,Periphery:3,TC:2,OA:2,TH:6,LA:3,Periphery.HR:3,SL:5-,FWL:3,SL.R:3,DC:3</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3174,8 +3155,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				CC:6,MOC:6,IS:6,Periphery.Deep:6,RWR:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:9,FWL:6,DC:6</availability>
+			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,RWR:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:9,FWL:6,DC:6</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 			</model>
@@ -3263,8 +3243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,RWR:2,MERC:4,Periphery.OS:2,FS:5,TC:2,Periphery:2,OA:2,LA:5,Periphery.HR:2,SL:8,FWL:4,DC:4</availability>
+			<availability>MOC:2,CC:5,RWR:2,MERC:4,Periphery.OS:2,FS:5,TC:2,Periphery:2,OA:2,LA:5,Periphery.HR:2,SL:8,FWL:4,DC:4</availability>
 			<model name='STU-K10'>
 				<availability>FS.DMM:8</availability>
 			</model>
@@ -3538,8 +3517,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				CC:4-,MOC:2-,IS:3-,RWR:2-,FS:3-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
+			<availability>CC:4-,MOC:2-,IS:3-,RWR:2-,FS:3-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3560,8 +3538,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery.OS:5,Periphery:5,TC:5,OA:5,TH:5,LA:5,Periphery.HR:5,SL:7,FWL:5,SL.R:1,DC:5</availability>
+			<availability>MOC:5,CC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery.OS:5,Periphery:5,TC:5,OA:5,TH:5,LA:5,Periphery.HR:5,SL:7,FWL:5,SL.R:1,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>

--- a/megamek/data/forcegenerator/2765.xml
+++ b/megamek/data/forcegenerator/2765.xml
@@ -288,7 +288,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,LA:5,SL:3-,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -299,7 +299,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>CC:5,MOC:3,OA:3,LA:5,SL:6,IS:5,FWL:5,RWR:3,FS:5,Periphery:3,TC:3,DC:6</availability>
+			<availability>SL:6,IS:5,FWL:5,RWR:3,Periphery:3,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -493,7 +493,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>CC:6,MOC:6,OA:6,LA:6,SL:9,IS:6,FWL:6,RWR:6,FS:6,Periphery:3,TC:6,DC:6</availability>
+			<availability>MOC:6,OA:6,SL:9,IS:6,RWR:6,Periphery:3,TC:6</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -508,7 +508,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,OA:10-,TH:4,LA:7-,Periphery.Deep:10-,RWR:10-,FS:6-,MERC:7-,Periphery:10-,TC:10-,DC:6-</availability>
+			<availability>TH:4,LA:7-,Periphery.Deep:10-,FS:6-,MERC:7-,Periphery:10-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -679,14 +679,14 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:4,MOC:2,IS:4,RWR:4,FS:4,MERC:3,TC:2,Periphery:2,TH:6,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>IS:4,RWR:4,MERC:3,TC:2,Periphery:2,TH:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SL:4,FWL:4,SL.R:1,RWR:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,TH:8,SL:8,IS:8,Periphery.Deep:8,SL.R:2,MERC:8,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,SL.R:2,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
@@ -776,7 +776,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>MOC:3,CC:5,OA:3,LA:5,SL:7,FWL:5,RWR:3,MERC:5,FS:5,Periphery:2,TC:3,DC:4</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>LA:8,SL:4,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>SL.R:8</availability>
@@ -786,7 +786,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:2,OA:2,LA:2,SL:4,IS:2,FWL:2,SL.R:2,RWR:2,FS:2,MERC:2,Periphery:2,DC:2</availability>
+			<availability>SL:4,IS:2,SL.R:2,MERC:2,Periphery:2</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -869,7 +869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,LA:7,SL:3-,IS:3,FWL:3,SL.R:0,RWR:3,FS:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>LA:7,SL:3-,IS:3,SL.R:0,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1132,7 +1132,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:4,OA:4,LA:4,SL:4-,IS:4,FWL:8,RWR:4,FS:4,Periphery:3,TC:4,DC:4</availability>
+			<availability>MOC:4,OA:4,SL:4-,IS:4,FWL:8,RWR:4,Periphery:3,TC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:4,FS:4</availability>
@@ -1451,7 +1451,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>CC:4,MOC:4,OA:4,LA:4,SL:4,IS:4,FWL:4,FS:3,Periphery:3,TC:4,DC:3</availability>
+			<availability>MOC:4,OA:4,SL:4,IS:4,FS:3,Periphery:3,TC:4</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1474,7 +1474,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:4,RWR:5,FS:8,Periphery:4,TC:6,OA:8,LA:5,SL:7,FWL:6,DC:8</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:4,RWR:5,FS:8,Periphery:4,TC:6,OA:8,LA:5,SL:7,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1488,7 +1488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,RWR:3,FS:6,MERC:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,FS.CH:7,RWR:3,FS:6,MERC:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1510,11 +1510,11 @@
 			<availability>MOC:2,OA:2,FWL:5,MERC:4,TC:2,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+				<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
+			<availability>CC:4,MOC:4,IS:3,RWR:3,MERC:3,TC:3,OA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:5</availability>
 			</model>
@@ -1701,7 +1701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
+			<availability>LA:4-,SL:4-,Periphery.Deep:4-,FS:4-,MERC:6-,Periphery:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1753,7 +1753,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:5,Periphery.ME:5,FWL:5,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:5,RWR:5,Periphery:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1799,7 +1799,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,LA:4,SL:4,FWL:5,IS:4,RWR:2,FS:3,DC:3,Periphery:3,TC:3</availability>
+			<availability>MOC:4,FWL:5,IS:4,RWR:2,FS:3,DC:3,Periphery:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1840,7 +1840,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,FWL:4,SL.R:0,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1877,7 +1877,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:5,IS:4,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:5,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:5,IS:4,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:5,TC:4</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2032,7 +2032,7 @@
 			<availability>TH:7,SL:6,IS:6,Periphery.Deep:6,Periphery:6</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>CC:5,MOC:4,OA:4,LA:5,SL:7,IS:5,SL.R:7,RWR:5,MERC:5,DC:5,TC:4</availability>
+			<availability>MOC:4,OA:4,SL:7,IS:5,SL.R:7,RWR:5,MERC:5,TC:4</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>SL:8,IS:8,DC:8</availability>
@@ -2067,7 +2067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:6,RWR:6,FS:4,Periphery:6,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:6,RWR:6,FS:4,Periphery:6,TC:5,OA:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2112,7 +2112,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,FWL:2,IS:3,RWR:3,FS:3,DC:3,Periphery:2,TC:2</availability>
+			<availability>CC:8,SL:5,FWL:2,IS:3,RWR:3,Periphery:2</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:3</availability>
 			</model>
@@ -2178,7 +2178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,IS:7,Periphery.Deep:7,RWR:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:1,DC:6</availability>
+			<availability>CC:6,IS:7,Periphery.Deep:7,FS:8,Periphery:7,SL:4,FWL:9,SL.R:1,DC:6</availability>
 			<model name='LGB-0C'>
 				<availability>Periphery.Deep:4,Periphery:4</availability>
 			</model>
@@ -2198,7 +2198,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,OA:2,LA:10,Periphery.MW:3,RWR:3,MERC:5,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4</availability>
 			</model>
@@ -2292,7 +2292,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,RWR:9,FS:9,MERC:9,Periphery:9,TC:9,OA:9,LA:10,FWL:8,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,RWR:9,MERC:9,Periphery:9,LA:10,FWL:8,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2314,7 +2314,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3-,Periphery:3</availability>
+			<availability>IS:3-,Periphery:3</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2342,7 +2342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,MERC:5,Periphery:5,TC:5,OA:5,LA:7,FWL:6,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,LA:7,FWL:6,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2430,7 +2430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:6,MERC:6,Periphery:6,OA:5,LA:6,SL:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -2732,7 +2732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:4,RWR:5,Periphery:4,SL:6</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2745,7 +2745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:6,MOC:3,TH:6,LA:6,SL:5-,IS:6,SL.R:5,RWR:5,DC:7,Periphery:3,TC:3</availability>
+			<availability>SL:5-,IS:6,SL.R:5,RWR:5,DC:7,Periphery:3</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:6,MERC:8,Periphery:8</availability>
@@ -2756,7 +2756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:5,LA:5,SL:5,FWL:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,MERC:5,DC:5,Periphery:5</availability>
+			<availability>IS:5,Periphery.Deep:5,MERC:5,Periphery:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,SL.R:4</availability>
@@ -2782,14 +2782,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>CC:4,MOC:3,OA:3,LA:4,SL:6,IS:3,FWL:4,RWR:3,FS:4,Periphery:3,TC:3,DC:4</availability>
+			<availability>CC:4,LA:4,SL:6,IS:3,FWL:4,FS:4,Periphery:3,DC:4</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:6,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,TH.HM:4,DC:3</availability>
+			<availability>MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:6,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,TH.HM:4</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2803,7 +2803,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:2,Periphery.DD:2,LA:2,SL:5-,FS.DMM:2,FWL:2,SL.R:0,MERC:2,Periphery.OS:2,FS:2,DC:2,Periphery:2</availability>
+			<availability>CC:2,LA:2,SL:5-,FS.DMM:2,FWL:2,SL.R:0,MERC:2,FS:2,DC:2,Periphery:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,SL:2-,RWR:8,DC:2,TC:8</availability>
 			</model>
@@ -3026,7 +3026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:7,OA:7,LA:7,SL:9,Periphery.Deep:8,IS:7,RWR:7,FS:7,MERC:7,Periphery:8,TC:7,DC:7</availability>
+			<availability>MOC:7,OA:7,SL:9,Periphery.Deep:8,IS:7,RWR:7,MERC:7,Periphery:8,TC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3047,7 +3047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,TH:6,SL:5-,IS:6,FWL:6,Periphery.Deep:5,SL.R:2,FS:6,Periphery:5</availability>
+			<availability>TH:6,SL:5-,IS:6,Periphery.Deep:5,SL.R:2,Periphery:5</availability>
 			<model name='RFL-1N'>
 				<roles>fire_support</roles>
 				<availability>MOC:3,Periphery:3</availability>
@@ -3146,7 +3146,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>SL:5,IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:6,SL.R:4</availability>
 			</model>
@@ -3168,7 +3168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,CC:6,IS:6,RWR:6,MERC:6,FS:6,Periphery:6,TC:6,OA:6,LA:6,SL:6,FWL:6,DC:6</availability>
+			<availability>IS:6,MERC:6,Periphery:6</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,SL.R:4,DC:8</availability>
@@ -3216,7 +3216,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,Periphery.R:4,OA:4,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
+			<availability>MOC:3,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3264,14 +3264,14 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,OA:3,SL:3-,SL.R:0,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -3357,7 +3357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,MOC:8,IS:7,Periphery.Deep:8,RWR:7,FS:7,Periphery:8,TC:8,OA:8,LA:7,SL:9-,FWL:8,DC:7</availability>
+			<availability>IS:7,Periphery.Deep:8,RWR:7,Periphery:8,SL:9-,FWL:8</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 			</model>
@@ -3408,7 +3408,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:4,TH:9,SL:6-,IS:9,Periphery.Deep:4,SL.R:4,MERC:4,Periphery:4,DC:6</availability>
+			<availability>SL:6-,IS:9,Periphery.Deep:4,SL.R:4,MERC:4,Periphery:4,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -3423,7 +3423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:4,IS:4,RWR:2,MERC:4,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:4,DC:4</availability>
+			<availability>IS:4,MERC:4,Periphery:2,Periphery.MW:3,SL:4,Periphery.ME:3</availability>
 			<model name='F-90'>
 				<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
 			</model>
@@ -3524,9 +3524,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>LA:6+,SL:8,FWL:6+,IS:6+,RWR:4+,FS:6+,TC:4+</availability>
+			<availability>SL:8,IS:6+,RWR:4+,TC:4+</availability>
 			<model name='THG-11E'>
-				<availability>SL:8,FWL:8+,IS:8+,SL.R:6,RWR:8,FS:8+,DC:8+,TC:8</availability>
+				<availability>SL:8,IS:8+,SL.R:6,RWR:8,TC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>SL.R:6</availability>
@@ -3546,7 +3546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:6,OA:6,LA:9,SL:5,IS:6,FWL:6,Periphery.Deep:6,FS:7,Periphery:6,TC:7,DC:6</availability>
+			<availability>LA:9,SL:5,IS:6,Periphery.Deep:6,FS:7,Periphery:6,TC:7</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,SL.R:5</availability>
@@ -3561,7 +3561,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,LA:8,SL:6-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5,TC:5</availability>
+			<availability>CC:8,LA:8,SL:6-,IS:5,Periphery.Deep:5,FS:7,MERC:5,DC:8,Periphery:5</availability>
 			<model name='TDR-1C'>
 				<availability>MOC:2,TC:2,Periphery:2</availability>
 			</model>
@@ -3667,7 +3667,7 @@
 			<availability>TH:5</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -3725,7 +3725,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,MOC:2-,IS:3-,RWR:2-,FS:3-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
+			<availability>CC:5-,IS:3-,Periphery:2-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3739,14 +3739,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,OA:3,LA:4,FWL:4,IS:3,RWR:3,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,OA:3,LA:4,FWL:4,IS:3,RWR:3,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:6,CC:6,IS:5,Periphery.Deep:5,RWR:6,FS:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,TH:5,LA:6,Periphery.HR:6,SL:6-,FWL:6,SL.R:1,DC:6</availability>
+			<availability>MOC:6,CC:6,IS:5,Periphery.Deep:5,RWR:6,FS:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,LA:6,Periphery.HR:6,SL:6-,FWL:6,SL.R:1,DC:6</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>
@@ -3811,7 +3811,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
-			<availability>CC:3,MOC:2,OA:2,LA:2,FWL:2,FS:2,MERC:2,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:3,LA:2,FWL:2,FS:2,MERC:2,DC:4,Periphery:2</availability>
 			<model name='(2405)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -3918,7 +3918,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,LA:7,SL:5,FWL:8,IS:7,Periphery.Deep:6,RWR:6,FS:7,DC:6,TC:4</availability>
+			<availability>SL:5,FWL:8,IS:7,Periphery.Deep:6,RWR:6,DC:6,TC:4</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -3997,7 +3997,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zero' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,OA:2,LA:3,SL:6,IS:3,FWL:3,RWR:2,FS:3,Periphery:2,TC:2,DC:5</availability>
+			<availability>SL:6,IS:3,Periphery:2,DC:5</availability>
 			<model name='ZRO-114'>
 				<availability>General:8,SL.R:5</availability>
 			</model>

--- a/megamek/data/forcegenerator/2765.xml
+++ b/megamek/data/forcegenerator/2765.xml
@@ -288,8 +288,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,RWR:4,FS:5,Periphery:4,TC:4,OA:4,TH:4,LA:5,SL:3-,FWL:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -509,8 +508,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,OA:10-,TH:4,LA:7-,Periphery.Deep:10-,RWR:10-,FS:6-,MERC:7-,Periphery:10-,TC:10-,DC:6-</availability>
+			<availability>MOC:10-,OA:10-,TH:4,LA:7-,Periphery.Deep:10-,RWR:10-,FS:6-,MERC:7-,Periphery:10-,TC:10-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -627,8 +625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,IS:7,Periphery.Deep:7,RWR:9,FS:6,MERC:7,TC:8,Periphery:7,LA:8,FWL:8,SL.R:0,TH.HM:6,DC:9</availability>
+			<availability>CC:9,MOC:8,IS:7,Periphery.Deep:7,RWR:9,FS:6,MERC:7,TC:8,Periphery:7,LA:8,FWL:8,SL.R:0,TH.HM:6,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -763,8 +760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:5,RWR:5,FS:4,MERC:4,Periphery:3,TC:5,OA:5,LA:4,Periphery.MW:4,SL:4-,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
+			<availability>CC:4,MOC:5,RWR:5,FS:4,MERC:4,Periphery:3,TC:5,OA:5,LA:4,Periphery.MW:4,SL:4-,Periphery.ME:4,FWL:5,SL.R:2,DC:4</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1478,8 +1474,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,IS:6,Periphery.Deep:4,RWR:5,FS:8,Periphery:4,TC:6,OA:8,LA:5,SL:7,FWL:6,DC:8</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:4,RWR:5,FS:8,Periphery:4,TC:6,OA:8,LA:5,SL:7,FWL:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1519,8 +1514,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
+			<availability>CC:4,MOC:4,IS:3,RWR:3,FS:3,MERC:3,TC:3,OA:3,LA:3,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,DC:3</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:5</availability>
 			</model>
@@ -1707,8 +1701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
+			<availability>MOC:4-,OA:4-,LA:4-,SL:4-,Periphery.Deep:4-,RWR:4-,FS:4-,MERC:6-,Periphery:4-,TC:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1760,8 +1753,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:5,Periphery.ME:5,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:5,Periphery.ME:5,FWL:5,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1848,8 +1840,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:4,Periphery:5,TC:7,OA:5,LA:5,FWL:4,SL.R:0,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1886,8 +1877,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:5,IS:4,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:5,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:5,IS:4,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:5,TC:4</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2077,8 +2067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:6,RWR:6,FS:4,Periphery:6,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:6,RWR:6,FS:4,Periphery:6,TC:5,OA:5,TH:5,LA:4,SL:4,FWL:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2189,8 +2178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,IS:7,Periphery.Deep:7,RWR:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:1,DC:6</availability>
+			<availability>MOC:7,CC:6,IS:7,Periphery.Deep:7,RWR:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:4,FWL:9,SL.R:1,DC:6</availability>
 			<model name='LGB-0C'>
 				<availability>Periphery.Deep:4,Periphery:4</availability>
 			</model>
@@ -2304,8 +2292,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,RWR:9,FS:9,MERC:9,Periphery:9,TC:9,OA:9,LA:10,FWL:8,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,RWR:9,FS:9,MERC:9,Periphery:9,TC:9,OA:9,LA:10,FWL:8,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2327,8 +2314,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3-,Periphery:3</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:3,Periphery.CM:3,IS:3-,Periphery:3</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2356,8 +2342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,MERC:5,Periphery:5,TC:5,OA:5,LA:7,FWL:6,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,RWR:5,FS:5,MERC:5,Periphery:5,TC:5,OA:5,LA:7,FWL:6,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2445,8 +2430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
+			<availability>CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -2748,8 +2732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,Periphery.Deep:4,RWR:5,FS:5,Periphery:4,TC:4,OA:4,TH:5,LA:5,Periphery.MW:4,SL:6,Periphery.ME:4,FWL:5,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2806,8 +2789,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:6,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,TH.HM:4,DC:3</availability>
+			<availability>MOC:2,CC:2,IS:3,RWR:2,FS:4,FS.CrMM:6,Periphery:3,TC:2,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,TH.HM:4,DC:3</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2821,8 +2803,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:2,Periphery.DD:2,LA:2,SL:5-,FS.DMM:2,FWL:2,SL.R:0,MERC:2,Periphery.OS:2,FS:2,DC:2,Periphery:2</availability>
+			<availability>CC:2,Periphery.DD:2,LA:2,SL:5-,FS.DMM:2,FWL:2,SL.R:0,MERC:2,Periphery.OS:2,FS:2,DC:2,Periphery:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,SL:2-,RWR:8,DC:2,TC:8</availability>
 			</model>
@@ -3045,8 +3026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,OA:7,LA:7,SL:9,Periphery.Deep:8,IS:7,RWR:7,FS:7,MERC:7,Periphery:8,TC:7,DC:7</availability>
+			<availability>MOC:7,OA:7,LA:7,SL:9,Periphery.Deep:8,IS:7,RWR:7,FS:7,MERC:7,Periphery:8,TC:7,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3166,8 +3146,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:6,SL.R:4</availability>
 			</model>
@@ -3237,8 +3216,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,Periphery.R:4,OA:4,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
+			<availability>MOC:3,Periphery.R:4,OA:4,LA:5,FWL:2,Periphery.Deep:4,FS:2,MERC:2,DC:2,Periphery:4,TC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3286,8 +3264,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,RWR:2,MERC:4,Periphery.OS:3,FS:4,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,SL.R:0,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3343,8 +3320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,Periphery.Deep:4,RWR:2,MERC:4,Periphery.OS:4,FS:5,Periphery:4,TC:2,OA:2,TH:6,LA:4,Periphery.HR:4,SL:5-,FWL:4,SL.R:2,DC:4</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,RWR:2,MERC:4,Periphery.OS:4,FS:5,Periphery:4,TC:2,OA:2,TH:6,LA:4,Periphery.HR:4,SL:5-,FWL:4,SL.R:2,DC:4</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3381,8 +3357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				CC:7,MOC:8,IS:7,Periphery.Deep:8,RWR:7,FS:7,Periphery:8,TC:8,OA:8,LA:7,SL:9-,FWL:8,DC:7</availability>
+			<availability>CC:7,MOC:8,IS:7,Periphery.Deep:8,RWR:7,FS:7,Periphery:8,TC:8,OA:8,LA:7,SL:9-,FWL:8,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 			</model>
@@ -3448,8 +3423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,IS:4,RWR:2,MERC:4,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:4,DC:4</availability>
+			<availability>MOC:2,CC:4,IS:4,RWR:2,MERC:4,FS:4,Periphery:2,TC:2,OA:2,LA:4,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:4,DC:4</availability>
 			<model name='F-90'>
 				<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
 			</model>
@@ -3478,8 +3452,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,RWR:3,MERC:4,Periphery.OS:3,FS:5,TC:3,Periphery:2,OA:3,LA:5,Periphery.HR:3,SL:8,FWL:4,DC:4</availability>
+			<availability>MOC:3,CC:5,RWR:3,MERC:4,Periphery.OS:3,FS:5,TC:3,Periphery:2,OA:3,LA:5,Periphery.HR:3,SL:8,FWL:4,DC:4</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -3752,8 +3725,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				CC:5-,MOC:2-,IS:3-,RWR:2-,FS:3-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
+			<availability>CC:5-,MOC:2-,IS:3-,RWR:2-,FS:3-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:4-,SL:4-,FWL:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3774,8 +3746,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:6,CC:6,IS:5,Periphery.Deep:5,RWR:6,FS:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,TH:5,LA:6,Periphery.HR:6,SL:6-,FWL:6,SL.R:1,DC:6</availability>
+			<availability>MOC:6,CC:6,IS:5,Periphery.Deep:5,RWR:6,FS:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,TH:5,LA:6,Periphery.HR:6,SL:6-,FWL:6,SL.R:1,DC:6</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>

--- a/megamek/data/forcegenerator/2780.xml
+++ b/megamek/data/forcegenerator/2780.xml
@@ -291,14 +291,14 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,OA:4,LA:5,SL:3-,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,LA:5,SL:3-,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>CC:5,MOC:3,OA:3,LA:5,SL:6,IS:5,FWL:4,NIOPS:6,FS:5,Periphery:3,TC:3,DC:7</availability>
+			<availability>SL:6,IS:5,FWL:4,NIOPS:6,Periphery:3,DC:7</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -391,7 +391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
+			<availability>CC:10,IS:9,Periphery.Deep:10,Periphery:10,DC:8</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -471,7 +471,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:2,MOC:1,OA:1,LA:3,SL:5,IS:2,FWL:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
+			<availability>MOC:1,OA:1,LA:3,SL:5,IS:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
 			<model name='AS7-D'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -495,7 +495,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,OA:6,LA:7,SL:9,FWL:8,NIOPS:8,DC:7</availability>
+			<availability>MOC:6,IS:7,Periphery.Deep:4,CIR:7,Periphery:4,TC:6,OA:6,SL:9,FWL:8,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -510,9 +510,9 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,OA:10-,LA:7-,Periphery.Deep:10-,FWL:6-,NIOPS:2-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,DC:6-</availability>
+			<availability>LA:7-,Periphery.Deep:10-,FWL:6-,NIOPS:2-,FS:6-,MERC:7-,Periphery:10-,DC:6-</availability>
 			<model name='BNC-3E'>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>General:8,Periphery.Deep:8,MERC:8</availability>
 			</model>
 			<model name='BNC-3M'>
 				<availability>MOC:4,OA:4,FWL:4</availability>
@@ -624,7 +624,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,Periphery.Deep:7,FWL:8,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,Periphery.Deep:7,FWL:8,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -677,7 +677,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,LA:4,SL:3-,FWL:4,NIOPS:2,DC:6</availability>
+			<availability>CC:6,IS:4,MERC:3,CIR:1,Periphery:2,SL:3-,FWL:4,NIOPS:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SL:4,FWL:4</availability>
@@ -778,7 +778,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>MOC:3,CC:5,OA:3,LA:8,SL:7,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>SL.R:8</availability>
@@ -867,13 +867,13 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,LA:7,SL:3-,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:3,LA:7,SL:3-,IS:3,NIOPS:3,CIR:3,Periphery:3,TC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:6,MOC:3,OA:3,LA:4,SL:7,IS:6,FWL:4,NIOPS:6,FS:5,CIR:2,TC:3,DC:4</availability>
+			<availability>MOC:3,OA:3,LA:4,SL:7,IS:6,FWL:4,NIOPS:6,FS:5,CIR:2,TC:3,DC:4</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1143,7 +1143,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,OA:4,LA:4,SL:4-,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,IS:4,CIR:4,Periphery:3,TC:4,OA:4,SL:4-,FWL:8,NIOPS:5-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:4,FS:4</availability>
@@ -1339,7 +1339,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>Periphery.R:4,LA:6,SL:8,FWL:5,NIOPS:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:4-</availability>
+				<availability>LA:4-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>LA:8+,FWL:8+,NIOPS:8</availability>
@@ -1465,7 +1465,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>CC:4,MOC:4,IS:4,FS:3,CIR:4,Periphery:3,TC:4,OA:4,LA:4,SL:4,FWL:4,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,IS:4,FS:3,CIR:4,Periphery:3,TC:4,OA:4,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1521,14 +1521,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:3,MOC:2,OA:2,LA:3,Periphery.MW:2,FWL:5,MERC:4,TC:2,Periphery:2</availability>
+			<availability>CC:3,LA:3,Periphery.MW:2,FWL:5,MERC:4,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
+			<availability>CC:4,MOC:4,IS:2,CIR:2,MERC:2,TC:2,OA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:4</availability>
 			</model>
@@ -1549,8 +1549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:7,OA:6,LA:9,SL:4-,IS:9,Periphery.Deep:5,NIOPS:4,MERC:6,TC:7,Periphery:5,DC:8</availability>
+			<availability>CC:7,MOC:7,OA:6,LA:9,SL:4-,IS:9,Periphery.Deep:5,NIOPS:4,MERC:6,TC:7,Periphery:5,DC:8</availability>
 			<model name='GRF-1A'>
 				<availability>Periphery:2,TC:2</availability>
 			</model>
@@ -1607,7 +1606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:4,OA:4,LA:6,SL:7,IS:6,FWL:6,NIOPS:7,FS:6,CIR:4,TC:4,DC:6</availability>
+			<availability>MOC:4,OA:4,SL:7,IS:6,NIOPS:7,CIR:4,TC:4</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -1725,7 +1724,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
+			<availability>CC:3-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,DC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1777,7 +1776,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:4-,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,Periphery.Deep:5,Periphery:5,SL:4-,NIOPS:5-</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1823,7 +1822,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,LA:4,SL:4,IS:4,FWL:5,NIOPS:4,FS:3,CIR:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:4,IS:4,FWL:5,NIOPS:4,FS:3,CIR:4,Periphery:3,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1864,7 +1863,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1905,7 +1904,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2005,7 +2004,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>SL:8,FWL:5,NIOPS:7,FS:6,MERC:3,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2</availability>
+				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>General:4,NIOPS:8,SL.R:2,FS:4,MERC:4</availability>
@@ -2074,7 +2073,7 @@
 			<availability>SL:5,IS:6,NIOPS:1-,Periphery.Deep:6,Periphery:6</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>CC:6,MOC:4,OA:4,LA:6,SL:6,IS:6,NIOPS:6,SL.R:6,MERC:6,CIR:4,TC:4,DC:6</availability>
+			<availability>MOC:4,OA:4,IS:6,NIOPS:6,SL.R:6,MERC:6,CIR:4,TC:4</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>SL:8,IS:8,NIOPS:8,DC:8</availability>
@@ -2109,7 +2108,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,OA:5,LA:4,SL:4,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:6,FS:4,Periphery:6,TC:5,OA:5,LA:4,SL:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2157,7 +2156,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,OA:2,LA:3,SL:5,IS:3,FWL:2,NIOPS:5-,FS:3,Periphery:2,TC:2,DC:3</availability>
+			<availability>CC:8,SL:5,IS:3,FWL:2,NIOPS:5-,Periphery:2</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:3</availability>
 			</model>
@@ -2223,7 +2222,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:3,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>CC:6,IS:7,Periphery.Deep:7,FS:8,Periphery:7,SL:3,FWL:9,NIOPS:4,DC:6</availability>
 			<model name='LGB-0C'>
 				<availability>Periphery:2</availability>
 			</model>
@@ -2243,7 +2242,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
 			</model>
@@ -2325,7 +2324,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2347,7 +2346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,Periphery.MW:3,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2375,7 +2374,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2463,7 +2462,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,Periphery:6,OA:5,LA:6,SL:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -2742,7 +2741,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:4,SL:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:4,SL:4,Periphery.ME:4,FWL:6,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2758,7 +2757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:6,MOC:3,LA:6,SL:4-,IS:6,NIOPS:4,SL.R:5,DC:6,Periphery:3,TC:3</availability>
+			<availability>CC:6,LA:6,SL:4-,IS:6,NIOPS:4,SL.R:5,DC:6,Periphery:3</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>SL:8,IS:8,Periphery.Deep:8,SL.R:5,MERC:8,Periphery:8</availability>
@@ -2772,7 +2771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:5,LA:5,SL:5,IS:5,FWL:5,NIOPS:4,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>IS:5,NIOPS:4,Periphery.Deep:5,MERC:5,Periphery:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,SL.R:4</availability>
@@ -2805,7 +2804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,IS:6,Periphery.Deep:6,FS.CrMM:7,Periphery:6,TC:5,OA:5,LA:8,FS.CMM:7,FS.DMM:7,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3009,7 +3008,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,IS:4,Periphery.Deep:4,FS:3,Periphery:4,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -3031,7 +3030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,OA:8,LA:8,SL:9,NIOPS:9,DC:7</availability>
+			<availability>Periphery.Deep:8,IS:7,MERC:8,Periphery:8,LA:8,SL:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3052,7 +3051,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,SL:4-,IS:6,FWL:6,NIOPS:6-,Periphery.Deep:5,FS:6,CIR:4,Periphery:5</availability>
+			<availability>SL:4-,IS:6,NIOPS:6-,Periphery.Deep:5,CIR:4,Periphery:5</availability>
 			<model name='RFL-1N'>
 				<roles>fire_support</roles>
 				<availability>MOC:2,Periphery:2</availability>
@@ -3092,7 +3091,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rogue' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:3,OA:3,LA:4,SL:5,IS:4,FWL:4,NIOPS:4,FS:3,CIR:2,TC:3,DC:3</availability>
+			<availability>MOC:3,OA:3,SL:5,IS:4,NIOPS:4,FS:3,CIR:2,TC:3,DC:3</availability>
 			<model name='RGU-133E'>
 				<availability>General:8,NIOPS:8,SL.R:6</availability>
 			</model>
@@ -3140,7 +3139,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>SL:5,IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:4</availability>
 			</model>
@@ -3162,7 +3161,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,CC:6,OA:6,LA:6,SL:5,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
+			<availability>SL:5,IS:6,MERC:6,Periphery:6</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,SL.R:4,DC:8</availability>
@@ -3210,7 +3209,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3271,14 +3270,14 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,OA:3,SL:3-,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -3327,7 +3326,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,OA:3,LA:4,Periphery.HR:4,SL:4-,FWL:2,NIOPS:3,DC:4</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,FS:7,CIR:3,TC:3,Periphery:4,OA:3,LA:4,SL:4-,FWL:2,NIOPS:3,DC:4</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3364,7 +3363,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,OA:9,LA:8,SL:9-,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>CC:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,LA:8,SL:9-,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 			</model>
@@ -3415,7 +3414,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:5,SL:5-,IS:9,NIOPS:4-,Periphery.Deep:5,SL.R:3,MERC:5,Periphery:5,DC:6</availability>
+			<availability>SL:5-,IS:9,NIOPS:4-,Periphery.Deep:5,SL.R:3,MERC:5,Periphery:5,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>SL:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -3430,7 +3429,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,OA:2,LA:6,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
+			<availability>CC:6,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,LA:6,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:6,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
 			</model>
@@ -3513,7 +3512,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-5'>
 				<availability>CC:5</availability>
 			</model>
@@ -3545,7 +3544,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,OA:6,LA:8,SL:5,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,LA:8,SL:5,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,SL.R:4</availability>
@@ -3560,7 +3559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,LA:8,SL:5-,IS:5,NIOPS:5-,Periphery.Deep:5,FS:7,MERC:5,Periphery:5,TC:5,DC:8</availability>
+			<availability>CC:8,LA:8,SL:5-,IS:5,NIOPS:5-,Periphery.Deep:5,FS:7,MERC:5,Periphery:5,DC:8</availability>
 			<model name='TDR-1C'>
 				<availability>MOC:1,TC:1,Periphery:1</availability>
 			</model>
@@ -3720,7 +3719,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:5-,SL:4-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>CC:6-,IS:3-,Periphery:2-,FS.CMM:5-,SL:4-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3734,7 +3733,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -3820,7 +3819,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>LA:9,SL:5,FWL:9,IS:8,NIOPS:6-,Periphery.Deep:4,TC:4,Periphery:4</availability>
+			<availability>LA:9,SL:5,FWL:9,IS:8,NIOPS:6-,Periphery.Deep:4,Periphery:4</availability>
 			<model name='WHM-6L'>
 				<availability>CC:3</availability>
 			</model>
@@ -3918,7 +3917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,LA:7,SL:3,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:7,TC:4,DC:6</availability>
+			<availability>SL:3,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,TC:4,DC:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -4005,7 +4004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zero' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:2,LA:2,SL:6,IS:2,FWL:2,NIOPS:5,FS:2,Periphery:2,TC:2,DC:4</availability>
+			<availability>SL:6,IS:2,NIOPS:5,Periphery:2,DC:4</availability>
 			<model name='ZRO-114'>
 				<availability>General:8,NIOPS:8,SL.R:4</availability>
 			</model>

--- a/megamek/data/forcegenerator/2780.xml
+++ b/megamek/data/forcegenerator/2780.xml
@@ -291,8 +291,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,OA:4,LA:5,SL:3-,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,OA:4,LA:5,SL:3-,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -496,8 +495,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,OA:6,LA:7,SL:9,FWL:8,NIOPS:8,DC:7</availability>
+			<availability>CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,OA:6,LA:7,SL:9,FWL:8,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -512,8 +510,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,OA:10-,LA:7-,Periphery.Deep:10-,FWL:6-,NIOPS:2-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,DC:6-</availability>
+			<availability>MOC:10-,OA:10-,LA:7-,Periphery.Deep:10-,FWL:6-,NIOPS:2-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -627,8 +624,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,Periphery.Deep:7,FWL:8,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,Periphery.Deep:7,FWL:8,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -762,8 +758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:5,SL:2-,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:5,SL:2-,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1493,8 +1488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,OA:8,LA:5,SL:7,FWL:6,NIOPS:6,DC:8</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,OA:8,LA:5,SL:7,FWL:6,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1534,8 +1528,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
+			<availability>CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,OA:2,LA:2,Periphery.MW:3,SL:9,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,SL.R:4</availability>
 			</model>
@@ -1732,8 +1725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
+			<availability>CC:3-,MOC:4-,OA:4-,LA:5-,SL:4-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1785,8 +1777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:4-,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,OA:5,LA:5,Periphery.MW:5,SL:4-,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1873,8 +1864,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1915,8 +1905,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2120,8 +2109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,OA:5,LA:4,SL:4,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,OA:5,LA:4,SL:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2235,8 +2223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:3,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,OA:7,LA:7,SL:3,FWL:9,NIOPS:4,DC:6</availability>
 			<model name='LGB-0C'>
 				<availability>Periphery:2</availability>
 			</model>
@@ -2338,8 +2325,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2361,8 +2347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2390,8 +2375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2479,8 +2463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,Periphery:6,TC:6,OA:5,LA:6,SL:4,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -2759,8 +2742,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:4,SL:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,OA:5,LA:6,Periphery.MW:4,SL:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2823,8 +2805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2842,8 +2823,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,LA:3,FS.DMM:3,SL:5-,FWL:3,NIOPS:2,SL.R:0,DC:8</availability>
+			<availability>CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,LA:3,FS.DMM:3,SL:5-,FWL:3,NIOPS:2,SL.R:0,DC:8</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,DC:1,TC:8</availability>
 			</model>
@@ -3014,8 +2994,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:8,Periphery.Deep:4,MERC:6,FS:8,CIR:6,Periphery:4,TC:5,OA:5,LA:8,SL:7-,FWL:8,NIOPS:8,SL.R:6,DC:7</availability>
+			<availability>MOC:5,CC:8,Periphery.Deep:4,MERC:6,FS:8,CIR:6,Periphery:4,TC:5,OA:5,LA:8,SL:7-,FWL:8,NIOPS:8,SL.R:6,DC:7</availability>
 			<model name='PAT-005'>
 				<availability>General:8,NIOPS:8</availability>
 			</model>
@@ -3030,8 +3009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -3053,8 +3031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,OA:8,LA:8,SL:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,OA:8,LA:8,SL:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3163,8 +3140,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,SL:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,SL:4</availability>
 			</model>
@@ -3234,8 +3210,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3296,8 +3271,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,OA:3,LA:4,SL:3-,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3353,8 +3327,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,OA:3,LA:4,Periphery.HR:4,SL:4-,FWL:2,NIOPS:3,DC:4</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,OA:3,LA:4,Periphery.HR:4,SL:4-,FWL:2,NIOPS:3,DC:4</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3391,8 +3364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,OA:9,LA:8,SL:9-,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,OA:9,LA:8,SL:9-,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,SL.R:2,Periphery:8</availability>
 			</model>
@@ -3458,8 +3430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,OA:2,LA:6,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
+			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,OA:2,LA:6,Periphery.MW:3,SL:4,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 			<model name='F-90'>
 				<availability>LA:8,SL:8,IS:8,SL.R:0,FS:8,Periphery:8</availability>
 			</model>
@@ -3476,15 +3447,13 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>
-				CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,Periphery:2,OA:7,LA:9,PIR:3,SL:4-,NIOPS:4,DC:8</availability>
+			<availability>CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,Periphery:2,OA:7,LA:9,PIR:3,SL:4-,NIOPS:4,DC:8</availability>
 			<model name='STC-2C'>
 				<availability>CC:8,General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,SL:7,FWL:3,DC:3</availability>
+			<availability>MOC:3,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,SL:7,FWL:3,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -3576,8 +3545,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,OA:6,LA:8,SL:5,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,OA:6,LA:8,SL:5,FWL:6,NIOPS:5-,DC:6</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,SL.R:4</availability>
@@ -3752,8 +3720,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:5-,SL:4-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,OA:2-,LA:3-,FS.CMM:5-,SL:4-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3774,8 +3741,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,LA:7,Periphery.HR:6,SL:5-,FWL:7,NIOPS:5-,DC:7</availability>
+			<availability>CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,OA:6,LA:7,Periphery.HR:6,SL:5-,FWL:7,NIOPS:5-,DC:7</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,SL:2,IS:1,FS:1</availability>
 			</model>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -298,14 +298,14 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>PP:6,CC:5,MOC:3,IS:5,FS:5,TC:3,Periphery:3,CS:6,OA:3,LA:5,FWL:4,NIOPS:6,DC:7</availability>
+			<availability>PP:6,IS:5,TC:3,Periphery:3,CS:6,FWL:4,NIOPS:6,DC:7</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -389,7 +389,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
+			<availability>PP:10,CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,DC:8</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -466,7 +466,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>PP:5,CC:2,MOC:1,CS:4-,OA:1,LA:3,IS:2,FWL:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
+			<availability>PP:5,MOC:1,CS:4-,OA:1,LA:3,IS:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
 			<model name='AS7-D'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -483,7 +483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,TC:6,Periphery:4,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
+			<availability>PP:8,MOC:6,IS:7,Periphery.Deep:4,CIR:7,TC:6,Periphery:4,CS:8,OA:6,FWL:8,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -498,7 +498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>Periphery.Deep:10-,FS:6-,MERC:7-,Periphery:10-,CS:2-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -529,7 +529,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>PP:4,CC:7,CS:8-,MOC:5,LA:8,PIR:6,IS:7,FWL:8,NIOPS:8-,FS:7,DC:7,TC:6</availability>
+			<availability>PP:4,CS:8-,MOC:5,LA:8,PIR:6,IS:7,FWL:8,NIOPS:8-,TC:6</availability>
 			<model name='BLR-1G'>
 				<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 			</model>
@@ -575,7 +575,7 @@
 				<availability>PP:4,CS:4,NIOPS:4,FWL:2+</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
+				<availability>LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:6-</availability>
@@ -677,7 +677,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>PP:2,CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
+			<availability>PP:2,CC:6,IS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,NIOPS:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:4,DC:4</availability>
@@ -712,7 +712,7 @@
 			<availability>CS:2-,NIOPS:2-,FS:6</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
-				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
+				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ceremonial Guard' unitType='Infantry'>
@@ -768,7 +768,7 @@
 			<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
-				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -802,7 +802,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,LA:5,FWL:5,NIOPS:3-,DC:5</availability>
+			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -863,7 +863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -876,7 +876,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>PP:7,CC:6,MOC:3,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>PP:7,MOC:3,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1108,7 +1108,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>PP:2,CC:3,LA:6,Periphery.HR:6,IS:6,Periphery.Deep:6,FS:6,MERC:8,TC:6,DC:8</availability>
+			<availability>PP:2,CC:3,Periphery.HR:6,IS:6,Periphery.Deep:6,MERC:8,TC:6,DC:8</availability>
 			<model name='DV-6M'>
 				<availability>PP:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1164,7 +1164,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,PP:4,IS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,FWL:8,NIOPS:5-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:4,FS:4</availability>
@@ -1231,7 +1231,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:4,MOC:2,IS:4,FS:4,CIR:2,Periphery:2,TC:2,CS:5,OA:2,LA:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>IS:4,CIR:2,Periphery:2,CS:5,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1379,7 +1379,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>PP:8,CS:5,Periphery.R:4,LA:6,FWL:5,NIOPS:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:4-</availability>
+				<availability>LA:4-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
@@ -1520,7 +1520,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>PP:4,CC:4,MOC:4,IS:4,FS:3,CIR:4,TC:4,Periphery:3,CS:4,OA:4,LA:4,FWL:4,NIOPS:4,DC:3</availability>
+			<availability>PP:4,MOC:4,IS:4,FS:3,CIR:4,TC:4,Periphery:3,CS:4,OA:4,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1543,7 +1543,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>PP:7,CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,TC:6,Periphery:4,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,DC:8</availability>
+			<availability>PP:7,CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,TC:6,Periphery:4,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1560,7 +1560,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1579,14 +1579,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:3,MOC:2,CS:2,OA:2,LA:4,Periphery.MW:2,FWL:5,MERC:4,TC:2,Periphery:2</availability>
+			<availability>CC:3,CS:2,LA:4,FWL:5,MERC:4,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
+			<availability>PP:9,CC:4,MOC:4,IS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>PP:6,General:6</availability>
 			</model>
@@ -1601,7 +1601,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,IS:6,NIOPS:4-,Periphery.Deep:6,MERC:7,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,IS:6,NIOPS:4-,Periphery.Deep:6,MERC:7,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1661,7 +1661,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>PP:7,CC:6,MOC:4,IS:6,FS:6,CIR:4,TC:4,CS:7,OA:4,LA:6,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>PP:7,MOC:4,IS:6,CIR:4,TC:4,CS:7,OA:4,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -1676,7 +1676,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:4,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1786,7 +1786,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
+			<availability>CC:3-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,DC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1828,7 +1828,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>PP:9,CC:5,CS:9,LA:5,FWL:5,NIOPS:9,IS:5,FS:5,MERC:5,DC:5</availability>
+			<availability>PP:9,CS:9,NIOPS:9,IS:5,MERC:5</availability>
 			<model name='HGN-732'>
 				<availability>PP:8,CC:8+,MOC:6+,CS:8,LA:8+,FWL:8+,IS:6+,NIOPS:8,FS:8+,MERC:6+,DC:8+</availability>
 			</model>
@@ -1862,7 +1862,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>PP:5,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,NIOPS:5-</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1907,7 +1907,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>PP:4,CC:4,MOC:4,IS:4,FS:3,CIR:4,TC:3,Periphery:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>PP:4,MOC:4,IS:4,FS:3,CIR:4,TC:3,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1951,7 +1951,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1992,7 +1992,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2081,7 +2081,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>PP:5,CC:2+,CS:6,LA:2+,FWL:2+,IS:2+,NIOPS:6,FS:2+,MERC:2+,DC:2+</availability>
+			<availability>PP:5,CS:6,IS:2+,NIOPS:6,MERC:2+</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,General:6,NIOPS:8</availability>
 			</model>
@@ -2092,7 +2092,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>PP:8,CS:7,FWL:5,NIOPS:7,FS:6,MERC:3,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2</availability>
+				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
@@ -2232,7 +2232,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>PP:5,CC:8,MOC:2,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
+			<availability>PP:5,CC:8,IS:3,Periphery:2,CS:5-,LA:3,FWL:2,NIOPS:5-</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:3</availability>
 			</model>
@@ -2302,7 +2302,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>PP:3,CC:6,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2319,7 +2319,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
 			</model>
@@ -2396,7 +2396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2430,7 +2430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2458,7 +2458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2546,7 +2546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,PP:4,CC:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>PP:4,CC:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -2806,7 +2806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>PP:4,CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>PP:4,MOC:5,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,FWL:6,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2822,7 +2822,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>PP:5,CC:6,MOC:4,CS:4,LA:6,IS:6,Periphery.Deep:4,NIOPS:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>PP:5,CS:4,LA:6,IS:6,Periphery.Deep:4,NIOPS:4,Periphery:4</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -2836,7 +2836,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>PP:5,CC:5,CS:4,LA:5,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>PP:5,CS:4,IS:5,Periphery.Deep:5,NIOPS:4,MERC:5,Periphery:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -2849,19 +2849,18 @@
 		<chassis name='Ostsol' unitType='Mek'>
 			<availability>CS:6,FWL:8,NIOPS:6,FS:8,MERC:8,Periphery:3</availability>
 			<model name='OTL-4D'>
-				<availability>PP:8,CLAN:8,IS:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				PP:7,CC:5,MOC:4,IS:4,FS:5,CIR:4,TC:4,Periphery:3,CS:7,OA:4,LA:5,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>PP:7,CC:5,MOC:4,IS:4,FS:5,CIR:4,TC:4,Periphery:3,CS:7,OA:4,LA:5,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,IS:6,Periphery.Deep:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2895,7 +2894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2912,7 +2911,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>IS:8,FWL:9,Periphery.Deep:7,CIR:7,Periphery:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3078,7 +3077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,CS:3-,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,IS:4,Periphery.Deep:4,FS:3,Periphery:4,CS:3-,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -3100,7 +3099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>PP:9,MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>PP:9,Periphery.Deep:8,IS:7,MERC:8,Periphery:8,CS:9,LA:8,NIOPS:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3121,7 +3120,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>PP:4,CC:6,CS:6-,IS:6,FWL:6,NIOPS:6-,Periphery.Deep:5,FS:6,CIR:4,Periphery:5</availability>
+			<availability>PP:4,CS:6-,IS:6,NIOPS:6-,Periphery.Deep:5,CIR:4,Periphery:5</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3153,7 +3152,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rogue' unitType='AeroSpaceFighter'>
-			<availability>PP:5,CC:4,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,LA:4,FWL:4,NIOPS:4,DC:3</availability>
+			<availability>PP:5,MOC:3,IS:4,FS:3,CIR:2,TC:3,CS:4,OA:3,NIOPS:4,DC:3</availability>
 			<model name='RGU-133E'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>
@@ -3210,7 +3209,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -3229,7 +3228,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
+			<availability>PP:5,IS:6,MERC:6,Periphery:6</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -3246,7 +3245,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,CS:5,OA:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3293,7 +3292,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3363,14 +3362,14 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>PP:4,CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -3419,7 +3418,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,FS:7,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,FWL:2,NIOPS:3,DC:4</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3446,13 +3445,13 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>PP:4,CC:5,CS:4,OA:2,LA:4,IS:4,FWL:7,NIOPS:4,FS:6,MERC:4,TC:2,DC:7</availability>
+			<availability>PP:4,CC:5,CS:4,OA:2,IS:4,FWL:7,NIOPS:4,FS:6,MERC:4,TC:2,DC:7</availability>
 			<model name='SDR-5V'>
 				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>PP:9,CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>PP:9,CC:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3497,7 +3496,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>PP:5,MOC:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6</availability>
+			<availability>PP:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -3512,7 +3511,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
+			<availability>CC:6,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,CS:3,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -3535,7 +3534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
+			<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -3598,7 +3597,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-5'>
 				<availability>CC:4</availability>
 			</model>
@@ -3630,7 +3629,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>PP:5,CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>PP:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,LA:8,FWL:6,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -3645,7 +3644,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>PP:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
+			<availability>PP:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,DC:8</availability>
 			<model name='TDR-5S'>
 				<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3758,7 +3757,7 @@
 			<availability>IS:4,DC:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -3816,7 +3815,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>PP:5,CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,TC:2-,Periphery:2-,CS:4-,OA:2-,LA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>PP:5,CC:6-,IS:3-,Periphery:2-,CS:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3837,7 +3836,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,MOC:2,CS:5,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -3923,7 +3922,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>PP:6,CS:6-,LA:9,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:5,Periphery:5</availability>
+			<availability>PP:6,CS:6-,LA:9,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='WHM-6L'>
 				<availability>CC:3</availability>
 			</model>
@@ -3960,7 +3959,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>PP:4,CS:4-,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+			<availability>PP:4,CS:4-,IS:10,NIOPS:4-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4014,7 +4013,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>PP:5,CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:7,TC:5,DC:6</availability>
+			<availability>PP:5,CS:5-,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,TC:5,DC:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -4098,7 +4097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zero' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,PP:6,CC:1,IS:1,FS:1,TC:2,Periphery:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:4</availability>
+			<availability>PP:6,IS:1,Periphery:2,CS:5,NIOPS:5,DC:4</availability>
 			<model name='ZRO-114'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -298,8 +298,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -390,8 +389,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
+			<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -485,8 +483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,TC:6,Periphery:4,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
+			<availability>PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,TC:6,Periphery:4,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -501,8 +498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -619,8 +615,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -682,8 +677,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				PP:2,CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
+			<availability>PP:2,CC:6,MOC:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:4,DC:4</availability>
@@ -771,8 +765,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1077,8 +1070,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1172,8 +1164,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,PP:4,CC:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:4,FS:4</availability>
@@ -1529,8 +1520,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				PP:4,CC:4,MOC:4,IS:4,FS:3,CIR:4,TC:4,Periphery:3,CS:4,OA:4,LA:4,FWL:4,NIOPS:4,DC:3</availability>
+			<availability>PP:4,CC:4,MOC:4,IS:4,FS:3,CIR:4,TC:4,Periphery:3,CS:4,OA:4,LA:4,FWL:4,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1553,8 +1543,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				PP:7,CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,TC:6,Periphery:4,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,DC:8</availability>
+			<availability>PP:7,CC:4,MOC:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,TC:6,Periphery:4,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1597,8 +1586,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
+			<availability>PP:9,CC:4,MOC:4,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9,DC:2</availability>
 			<model name='GTHA-100'>
 				<availability>PP:6,General:6</availability>
 			</model>
@@ -1619,8 +1607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				PP:4,CC:7,MOC:7,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,NIOPS:4,DC:8</availability>
+			<availability>PP:4,CC:7,MOC:7,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1689,8 +1676,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:4,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:4,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1800,8 +1786,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
+			<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,Periphery:4-,TC:4-,DC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -1877,8 +1862,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1967,8 +1951,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2009,8 +1992,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2208,8 +2190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				PP:5,CC:4,MOC:5,IS:5,Periphery.Deep:6,FS:4,CIR:6,TC:5,Periphery:6,CS:4,OA:5,LA:4,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>PP:5,CC:4,MOC:5,IS:5,Periphery.Deep:6,FS:4,CIR:6,TC:5,Periphery:6,CS:4,OA:5,LA:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2321,8 +2302,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2416,8 +2396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2451,8 +2430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2480,8 +2458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2569,8 +2546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,PP:4,CC:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,PP:4,CC:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -2830,8 +2806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				PP:4,CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>PP:4,CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2861,8 +2836,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				PP:5,CC:5,CS:4,LA:5,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>PP:5,CC:5,CS:4,LA:5,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -2887,8 +2861,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2906,8 +2879,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
+			<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,DC:1,TC:8</availability>
 			</model>
@@ -2923,8 +2895,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2941,8 +2912,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3093,8 +3063,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:5,PP:8,CC:7,Periphery.Deep:4,MERC:6,FS:7,CIR:6,Periphery:4,TC:5,CS:8,OA:5,LA:7,FWL:7,NIOPS:8,DC:7</availability>
+			<availability>MOC:5,PP:8,CC:7,Periphery.Deep:4,MERC:6,FS:7,CIR:6,Periphery:4,TC:5,CS:8,OA:5,LA:7,FWL:7,NIOPS:8,DC:7</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>
@@ -3109,8 +3078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,CS:3-,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,CS:3-,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -3132,8 +3100,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				PP:9,MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>PP:9,MOC:8,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3243,8 +3210,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -3280,8 +3246,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3297,8 +3262,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				PP:2-,CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
+			<availability>PP:2-,CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -3329,8 +3293,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3400,8 +3363,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3457,8 +3419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3491,8 +3452,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				PP:9,CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>PP:9,CC:7,MOC:9,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3552,8 +3512,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
+			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -3570,15 +3529,13 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>
-				PP:6,CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,CS:4,OA:7,LA:9,PIR:4,NIOPS:4,DC:8</availability>
+			<availability>PP:6,CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,CS:4,OA:7,LA:9,PIR:4,NIOPS:4,DC:8</availability>
 			<model name='STC-2C'>
 				<availability>CC:8,General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
+			<availability>MOC:3,PP:8,CC:4,MERC:4,Periphery.OS:3,FS:6,CIR:2,Periphery:2,TC:3,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -3673,8 +3630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:5,CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>PP:5,CC:6,MOC:6,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -3689,8 +3645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				PP:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
+			<availability>PP:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
 			<model name='TDR-5S'>
 				<availability>CC:8,LA:8,General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3861,8 +3816,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				PP:5,CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,TC:2-,Periphery:2-,CS:4-,OA:2-,LA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>PP:5,CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,TC:2-,Periphery:2-,CS:4-,OA:2-,LA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3890,8 +3844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
+			<availability>PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4047,8 +4000,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -32,8 +32,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
+			<salvage pct='5'>CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
 			<weightDistribution era='2815' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2815' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -43,8 +42,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
+			<salvage pct='5'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -52,8 +50,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:8,CHH:1,CSR:5,CIH:8,CWOV:1,CSV:3,CFM:8,CGS:1,CSA:5,CDS:2,CW:1,CBS:1,CNC:5,CSJ:8,CJF:10,CB:5</salvage>
+			<salvage pct='5'>CCC:8,CHH:1,CSR:5,CIH:8,CWOV:1,CSV:3,CFM:8,CGS:1,CSA:5,CDS:2,CW:1,CBS:1,CNC:5,CSJ:8,CJF:10,CB:5</salvage>
 			<weightDistribution era='2815' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2815' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -63,8 +60,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:3,CNC:1,CSJ:3,CMG:3,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='5'>CCC:1,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:3,CNC:1,CSJ:3,CMG:3,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -72,8 +68,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CHH:10,CCC:3,CIH:5,CSR:1,CWOV:3,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
+			<salvage pct='5'>CHH:10,CCC:3,CIH:5,CSR:1,CWOV:3,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
 			<weightDistribution era='2815' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2815' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -83,8 +78,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
+			<salvage pct='5'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -92,8 +86,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:2,CSR:6,CIH:8,CWOV:2,CSV:4,CFM:8,CCO:2,CGS:6,CSA:4,CDS:10,CW:4,CWI:4,CBS:2,CNC:10,CSJ:6,CMG:2,CJF:10,CGB:8,CB:8</salvage>
+			<salvage pct='5'>CCC:2,CSR:6,CIH:8,CWOV:2,CSV:4,CFM:8,CCO:2,CGS:6,CSA:4,CDS:10,CW:4,CWI:4,CBS:2,CNC:10,CSJ:6,CMG:2,CJF:10,CGB:8,CB:8</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -101,8 +94,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:2,CHH:3,CSR:4,CWOV:1,CSV:5,CFM:10,CCO:5,CGS:5,CSA:8,CDS:5,CW:4,CWI:1,CNC:2,CSJ:3,CMG:5,CJF:8,CGB:2,CB:2</salvage>
+			<salvage pct='5'>CCC:2,CHH:3,CSR:4,CWOV:1,CSV:5,CFM:10,CCO:5,CGS:5,CSA:8,CDS:5,CW:4,CWI:1,CNC:2,CSJ:3,CMG:5,CJF:8,CGB:2,CB:2</salvage>
 			<weightDistribution era='2815' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2815' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -112,8 +104,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:3,CHH:4,CSR:4,CIH:8,CWOV:1,CSV:10,CFM:9,CCO:6,CGS:6,CSA:9,CDS:4,CW:10,CWI:1,CBS:1,CNC:2,CSJ:1,CMG:3,CGB:1,CB:2</salvage>
+			<salvage pct='5'>CCC:3,CHH:4,CSR:4,CIH:8,CWOV:1,CSV:10,CFM:9,CCO:6,CGS:6,CSA:9,CDS:4,CW:10,CWI:1,CBS:1,CNC:2,CSJ:1,CMG:3,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -138,8 +129,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:8,CSR:7,CIH:10,CWOV:2,CSV:8,CFM:5,CCO:3,CGS:5,CSA:10,CW:3,CWI:2,CNC:2,CSJ:5,CMG:2,CJF:8,CB:5</salvage>
+			<salvage pct='5'>CCC:1,CHH:8,CSR:7,CIH:10,CWOV:2,CSV:8,CFM:5,CCO:3,CGS:5,CSA:10,CW:3,CWI:2,CNC:2,CSJ:5,CMG:2,CJF:8,CB:5</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -147,8 +137,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='5'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -156,8 +145,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
+			<salvage pct='5'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -165,8 +153,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
+			<salvage pct='5'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
 			<weightDistribution era='2815' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2815' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -176,8 +163,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CWOV:1,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='5'>CCC:1,CHH:1,CSR:3,CIH:4,CWOV:1,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CWI'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -193,8 +179,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='5'>
-				CCC:2,CHH:1,CSR:2,CIH:4,CWOV:3,CSV:4,CFM:3,CCO:1,CGS:1,CSA:4,CDS:1,CWI:1,CBS:1,CNC:1,CSJ:3,CMG:1,CJF:10,CGB:2,CB:1</salvage>
+			<salvage pct='5'>CCC:2,CHH:1,CSR:2,CIH:4,CWOV:3,CSV:4,CFM:3,CCO:1,CGS:1,CSA:4,CDS:1,CWI:1,CBS:1,CNC:1,CSJ:3,CMG:1,CJF:10,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CWOV'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -202,8 +187,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:3,CSR:10,CIH:3,CSV:3,CFM:3,CCO:3,CGS:3,CSA:5,CDS:3,CW:10,CJF:5,CGB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:3,CSR:10,CIH:3,CSV:3,CFM:3,CCO:3,CGS:3,CSA:5,CDS:3,CW:10,CJF:5,CGB:3</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -484,24 +468,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				PP:6,CC:5,MOC:3,CLAN:6,IS:5,FS:5,Periphery:3,TC:3,CS:6,OA:3,LA:5,FWL:4,NIOPS:6,DC:7</availability>
+			<availability>PP:6,CC:5,MOC:3,CLAN:6,IS:5,FS:5,Periphery:3,TC:3,CS:6,OA:3,LA:5,FWL:4,NIOPS:6,DC:7</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				PP:5,CC:5,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:5,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
+			<availability>PP:5,CC:5,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:5,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:6</availability>
@@ -521,8 +502,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:2+,PP:5,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:5+</availability>
+			<availability>MOC:2+,PP:5,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:5+</availability>
 			<model name='Mk III'>
 				<availability>General:2</availability>
 			</model>
@@ -585,8 +565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
+			<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -694,8 +673,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
+			<availability>PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -713,8 +691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -783,8 +760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				PP:10,CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:6,FS:5,MERC:4,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:4,CNC:10,FWL:6,NIOPS:7,CJF:8,CGB:10,DC:4</availability>
+			<availability>PP:10,CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:6,FS:5,MERC:4,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:4,CNC:10,FWL:6,NIOPS:7,CJF:8,CGB:10,DC:4</availability>
 			<model name='BL-6-KNT'>
 				<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
 			</model>
@@ -832,8 +808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -845,8 +820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>
-				PP:8,CC:6,CHH:8,CLAN:6,FS:6,MERC:6,CS:7,CDS:6,LA:6,CNC:6,FWL:6,NIOPS:7,CJF:6,DC:6</availability>
+			<availability>PP:8,CC:6,CHH:8,CLAN:6,FS:6,MERC:6,CS:7,CDS:6,LA:6,CNC:6,FWL:6,NIOPS:7,CJF:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -896,8 +870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				PP:2,CC:6,MOC:2,CLAN:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
+			<availability>PP:2,CC:6,MOC:2,CLAN:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:4,DC:4</availability>
@@ -929,8 +902,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:2,IS:3,FWL:2,NIOPS:2-,FS:8,Periphery.OS:2,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:2,IS:3,FWL:2,NIOPS:2-,FS:8,Periphery.OS:2,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -989,8 +961,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:5,Periphery.Deep:4,FS:5,MERC:5,CIR:5,Periphery:4,TC:5,CS:3,OA:5,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3,DC:5</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1279,8 +1250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				PP:5,CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>PP:5,CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:5,Periphery.Deep:5,NIOPS:0,Periphery:5</availability>
@@ -1298,8 +1268,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				PP:10,CC:7,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:7,CGS:8,CS:8,CDS:8,CW:10,LA:7,CBS:10,FWL:7,NIOPS:8,CJF:8,CGB:10,DC:7</availability>
+			<availability>PP:10,CC:7,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:7,CGS:8,CS:8,CDS:8,CW:10,LA:7,CBS:10,FWL:7,NIOPS:8,CJF:8,CGB:10,DC:7</availability>
 			<model name='CRK-5003-1'>
 				<availability>CS:8,General:7+,NIOPS:8</availability>
 			</model>
@@ -1426,8 +1395,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1521,8 +1489,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1585,8 +1552,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>
-				PP:5,CC:2,CSR:3,CIH:3,CSV:3,CLAN:3,CCO:3,CGS:3,CSA:3,CDS:3,LA:4,CSJ:4,CGB:3,DC:4,CB:3</availability>
+			<availability>PP:5,CC:2,CSR:3,CIH:3,CSV:3,CLAN:3,CCO:3,CGS:3,CSA:3,CDS:3,LA:4,CSJ:4,CGB:3,DC:4,CB:3</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>PP:8,CLAN:8,IS:8,DC:8</availability>
@@ -1748,8 +1714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				PP:8,CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:5,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>PP:8,CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:5,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:5-</availability>
 			</model>
@@ -1892,8 +1857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,PP:4,CC:4,CHH:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:4,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,PP:4,CC:4,CHH:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:4,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1916,8 +1880,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,PP:7,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,PP:7,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1960,8 +1923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
+			<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
 			<model name='GTHA-100'>
 				<availability>PP:6,General:6</availability>
 			</model>
@@ -1982,8 +1944,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				PP:4,CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+			<availability>PP:4,CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2037,8 +1998,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,PP:7,CC:5,CLAN:7,IS:5,FS:5,CIR:4,TC:4,CS:7,OA:4,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:4,PP:7,CC:5,CLAN:7,IS:5,FS:5,CIR:4,TC:4,CS:7,OA:4,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2053,8 +2013,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2164,8 +2123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
+			<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2231,8 +2189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,Periphery.HR:4,FS.CMM:4,FS.DMM:4,FS:4,MERC:4,Periphery.OS:4,FS.CrMM:4,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:4,FS.CMM:4,FS.DMM:4,FS:4,MERC:4,Periphery.OS:4,FS.CrMM:4,TC:4</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2245,8 +2202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2291,8 +2247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2311,8 +2266,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,CNC:7,FWL:6,NIOPS:6,DC:6</availability>
+			<availability>PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,CNC:7,FWL:6,NIOPS:6,DC:6</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8</availability>
 			</model>
@@ -2337,8 +2291,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2379,8 +2332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>FS:5</availability>
@@ -2473,8 +2425,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				PP:5,CC:2+,CLAN:6,IS:2+,FS:2+,MERC:2+,CGS:7,CS:6,LA:2+,FWL:2+,NIOPS:6,CGB:7,DC:2+</availability>
+			<availability>PP:5,CC:2+,CLAN:6,IS:2+,FS:2+,MERC:2+,CGS:7,CS:6,LA:2+,FWL:2+,NIOPS:6,CGB:7,DC:2+</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,General:5,NIOPS:8</availability>
 			</model>
@@ -2560,8 +2511,7 @@
 			<availability>CS:1-,IS:6,NIOPS:1-,Periphery.Deep:6,Periphery:6</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:4,PP:6,CC:6,CIH:6,CLAN:6,IS:6,CFM:6,MERC:6,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:6,NIOPS:6,DC:6</availability>
+			<availability>MOC:4,PP:6,CC:6,CIH:6,CLAN:6,IS:6,CFM:6,MERC:6,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:6,NIOPS:6,DC:6</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>PP:6,CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
@@ -2590,8 +2540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:5,PP:5,CC:4,CHH:3,CLAN:4,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,CS:4,OA:5,LA:4,CBS:4,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>MOC:5,PP:5,CC:4,CHH:3,CLAN:4,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,CS:4,OA:5,LA:4,CBS:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2633,8 +2582,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
+			<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:3</availability>
 			</model>
@@ -2690,8 +2638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				PP:6,CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
+			<availability>PP:6,CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -2705,8 +2652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2800,8 +2746,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2838,8 +2783,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2864,8 +2808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2953,8 +2896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				PP:4,CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>PP:4,CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -3084,8 +3026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CMG:6,CJF:7,CGB:5,DC:6+</availability>
+			<availability>PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CMG:6,CJF:7,CGB:5,DC:6+</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>PP:8,CS:8,NIOPS:8,IS:6+,Periphery:6+</availability>
@@ -3233,8 +3174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				PP:4,CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>PP:4,CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3264,8 +3204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				PP:5,CC:5,CLAN:4-,IS:5,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,CS:4,LA:5,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>PP:5,CC:5,CLAN:4-,IS:5,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,CS:4,LA:5,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3289,16 +3228,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,PP:7,CC:5,CHH:7,CLAN:7,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:4,PP:7,CC:5,CHH:7,CLAN:7,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3316,8 +3253,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
+			<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,DC:1,TC:8</availability>
 			</model>
@@ -3333,8 +3269,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3351,8 +3286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3447,8 +3381,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				PP:5,CCC:4,CHH:4,CSR:5,CIH:4,CSV:4,CLAN:4,CFM:4,CCO:4,CGS:5,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
+			<availability>PP:5,CCC:4,CHH:4,CSR:5,CIH:4,CSV:4,CLAN:4,CFM:4,CCO:4,CGS:5,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3510,8 +3443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:4,PP:8,CC:6,CLAN:8,Periphery.Deep:4,MERC:5,FS:6,CIR:5,Periphery:4,TC:4,CS:8,OA:4,LA:6,FWL:6,NIOPS:8,CJF:8,DC:6</availability>
+			<availability>MOC:4,PP:8,CC:6,CLAN:8,Periphery.Deep:4,MERC:5,FS:6,CIR:5,Periphery:4,TC:4,CS:8,OA:4,LA:6,FWL:6,NIOPS:8,CJF:8,DC:6</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>
@@ -3526,8 +3458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,CS:3-,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,CS:3-,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:6,OA:6,FWL:8,DC:8,TC:6</availability>
 			</model>
@@ -3552,8 +3483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				PP:9,MOC:8,CLAN:9,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>PP:9,MOC:8,CLAN:9,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3567,8 +3497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:4,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:4,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:4,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
 			</model>
@@ -3676,8 +3605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5-,MOC:5-,OA:5-,LA:5-,CLAN:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,CLAN:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -3719,8 +3647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3736,8 +3663,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				PP:2-,CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
+			<availability>PP:2-,CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -3763,8 +3689,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				PP:6,CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:6,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>PP:6,CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:6,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
 			<model name='STN-1S'>
 				<availability>LA:2,FWL:2,FS:2</availability>
 			</model>
@@ -3776,8 +3701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3847,8 +3771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3882,8 +3805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>
-				PP:5,CSR:4,CSV:3,CLAN:3,CFM:3,CGS:3,CCO:4,CSA:4,CS:1,CDS:3,CW:3,NIOPS:1,CSJ:3,CJF:3</availability>
+			<availability>PP:5,CSR:4,CSV:3,CLAN:3,CFM:3,CGS:3,CCO:4,CSA:4,CS:1,CDS:3,CW:3,NIOPS:1,CSJ:3,CJF:3</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3905,8 +3827,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:7,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:2,NIOPS:3,DC:4</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -3939,8 +3860,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				PP:9,CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>PP:9,CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4003,8 +3923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
+			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4021,15 +3940,13 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>
-				PP:6,CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,CS:4,OA:7,LA:9,PIR:4,NIOPS:4,DC:8</availability>
+			<availability>PP:6,CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,CS:4,OA:7,LA:9,PIR:4,NIOPS:4,DC:8</availability>
 			<model name='STC-2C'>
 				<availability>CC:8,General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,PP:8,CC:4,CLAN:6,MERC:4,Periphery.OS:3,FS:6,CIR:2,TC:3,Periphery:2,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
+			<availability>MOC:3,PP:8,CC:4,CLAN:6,MERC:4,Periphery.OS:3,FS:6,CIR:2,TC:3,Periphery:2,OA:3,LA:4,Periphery.HR:3,FWL:3,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4113,8 +4030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				PP:8,CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>PP:8,CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-11E'>
 				<availability>PP:8,CS:8,FWL:8+,IS:8+,NIOPS:8,FS:8+,DC:8+,TC:8</availability>
 			</model>
@@ -4136,8 +4052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:5,CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>PP:5,CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -4152,8 +4067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
+			<availability>PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -4188,8 +4102,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:9,CC:5,MOC:2,CLAN:9,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:6,FWL:5,NIOPS:9,DC:2</availability>
+			<availability>PP:9,CC:5,MOC:2,CLAN:9,FS:3,MERC:3,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:6,FWL:5,NIOPS:9,DC:2</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:2</availability>
@@ -4247,8 +4160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
-			<availability>
-				PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
+			<availability>PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
 			<model name='TRN-3T'>
 				<availability>PP:8,CS:8,OA:5+,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
 			</model>
@@ -4335,8 +4247,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				PP:5,CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,CS:4-,OA:2-,LA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>PP:5,CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,CS:4-,OA:2-,LA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4364,8 +4275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
+			<availability>PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4384,8 +4294,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				PP:4,CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:4,TC:1,CSA:2,CW:4,LA:4,CNC:2,FWL:4,CSJ:5,CJF:2,DC:3,CB:2</availability>
+			<availability>PP:4,CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:4,TC:1,CSA:2,CW:4,LA:4,CNC:2,FWL:4,CSJ:5,CJF:2,DC:3,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>PP:8,CLAN:8,IS:8,TC:8</availability>
@@ -4522,8 +4431,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
@@ -4543,8 +4451,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				PP:5,CC:7,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,FS:7,TC:5,CS:5-,LA:7,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>PP:5,CC:7,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,FS:7,TC:5,CS:5-,LA:7,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -4628,8 +4535,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zero' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
+			<availability>MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
 			<model name='ZRO-114'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -468,21 +468,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>PP:6,CC:5,MOC:3,CLAN:6,IS:5,FS:5,Periphery:3,TC:3,CS:6,OA:3,LA:5,FWL:4,NIOPS:6,DC:7</availability>
+			<availability>PP:6,CLAN:6,IS:5,Periphery:3,CS:6,OA:3,LA:5,FWL:4,NIOPS:6,DC:7</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>PP:5,CC:5,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:5,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
+			<availability>PP:5,CC:5,CSR:5,CLAN:4,FS:5,LA:3,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:6</availability>
@@ -502,7 +502,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:2+,PP:5,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:5+</availability>
+			<availability>MOC:2+,PP:5,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,LA:4+,FWL:4+,NIOPS:7,DC:5+</availability>
 			<model name='Mk III'>
 				<availability>General:2</availability>
 			</model>
@@ -565,7 +565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>PP:10,CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,Periphery:10,TC:10,DC:8</availability>
+			<availability>PP:10,CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,Periphery:10,DC:8</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PP:4,PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -642,7 +642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>PP:5,CC:2,MOC:1,CS:4-,OA:1,LA:3,IS:2,FWL:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
+			<availability>PP:5,MOC:1,CS:4-,OA:1,LA:3,IS:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -666,14 +666,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:2,MOC:2,OA:2,LA:4,FWL:2,IS:2,FS:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>LA:4,IS:2,FS:3,Periphery:2</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>PP:8,CC:7,MOC:6,IS:7,Periphery.Deep:4,FS:7,CIR:7,Periphery:4,TC:6,CS:8,OA:6,LA:7,FWL:8,NIOPS:8,DC:7</availability>
+			<availability>PP:8,MOC:6,IS:7,Periphery.Deep:4,CIR:7,Periphery:4,TC:6,CS:8,OA:6,FWL:8,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -691,7 +691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>Periphery.Deep:10-,FS:6-,MERC:7-,Periphery:10-,CS:2-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -722,7 +722,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>PP:4,CC:7,MOC:6,CLAN:4,IS:7,FS:7,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
+			<availability>PP:4,MOC:6,CLAN:4,IS:7,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4</availability>
 			<model name='BLR-1G'>
 				<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 			</model>
@@ -768,7 +768,7 @@
 				<availability>PP:2,CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
+				<availability>LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:6-</availability>
@@ -781,7 +781,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Lion II Battlecruiser' unitType='Warship'>
-			<availability>PP:5,CSA:4,CS:1,CW:5,CBS:4,CNC:5,CLAN:4,NIOPS:1,CSJ:4,CJF:5,CGB:4</availability>
+			<availability>PP:5,CS:1,CW:5,CNC:5,CLAN:4,NIOPS:1,CJF:5</availability>
 			<model name='(2691)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -808,7 +808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -820,7 +820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>PP:8,CC:6,CHH:8,CLAN:6,FS:6,MERC:6,CS:7,CDS:6,LA:6,CNC:6,FWL:6,NIOPS:7,CJF:6,DC:6</availability>
+			<availability>PP:8,CC:6,CHH:8,CLAN:6,FS:6,MERC:6,CS:7,LA:6,FWL:6,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -854,7 +854,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>PP:2,CHH:1,CCC:1,CSR:2,CSV:1,CLAN:1,CGS:2,CCO:1,CS:1,CW:2,NIOPS:1,CJF:1,CGB:1</availability>
+			<availability>PP:2,CSR:2,CLAN:1,CGS:2,CS:1,CW:2,NIOPS:1</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -870,7 +870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>PP:2,CC:6,MOC:2,CLAN:2,IS:4,FS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,LA:4,FWL:4,NIOPS:2,DC:6</availability>
+			<availability>PP:2,CC:6,CLAN:2,IS:4,MERC:3,CIR:1,Periphery:2,CS:2,NIOPS:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:4,DC:4</availability>
@@ -902,7 +902,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,CS:2-,LA:2,Periphery.HR:2,IS:3,FWL:2,NIOPS:2-,FS:8,Periphery.OS:2,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,IS:3,FWL:2,NIOPS:2-,FS:8,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -931,7 +931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>PP:5,CC:7,CHH:6,CLAN:5,IS:6,MERC:6,FS:6,CS:5,LA:7,FWL:6,NIOPS:5,CGB:6,DC:6</availability>
+			<availability>PP:5,CC:7,CHH:6,CLAN:5,IS:6,MERC:6,FS:6,CS:5,LA:7,NIOPS:5,CGB:6</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
 				<availability>PP:8,CC:6+,CS:8,NIOPS:8</availability>
@@ -1121,7 +1121,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,LA:5,FWL:5,NIOPS:3-,DC:5</availability>
+			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1182,7 +1182,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1195,7 +1195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>PP:7,CC:6,MOC:3,CLAN:5,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>PP:7,MOC:3,CLAN:5,IS:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -1212,7 +1212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Congress Frigate' unitType='Warship'>
-			<availability>PP:3,CS:2,CHH:2,CSR:2,CW:2,CSV:2,CLAN:2,NIOPS:2,CSJ:5,CGS:3,CJF:3</availability>
+			<availability>PP:3,CS:2,CLAN:2,NIOPS:2,CSJ:5,CGS:3,CJF:3</availability>
 			<model name='(2542)'>
 				<roles>frigate</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -1250,7 +1250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>PP:5,CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>PP:5,CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:5,Periphery.Deep:5,NIOPS:0,Periphery:5</availability>
@@ -1433,7 +1433,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>PP:2,CC:4,LA:6,Periphery.HR:6,CLAN:4,IS:8,Periphery.Deep:6,FS:6,MERC:8,TC:6,DC:8</availability>
+			<availability>PP:2,CC:4,LA:6,Periphery.HR:6,CLAN:4,IS:8,Periphery.Deep:6,FS:6,MERC:8,TC:6</availability>
 			<model name='DV-6M'>
 				<availability>PP:4,CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1489,7 +1489,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>PP:4,MOC:4,CLAN:4,IS:4,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,FWL:8,NIOPS:5-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1505,7 +1505,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:5,PP:3,CC:6,CS:7,OA:5,CLAN:3,CNC:3,FWL:7,NIOPS:7,FS:6,MERC:6,TC:5</availability>
+			<availability>MOC:5,PP:3,CC:6,CS:7,OA:5,CLAN:3,FWL:7,NIOPS:7,FS:6,MERC:6,TC:5</availability>
 			<model name='EMP-5A'>
 				<availability>PP:2,General:8</availability>
 			</model>
@@ -1552,14 +1552,14 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>PP:5,CC:2,CSR:3,CIH:3,CSV:3,CLAN:3,CCO:3,CGS:3,CSA:3,CDS:3,LA:4,CSJ:4,CGB:3,DC:4,CB:3</availability>
+			<availability>PP:5,CC:2,CLAN:3,LA:4,CSJ:4,DC:4</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>PP:8,CLAN:8,IS:8,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:4,MOC:2,IS:4,FS:4,CIR:2,Periphery:2,TC:2,CS:5,OA:2,LA:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>IS:4,Periphery:2,CS:5,OA:2,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1716,7 +1716,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>PP:8,CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:5,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:5-</availability>
+				<availability>LA:5-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:8+,CLAN:8,FWL:8+,NIOPS:8</availability>
@@ -1844,7 +1844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
-			<availability>PP:7,CC:4,CHH:8,CW:8,LA:4,CLAN:8,FWL:4,FS:4,MERC:4,CJF:8,DC:4,CGB:8</availability>
+			<availability>PP:7,CC:4,LA:4,CLAN:8,FWL:4,FS:4,MERC:4,DC:4</availability>
 			<model name='(Fury II)'>
 				<availability>General:4</availability>
 			</model>
@@ -1857,7 +1857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,PP:4,CC:4,CHH:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:4,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,PP:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,CBS:4,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1880,7 +1880,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,PP:7,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,PP:7,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -1890,14 +1890,14 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>PP:3,CS:4,CHH:3,CBS:3,CLAN:3,CNC:3,IS:6,NIOPS:4,Periphery.Deep:6,Periphery:6</availability>
+			<availability>PP:3,CS:4,CLAN:3,IS:6,NIOPS:4,Periphery.Deep:6,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1916,14 +1916,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:3,MOC:2,CS:2,OA:2,LA:4,Periphery.MW:2,FWL:5,MERC:4,TC:2,Periphery:2</availability>
+			<availability>CC:3,CS:2,LA:4,FWL:5,MERC:4,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:9,NIOPS:9,DC:2</availability>
+			<availability>PP:9,CC:4,MOC:4,CLAN:9,IS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,Periphery.MW:3,Periphery.ME:3,FWL:9,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>PP:6,General:6</availability>
 			</model>
@@ -1944,7 +1944,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>PP:4,CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+			<availability>PP:4,CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1953,7 +1953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>PP:9,CC:8,CS:7,CHH:9,CSR:9,CLAN:9,IS:8,FWL:8,NIOPS:7,FS:7,MERC:8,DC:8</availability>
+			<availability>PP:9,CS:7,CLAN:9,IS:8,NIOPS:7,FS:7,MERC:8</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>PP:8,CS:8,CLAN:8,IS:8+,NIOPS:8,DC:8+</availability>
@@ -1998,7 +1998,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,PP:7,CC:5,CLAN:7,IS:5,FS:5,CIR:4,TC:4,CS:7,OA:4,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:4,PP:7,CLAN:7,IS:5,CIR:4,TC:4,CS:7,OA:4,CNC:7,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2013,7 +2013,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:5,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2123,7 +2123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-,TC:4-</availability>
+			<availability>CC:3-,OA:4-,LA:5-,FWL:3-,Periphery.Deep:4-,FS:5-,MERC:6-,DC:3-,Periphery:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2146,7 +2146,7 @@
 			</model>
 			<model name='HER-2S'>
 				<roles>recon</roles>
-				<availability>FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
+				<availability>Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='HER-4K &apos;Hermes III&apos;'>
 				<roles>recon</roles>
@@ -2165,7 +2165,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>PP:9,CC:4,CLAN:9,IS:4,CFM:10,MERC:4,FS:4,CS:9,LA:4,FWL:4,NIOPS:9,CJF:10,DC:4</availability>
+			<availability>PP:9,CLAN:9,IS:4,CFM:10,MERC:4,CS:9,NIOPS:9,CJF:10</availability>
 			<model name='HGN-732'>
 				<availability>PP:8,CC:7+,MOC:6+,CS:8,LA:7+,FWL:7+,IS:6+,NIOPS:8,FS:7+,MERC:6+,DC:7+</availability>
 			</model>
@@ -2202,7 +2202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>PP:5,CC:5,MOC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>PP:5,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,NIOPS:5-</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2247,7 +2247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>PP:4,CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>PP:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2266,7 +2266,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,CNC:7,FWL:6,NIOPS:6,DC:6</availability>
+			<availability>PP:7,CC:6,MOC:3,CLAN:7,IS:5,FWL.OH:6,FS:6,CIR:3,TC:3,CS:6,OA:3,LA:6,FWL:6,NIOPS:6,DC:6</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8</availability>
 			</model>
@@ -2291,7 +2291,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2332,7 +2332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>FS:5</availability>
@@ -2425,7 +2425,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>PP:5,CC:2+,CLAN:6,IS:2+,FS:2+,MERC:2+,CGS:7,CS:6,LA:2+,FWL:2+,NIOPS:6,CGB:7,DC:2+</availability>
+			<availability>PP:5,CLAN:6,IS:2+,MERC:2+,CGS:7,CS:6,NIOPS:6,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,General:5,NIOPS:8</availability>
 			</model>
@@ -2442,7 +2442,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>PP:8,CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:5,NIOPS:7,FS:6,MERC:3,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2</availability>
+				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
@@ -2511,7 +2511,7 @@
 			<availability>CS:1-,IS:6,NIOPS:1-,Periphery.Deep:6,Periphery:6</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:4,PP:6,CC:6,CIH:6,CLAN:6,IS:6,CFM:6,MERC:6,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:6,NIOPS:6,DC:6</availability>
+			<availability>MOC:4,PP:6,CLAN:6,IS:6,MERC:6,CIR:4,TC:4,CS:6,OA:4,NIOPS:6</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>PP:6,CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
@@ -2540,7 +2540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:5,PP:5,CC:4,CHH:3,CLAN:4,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,CS:4,OA:5,LA:4,CBS:4,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>MOC:5,PP:5,CC:4,CHH:3,CLAN:4,IS:5,Periphery.Deep:6,FS:4,CIR:6,Periphery:6,TC:5,CS:4,OA:5,LA:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2582,7 +2582,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
+			<availability>PP:5,CC:8,MOC:2,CLAN:5,IS:3,TC:2,Periphery:2,CS:5-,OA:2,FWL:2,NIOPS:5-</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:3</availability>
 			</model>
@@ -2638,7 +2638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>PP:6,CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
+			<availability>PP:6,CCC:3,CHH:4,CSR:5,CIH:4,CLAN:3,CFM:4,CSA:4</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -2652,7 +2652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>PP:3,CC:6,MOC:7,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>PP:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2669,7 +2669,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:4,Periphery:4</availability>
 			</model>
@@ -2746,13 +2746,13 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>PP:8,CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:2+,CS:8,LA:6,FWL:6,NIOPS:8,DC:6,CGB:8</availability>
+			<availability>PP:8,CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:2+,CS:8,LA:6,FWL:6,NIOPS:8,DC:6</availability>
 			<model name='MAD-1R'>
 				<availability>PP:8,CS:8,MOC:8,IS:6+,NIOPS:8,MERC:0,TC:8+</availability>
 			</model>
@@ -2783,7 +2783,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2808,7 +2808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,CIR:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -2896,7 +2896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>PP:4,CC:4,MOC:6,IS:5,Periphery.Deep:6,FS:5,MERC:6,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>PP:4,CC:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:1,LA:4,MERC:1</availability>
@@ -3026,7 +3026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CMG:6,CJF:7,CGB:5,DC:6+</availability>
+			<availability>PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CJF:7,CGB:5,DC:6+</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>PP:8,CS:8,NIOPS:8,IS:6+,Periphery:6+</availability>
@@ -3174,7 +3174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>PP:4,CC:5,MOC:5,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>PP:4,MOC:5,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,FWL:6,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3190,7 +3190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>PP:5,CC:6,MOC:4,CS:4,LA:6,IS:6,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>PP:5,CS:4,IS:6,NIOPS:4,Periphery.Deep:4,Periphery:4</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -3204,7 +3204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>PP:5,CC:5,CLAN:4-,IS:5,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,CS:4,LA:5,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>PP:5,CLAN:4-,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:4,NIOPS:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3228,14 +3228,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,PP:7,CC:5,CHH:7,CLAN:7,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:4,PP:7,CC:5,CLAN:7,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:7,OA:4,LA:5,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:5,CC:6,IS:6,Periphery.Deep:6,FS:6,CIR:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,IS:6,Periphery.Deep:6,FS.CrMM:7,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:7,FS.DMM:7,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3269,7 +3269,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3286,7 +3286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>IS:8,FWL:9,Periphery.Deep:7,Periphery:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3381,7 +3381,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>PP:5,CCC:4,CHH:4,CSR:5,CIH:4,CSV:4,CLAN:4,CFM:4,CCO:4,CGS:5,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
+			<availability>PP:5,CSR:5,CLAN:4,CGS:5,CS:1,CDS:5,NIOPS:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3443,7 +3443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:4,PP:8,CC:6,CLAN:8,Periphery.Deep:4,MERC:5,FS:6,CIR:5,Periphery:4,TC:4,CS:8,OA:4,LA:6,FWL:6,NIOPS:8,CJF:8,DC:6</availability>
+			<availability>PP:8,CC:6,CLAN:8,Periphery.Deep:4,MERC:5,FS:6,CIR:5,Periphery:4,CS:8,LA:6,FWL:6,NIOPS:8,CJF:8,DC:6</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>
@@ -3458,7 +3458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:4,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:4,CS:3-,OA:4,LA:4,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,IS:4,Periphery.Deep:4,FS:3,Periphery:4,CS:3-,OA:4,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:6,OA:6,FWL:8,DC:8,TC:6</availability>
 			</model>
@@ -3483,7 +3483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>PP:9,MOC:8,CLAN:9,Periphery.Deep:8,IS:7,FS:7,CIR:8,MERC:8,Periphery:8,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>PP:9,CLAN:9,Periphery.Deep:8,IS:7,CIR:8,MERC:8,Periphery:8,CS:9,LA:8,NIOPS:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3513,7 +3513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>PP:4,CC:6,CS:6-,IS:6,FWL:6,NIOPS:6-,Periphery.Deep:5,FS:6,CIR:4,Periphery:5</availability>
+			<availability>PP:4,CS:6-,IS:6,NIOPS:6-,Periphery.Deep:5,CIR:4,Periphery:5</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:8-,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3545,7 +3545,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rogue' unitType='AeroSpaceFighter'>
-			<availability>PP:5,CC:3,MOC:2,CLAN:4,IS:3,FS:3,CIR:2,TC:2,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:2</availability>
+			<availability>PP:5,MOC:2,CLAN:4,IS:3,CIR:2,TC:2,CS:4,OA:3,NIOPS:4,DC:2</availability>
 			<model name='RGU-133E'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>
@@ -3605,7 +3605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:5-,MOC:5-,OA:5-,LA:5-,CLAN:5,IS:5-,FWL:5-,Periphery.Deep:5-,FS:5-,MERC:5-,Periphery:5-,DC:6-</availability>
+			<availability>CLAN:5,IS:5-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:6-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -3630,7 +3630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,PP:5,CC:6,OA:6,LA:6,IS:6,FWL:6,MERC:6,FS:6,Periphery:6,TC:6,DC:6</availability>
+			<availability>PP:5,IS:6,MERC:6,Periphery:6</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -3647,7 +3647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,CS:5,OA:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3701,7 +3701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3712,7 +3712,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>PP:4,CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5,CGB:4</availability>
+			<availability>PP:4,CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:8</availability>
 			</model>
@@ -3771,14 +3771,14 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>PP:4,CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>PP:4,CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:2,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:2,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -3805,7 +3805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>PP:5,CSR:4,CSV:3,CLAN:3,CFM:3,CGS:3,CCO:4,CSA:4,CS:1,CDS:3,CW:3,NIOPS:1,CSJ:3,CJF:3</availability>
+			<availability>PP:5,CSR:4,CLAN:3,CCO:4,CSA:4,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3854,13 +3854,13 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>PP:4,CC:5,CS:4,OA:2,LA:4,IS:4,FWL:7,NIOPS:4,FS:6,MERC:4,TC:2,DC:7</availability>
+			<availability>PP:4,CC:5,CS:4,OA:2,IS:4,FWL:7,NIOPS:4,FS:6,MERC:4,TC:2,DC:7</availability>
 			<model name='SDR-5V'>
 				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>PP:9,CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>PP:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,CS:6,LA:8,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3908,7 +3908,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>PP:5,MOC:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,DC:6,Periphery:5</availability>
+			<availability>PP:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,DC:6,Periphery:5</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -3923,7 +3923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:2,IS:4,FS:4,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3,DC:4</availability>
+			<availability>CC:6,IS:4,MERC:4,CIR:3,Periphery:2,CS:3,LA:6,Periphery.MW:3,Periphery.ME:3,FWL:6,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4020,7 +4020,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-5'>
 				<availability>CC:4-</availability>
 			</model>
@@ -4030,7 +4030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>PP:8,CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>PP:8,CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-11E'>
 				<availability>PP:8,CS:8,FWL:8+,IS:8+,NIOPS:8,FS:8+,DC:8+,TC:8</availability>
 			</model>
@@ -4052,7 +4052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>PP:5,CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>PP:5,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -4067,7 +4067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
+			<availability>PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -4160,7 +4160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
-			<availability>PP:7,CC:5,MOC:4,CSR:7,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
+			<availability>PP:7,CC:5,MOC:4,CLAN:7,FS:5,MERC:5,CIR:4,TC:4,CS:7,OA:5,LA:2,FWL:3,NIOPS:7,DC:5</availability>
 			<model name='TRN-3T'>
 				<availability>PP:8,CS:8,OA:5+,IS:5+,NIOPS:8,Periphery.Deep:5+,Periphery:5+</availability>
 			</model>
@@ -4189,7 +4189,7 @@
 			<availability>IS:4,DC:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -4247,7 +4247,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>PP:5,CC:6-,MOC:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,CS:4-,OA:2-,LA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>PP:5,CC:6-,IS:3-,Periphery:2-,CS:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4268,7 +4268,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -4294,7 +4294,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>PP:4,CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:4,TC:1,CSA:2,CW:4,LA:4,CNC:2,FWL:4,CSJ:5,CJF:2,DC:3,CB:2</availability>
+			<availability>PP:4,CCC:1,CSR:3,CLAN:2,FS:4,TC:1,CW:4,LA:4,FWL:4,CSJ:5,DC:3</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>PP:8,CLAN:8,IS:8,TC:8</availability>
@@ -4354,7 +4354,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>PP:6,CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>PP:6,CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6L'>
 				<availability>CC:3</availability>
 			</model>
@@ -4451,7 +4451,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>PP:5,CC:7,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,FS:7,TC:5,CS:5-,LA:7,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>PP:5,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,TC:5,CS:5-,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -4535,7 +4535,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zero' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,PP:6,CC:1,CLAN:6,IS:1,FS:1,Periphery:2,TC:2,CS:5,OA:2,LA:1,FWL:1,NIOPS:5,DC:3</availability>
+			<availability>PP:6,CLAN:6,IS:1,Periphery:2,CS:5,NIOPS:5,DC:3</availability>
 			<model name='ZRO-114'>
 				<availability>CS:8,General:8,NIOPS:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -531,21 +531,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>CC:4,MOC:3,CLAN:5,IS:4,FS:4,Periphery:2,TC:3,CS:6,OA:3,LA:4,FWL:3,NIOPS:6,DC:6</availability>
+			<availability>MOC:3,CLAN:5,IS:4,Periphery:2,TC:3,CS:6,OA:3,FWL:3,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CC:4,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:4,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
+			<availability>CC:4,CSR:5,CLAN:4,FS:4,LA:3,CNC:5,FWL:4,CJF:5,DC:4</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -565,7 +565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:2+,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:4+</availability>
+			<availability>MOC:2+,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,LA:4+,FWL:4+,NIOPS:7,CJF:7,DC:4+</availability>
 			<model name='Mk III'>
 				<availability>General:2</availability>
 			</model>
@@ -606,7 +606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:6</availability>
@@ -637,7 +637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -738,14 +738,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
+			<availability>MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,CIR:7,TC:7,Periphery:5,CS:8,OA:7,FWL:9,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -763,7 +763,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,CS:2-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -794,7 +794,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:4,IS:6,FS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
+			<availability>CC:7,MOC:6,CLAN:4,IS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,DC:7</availability>
 			<model name='BLR-1G'>
 				<availability>IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
 			</model>
@@ -840,7 +840,7 @@
 				<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
+				<availability>LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8-</availability>
@@ -884,7 +884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -896,7 +896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:5,CHH:8,CLAN:6,FS:5,MERC:5,CS:7,CDS:6,LA:5,CNC:6,FWL:5,NIOPS:7,CJF:6,DC:5</availability>
+			<availability>CC:5,CHH:8,CLAN:6,FS:5,MERC:5,CS:7,LA:5,FWL:5,NIOPS:7,CJF:6,DC:5</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -927,7 +927,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -940,7 +940,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,TC:1,Periphery:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:3,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:4,DC:4</availability>
@@ -1060,7 +1060,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>CC:4,MOC:3,OA:3,LA:8,CLAN:5,FWL:5,FS:5,MERC:4,CIR:3,Periphery:2,TC:3,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:8,CGS:6</availability>
@@ -1221,7 +1221,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:4,CS:3-,OA:4,LA:5,CLAN:3-,IS:5,FWL:5,NIOPS:3-,FS:6,MERC:5,DC:5</availability>
+			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:5,NIOPS:3-,FS:6,MERC:5</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1282,7 +1282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1295,7 +1295,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:5,MOC:3,CLAN:4,IS:5,FS:4,CIR:2,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
+			<availability>MOC:3,CLAN:4,IS:5,FS:4,CIR:2,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -1341,7 +1341,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1350,7 +1350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
@@ -1516,7 +1516,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:6,Periphery.HR:6,CLAN:4,IS:6,Periphery.Deep:6,FS:8,MERC:6,TC:6,DC:6</availability>
+			<availability>CC:4,Periphery.HR:6,CLAN:4,IS:6,Periphery.Deep:6,FS:8,MERC:6,TC:6</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1572,7 +1572,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,FWL:8,NIOPS:5-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1642,14 +1642,14 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CIH:3,CSR:3,CSV:3,CLAN:3,CGS:3,CCO:3,CSA:3,CDS:3,LA:2,CSJ:4,CGB:3,DC:2,CB:3</availability>
+			<availability>CLAN:3,LA:2,CSJ:4,DC:2</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>CLAN:8,IS:8,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:5</availability>
+			<availability>MOC:3,IS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1798,7 +1798,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:6-</availability>
+				<availability>LA:6-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8</availability>
@@ -1928,7 +1928,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
-			<availability>CC:4,CHH:8,CW:8,LA:4,CLAN:8,FWL:4,FS:4,MERC:4,CJF:8,DC:4,CGB:8</availability>
+			<availability>CC:4,LA:4,CLAN:8,FWL:4,FS:4,MERC:4,DC:4</availability>
 			<model name='(Fury II)'>
 				<availability>General:4</availability>
 			</model>
@@ -1941,7 +1941,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -1964,21 +1964,21 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,CBS:3,CLAN:3,CNC:3,IS:6,NIOPS:4,Periphery.Deep:6,Periphery:6</availability>
+			<availability>CS:4,CLAN:3,IS:6,NIOPS:4,Periphery.Deep:6,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3,TC:3</availability>
+			<availability>CC:2,LA:4,FS.CH:7,FS:6,MERC:4,CIR:4,DC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -1997,14 +1997,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:3,MOC:2,CS:2,OA:2,LA:4,Periphery.MW:2,FWL:5,MERC:3,TC:2,Periphery:2</availability>
+			<availability>CC:3,CS:2,LA:4,FWL:5,MERC:3,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
+			<availability>MOC:4,CLAN:9,IS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,CLAN:4</availability>
 			</model>
@@ -2012,7 +2012,7 @@
 				<availability>CLAN:2,FWL:6</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
+				<availability>CS:6,CLAN:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:8</availability>
@@ -2025,7 +2025,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2090,7 +2090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:5,CLAN:7,IS:5,FS:5,CIR:3,TC:3,CS:7,OA:3,LA:5,CNC:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:3,CLAN:7,IS:5,CIR:3,TC:3,CS:7,OA:3,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2105,7 +2105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:5,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2199,7 +2199,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='HCT-213B'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,IS:6,DC:6,Periphery:6</availability>
@@ -2212,7 +2212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
+			<availability>CC:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2246,11 +2246,11 @@
 			<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:4</availability>
+				<availability>FWL:4</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2299,7 +2299,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:5,MOC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,FWL:6,NIOPS:5-</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2347,7 +2347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:4,IS:4,FS:3,CIR:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2366,7 +2366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
+			<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,FWL:6,NIOPS:6,DC:5</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -2401,7 +2401,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2442,7 +2442,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>FS:5</availability>
@@ -2532,7 +2532,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:2+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,General:5,CLAN:6,NIOPS:8,CB:5</availability>
 			</model>
@@ -2549,7 +2549,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:4,NIOPS:7,FS:6,MERC:3,DC:4</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2</availability>
+				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+</availability>
@@ -2627,7 +2627,7 @@
 			<availability>CS:1-,IS:5,NIOPS:1-,Periphery.Deep:5,Periphery:5</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
+			<availability>MOC:4,CLAN:6,IS:5,MERC:5,CIR:4,TC:4,CS:6,OA:4,NIOPS:6</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
@@ -2656,7 +2656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:6,CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,Periphery:6,TC:6,CS:4,OA:6,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,Periphery:6,CS:4,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2698,7 +2698,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:5,IS:3,Periphery:2,CS:5-,FWL:2,NIOPS:5-</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:2</availability>
 			</model>
@@ -2754,7 +2754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CLAN:3,CFM:4,CSA:4</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -2768,7 +2768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2785,7 +2785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -2860,7 +2860,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2894,7 +2894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2919,7 +2919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,FS:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3007,7 +3007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:6,CLAN:4,IS:5,Periphery.Deep:6,FS:5,MERC:6,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3301,7 +3301,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>CC:5,MOC:5,CLAN:4,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:4,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,FWL:8,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3317,7 +3317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -3331,7 +3331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>CS:4,CLAN:4-,IS:5,Periphery.Deep:5,NIOPS:4,MERC:5,Periphery:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:6-</availability>
@@ -3355,14 +3355,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:7,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
+			<availability>MOC:4,IS:5,Periphery.Deep:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3400,7 +3400,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3417,7 +3417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>CC:8,LA:8,IS:8,FWL:9,Periphery.Deep:7,CIR:7,Periphery:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3580,7 +3580,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
+			<availability>CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,CS:8,LA:5,FWL:5,NIOPS:8,DC:5</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:6,CW:6,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3595,7 +3595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3629,7 +3629,7 @@
 			<availability>CWI:3</availability>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -3662,7 +3662,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:7,CCC:3,CSV:3,CLAN:3,IS:7,Periphery.Deep:5,CFM:3,FS:7,CIR:4,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:7,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CLAN:3,IS:7,Periphery.Deep:5,CIR:4,Periphery:5,CS:6-,Clan.IS:3,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:8-,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3672,7 +3672,7 @@
 			<availability>CLAN:1</availability>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>
-			<availability>CC:3+,CS:5,CHH:5,CSR:4,LA:3+,CLAN:4,FWL:3+,NIOPS:5,FS:4+,CJF:4,DC:3+</availability>
+			<availability>CC:3+,CS:5,CHH:5,LA:3+,CLAN:4,FWL:3+,NIOPS:5,FS:4+,DC:3+</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -3694,7 +3694,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rogue' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
+			<availability>MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,NIOPS:4,DC:1</availability>
 			<model name='RGU-133E'>
 				<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3745,7 +3745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -3770,7 +3770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,OA:6,LA:5,CLAN:4,IS:5,FWL:5,MERC:5,FS:5,Periphery:5,TC:5,DC:5</availability>
+			<availability>OA:6,CLAN:4,IS:5,MERC:5,Periphery:5</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -3787,7 +3787,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3857,7 +3857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3927,14 +3927,14 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:3,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:3,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -3961,7 +3961,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:4,CSV:3,CLAN:3,CFM:3,CGS:3,CCO:4,CSA:4,CS:1,CDS:3,CW:3,NIOPS:1,CSJ:3,CJF:3</availability>
+			<availability>CSR:4,CLAN:3,CCO:4,CSA:4,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -4030,7 +4030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4082,7 +4082,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:5,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6,CGB:3-</availability>
+			<availability>CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6,CGB:3-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -4097,7 +4097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
+			<availability>CC:5,IS:3,MERC:4,CIR:3,Periphery:2,CS:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4123,7 +4123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
+			<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4209,7 +4209,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-5'>
 				<availability>CC:3-</availability>
 			</model>
@@ -4241,7 +4241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4256,7 +4256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -4297,7 +4297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
+			<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,LA:5,FWL:4,NIOPS:9,DC:2</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -4387,7 +4387,7 @@
 			<availability>IS:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -4452,7 +4452,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,MOC:2-,CLAN:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,CS:4-,OA:2-,LA:3-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:2-,IS:3-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4473,7 +4473,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -4499,7 +4499,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:2,TC:1,CSA:2,CW:4,LA:2,CNC:2,FWL:2,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CLAN:2,FS:2,TC:1,CW:4,LA:2,FWL:2,CSJ:5,DC:1</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -4584,7 +4584,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
 			</model>
@@ -4623,7 +4623,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:2-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+			<availability>CS:4-,CW:2-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4683,7 +4683,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,CWOV:6,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5,DC:7</availability>
+			<availability>CS:5-,CWOV:6,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -32,8 +32,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
 			<weightDistribution era='2823' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2823' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -43,8 +42,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -52,8 +50,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:8,CHH:1,CSR:5,CIH:8,CWOV:1,CSV:3,CFM:8,CGS:1,CSA:5,CDS:2,CW:1,CBS:1,CNC:5,CSJ:8,CJF:10,CB:5</salvage>
+			<salvage pct='10'>CCC:8,CHH:1,CSR:5,CIH:8,CWOV:1,CSV:3,CFM:8,CGS:1,CSA:5,CDS:2,CW:1,CBS:1,CNC:5,CSJ:8,CJF:10,CB:5</salvage>
 			<weightDistribution era='2823' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2823' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -63,8 +60,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:3,CNC:1,CSJ:3,CMG:3,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:3,CNC:1,CSJ:3,CMG:3,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -72,8 +68,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:3,CIH:5,CSR:1,CWOV:3,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
+			<salvage pct='10'>CHH:10,CCC:3,CIH:5,CSR:1,CWOV:3,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
 			<weightDistribution era='2823' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2823' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -83,8 +78,7 @@
 			<pctSL>100,100,95,90,85</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -92,8 +86,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:6,CIH:8,CWOV:2,CSV:4,CFM:8,CCO:2,CGS:6,CSA:4,CDS:10,CW:4,CWI:4,CBS:2,CNC:10,CSJ:6,CMG:2,CJF:10,CGB:8,CB:8</salvage>
+			<salvage pct='10'>CCC:2,CSR:6,CIH:8,CWOV:2,CSV:4,CFM:8,CCO:2,CGS:6,CSA:4,CDS:10,CW:4,CWI:4,CBS:2,CNC:10,CSJ:6,CMG:2,CJF:10,CGB:8,CB:8</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -101,8 +94,7 @@
 			<pctSL>100,100,100,90,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:4,CWOV:1,CSV:5,CFM:10,CCO:5,CGS:5,CSA:8,CDS:5,CW:4,CWI:1,CNC:2,CSJ:3,CMG:5,CJF:8,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:4,CWOV:1,CSV:5,CFM:10,CCO:5,CGS:5,CSA:8,CDS:5,CW:4,CWI:1,CNC:2,CSJ:3,CMG:5,CJF:8,CGB:2,CB:2</salvage>
 			<weightDistribution era='2823' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2823' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -112,8 +104,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:4,CSR:4,CIH:8,CWOV:1,CSV:10,CFM:9,CCO:6,CGS:6,CSA:9,CDS:4,CW:10,CWI:1,CBS:1,CNC:2,CSJ:1,CMG:3,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CIH:8,CWOV:1,CSV:10,CFM:9,CCO:6,CGS:6,CSA:9,CDS:4,CW:10,CWI:1,CBS:1,CNC:2,CSJ:1,CMG:3,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -121,8 +112,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -130,8 +120,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:7,CHH:8,CSR:5,CIH:3,CFM:3,CCO:7,CGS:3,CDS:2,CW:3,CWI:2,CBS:2,CSJ:5,CJF:5,CB:10</salvage>
+			<salvage pct='10'>CCC:7,CHH:8,CSR:5,CIH:3,CFM:3,CCO:7,CGS:3,CDS:2,CW:3,CWI:2,CBS:2,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -139,8 +128,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:8,CSR:7,CIH:10,CWOV:2,CSV:8,CFM:5,CCO:3,CGS:5,CSA:10,CW:3,CWI:2,CNC:2,CSJ:5,CMG:2,CJF:8,CB:5</salvage>
+			<salvage pct='12'>CCC:1,CHH:8,CSR:7,CIH:10,CWOV:2,CSV:8,CFM:5,CCO:3,CGS:5,CSA:10,CW:3,CWI:2,CNC:2,CSJ:5,CMG:2,CJF:8,CB:5</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -148,8 +136,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -157,8 +144,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -166,8 +152,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
 			<weightDistribution era='2823' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2823' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -177,8 +162,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CWOV:1,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CWOV:1,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CWI'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -194,8 +178,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:2,CIH:4,CWOV:3,CSV:4,CFM:3,CCO:1,CGS:1,CSA:4,CDS:1,CWI:1,CBS:1,CNC:1,CSJ:3,CMG:1,CJF:10,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:2,CIH:4,CWOV:3,CSV:4,CFM:3,CCO:1,CGS:1,CSA:4,CDS:1,CWI:1,CBS:1,CNC:1,CSJ:3,CMG:1,CJF:10,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CWOV'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -203,8 +186,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:3,CSR:10,CIH:3,CSV:3,CFM:3,CCO:3,CGS:3,CSA:5,CDS:3,CW:10,CJF:5,CGB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:3,CSR:10,CIH:3,CSV:3,CFM:3,CCO:3,CGS:3,CSA:5,CDS:3,CW:10,CJF:5,CGB:3</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -380,8 +362,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -389,8 +370,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -398,8 +378,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -407,8 +386,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -416,8 +394,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -425,8 +402,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -434,8 +410,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -443,8 +418,7 @@
 			<pctSL>100,100,100,100,100</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CC.LG'>
 			<salvage pct='6'></salvage>
@@ -557,8 +531,7 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -572,8 +545,7 @@
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CC:4,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:4,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
+			<availability>CC:4,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:4,CGS:4,CSA:4,CDS:4,LA:3,CBS:4,CNC:5,FWL:4,CJF:5,DC:4,CB:4</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -593,8 +565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:2+,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:4+</availability>
+			<availability>MOC:2+,CC:4+,CLAN:7,MERC:4+,FS:4+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:4+,CNC:7,FWL:4+,NIOPS:7,CJF:7,DC:4+</availability>
 			<model name='Mk III'>
 				<availability>General:2</availability>
 			</model>
@@ -635,8 +606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:6</availability>
@@ -775,8 +745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				CC:7,MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
+			<availability>CC:7,MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -794,8 +763,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -864,8 +832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:5,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:5,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+</availability>
 			</model>
@@ -917,8 +884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -974,8 +940,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,TC:1,Periphery:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,TC:1,Periphery:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:4,DC:4</availability>
@@ -1010,8 +975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:3,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:3,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:3,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:3,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1073,8 +1037,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:5</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1387,8 +1350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
@@ -1406,8 +1368,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
+			<availability>CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
 			<model name='CRK-5003-1'>
 				<availability>CS:8,General:6+,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -1520,8 +1481,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1612,8 +1572,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1837,8 +1796,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:6-</availability>
 			</model>
@@ -1983,8 +1941,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2007,8 +1964,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2048,8 +2004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
+			<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
 			<model name='GTHA-100'>
 				<availability>General:6,CLAN:4</availability>
 			</model>
@@ -2070,8 +2025,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2151,8 +2105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:5,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2259,8 +2212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
+			<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2334,8 +2286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:3,OA:3,Periphery.HR:3,FS.CMM:3,FS.DMM:3,FS:3,MERC:4,Periphery.OS:3,FS.CrMM:3,TC:3</availability>
+			<availability>MOC:3,OA:3,Periphery.HR:3,FS.CMM:3,FS.DMM:3,FS:3,MERC:4,Periphery.OS:3,FS.CrMM:3,TC:3</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2348,8 +2299,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2416,8 +2366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
+			<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:3,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -2452,8 +2401,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2494,8 +2442,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>FS:5</availability>
@@ -2680,8 +2627,7 @@
 			<availability>CS:1-,IS:5,NIOPS:1-,Periphery.Deep:5,Periphery:5</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
+			<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:7,NIOPS:8,DC:7</availability>
@@ -2710,8 +2656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:6,CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,Periphery:6,TC:6,CS:4,OA:6,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:6,CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,Periphery:6,TC:6,CS:4,OA:6,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2809,8 +2754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -2824,8 +2768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2842,8 +2785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -2918,8 +2860,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2953,8 +2894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -2979,8 +2919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3068,8 +3007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:6,CLAN:4,IS:5,Periphery.Deep:6,FS:5,MERC:6,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,MOC:6,CLAN:4,IS:5,Periphery.Deep:6,FS:5,MERC:6,CIR:5,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3209,8 +3147,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CMG:6,CJF:7,CGB:5,DC:5+</availability>
+			<availability>MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CMG:6,CJF:7,CGB:5,DC:5+</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,IS:6+,Periphery:6+</availability>
@@ -3364,8 +3301,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,CLAN:4,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:4,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3395,8 +3331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:6-</availability>
@@ -3420,16 +3355,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:4,CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
+			<availability>MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3451,8 +3384,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:3,CLAN:4-,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:4-,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -3468,8 +3400,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3486,8 +3417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3582,8 +3512,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:4,CCC:4,CIH:4,CSR:5,CSV:4,CLAN:3,CFM:4,CGS:5,CCO:4,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
+			<availability>CHH:4,CCC:4,CIH:4,CSR:5,CSV:4,CLAN:3,CFM:4,CGS:5,CCO:4,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3651,8 +3580,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
+			<availability>MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:6,CW:6,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3667,8 +3595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3702,8 +3629,7 @@
 			<availability>CWI:3</availability>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -3717,8 +3643,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
 			</model>
@@ -3737,8 +3662,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:7,CCC:3,CSV:3,CLAN:3,IS:7,Periphery.Deep:5,CFM:3,FS:7,CIR:4,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:7,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CC:7,CCC:3,CSV:3,CLAN:3,IS:7,Periphery.Deep:5,CFM:3,FS:7,CIR:4,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:7,NIOPS:6-,CJF:3,CB:3</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:8-,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3821,8 +3745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -3864,8 +3787,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3914,8 +3836,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
 			<model name='STN-1S'>
 				<availability>LA:1,FWL:1,FS:1</availability>
 			</model>
@@ -3936,8 +3857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4007,8 +3927,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,FS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4064,8 +3983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,TC:3,Periphery:4,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4112,8 +4030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>CC:7,MOC:9,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,TC:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4165,8 +4082,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:5,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6,CGB:3-</availability>
+			<availability>MOC:5,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6,CGB:3-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -4181,8 +4097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
+			<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4208,8 +4123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
+			<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,TC:3,Periphery:2,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4283,8 +4197,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
+			<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
 			<model name='THE-F'>
 				<availability>CC:2+,FWL:2+,FS:2+</availability>
 			</model>
@@ -4306,8 +4219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-11E'>
 				<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,DC:6+,TC:8</availability>
 			</model>
@@ -4329,8 +4241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,Periphery:6,TC:7,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4345,8 +4256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -4542,8 +4452,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				CC:5-,MOC:2-,CLAN:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,CS:4-,OA:2-,LA:3-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,MOC:2-,CLAN:2-,IS:3-,FS:3-,CIR:2-,Periphery:2-,TC:2-,CS:4-,OA:2-,LA:3-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4571,8 +4480,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				CC:6,MOC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4591,8 +4499,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:2,TC:1,CSA:2,CW:4,LA:2,CNC:2,FWL:2,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:2,TC:1,CSA:2,CW:4,LA:2,CNC:2,FWL:2,CSJ:5,CJF:2,DC:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -4756,8 +4663,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -530,21 +530,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:3,CC:4,CLAN:5,IS:4,FS:4,BAN:5,TC:3,Periphery:2,CS:6,OA:3,LA:4,FWL:3,NIOPS:6,DC:6</availability>
+			<availability>MOC:3,CLAN:5,IS:4,BAN:5,TC:3,Periphery:2,CS:6,OA:3,FWL:3,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CC:3,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:3,CGS:4,CSA:4,CDS:4,LA:2,CBS:4,CNC:5,FWL:3,CJF:5,DC:3,CB:4</availability>
+			<availability>CC:3,CSR:5,CLAN:4,FS:3,CSA:4,LA:2,CNC:5,FWL:3,CJF:5,DC:3</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -564,7 +564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:2+,CC:3+,CLAN:7,MERC:3+,FS:3+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:3+,CNC:7,FWL:3+,NIOPS:7,CJF:7,DC:3+</availability>
+			<availability>MOC:2+,CC:3+,CLAN:7,MERC:3+,FS:3+,TC:2+,CS:7,OA:2+,LA:3+,FWL:3+,NIOPS:7,DC:3+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -643,7 +643,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -720,7 +720,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CWI:2,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CWI:2,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -754,7 +754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,CIR:7,TC:7,Periphery:5,CS:8,OA:7,FWL:9,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -778,7 +778,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,CS:2-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -809,7 +809,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:4,IS:6,FS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4,DC:7</availability>
+			<availability>CC:7,MOC:6,CLAN:4,IS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,DC:7</availability>
 			<model name='BLR-1G'>
 				<availability>IS:8,Periphery.Deep:8,FS:8,BAN:8,Periphery:8</availability>
 			</model>
@@ -855,7 +855,7 @@
 				<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
+				<availability>LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8-</availability>
@@ -899,7 +899,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -911,7 +911,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:5,CHH:8,CLAN:6,FS:5,MERC:5,CS:7,CDS:6,LA:5,CNC:6,FWL:5,NIOPS:7,CJF:6,DC:5</availability>
+			<availability>CC:5,CHH:8,CLAN:6,FS:5,MERC:5,CS:7,LA:5,FWL:5,NIOPS:7,DC:5</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -942,7 +942,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -955,7 +955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:3,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:3,DC:3</availability>
@@ -1019,7 +1019,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:5,FWL:5,NIOPS:5,MERC:5,FS:5,CGB:6,DC:5</availability>
+			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:5,NIOPS:5,MERC:5,CGB:6</availability>
 			<model name='C'>
 				<availability>CHH:4,CLAN:6,CGB:4</availability>
 			</model>
@@ -1075,7 +1075,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>MOC:3,CC:4,OA:3,LA:8,CLAN:4,FWL:5,MERC:4,FS:5,CIR:3,TC:3,Periphery:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+				<availability>LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:8,CGS:6,BAN:4</availability>
@@ -1236,7 +1236,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:4,CS:3-,OA:4,LA:5,CLAN:3-,IS:5,FWL:5,NIOPS:3-,FS:6,MERC:5,DC:5</availability>
+			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:5,NIOPS:3-,FS:6,MERC:5</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1297,7 +1297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1310,7 +1310,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:5,MOC:3,CLAN:4,IS:5,FS:4,CIR:1,BAN:4,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
+			<availability>MOC:3,CLAN:4,IS:5,FS:4,CIR:1,BAN:4,TC:3,CS:6,OA:3,LA:3,FWL:3,NIOPS:6,DC:3</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -1360,7 +1360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:4,FS:7,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -1369,7 +1369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
@@ -1535,7 +1535,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:6,Periphery.HR:6,CLAN:3,IS:6,Periphery.Deep:6,FS:8,MERC:6,TC:6,DC:6</availability>
+			<availability>CC:4,Periphery.HR:6,CLAN:3,IS:6,Periphery.Deep:6,FS:8,MERC:6,TC:6</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1594,7 +1594,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,FWL:8,NIOPS:5-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1657,14 +1657,14 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CIH:3,CSR:3,CSV:3,CLAN:3,CGS:3,CCO:3,CSA:3,CDS:3,LA:2,CSJ:4,CGB:3,DC:2,CB:3</availability>
+			<availability>CLAN:3,LA:2,CSJ:4,DC:2</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>CLAN:8,IS:8,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:5</availability>
+			<availability>MOC:3,IS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1828,7 +1828,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:6-</availability>
+				<availability>LA:6-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8,BAN:8</availability>
@@ -1971,7 +1971,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2000,21 +2000,21 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,CBS:3,CLAN:3,CNC:3,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CLAN:3,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>CC:2,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2033,14 +2033,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:3,MOC:2,CS:2,OA:2,LA:4,Periphery.MW:2,FWL:5,MERC:3,TC:2,Periphery:2</availability>
+			<availability>CC:3,CS:2,LA:4,FWL:5,MERC:3,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
+			<availability>MOC:4,CLAN:9,IS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:5,CLAN:4</availability>
 			</model>
@@ -2048,7 +2048,7 @@
 				<availability>CLAN:2,FWL:6,BAN:6</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+				<availability>CS:6,CLAN:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:8,BAN:4</availability>
@@ -2061,7 +2061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 			</model>
@@ -2080,7 +2080,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:7,CS:7,CHH:9,CSR:9,CLAN:9,IS:7,FWL:7,NIOPS:7,FS:6,MERC:7,DC:7</availability>
+			<availability>CS:7,CLAN:9,IS:7,NIOPS:7,FS:6,MERC:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,IS:6+,NIOPS:8,BAN:8,DC:6+</availability>
@@ -2133,7 +2133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:3,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
+			<availability>MOC:3,CLAN:7,IS:4,CIR:3,TC:3,CS:7,OA:3,CNC:7,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2148,7 +2148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:6,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2242,7 +2242,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,CNC:6,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='HCT-213B'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,IS:6,DC:6,Periphery:5</availability>
@@ -2255,7 +2255,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
+			<availability>CC:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2295,11 +2295,11 @@
 			<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:4</availability>
+				<availability>FWL:4</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2311,7 +2311,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:3,CS:9,LA:3,CLAN:9,FWL:3,NIOPS:9,IS:3,CFM:10,MERC:3,FS:3,CJF:10,DC:3</availability>
+			<availability>CS:9,CLAN:9,NIOPS:9,IS:3,CFM:10,MERC:3,CJF:10</availability>
 			<model name='HGN-732'>
 				<availability>CC:6+,MOC:5+,CS:8,LA:6+,CLAN:6,FWL:6+,IS:5+,NIOPS:8,FS:6+,MERC:5+,BAN:8,DC:6+</availability>
 			</model>
@@ -2348,7 +2348,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:2-,IS:5,Periphery.Deep:5,TC:5,Periphery:5,CS:5-,FWL:6,NIOPS:5-</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2409,7 +2409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:4,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2431,7 +2431,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
+			<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,FWL:6,NIOPS:6,DC:5</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -2471,7 +2471,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2512,7 +2512,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2605,7 +2605,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:2+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -2622,7 +2622,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:3,NIOPS:7,FS:6,MERC:3,DC:3</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2</availability>
+				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+,BAN:7</availability>
@@ -2700,7 +2700,7 @@
 			<availability>CS:1-,IS:5,NIOPS:1-,Periphery.Deep:5,Periphery:5</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,BAN:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
+			<availability>MOC:4,CLAN:6,IS:5,MERC:5,CIR:4,BAN:6,TC:4,CS:6,OA:4,NIOPS:6</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:6,NIOPS:8,BAN:6,DC:6</availability>
@@ -2729,7 +2729,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:6,CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,BAN:5,Periphery:6,TC:6,CS:4,OA:6,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,BAN:5,Periphery:6,CS:4,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2771,7 +2771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:5,IS:3,Periphery:2,CS:5-,FWL:2,NIOPS:5-</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:2</availability>
 			</model>
@@ -2833,7 +2833,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CLAN:3,CFM:4,CSA:4</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -2847,7 +2847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2864,7 +2864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -2939,7 +2939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -2976,7 +2976,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,Periphery.MW:3,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3001,7 +3001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3093,7 +3093,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3398,7 +3398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:4,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,FWL:8,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3414,7 +3414,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:8,Periphery:8</availability>
@@ -3428,7 +3428,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>CS:4,CLAN:4-,IS:5,Periphery.Deep:5,NIOPS:4,FS:5,MERC:5,Periphery:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:6-,BAN:8</availability>
@@ -3452,14 +3452,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,BAN:4,Periphery:4,CS:7,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:6,BAN:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
+			<availability>MOC:4,IS:5,Periphery.Deep:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,NIOPS:6,DC:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3501,7 +3501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3518,7 +3518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>IS:8,FWL:9,Periphery.Deep:7,Periphery:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3547,7 +3547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:8,FWL:8,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:3</availability>
+			<availability>CS:7,CLAN:3,IS:8,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -3681,7 +3681,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
+			<availability>CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,CS:8,LA:5,FWL:5,NIOPS:8,DC:5</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:6,CW:6,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3696,7 +3696,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3727,7 +3727,7 @@
 			<availability>CWI:4</availability>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -3760,7 +3760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:7,CCC:3,CSV:3,CLAN:3,IS:7,Periphery.Deep:5,CFM:3,FS:7,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:7,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CLAN:3,IS:7,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,Clan.IS:3,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:7-,General:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
@@ -3770,7 +3770,7 @@
 			<availability>CLAN:1</availability>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>
-			<availability>CC:2+,CS:5,CHH:5,CSR:4,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:3+,CJF:4,DC:2+</availability>
+			<availability>CC:2+,CS:5,CHH:5,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:3+,DC:2+</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8,CLAN:6,BAN:8</availability>
@@ -3792,7 +3792,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rogue' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,LA:3,FWL:3,NIOPS:4,DC:1</availability>
+			<availability>MOC:1,CLAN:4,IS:3,FS:1,CIR:1,TC:1,CS:4,OA:3,FWL:3,NIOPS:4,DC:1</availability>
 			<model name='RGU-133E'>
 				<availability>CS:8,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3843,7 +3843,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -3868,7 +3868,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,OA:6,LA:4,CLAN:4,IS:4,FWL:4,MERC:4,FS:4,TC:4,Periphery:4,DC:5</availability>
+			<availability>OA:6,CLAN:4,IS:4,MERC:4,Periphery:4,DC:5</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -3885,7 +3885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,CS:5,OA:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3896,7 +3896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
+			<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3955,7 +3955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -3972,7 +3972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:4</availability>
+			<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -4031,14 +4031,14 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -4065,7 +4065,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:4,CSV:3,CLAN:3,CFM:3,CGS:3,CCO:4,CSA:4,CS:1,CDS:3,CW:3,NIOPS:1,CSJ:3,CJF:3</availability>
+			<availability>CSR:4,CLAN:3,CCO:4,CSA:4,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -4114,7 +4114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:4,CLAN:2-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>CC:5,CS:4,OA:2,CLAN:2-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4128,7 +4128,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4180,7 +4180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
+			<availability>CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
@@ -4195,7 +4195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
+			<availability>CC:5,IS:3,MERC:4,CIR:3,Periphery:2,CS:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4310,7 +4310,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-5'>
 				<availability>CC:2-</availability>
 			</model>
@@ -4320,7 +4320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,TC:3+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-11E'>
 				<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,BAN:8,DC:6+,TC:8</availability>
 			</model>
@@ -4342,7 +4342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4357,7 +4357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -4398,7 +4398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:9,LA:5,FWL:4,NIOPS:9,DC:2</availability>
+			<availability>CC:4,MOC:2,CLAN:9,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,LA:5,FWL:4,NIOPS:9,DC:2</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -4459,7 +4459,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:3,CSR:7,CLAN:7,FS:4,MERC:4,CIR:2,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
+			<availability>CC:4,MOC:3,CLAN:7,FS:4,MERC:4,CIR:2,TC:3,CS:7,OA:4,LA:1,FWL:2,NIOPS:7,DC:4</availability>
 			<model name='TRN-3T'>
 				<availability>CS:8,OA:4+,CLAN:6,IS:4+,NIOPS:8,Periphery.Deep:4+,BAN:8,Periphery:4+</availability>
 			</model>
@@ -4488,7 +4488,7 @@
 			<availability>IS:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -4553,7 +4553,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:2-,CC:5-,CLAN:2-,IS:3-,FS:3-,CIR:2-,TC:2-,Periphery:2-,CS:4-,OA:2-,LA:3-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:2-,IS:3-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4574,14 +4574,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:4,MOC:2,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2,TC:2</availability>
+			<availability>CC:4,CS:5,OA:3,LA:4,FWL:4,IS:3,NIOPS:5,FS:4,DC:4,Periphery:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:6,CC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
+			<availability>MOC:6,CC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,DC:6</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4600,7 +4600,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:2,TC:1,CSA:2,CW:4,LA:2,CNC:2,FWL:2,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CLAN:2,FS:2,TC:1,CW:4,LA:2,FWL:2,CSJ:5,DC:1</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -4622,14 +4622,14 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Von Luckner Heavy Tank' unitType='Tank'>
-			<availability>CC:3,LA:7,CLAN:3,IS:3,FWL:6,MERC:3,FS:6,DC:7</availability>
+			<availability>LA:7,CLAN:3,IS:3,FWL:6,MERC:3,FS:6,DC:7</availability>
 			<model name='(Royal)'>
 				<availability>CLAN:5</availability>
 			</model>
@@ -4658,7 +4658,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
-			<availability>CC:2,MOC:2,OA:2,LA:1,FWL:1,FS:1,MERC:2,DC:3,Periphery:2,TC:2</availability>
+			<availability>CC:2,LA:1,FWL:1,FS:1,MERC:2,DC:3,Periphery:2</availability>
 			<model name='(2405)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -4691,7 +4691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
 			</model>
@@ -4730,7 +4730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:2-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
+			<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4784,7 +4784,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>0,0</pctClan>
 			<pctSL>90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CWI:2,CBS:1,CNC:2,CSJ:2,CMG:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CWI:2,CBS:1,CNC:2,CSJ:2,CMG:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -39,8 +38,7 @@
 			<pctSL>100,100,100,85,70</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
 			<weightDistribution era='2830' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2830' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -50,8 +48,7 @@
 			<pctSL>100,100,95,85,75</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -59,8 +56,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:7,CHH:1,CSR:3,CIH:10,CSV:3,CFM:7,CGS:1,CSA:5,CDS:1,CW:1,CBS:1,CNC:3,CSJ:7,CJF:3,CB:3</salvage>
+			<salvage pct='10'>CCC:7,CHH:1,CSR:3,CIH:10,CSV:3,CFM:7,CGS:1,CSA:5,CDS:1,CW:1,CBS:1,CNC:3,CSJ:7,CJF:3,CB:3</salvage>
 			<weightDistribution era='2830' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2830' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -70,8 +66,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:10,CSV:5,CCO:6,CGS:7,CSA:10,CDS:3,CW:1,CNC:2,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:10,CSV:5,CCO:6,CGS:7,CSA:10,CDS:3,CW:1,CNC:2,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -79,8 +74,7 @@
 			<pctSL>100,100,90,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:3,CIH:5,CSR:1,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
+			<salvage pct='10'>CHH:10,CCC:3,CIH:5,CSR:1,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
 			<weightDistribution era='2830' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2830' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -90,8 +84,7 @@
 			<pctSL>100,100,95,90,85</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:1,CWI:3,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:1,CWI:3,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -99,8 +92,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,10,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,90,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:7,CIH:10,CSV:4,CFM:7,CCO:1,CGS:6,CSA:4,CDS:7,CW:3,CWI:4,CBS:2,CNC:10,CSJ:3,CMG:3,CJF:3,CGB:8,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:4,CFM:7,CCO:1,CGS:6,CSA:4,CDS:7,CW:3,CWI:4,CBS:2,CNC:10,CSJ:3,CMG:3,CJF:3,CGB:8,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -108,8 +100,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:4,CSR:3,CSV:1,CFM:10,CCO:9,CGS:5,CSA:1,CDS:4,CW:4,CWI:1,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:4,CSR:3,CSV:1,CFM:10,CCO:9,CGS:5,CSA:1,CDS:4,CW:4,CWI:1,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
 			<weightDistribution era='2830' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2830' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -119,8 +110,7 @@
 			<pctSL>100,100,95,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:7,CIH:7,CSV:7,CFM:10,CCO:7,CGS:6,CSA:3,CDS:4,CW:7,CWI:1,CBS:1,CNC:2,CSJ:3,CMG:3,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:7,CIH:7,CSV:7,CFM:10,CCO:7,CGS:6,CSA:3,CDS:4,CW:7,CWI:1,CBS:1,CNC:2,CSJ:3,CMG:3,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -128,8 +118,7 @@
 			<pctSL>100,100,100,85,75</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -137,8 +126,7 @@
 			<pctSL>100,100,100,80,70</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:10,CSR:3,CIH:7,CFM:3,CCO:7,CGS:3,CDS:3,CW:7,CWI:2,CBS:2,CSJ:3,CJF:5,CB:7</salvage>
+			<salvage pct='10'>CCC:5,CHH:10,CSR:3,CIH:7,CFM:3,CCO:7,CGS:3,CDS:3,CW:7,CWI:2,CBS:2,CSJ:3,CJF:5,CB:7</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -146,8 +134,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='12'>
-				CCC:2,CHH:7,CSR:3,CIH:10,CSV:3,CFM:4,CCO:3,CGS:4,CSA:8,CW:3,CWI:1,CNC:3,CSJ:7,CMG:1,CJF:6,CB:3</salvage>
+			<salvage pct='12'>CCC:2,CHH:7,CSR:3,CIH:10,CSV:3,CFM:4,CCO:3,CGS:4,CSA:8,CW:3,CWI:1,CNC:3,CSJ:7,CMG:1,CJF:6,CB:3</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -155,8 +142,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -164,8 +150,7 @@
 			<pctSL>100,100,95,80,70</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:7,CIH:7,CSV:5,CFM:7,CCO:7,CGS:1,CSA:1,CDS:3,CW:3,CWI:1,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
+			<salvage pct='10'>CCC:1,CHH:7,CIH:7,CSV:5,CFM:7,CCO:7,CGS:1,CSA:1,CDS:3,CW:3,CWI:1,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -173,8 +158,7 @@
 			<pctSL>100,100,100,75,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:3,CGS:5,CDS:5,CW:10,CSJ:1,CMG:3,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:3,CGS:5,CDS:5,CW:10,CSJ:1,CMG:3,CJF:10,CGB:3,CB:1</salvage>
 			<weightDistribution era='2830' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2830' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -184,8 +168,7 @@
 			<pctSL>100,100,90,80,70</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CWI'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -201,8 +184,7 @@
 			<pctSL>100,100,95,85,75</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:2,CSR:3,CIH:8,CSV:10,CFM:3,CCO:1,CGS:1,CSA:3,CDS:2,CWI:1,CBS:1,CNC:5,CSJ:10,CMG:3,CJF:5,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:3,CHH:2,CSR:3,CIH:8,CSV:10,CFM:3,CCO:1,CGS:1,CSA:3,CDS:2,CWI:1,CBS:1,CNC:5,CSJ:10,CMG:3,CJF:5,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -382,8 +364,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -391,8 +372,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -400,8 +380,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -409,8 +388,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -418,8 +396,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -427,8 +404,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -436,8 +412,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CFM.P:8,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -445,8 +420,7 @@
 			<pctSL>100,100,100,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:9,CSV:5,CCO:5,CGS:7,CSA:10,CDS:3,CW:3,CNC:2,CSJ:3,CMG:3,CJF:9,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='6'></salvage>
@@ -556,24 +530,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:4,CLAN:5,IS:4,FS:4,BAN:5,TC:3,Periphery:2,CS:6,OA:3,LA:4,FWL:3,NIOPS:6,DC:6</availability>
+			<availability>MOC:3,CC:4,CLAN:5,IS:4,FS:4,BAN:5,TC:3,Periphery:2,CS:6,OA:3,LA:4,FWL:3,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CC:3,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:3,CGS:4,CSA:4,CDS:4,LA:2,CBS:4,CNC:5,FWL:3,CJF:5,DC:3,CB:4</availability>
+			<availability>CC:3,CCC:4,CSR:5,CIH:4,CSV:4,CLAN:4,FS:3,CGS:4,CSA:4,CDS:4,LA:2,CBS:4,CNC:5,FWL:3,CJF:5,DC:3,CB:4</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -593,8 +564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:2+,CC:3+,CLAN:7,MERC:3+,FS:3+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:3+,CNC:7,FWL:3+,NIOPS:7,CJF:7,DC:3+</availability>
+			<availability>MOC:2+,CC:3+,CLAN:7,MERC:3+,FS:3+,TC:2+,CS:7,OA:2+,CDS:7,CW:7,LA:3+,CNC:7,FWL:3+,NIOPS:7,CJF:7,DC:3+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -635,8 +605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:6</availability>
@@ -751,8 +720,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CWI:2,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CWI:2,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -786,8 +754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:7,CC:7,CLAN:4-,IS:7,Periphery.Deep:5,FS:7,CIR:7,TC:7,Periphery:5,CS:8,OA:7,LA:7,FWL:9,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -811,8 +778,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:6-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:7-,FWL:6-,NIOPS:2-,DC:6-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -881,8 +847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:4,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:4,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+,BAN:6</availability>
 			</model>
@@ -934,8 +899,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -991,8 +955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:3,DC:3</availability>
@@ -1027,8 +990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1090,8 +1052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:4</availability>
+			<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:5,Periphery:3,TC:5,CS:3,OA:5,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:3,DC:4</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1408,8 +1369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:4,CJF:4,CGB:4,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
@@ -1427,8 +1387,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
+			<availability>CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
 			<model name='CRK-5003-1'>
 				<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:8</availability>
 			</model>
@@ -1541,8 +1500,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1636,8 +1594,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
+			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:5,CIR:4,Periphery:3,TC:4,CS:5-,OA:4,LA:4,FWL:8,NIOPS:5-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1869,8 +1826,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:6-</availability>
 			</model>
@@ -2015,8 +1971,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2045,8 +2000,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2086,8 +2040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
+			<availability>CC:2,MOC:4,CLAN:9,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:9,LA:2,Periphery.MW:3,Periphery.ME:3,CNC:9,FWL:8,NIOPS:9,DC:2</availability>
 			<model name='GTHA-100'>
 				<availability>General:5,CLAN:4</availability>
 			</model>
@@ -2095,8 +2048,7 @@
 				<availability>CLAN:2,FWL:6,BAN:6</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:8,BAN:4</availability>
@@ -2109,8 +2061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 			</model>
@@ -2197,8 +2148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2305,8 +2255,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
+			<availability>CC:3-,MOC:4-,OA:4-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:4-,TC:4-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2386,8 +2335,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:3,OA:3,Periphery.HR:3,FS.CMM:3,FS.DMM:3,FS:3,MERC:4,Periphery.OS:3,FS.CrMM:3,TC:3</availability>
+			<availability>MOC:3,OA:3,Periphery.HR:3,FS.CMM:3,FS.DMM:3,FS:3,MERC:4,Periphery.OS:3,FS.CrMM:3,TC:3</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2400,8 +2348,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2462,8 +2409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,CLAN:4,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2485,8 +2431,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
+			<availability>CC:5,MOC:3,CLAN:7,IS:4,FWL.OH:6,FS:5,CIR:2,TC:3,CS:6,OA:3,LA:5,CNC:7,FWL:6,NIOPS:6,DC:5</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -2526,8 +2471,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2568,8 +2512,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2757,8 +2700,7 @@
 			<availability>CS:1-,IS:5,NIOPS:1-,Periphery.Deep:5,Periphery:5</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,BAN:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
+			<availability>MOC:4,CC:5,CIH:6,CLAN:6,IS:5,CFM:6,MERC:5,CIR:4,CGS:6,BAN:6,TC:4,CS:6,OA:4,LA:5,NIOPS:6,DC:5</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:6,NIOPS:8,BAN:6,DC:6</availability>
@@ -2787,8 +2729,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:6,CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,BAN:5,Periphery:6,TC:6,CS:4,OA:6,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:6,CC:5,CHH:4,CLAN:5,IS:6,Periphery.Deep:6,FS:5,CIR:7,BAN:5,Periphery:6,TC:6,CS:4,OA:6,LA:5,CBS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2892,8 +2833,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:3,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:3,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:3,CBS:3,CNC:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -2907,8 +2847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2925,8 +2864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:2,Periphery:2,TC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3001,8 +2939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3017,8 +2954,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:3+,Periphery:2,CS:8,LA:6,FWL:5,NIOPS:8,DC:6,CGB:8</availability>
+			<availability>CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:3+,Periphery:2,CS:8,LA:6,FWL:5,NIOPS:8,DC:6,CGB:8</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,MOC:5,CLAN:4,IS:5+,NIOPS:8,MERC:0,BAN:4,TC:5+</availability>
 			</model>
@@ -3040,8 +2976,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
+			<availability>Periphery.R:3,LA:3-,Periphery.MW:3,Periphery.HR:2,Periphery.CM:2,IS:3-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3066,8 +3001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3159,8 +3093,7 @@
 			</model>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Steinadler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3301,8 +3234,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CMG:7,CJF:7,CGB:5,DC:5+</availability>
+			<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CMG:7,CJF:7,CGB:5,DC:5+</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,IS:5+,BAN:8,Periphery:5+</availability>
@@ -3466,8 +3398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3497,8 +3428,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
+			<availability>CC:5,CS:4,LA:5,CLAN:4-,IS:5,Periphery.Deep:5,FWL:5,NIOPS:4,FS:5,MERC:5,Periphery:5,DC:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:6-,BAN:8</availability>
@@ -3522,16 +3452,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
+			<availability>MOC:4,CC:5,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:5,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:5,CBS:7,FWL:5,NIOPS:7,DC:5</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:6,BAN:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
+			<availability>MOC:4,CC:5,IS:5,Periphery.Deep:5,FS:5,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3557,8 +3485,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -3574,8 +3501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3592,8 +3518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
+			<availability>CC:8,MOC:7,OA:7,LA:8,IS:8,FWL:9,Periphery.Deep:7,FS:8,CIR:7,Periphery:7,TC:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3688,8 +3613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:4,CCC:4,CIH:4,CSR:5,CSV:4,CLAN:3,CFM:4,CGS:5,CCO:4,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
+			<availability>CHH:4,CCC:4,CIH:4,CSR:5,CSV:4,CLAN:3,CFM:4,CGS:5,CCO:4,CSA:4,CS:1,CDS:5,CW:4,NIOPS:1,CSJ:4</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3757,8 +3681,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
+			<availability>MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:6,CW:6,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3773,8 +3696,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:7,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3805,8 +3727,7 @@
 			<availability>CWI:4</availability>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,Periphery:9,TC:8,CS:9,OA:8,LA:8,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -3820,8 +3741,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8,DC:2</availability>
 			</model>
@@ -3840,8 +3760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:7,CCC:3,CSV:3,CLAN:3,IS:7,Periphery.Deep:5,CFM:3,FS:7,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:7,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CC:7,CCC:3,CSV:3,CLAN:3,IS:7,Periphery.Deep:5,CFM:3,FS:7,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:7,NIOPS:6-,CJF:3,CB:3</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:7-,General:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
@@ -3924,8 +3843,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -3967,8 +3885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,MOC:6,IS:6,Periphery.Deep:6,FS:5,MERC:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3991,8 +3908,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-,BAN:2-</availability>
+			<availability>CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-,BAN:2-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -4018,8 +3934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
 			<model name='STN-1S'>
 				<availability>LA:1,FWL:1,FS:1</availability>
 			</model>
@@ -4040,8 +3955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:3,LA:6,FWL:2,Periphery.Deep:4,FS:2,CIR:3,MERC:2,Periphery:4,TC:2,DC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4117,8 +4031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4174,8 +4087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
+			<availability>MOC:3,CC:4,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:8,CIR:3,Periphery:4,TC:3,CS:3,OA:3,LA:4,Periphery.HR:4,FWL:1,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4216,8 +4128,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>MOC:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,TC:9,Periphery:9,CS:6,OA:9,LA:8,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4269,8 +4180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
+			<availability>MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
@@ -4285,8 +4195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
+			<availability>CC:5,MOC:2,IS:3,FS:3,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4312,8 +4221,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,Periphery:2,TC:3,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:2</availability>
+			<availability>MOC:3,CC:3,CLAN:6,MERC:4,Periphery.OS:3,FS:7,CIR:2,Periphery:2,TC:3,OA:3,LA:3,Periphery.HR:3,FWL:2,DC:2</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4390,8 +4298,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
+			<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
 			<model name='THE-F'>
 				<availability>CC:2+,FWL:2+,FS:2+</availability>
 			</model>
@@ -4413,8 +4320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-11E'>
 				<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,BAN:8,DC:6+,TC:8</availability>
 			</model>
@@ -4436,8 +4342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:6,FS:7,CIR:5,TC:7,Periphery:6,CS:5-,OA:6,LA:8,FWL:6,NIOPS:5-,DC:6</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4452,8 +4357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -4649,8 +4553,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:2-,CC:5-,CLAN:2-,IS:3-,FS:3-,CIR:2-,TC:2-,Periphery:2-,CS:4-,OA:2-,LA:3-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:2-,CC:5-,CLAN:2-,IS:3-,FS:3-,CIR:2-,TC:2-,Periphery:2-,CS:4-,OA:2-,LA:3-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4678,8 +4581,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:6,CC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
+			<availability>MOC:6,CC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4698,8 +4600,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:2,TC:1,CSA:2,CW:4,LA:2,CNC:2,FWL:2,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:2,TC:1,CSA:2,CW:4,LA:2,CNC:2,FWL:2,CSJ:5,CJF:2,DC:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -4869,8 +4770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -523,21 +523,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>CLAN:4,IS:3,BAN:5,Periphery:2,CS:6,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CC:2,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:2,CGS:3,CSA:3,CDS:3,LA:2,CBS:3,CNC:5,FWL:2,CJF:5,DC:2,CB:3</availability>
+			<availability>CC:2,CSR:5,CSV:3,CLAN:3,FS:2,LA:2,CNC:5,FWL:2,CJF:5,DC:2</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -561,7 +561,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:1+,CC:2+,CLAN:7,MERC:2+,FS:2+,TC:1+,CS:7,OA:1+,CDS:7,CW:7,LA:2+,CNC:7,FWL:2+,NIOPS:7,CJF:7,DC:2+</availability>
+			<availability>MOC:1+,CC:2+,CLAN:7,MERC:2+,FS:2+,TC:1+,CS:7,OA:1+,LA:2+,FWL:2+,NIOPS:7,DC:2+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -608,7 +608,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -659,7 +659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -743,7 +743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -770,14 +770,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:5,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
+			<availability>MOC:3,OA:3,LA:5,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,CLAN:4-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CLAN:4-,IS:7,Periphery.Deep:6,CIR:8,TC:8,Periphery:6,CS:8,OA:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -801,7 +801,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>Periphery.Deep:10-,FS:5-,MERC:7-,Periphery:10-,CS:2-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -823,7 +823,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -884,7 +884,7 @@
 				<availability>CS:4,CLAN:7,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -932,7 +932,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -944,7 +944,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:4,CHH:8,CLAN:6,FS:4,MERC:4,CS:7,CDS:6,LA:4,CNC:6,FWL:4,NIOPS:7,CJF:6,DC:4</availability>
+			<availability>CC:4,CHH:8,CLAN:6,FS:4,MERC:4,CS:7,LA:4,FWL:4,NIOPS:7,DC:4</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -979,7 +979,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:7</availability>
@@ -996,14 +996,14 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:3,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:3,DC:3</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
@@ -1053,7 +1053,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
-			<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
+			<availability>CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -1066,7 +1066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
+			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1120,9 +1120,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:4,FWL:4,MERC:3,FS:4,CIR:2,TC:2,Periphery:2,DC:3</availability>
+			<availability>CC:3,OA:2,LA:6,CLAN:4,FWL:4,MERC:3,FS:4,Periphery:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:7,CGS:6,BAN:4</availability>
@@ -1289,7 +1289,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:4,CS:3-,OA:4,LA:4,CLAN:3-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1350,7 +1350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1369,7 +1369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:3,MOC:2,CLAN:2,IS:3,FS:3,CIR:1,BAN:3,TC:2,CS:6,OA:2,LA:3,FWL:3,NIOPS:6,DC:3</availability>
+			<availability>MOC:2,CLAN:2,IS:3,CIR:1,BAN:3,TC:2,CS:6,OA:2,FWL:3,NIOPS:6</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:7</availability>
@@ -1386,7 +1386,7 @@
 			</model>
 		</chassis>
 		<chassis name='Congress Frigate' unitType='Warship'>
-			<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:5,CGS:2,CJF:2</availability>
+			<availability>CS:2,CW:2,CLAN:1,NIOPS:2,CSJ:5,CGS:2,CJF:2</availability>
 			<model name='(2542)'>
 				<roles>frigate</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -1419,7 +1419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -1437,7 +1437,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
@@ -1588,7 +1588,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demon Tank' unitType='Tank'>
-			<availability>CC:2+,CS:8,LA:2+,CLAN:9,FWL:2+,NIOPS:8,FS:2+,MERC:2+,CJF:9,DC:2+</availability>
+			<availability>CC:2+,CS:8,LA:2+,CLAN:9,FWL:2+,NIOPS:8,FS:2+,MERC:2+,DC:2+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1600,7 +1600,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:5,Periphery.HR:5,CLAN:3,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5,DC:5</availability>
+			<availability>CC:4,Periphery.HR:5,CLAN:3,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1675,7 +1675,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:4,CC:5,CS:7,OA:5,CLAN:3,CNC:3,FWL:6,NIOPS:7,FS:5,MERC:5,TC:5</availability>
+			<availability>MOC:4,CC:5,CS:7,OA:5,CLAN:3,FWL:6,NIOPS:7,FS:5,MERC:5,TC:5</availability>
 			<model name='EMP-5A'>
 				<availability>General:8,BAN:2</availability>
 			</model>
@@ -1722,14 +1722,14 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CIH:2,CSR:2,CSV:2,CLAN:2,CGS:2,CCO:2,CSA:2,CDS:3,LA:1,CSJ:4,CGB:3,DC:1,CB:2</availability>
+			<availability>CLAN:2,CDS:3,LA:1,CSJ:4,CGB:3,DC:1</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>CLAN:8,IS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1897,7 +1897,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:6</availability>
+				<availability>LA:6</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:3+,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2040,7 +2040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2069,7 +2069,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2083,7 +2083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>CC:1,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2109,7 +2109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
+			<availability>MOC:3,CLAN:8,IS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,Periphery.MW:2,Periphery.ME:2,FWL:5,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:4,CLAN:3</availability>
 			</model>
@@ -2117,7 +2117,7 @@
 				<availability>CLAN:2,FWL:5,BAN:4</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+				<availability>CS:6,CLAN:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2142,7 +2142,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 			</model>
@@ -2161,7 +2161,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:6,CS:7,CHH:9,CSR:9,CLAN:8,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
+			<availability>CS:7,CHH:9,CSR:9,CLAN:8,IS:6,NIOPS:7,FS:5,MERC:6</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:8,DC:4+</availability>
@@ -2221,7 +2221,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:4,CLAN:7,IS:4,FS:4,CIR:2,TC:3,CS:7,OA:3,LA:4,CNC:7,FWL:4,NIOPS:7,DC:4</availability>
+			<availability>MOC:3,CLAN:7,IS:4,CIR:2,TC:3,CS:7,OA:3,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2236,7 +2236,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:6,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2339,7 +2339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:3+,CLAN:5,IS:3,FS:3,TC:3+,CS:6,OA:3+,LA:3,CNC:5,FWL:2,NIOPS:6,DC:3</availability>
+			<availability>CC:2,MOC:3+,CLAN:5,IS:3,TC:3+,CS:6,OA:3+,FWL:2,NIOPS:6</availability>
 			<model name='HCT-212'>
 				<availability>LA:6,IS:6,FS:6,Periphery:6</availability>
 			</model>
@@ -2355,7 +2355,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:3-,OA:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
+			<availability>CC:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2398,11 +2398,11 @@
 			<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:3,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2414,7 +2414,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:2,CFM:10,MERC:2,FS:2,CJF:10,DC:2</availability>
+			<availability>CS:9,CLAN:9,NIOPS:9,IS:2,CFM:10,MERC:2,CJF:10</availability>
 			<model name='HGN-732'>
 				<availability>CC:5+,MOC:4+,CS:8,LA:5+,CLAN:6,FWL:5+,IS:4+,NIOPS:8,FS:5+,MERC:4+,BAN:8,DC:5+</availability>
 			</model>
@@ -2455,7 +2455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2528,7 +2528,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2550,7 +2550,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,CNC:6,FWL:5,NIOPS:6,DC:4</availability>
+			<availability>MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,FWL:5,NIOPS:6,DC:4</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -2608,7 +2608,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2642,7 +2642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2738,7 +2738,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -2755,7 +2755,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:3,NIOPS:7,FS:6,MERC:3,DC:3</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2</availability>
+				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -2825,7 +2825,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:6,CW:6,CSV:6,CLAN:6,CNC:6,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CLAN:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -2848,7 +2848,7 @@
 			<availability>CS:1-,IS:5,NIOPS:1-,Periphery.Deep:5,Periphery:5</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:5</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6,DC:5+</availability>
@@ -2881,7 +2881,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>CC:6,CLAN:1,IS:7,Periphery.Deep:7,FS:6,BAN:5,Periphery:7,CS:4,LA:6,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2923,7 +2923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,CLAN:5,IS:3,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:2,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:5,IS:3,Periphery:2,CS:5-,FWL:2,NIOPS:5-</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:2</availability>
 			</model>
@@ -2991,7 +2991,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -3012,7 +3012,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3029,7 +3029,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:6,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:6,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3107,7 +3107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3122,7 +3122,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:7</availability>
+			<availability>MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,NIOPS:8,DC:5,CGB:7</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,MOC:4,CLAN:4,IS:4+,NIOPS:8,MERC:0,BAN:4,TC:4+</availability>
 			</model>
@@ -3150,7 +3150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:2,Periphery.CM:2,IS:2-,Periphery:2</availability>
+			<availability>IS:2-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3184,7 +3184,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3287,7 +3287,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3620,7 +3620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3645,7 +3645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:7,Periphery:8</availability>
@@ -3665,7 +3665,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:5,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:5,DC:4</availability>
+			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:5,NIOPS:4,MERC:4,Periphery:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:6-,BAN:8</availability>
@@ -3689,21 +3689,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,BAN:4,Periphery:4,CS:7,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:5,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
+				<availability>PIR:4,General:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -3742,7 +3742,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3759,7 +3759,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,LA:9,IS:8,FWL:10,Periphery.Deep:8,Periphery:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3798,7 +3798,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+			<availability>CS:7,CLAN:3,IS:9,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -3935,7 +3935,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
+			<availability>CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,CS:8,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:6,CW:6,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -3950,7 +3950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3978,7 +3978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -4025,7 +4025,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,Clan.IS:3,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:6-,General:8,Periphery.Deep:8,BAN:7,Periphery:8</availability>
@@ -4035,7 +4035,7 @@
 			<availability>CLAN:1</availability>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>
-			<availability>CC:2+,CS:5,CHH:5,CSR:4,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:2+,CJF:4,DC:2+</availability>
+			<availability>CC:2+,CS:5,CHH:5,LA:2+,CLAN:4,FWL:2+,NIOPS:5,FS:2+,DC:2+</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8,CLAN:5,BAN:8</availability>
@@ -4108,7 +4108,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -4133,7 +4133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,OA:5,LA:3,CLAN:2,IS:4,FWL:3,MERC:4,FS:4,TC:4,Periphery:4,DC:4</availability>
+			<availability>CC:3,OA:5,LA:3,CLAN:2,IS:4,FWL:3,MERC:4,Periphery:4</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -4150,7 +4150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4161,7 +4161,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>CC:7,LA:7,FWL:7,IS:7,Periphery.Deep:7,FS:7,DC:7,Periphery:7</availability>
+			<availability>IS:7,Periphery.Deep:7,Periphery:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4220,7 +4220,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+			<availability>MOC:2,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4313,7 +4313,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4324,7 +4324,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -4360,7 +4360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:3,CSV:2,CLAN:2,CFM:2,CGS:2,CCO:3,CSA:3,CS:1,CDS:2,CW:2,NIOPS:1,CSJ:2,CJF:2</availability>
+			<availability>CSR:3,CLAN:2,CCO:3,CSA:3,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4413,7 +4413,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4427,7 +4427,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4479,7 +4479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
+			<availability>CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
@@ -4494,7 +4494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,IS:2,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:2</availability>
+			<availability>CC:4,IS:2,MERC:4,CIR:3,Periphery:2,CS:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4636,7 +4636,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-5'>
 				<availability>CC:2-</availability>
 			</model>
@@ -4646,7 +4646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:4,CFM:10,FS:4,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:5,CNC:7,FWL:6,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:4,CFM:10,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:5,CNC:7,FWL:6,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:4,DC:4</availability>
 			</model>
@@ -4671,7 +4671,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:4,IS:5,Periphery.Deep:5,FS:6,TC:6,Periphery:5,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:5</availability>
@@ -4686,7 +4686,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3-</availability>
 			</model>
@@ -4733,7 +4733,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,CLAN:8,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:8,LA:2,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>CC:3,MOC:2,CLAN:8,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -4826,7 +4826,7 @@
 			<availability>IS:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Typhoon' unitType='AeroSpaceFighter'>
@@ -4898,7 +4898,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:5-,CLAN:2-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:2-,IS:4-,TC:3-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4919,14 +4919,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:3,MOC:1,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1,TC:1</availability>
+			<availability>CC:3,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:3-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:3-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:3-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4945,7 +4945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:1,TC:1,CSA:2,CW:4,LA:1,CNC:2,FWL:1,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CLAN:2,FS:1,TC:1,CW:4,LA:1,FWL:1,CSJ:5,DC:1</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -4970,7 +4970,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -5043,7 +5043,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
 			</model>
@@ -5082,7 +5082,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:2-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
+			<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5136,7 +5136,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>0,0</pctClan>
 			<pctSL>80,80</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -41,8 +40,7 @@
 			<pctSL>100,100,100,75,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
 			<weightDistribution era='2835' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2835' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -52,8 +50,7 @@
 			<pctSL>100,100,90,75,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:7,CDS:1,CW:5,CBS:2,CNC:7,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:7,CDS:1,CW:5,CBS:2,CNC:7,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -61,8 +58,7 @@
 			<pctSL>100,100,95,75,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:7,CIH:10,CSR:5,CSV:3,CFM:7,CGS:1,CSA:8,CDS:1,CW:1,CBS:1,CNC:3,CSJ:7,CJF:3,CB:3</salvage>
+			<salvage pct='10'>CHH:1,CCC:7,CIH:10,CSR:5,CSV:3,CFM:7,CGS:1,CSA:8,CDS:1,CW:1,CBS:1,CNC:3,CSJ:7,CJF:3,CB:3</salvage>
 			<weightDistribution era='2835' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2835' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -72,8 +68,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:10,CSV:4,CCO:6,CGS:5,CSA:10,CDS:2,CW:1,CNC:2,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:10,CSV:4,CCO:6,CGS:5,CSA:10,CDS:2,CW:1,CNC:2,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -91,8 +86,7 @@
 			<pctSL>100,100,90,85,80</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:2,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:2,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -100,8 +94,7 @@
 			<pctSL>100,100,90,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,15,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,80</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:5,CSA:5,CDS:7,CW:3,CBS:2,CNC:10,CSJ:3,CMG:3,CJF:3,CGB:7,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:5,CSA:5,CDS:7,CW:3,CBS:2,CNC:10,CSJ:3,CMG:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -109,8 +102,7 @@
 			<pctSL>100,100,90,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:5,CSA:1,CDS:4,CW:6,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:5,CSA:1,CDS:4,CW:6,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
 			<weightDistribution era='2835' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2835' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -120,8 +112,7 @@
 			<pctSL>100,100,90,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:7,CIH:7,CSV:7,CFM:10,CCO:7,CGS:4,CSA:3,CDS:3,CW:7,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:7,CIH:7,CSV:7,CFM:10,CCO:7,CGS:4,CSA:3,CDS:3,CW:7,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -129,8 +120,7 @@
 			<pctSL>100,100,90,75,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -138,8 +128,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:10,CSR:3,CIH:7,CSV:1,CFM:4,CCO:7,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:3,CJF:5,CB:7</salvage>
+			<salvage pct='10'>CCC:5,CHH:10,CSR:3,CIH:7,CSV:1,CFM:4,CCO:7,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:3,CJF:5,CB:7</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -147,8 +136,7 @@
 			<pctSL>100,100,85,75,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='12'>
-				CCC:2,CHH:7,CSR:7,CIH:10,CSV:3,CFM:3,CCO:3,CGS:3,CSA:7,CW:3,CNC:3,CSJ:7,CMG:1,CJF:5,CB:3</salvage>
+			<salvage pct='12'>CCC:2,CHH:7,CSR:7,CIH:10,CSV:3,CFM:3,CCO:3,CGS:3,CSA:7,CW:3,CNC:3,CSJ:7,CMG:1,CJF:5,CB:3</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -156,8 +144,7 @@
 			<pctSL>100,100,90,60,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -165,8 +152,7 @@
 			<pctSL>100,100,85,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:7,CIH:10,CSV:4,CFM:7,CCO:10,CGS:1,CSA:2,CDS:7,CW:10,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
+			<salvage pct='10'>CCC:1,CHH:7,CIH:10,CSV:4,CFM:7,CCO:10,CGS:1,CSA:2,CDS:7,CW:10,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -174,8 +160,7 @@
 			<pctSL>100,100,90,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:4,CGS:4,CDS:4,CW:10,CNC:3,CSJ:1,CMG:2,CJF:10,CGB:3,CB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:4,CGS:4,CDS:4,CW:10,CNC:3,CSJ:1,CMG:2,CJF:10,CGB:3,CB:2</salvage>
 			<weightDistribution era='2835' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2835' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -185,8 +170,7 @@
 			<pctSL>100,100,80,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -194,8 +178,7 @@
 			<pctSL>100,100,90,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:2,CCC:5,CIH:10,CSR:8,CSV:10,CFM:3,CGS:1,CCO:1,CSA:3,CDS:3,CNC:5,CSJ:10,CMG:3,CJF:5,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CHH:2,CCC:5,CIH:10,CSR:8,CSV:10,CFM:3,CGS:1,CCO:1,CSA:3,CDS:3,CNC:5,CSJ:10,CMG:3,CJF:5,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -374,8 +357,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -383,8 +365,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -392,8 +373,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -401,8 +381,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -410,8 +389,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -419,8 +397,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -428,8 +405,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -437,8 +413,7 @@
 			<pctSL>100,100,95,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='6'></salvage>
@@ -548,24 +523,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CC:2,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:2,CGS:3,CSA:3,CDS:3,LA:2,CBS:3,CNC:5,FWL:2,CJF:5,DC:2,CB:3</availability>
+			<availability>CC:2,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:2,CGS:3,CSA:3,CDS:3,LA:2,CBS:3,CNC:5,FWL:2,CJF:5,DC:2,CB:3</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -589,8 +561,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:1+,CC:2+,CLAN:7,MERC:2+,FS:2+,TC:1+,CS:7,OA:1+,CDS:7,CW:7,LA:2+,CNC:7,FWL:2+,NIOPS:7,CJF:7,DC:2+</availability>
+			<availability>MOC:1+,CC:2+,CLAN:7,MERC:2+,FS:2+,TC:1+,CS:7,OA:1+,CDS:7,CW:7,LA:2+,CNC:7,FWL:2+,NIOPS:7,CJF:7,DC:2+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -637,8 +608,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -773,8 +743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -808,8 +777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,CLAN:4-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,CLAN:4-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -833,8 +801,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -909,8 +876,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:3,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:3,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 			</model>
@@ -966,8 +932,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1031,8 +996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,MOC:1,CLAN:3,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:3,DC:3</availability>
@@ -1067,8 +1031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1136,8 +1099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:5,FS:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:4</availability>
+			<availability>CC:4,MOC:5,FS:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:4</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1475,8 +1437,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
@@ -1494,8 +1455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:5,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:5,CGS:8,CS:8,CDS:8,CW:10,LA:5,CBS:10,FWL:5,NIOPS:8,CJF:8,CGB:10,DC:5</availability>
+			<availability>CC:5,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:5,CGS:8,CS:8,CDS:8,CW:10,LA:5,CBS:10,FWL:5,NIOPS:8,CJF:8,CGB:10,DC:5</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -1605,8 +1565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1700,8 +1659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:3,FS:4</availability>
@@ -1937,8 +1895,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:6</availability>
 			</model>
@@ -2083,8 +2040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2113,8 +2069,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:7,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:7,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2154,8 +2109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
+			<availability>CC:2,MOC:3,CLAN:8,IS:2,FS:2,CIR:2,MERC:2,TC:2,CS:9,OA:2,CDS:8,LA:2,Periphery.MW:2,Periphery.ME:2,CNC:8,FWL:5,NIOPS:9,DC:2</availability>
 			<model name='GTHA-100'>
 				<availability>General:4,CLAN:3</availability>
 			</model>
@@ -2163,8 +2117,7 @@
 				<availability>CLAN:2,FWL:5,BAN:4</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
+				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:6,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2189,8 +2142,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:6,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
 			</model>
@@ -2284,8 +2236,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:6,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2404,8 +2355,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:3-,OA:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
+			<availability>CC:3-,MOC:3-,OA:3-,LA:6-,FWL:3-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2485,8 +2435,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2506,8 +2455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2580,8 +2528,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2603,8 +2550,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,CNC:6,FWL:5,NIOPS:6,DC:4</availability>
+			<availability>CC:3,MOC:2,CLAN:6,IS:3,FWL.OH:5,FS:4,CIR:2,TC:2,CS:6,OA:2,LA:4,CNC:6,FWL:5,NIOPS:6,DC:4</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -2662,8 +2608,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2697,8 +2642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2904,8 +2848,7 @@
 			<availability>CS:1-,IS:5,NIOPS:1-,Periphery.Deep:5,Periphery:5</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:5</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6,DC:5+</availability>
@@ -2938,8 +2881,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3049,8 +2991,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -3071,8 +3012,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3089,8 +3029,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:2,DC:6,Periphery:2,TC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3168,8 +3107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3184,8 +3122,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:7</availability>
+			<availability>CC:4,MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:7</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,MOC:4,CLAN:4,IS:4+,NIOPS:8,MERC:0,BAN:4,TC:4+</availability>
 			</model>
@@ -3213,8 +3150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:2,Periphery.CM:2,IS:2-,Periphery:2</availability>
+			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:2,Periphery.CM:2,IS:2-,Periphery:2</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3248,8 +3184,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3352,8 +3287,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3509,8 +3443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:5+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:4+,NIOPS:6,CMG:8,CJF:7,CGB:5,DC:4+</availability>
+			<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:5+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:4+,NIOPS:6,CMG:8,CJF:7,CGB:5,DC:4+</availability>
 			<model name='C'>
 				<availability>CIH:3,CMG:6,CJF:3,CGB:3</availability>
 			</model>
@@ -3687,8 +3620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3733,8 +3665,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:5,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:5,DC:4</availability>
+			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:5,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:5,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:6-,BAN:8</availability>
@@ -3758,16 +3689,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:5,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3797,8 +3726,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -3814,8 +3742,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3832,8 +3759,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3938,8 +3864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -4010,8 +3935,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
+			<availability>MOC:3,CC:5,CLAN:8,MERC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:8,OA:3,LA:5,FWL:5,NIOPS:8,CJF:8,DC:5</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:6,CW:6,General:8,CLAN:6,NIOPS:8</availability>
 			</model>
@@ -4026,8 +3950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4055,8 +3978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:6,CW:6,General:8,CLAN:6,CNC:6</availability>
 			</model>
@@ -4078,8 +4000,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:3,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:3,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4104,8 +4025,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:6-,General:8,Periphery.Deep:8,BAN:7,Periphery:8</availability>
@@ -4188,8 +4108,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:4</availability>
 			</model>
@@ -4231,8 +4150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4258,8 +4176,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -4285,8 +4202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CC:1-,CSV:5,CLAN:6,CFM:7,FS:2-,CGS:5,CS:4,CDS:5,CW:5,LA:5-,CBS:5,FWL:2-,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:2-,CGS:5,CS:4,CDS:5,CW:5,LA:5-,CBS:5,FWL:2-,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -4304,8 +4220,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4398,8 +4313,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4472,8 +4386,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4514,8 +4427,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4567,8 +4479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
+			<availability>MOC:6,CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:3-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
@@ -4583,8 +4494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:2,IS:2,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:2</availability>
+			<availability>CC:4,MOC:2,IS:2,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4614,8 +4524,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:2,DC:3</availability>
+			<availability>MOC:2,CC:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4705,8 +4614,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor Artillery Vehicle' unitType='Tank'>
-			<availability>
-				CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
+			<availability>CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
 			<model name=''>
 				<roles>artillery</roles>
 				<availability>CS:8,General:8,NIOPS:8,BAN:4</availability>
@@ -4738,8 +4646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:4,CFM:10,FS:4,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:5,CNC:7,FWL:6,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:4,CFM:10,FS:4,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:5,CNC:7,FWL:6,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:4,DC:4</availability>
 			</model>
@@ -4764,8 +4671,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:5</availability>
@@ -4780,8 +4686,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:3-</availability>
 			</model>
@@ -4993,8 +4898,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:5-,CLAN:2-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:3-,CC:5-,CLAN:2-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -5022,8 +4926,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:3-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:3-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:3-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:3-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5042,8 +4945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:1,TC:1,CSA:2,CW:4,LA:1,CNC:2,FWL:1,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:1,TC:1,CSA:2,CW:4,LA:1,CNC:2,FWL:1,CSJ:5,CJF:2,DC:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -5220,8 +5122,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>5,5</pctClan>
 			<pctSL>85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -41,8 +40,7 @@
 			<pctSL>100,100,100,70,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
 			<weightDistribution era='2855' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2855' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -52,8 +50,7 @@
 			<pctSL>100,100,85,70,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,20,25</pctOmni>
@@ -61,8 +58,7 @@
 			<pctSL>90,90,85,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,25,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,75</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
 			<weightDistribution era='2855' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2855' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -72,8 +68,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -91,8 +86,7 @@
 			<pctSL>100,100,85,80,70</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -100,8 +94,7 @@
 			<pctSL>100,100,85,70,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,20,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,75</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -109,8 +102,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
 			<weightDistribution era='2855' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2855' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -120,8 +112,7 @@
 			<pctSL>100,100,80,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -129,8 +120,7 @@
 			<pctSL>100,100,90,70,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -138,8 +128,7 @@
 			<pctSL>100,100,95,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,15,20</pctOmni>
@@ -147,8 +136,7 @@
 			<pctSL>100,100,80,70,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='12'>
-				CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
+			<salvage pct='12'>CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,10,20</pctOmni>
@@ -156,8 +144,7 @@
 			<pctSL>100,100,90,55,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -165,8 +152,7 @@
 			<pctSL>100,100,80,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -174,8 +160,7 @@
 			<pctSL>100,100,80,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
+			<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
 			<weightDistribution era='2855' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2855' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -185,8 +170,7 @@
 			<pctSL>100,100,75,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,15,20</pctOmni>
@@ -194,8 +178,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
+			<salvage pct='10'>CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -374,8 +357,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -383,8 +365,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -392,8 +373,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -401,8 +381,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -410,8 +389,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -419,8 +397,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -428,8 +405,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,5,10</pctOmni>
@@ -437,8 +413,7 @@
 			<pctSL>100,100,90,65,55</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:6,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:6,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='6'></salvage>
@@ -548,24 +523,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CC:1,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:1,CGS:3,CSA:3,CDS:3,LA:1,CBS:3,CNC:5,FWL:1,CJF:5,DC:1,CB:3</availability>
+			<availability>CC:1,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:1,CGS:3,CSA:3,CDS:3,LA:1,CBS:3,CNC:5,FWL:1,CJF:5,DC:1,CB:3</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -589,8 +561,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -637,8 +608,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -773,8 +743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -815,8 +784,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -840,8 +808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -920,8 +887,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 			</model>
@@ -977,8 +943,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1042,8 +1007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:2</availability>
@@ -1078,8 +1042,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1147,8 +1110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1505,8 +1467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1524,8 +1485,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:4,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:4,CGS:8,CS:8,CDS:8,CW:10,LA:4,CBS:10,FWL:4,NIOPS:8,CJF:8,CGB:10,DC:4</availability>
+			<availability>CC:4,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:4,CGS:8,CS:8,CDS:8,CW:10,LA:4,CBS:10,FWL:4,NIOPS:8,CJF:8,CGB:10,DC:4</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -1635,8 +1595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1730,8 +1689,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:2,FS:4</availability>
@@ -1967,8 +1925,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:7</availability>
 			</model>
@@ -2110,8 +2067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2140,8 +2096,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2181,8 +2136,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
 			<model name='GTHA-100'>
 				<availability>General:4,CLAN:2</availability>
 			</model>
@@ -2190,8 +2144,7 @@
 				<availability>CLAN:2,FWL:4,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2216,8 +2169,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 			</model>
@@ -2311,8 +2263,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2431,8 +2382,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
+			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2518,8 +2468,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2545,8 +2494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2622,8 +2570,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2645,8 +2592,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:2,CLAN:5,IS:3,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
+			<availability>CC:3,MOC:2,CLAN:5,IS:3,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:4,CNC:4</availability>
 			</model>
@@ -2704,8 +2650,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2739,8 +2684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2936,8 +2880,7 @@
 			<availability>CS:1-,IS:4,NIOPS:1-,Periphery.Deep:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
+			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
@@ -2970,8 +2913,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3081,8 +3023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -3103,8 +3044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3121,8 +3061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3213,8 +3152,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3257,8 +3195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3292,8 +3229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3396,8 +3332,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3546,8 +3481,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:4+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:3+,NIOPS:6,CMG:9,CJF:7,CGB:5,DC:3+</availability>
+			<availability>MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:4+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:3+,NIOPS:6,CMG:9,CJF:7,CGB:5,DC:3+</availability>
 			<model name='C'>
 				<availability>CIH:4,CMG:8,CJF:4,CGB:4</availability>
 			</model>
@@ -3718,8 +3652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3764,8 +3697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:8</availability>
@@ -3789,16 +3721,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:4,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3828,8 +3758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -3845,8 +3774,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3863,8 +3791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3983,8 +3910,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -4055,8 +3981,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:4,FWL:4,NIOPS:8,CJF:8,DC:4</availability>
+			<availability>MOC:2,CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:4,FWL:4,NIOPS:8,CJF:8,DC:4</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:5,NIOPS:8</availability>
 			</model>
@@ -4071,8 +3996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4100,8 +4024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4123,8 +4046,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4149,8 +4071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:5-,General:8,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -4233,8 +4154,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4270,8 +4190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4297,8 +4216,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -4324,8 +4242,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CC:1-,CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -4343,8 +4260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+			<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4437,8 +4353,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4511,8 +4426,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4553,8 +4467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4606,8 +4519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4622,8 +4534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+			<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4649,8 +4560,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4740,8 +4650,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor Artillery Vehicle' unitType='Tank'>
-			<availability>
-				CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
+			<availability>CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
 			<model name=''>
 				<roles>artillery</roles>
 				<availability>CS:8,General:8,NIOPS:8,BAN:4</availability>
@@ -4774,8 +4683,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:4,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:4,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:5,DC:5</availability>
 			</model>
@@ -4809,8 +4717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -4825,8 +4732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:2-</availability>
 			</model>
@@ -5019,8 +4925,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -5048,8 +4953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5068,8 +4972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:1,TC:1,CSA:2,CW:4,LA:1,CNC:2,FWL:1,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:1,TC:1,CSA:2,CW:4,LA:1,CNC:2,FWL:1,CSJ:5,CJF:2,DC:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -5246,8 +5149,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -523,21 +523,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>CLAN:4,IS:3,BAN:5,Periphery:2,CS:6,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CC:1,CCC:3,CSR:5,CIH:3,CSV:3,CLAN:3,FS:1,CGS:3,CSA:3,CDS:3,LA:1,CBS:3,CNC:5,FWL:1,CJF:5,DC:1,CB:3</availability>
+			<availability>CC:1,CSR:5,CLAN:3,FS:1,LA:1,CNC:5,FWL:1,CJF:5,DC:1,CB:3</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -552,7 +552,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ahab' unitType='AeroSpaceFighter'>
-			<availability>CC:3+,CS:7,LA:3+,CLAN:6,FWL:4+,IS:3+,NIOPS:7,FS:3+,DC:3+</availability>
+			<availability>CS:7,CLAN:6,FWL:4+,IS:3+,NIOPS:7</availability>
 			<model name='AHB-443'>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -561,7 +561,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,LA:1+,FWL:1+,NIOPS:7,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -608,7 +608,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+			<availability>CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -659,7 +659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -743,7 +743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -777,14 +777,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
+			<availability>MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CLAN:3-,IS:7,Periphery.Deep:6,CIR:8,TC:8,Periphery:6,CS:8,OA:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -808,7 +808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>Periphery.Deep:10-,FS:5-,MERC:7-,Periphery:10-,CS:2-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -830,7 +830,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -895,7 +895,7 @@
 				<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -955,7 +955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:3,CHH:8,CLAN:5,FS:3,MERC:3,CS:7,CDS:5,LA:3,CNC:5,FWL:3,NIOPS:7,CJF:5,DC:3</availability>
+			<availability>CC:3,CHH:8,CLAN:5,FS:3,MERC:3,CS:7,LA:3,FWL:3,NIOPS:7,DC:3</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -990,7 +990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -1007,7 +1007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:2,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:2</availability>
@@ -1064,7 +1064,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
-			<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
+			<availability>CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -1077,7 +1077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
+			<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1131,9 +1131,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
+			<availability>CC:3,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,Periphery:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+				<availability>IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:7,CGS:6,BAN:4</availability>
@@ -1368,7 +1368,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1387,7 +1387,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
+			<availability>MOC:1,CLAN:2,IS:2,BAN:3,TC:2,CS:6,OA:1,NIOPS:6</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -1404,7 +1404,7 @@
 			</model>
 		</chassis>
 		<chassis name='Congress Frigate' unitType='Warship'>
-			<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:5,CGS:2,CJF:2</availability>
+			<availability>CS:2,CW:2,CLAN:1,NIOPS:2,CSJ:5,CGS:2,CJF:2</availability>
 			<model name='(2542)'>
 				<roles>frigate</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -1437,7 +1437,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -1467,7 +1467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1618,7 +1618,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demon Tank' unitType='Tank'>
-			<availability>CC:1+,CS:8,LA:1+,CLAN:9,FWL:1+,NIOPS:8,FS:1+,MERC:1+,CJF:9,DC:1+</availability>
+			<availability>CC:1+,CS:8,LA:1+,CLAN:9,FWL:1+,NIOPS:8,FS:1+,MERC:1+,DC:1+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1630,7 +1630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:5,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5,DC:5</availability>
+			<availability>CC:4,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1705,7 +1705,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:3,CC:4,CS:7,OA:4,CLAN:2,CNC:2,FWL:5,NIOPS:7,FS:4,MERC:4,TC:4</availability>
+			<availability>MOC:3,CC:4,CS:7,OA:4,CLAN:2,FWL:5,NIOPS:7,FS:4,MERC:4,TC:4</availability>
 			<model name='EMP-5A'>
 				<availability>General:8,BAN:2</availability>
 			</model>
@@ -1752,14 +1752,14 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CIH:2,CSR:2,CSV:2,CLAN:2,CGS:2,CCO:2,CSA:2,CDS:3,LA:1,CSJ:4,CGB:3,DC:1,CB:2</availability>
+			<availability>CLAN:2,CDS:3,LA:1,CSJ:4,CGB:3,DC:1,CB:2</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>CLAN:8,IS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,CIR:2,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1927,7 +1927,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:7</availability>
+				<availability>LA:7</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2067,7 +2067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2096,14 +2096,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,CBS:3,CLAN:2,CNC:2,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,CBS:3,CLAN:2,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2136,7 +2136,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>MOC:2,CLAN:7,IS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,Periphery.MW:1,Periphery.ME:1,FWL:4,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:4,CLAN:2</availability>
 			</model>
@@ -2144,14 +2144,14 @@
 				<availability>CLAN:2,FWL:4,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+				<availability>CS:6,CLAN:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,IS:6,NIOPS:4-,Periphery.Deep:6,MERC:7,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,IS:6,NIOPS:4-,Periphery.Deep:6,MERC:7,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2169,7 +2169,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 			</model>
@@ -2248,7 +2248,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
+			<availability>MOC:2,CLAN:6,IS:3,CIR:2,TC:2,CS:7,OA:2,CNC:6,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2263,7 +2263,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:7,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2366,7 +2366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
+			<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,CNC:4,NIOPS:6</availability>
 			<model name='HCT-212'>
 				<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -2382,7 +2382,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
+			<availability>CC:2-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2425,11 +2425,11 @@
 			<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2447,7 +2447,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:2,CFM:10,MERC:2,FS:2,CJF:10,DC:2</availability>
+			<availability>CS:9,CLAN:9,NIOPS:9,IS:2,CFM:10,MERC:2,CJF:10</availability>
 			<model name='HGN-732'>
 				<availability>CC:4+,MOC:3+,CS:8,LA:4+,CLAN:6,FWL:4+,IS:3+,NIOPS:8,FS:4+,MERC:3+,BAN:8,DC:4+</availability>
 			</model>
@@ -2494,7 +2494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2570,7 +2570,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2592,7 +2592,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,CLAN:5,IS:3,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
+			<availability>MOC:2,CLAN:5,IS:3,FWL.OH:5,CIR:1,TC:2,CS:6,OA:2,FWL:4,NIOPS:6</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:4,CNC:4</availability>
 			</model>
@@ -2650,7 +2650,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2684,7 +2684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2777,7 +2777,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -2794,7 +2794,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:2,NIOPS:7,FS:6,MERC:2,DC:2</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:4</availability>
+				<availability>FS:4</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -2857,7 +2857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:6,CW:6,CSV:6,CLAN:6,CNC:6,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CLAN:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -2880,7 +2880,7 @@
 			<availability>CS:1-,IS:4,NIOPS:1-,Periphery.Deep:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
+			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:4</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
@@ -2913,7 +2913,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>CC:6,CLAN:1,IS:7,Periphery.Deep:7,FS:6,BAN:5,Periphery:7,CS:4,LA:6,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2955,7 +2955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:4,IS:2,FS:3,Periphery:2,CS:5-,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:1</availability>
 			</model>
@@ -3023,7 +3023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -3044,7 +3044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3061,7 +3061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3152,7 +3152,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3195,7 +3195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,Periphery.MW:2,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3229,7 +3229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3332,7 +3332,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3652,7 +3652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3697,7 +3697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:8</availability>
@@ -3721,14 +3721,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,BAN:4,Periphery:4,CS:7,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:4,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3774,7 +3774,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3791,7 +3791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,LA:9,IS:8,FWL:10,Periphery.Deep:8,CIR:8,Periphery:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3820,7 +3820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CCC:3,CIH:3,CSR:3,CDS:3,CSV:4,CLAN:3,CFM:3,CGS:3,CCO:3,CB:2</availability>
+			<availability>CSV:4,CLAN:3,CB:2</availability>
 			<model name=''>
 				<availability>CCC:8,CIH:8,CSR:8,CDS:8,CSV:8,CLAN:8,CNC:8,CFM:8,CCO:8</availability>
 			</model>
@@ -3981,7 +3981,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:4,FWL:4,NIOPS:8,CJF:8,DC:4</availability>
+			<availability>CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,CS:8,LA:4,FWL:4,NIOPS:8,DC:4</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:5,NIOPS:8</availability>
 			</model>
@@ -3996,7 +3996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4024,7 +4024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4071,7 +4071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,Clan.IS:3,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:5-,General:8,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -4154,7 +4154,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4179,7 +4179,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:3,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:4,TC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:3,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:4,Periphery:4,DC:4</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -4190,7 +4190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4284,7 +4284,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -4353,7 +4353,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4364,7 +4364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -4400,7 +4400,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:3,CSV:2,CLAN:2,CFM:2,CGS:2,CCO:3,CSA:3,CS:1,CDS:2,CW:2,NIOPS:1,CSJ:2,CJF:2</availability>
+			<availability>CSR:3,CLAN:2,CCO:3,CSA:3,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -4453,7 +4453,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4467,7 +4467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4519,7 +4519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4534,7 +4534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+			<availability>CC:4,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,CS:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4560,7 +4560,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4676,14 +4676,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:4,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:4,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:5,DC:5</availability>
 			</model>
@@ -4717,7 +4717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:4,IS:5,Periphery.Deep:5,FS:6,TC:6,Periphery:5,CS:5-,LA:8,FWL:5,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -4732,7 +4732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:2-</availability>
 			</model>
@@ -4746,7 +4746,7 @@
 				<availability>CC:2</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>CC:8,LA:8,General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+				<availability>General:8,CLAN:1-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:2</availability>
@@ -4779,7 +4779,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -4868,7 +4868,7 @@
 			<availability>IS:2,DC:2</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Union C' unitType='Dropship'>
@@ -4925,7 +4925,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:1-,IS:4-,CIR:3-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4946,14 +4946,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:3,MOC:1,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1,TC:1</availability>
+			<availability>CC:3,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4972,7 +4972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CCC:1,CSR:3,CSV:2,CLAN:2,CFM:2,FS:1,TC:1,CSA:2,CW:4,LA:1,CNC:2,FWL:1,CSJ:5,CJF:2,DC:1,CB:2</availability>
+			<availability>CCC:1,CSR:3,CLAN:2,FS:1,TC:1,CW:4,LA:1,FWL:1,CSJ:5,DC:1</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8,TC:8</availability>
@@ -4997,7 +4997,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -5070,7 +5070,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
 			</model>
@@ -5109,7 +5109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:1-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5163,7 +5163,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+			<availability>CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>5,5</pctClan>
 			<pctSL>85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -41,8 +40,7 @@
 			<pctSL>100,100,100,65,30</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
 			<weightDistribution era='2860' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2860' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -52,8 +50,7 @@
 			<pctSL>100,100,85,65,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,30,40</pctOmni>
@@ -61,8 +58,7 @@
 			<pctSL>90,90,85,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,25,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,75</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
 			<weightDistribution era='2860' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2860' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -72,8 +68,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,15,25</pctOmni>
@@ -91,8 +86,7 @@
 			<pctSL>100,100,80,75,65</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,15,20</pctOmni>
@@ -100,8 +94,7 @@
 			<pctSL>100,100,80,65,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,20,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,10,25</pctOmni>
@@ -109,8 +102,7 @@
 			<pctSL>100,100,85,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
 			<weightDistribution era='2860' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2860' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -120,8 +112,7 @@
 			<pctSL>100,100,75,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG' />
 		<faction key='CNC'>
@@ -130,8 +121,7 @@
 			<pctSL>100,100,90,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,30,35</pctOmni>
@@ -139,8 +129,7 @@
 			<pctSL>100,100,80,60,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='12'>
-				CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
+			<salvage pct='12'>CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,20,30</pctOmni>
@@ -148,8 +137,7 @@
 			<pctSL>100,100,85,50,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,5,10,30</pctOmni>
@@ -157,8 +145,7 @@
 			<pctSL>100,100,75,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,10,20</pctOmni>
@@ -166,8 +153,7 @@
 			<pctSL>100,100,75,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
+			<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
 			<weightDistribution era='2860' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2860' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -177,8 +163,7 @@
 			<pctSL>95,95,70,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,20,30</pctOmni>
@@ -186,8 +171,7 @@
 			<pctSL>95,95,85,60,50</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
+			<salvage pct='10'>CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -366,8 +350,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,10,25</pctOmni>
@@ -375,8 +358,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,5,25</pctOmni>
@@ -384,8 +366,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,10,25</pctOmni>
@@ -393,8 +374,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,10,20</pctOmni>
@@ -402,8 +382,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,10,25</pctOmni>
@@ -411,8 +390,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,10,25</pctOmni>
@@ -420,8 +398,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,10,25</pctOmni>
@@ -429,8 +406,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:8,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:8,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='6'></salvage>
@@ -541,16 +517,14 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -581,8 +555,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -629,8 +602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -765,8 +737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -800,8 +771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -825,8 +795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -898,8 +867,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 			</model>
@@ -949,8 +917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1008,8 +975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:2</availability>
@@ -1044,8 +1010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1113,8 +1078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:5,FS:2,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1456,8 +1420,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1475,8 +1438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:3,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:3,CGS:8,CS:8,CDS:8,CW:10,LA:3,CBS:10,FWL:3,NIOPS:8,CJF:8,CGB:10,DC:3</availability>
+			<availability>CC:3,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:3,CGS:8,CS:8,CDS:8,CW:10,LA:3,CBS:10,FWL:3,NIOPS:8,CJF:8,CGB:10,DC:3</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -1557,8 +1519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1645,8 +1606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:2,FS:4</availability>
@@ -1886,8 +1846,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:7</availability>
 			</model>
@@ -2029,8 +1988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2059,8 +2017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2109,8 +2066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
 			<model name='GTHA-100'>
 				<availability>General:3,CLAN:2</availability>
 			</model>
@@ -2118,8 +2074,7 @@
 				<availability>CLAN:2,FWL:4,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2144,8 +2099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 			</model>
@@ -2239,8 +2193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2359,8 +2312,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
+			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2446,8 +2398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2473,8 +2424,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2553,8 +2503,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2576,8 +2525,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2,MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
+			<availability>CC:2,MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:4,CNC:4</availability>
 			</model>
@@ -2635,8 +2583,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2670,8 +2617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2867,8 +2813,7 @@
 			<availability>CS:1-,IS:4,NIOPS:1-,Periphery.Deep:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
+			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
@@ -2890,8 +2835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3001,8 +2945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -3023,8 +2966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3041,8 +2983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3126,8 +3067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3170,8 +3110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3205,8 +3144,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3309,8 +3247,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3459,8 +3396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:3+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:2+,NIOPS:6,CMG:10,CJF:7,CGB:5,DC:2+</availability>
+			<availability>MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:3+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:2+,NIOPS:6,CMG:10,CJF:7,CGB:5,DC:2+</availability>
 			<model name='C'>
 				<availability>CIH:4,CMG:8,CJF:4,CGB:4</availability>
 			</model>
@@ -3626,8 +3562,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3672,8 +3607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:6</availability>
@@ -3697,16 +3631,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:3,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3736,8 +3668,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -3753,8 +3684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3771,8 +3701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3884,8 +3813,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3960,8 +3888,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:4,FWL:4,NIOPS:8,CJF:8,DC:4</availability>
+			<availability>MOC:2,CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:4,FWL:4,NIOPS:8,CJF:8,DC:4</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:5,NIOPS:8</availability>
 			</model>
@@ -3976,8 +3903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4005,8 +3931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4028,8 +3953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4054,8 +3978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -4127,8 +4050,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4154,8 +4076,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4181,8 +4102,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -4208,8 +4128,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -4227,8 +4146,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+			<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4321,8 +4239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4389,8 +4306,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4434,8 +4350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4487,8 +4402,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4503,8 +4417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+			<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4536,8 +4449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4620,8 +4532,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor Artillery Vehicle' unitType='Tank'>
-			<availability>
-				CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
+			<availability>CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
 			<model name=''>
 				<roles>artillery</roles>
 				<availability>CS:8,General:8,NIOPS:8,BAN:4</availability>
@@ -4654,8 +4565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,DC:6</availability>
 			</model>
@@ -4689,8 +4599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -4705,8 +4614,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:2-</availability>
 			</model>
@@ -4899,8 +4807,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4928,8 +4835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5118,8 +5024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:5</availability>
 			</model>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -517,21 +517,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,OA:4,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>CLAN:4,IS:3,BAN:5,Periphery:2,CS:6,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+			<availability>CSR:5,CNC:5,CLAN:3,CJF:5</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -555,7 +555,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:6,CW:6,LA:1+,CNC:6,FWL:1+,NIOPS:7,CJF:6,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:6,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CW:6,LA:1+,FWL:1+,NIOPS:7,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -602,7 +602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:1</availability>
+			<availability>CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -653,7 +653,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -737,7 +737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -764,14 +764,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
+			<availability>MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,TC:8,Periphery:6,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CLAN:3-,IS:7,Periphery.Deep:6,CIR:8,TC:8,Periphery:6,CS:8,OA:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -795,7 +795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,Periphery:10-,TC:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>Periphery.Deep:10-,FS:5-,MERC:7-,Periphery:10-,CS:2-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -810,7 +810,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -875,7 +875,7 @@
 				<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -917,7 +917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -929,7 +929,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:2,CHH:8,CLAN:5,FS:2,MERC:2,CS:7,CDS:5,LA:2,CNC:5,FWL:2,NIOPS:7,CJF:5,DC:2</availability>
+			<availability>CC:2,CHH:8,CLAN:5,FS:2,MERC:2,CS:7,LA:2,FWL:2,NIOPS:7,DC:2</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -964,7 +964,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:5</availability>
@@ -975,7 +975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:2,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:2</availability>
@@ -1032,7 +1032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
-			<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
+			<availability>CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CMG:7,CJF:5,CGB:5,CB:7</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -1045,7 +1045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
+			<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1108,9 +1108,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:3,TC:2,Periphery:2,DC:3</availability>
+			<availability>CC:3,LA:6,CLAN:3,FWL:4,MERC:3,FS:3,Periphery:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+				<availability>LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:7,CGS:6,BAN:4</availability>
@@ -1277,7 +1277,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+			<availability>CC:6,MOC:3,CS:3-,OA:3,CLAN:2-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1327,7 +1327,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1346,7 +1346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
+			<availability>MOC:1,CLAN:2,IS:2,BAN:3,TC:2,CS:6,OA:1,NIOPS:6</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:5</availability>
@@ -1390,7 +1390,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:2,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -1420,7 +1420,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1542,7 +1542,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demon Tank' unitType='Tank'>
-			<availability>CC:1+,CS:8,LA:1+,CLAN:9,FWL:1+,NIOPS:8,FS:1+,MERC:1+,CJF:9,DC:1+</availability>
+			<availability>CC:1+,CS:8,LA:1+,CLAN:9,FWL:1+,NIOPS:8,FS:1+,MERC:1+,DC:1+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1554,7 +1554,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:5,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5,DC:5</availability>
+			<availability>CC:4,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1622,7 +1622,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:2,CC:3,CS:7,OA:3,CLAN:2,CNC:2,FWL:4,NIOPS:7,FS:3,MERC:3,TC:3</availability>
+			<availability>MOC:2,CC:3,CS:7,OA:3,CLAN:2,FWL:4,NIOPS:7,FS:3,MERC:3,TC:3</availability>
 			<model name='EMP-5A'>
 				<availability>General:8,BAN:2</availability>
 			</model>
@@ -1669,7 +1669,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
+			<availability>CDS:3,CLAN:2,CSJ:4,CGB:3</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>CLAN:6,IS:8</availability>
@@ -1680,7 +1680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1848,7 +1848,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:7</availability>
+				<availability>LA:7</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -1988,7 +1988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2017,21 +2017,21 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,CBS:3,CLAN:2,CNC:2,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,CBS:3,CLAN:2,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>CC:1,LA:3,FS.CH:7,FS:6,MERC:4,CIR:4,Periphery:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2066,7 +2066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>MOC:2,CLAN:7,IS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,Periphery.MW:1,Periphery.ME:1,FWL:4,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:3,CLAN:2</availability>
 			</model>
@@ -2074,20 +2074,20 @@
 				<availability>CLAN:2,FWL:4,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
+				<availability>CS:6,CLAN:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:5,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,IS:6,NIOPS:4-,Periphery.Deep:6,MERC:7,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,IS:6,NIOPS:4-,Periphery.Deep:6,MERC:7,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CHH:3,CSV:5,CLAN:3,CFM:5,CSJ:5,CMG:5,CCO:5,CB:5,CGB:3</availability>
+			<availability>CCC:5,CSV:5,CLAN:3,CFM:5,CSJ:5,CMG:5,CCO:5,CB:5</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -2099,7 +2099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
 			</model>
@@ -2118,7 +2118,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
+			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8,DC:3+</availability>
@@ -2178,7 +2178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,CLAN:6,IS:3,FS:3,CIR:2,TC:2,CS:7,OA:2,LA:3,CNC:6,FWL:3,NIOPS:7,DC:3</availability>
+			<availability>MOC:2,CLAN:6,IS:3,CIR:2,TC:2,CS:7,OA:2,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2193,7 +2193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:7,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2296,7 +2296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:2,TC:2+,CS:6,OA:2+,LA:2,CNC:4,FWL:2,NIOPS:6,DC:2</availability>
+			<availability>CC:1,MOC:2+,CLAN:4,IS:2,TC:2+,CS:6,OA:2+,NIOPS:6</availability>
 			<model name='HCT-212'>
 				<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -2312,7 +2312,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-,TC:3-</availability>
+			<availability>CC:2-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,DC:3-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2355,11 +2355,11 @@
 			<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2424,7 +2424,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,TC:5,Periphery:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2503,7 +2503,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2525,7 +2525,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,CNC:5,FWL:4,NIOPS:6,DC:3</availability>
+			<availability>MOC:2,CLAN:5,IS:2,FWL.OH:5,FS:3,CIR:1,TC:2,CS:6,OA:2,LA:3,FWL:4,NIOPS:6,DC:3</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:4,CNC:4</availability>
 			</model>
@@ -2583,7 +2583,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2617,7 +2617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2710,7 +2710,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -2727,7 +2727,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:2,NIOPS:7,FS:6,MERC:2,DC:2</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:5</availability>
+				<availability>FS:5</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -2790,7 +2790,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:6,CW:6,CSV:6,CLAN:6,CNC:6,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CLAN:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -2813,7 +2813,7 @@
 			<availability>CS:1-,IS:4,NIOPS:1-,Periphery.Deep:4,Periphery:4</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
+			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:4</availability>
 			<model name='LNC25-01'>
 				<roles>anti_aircraft</roles>
 				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
@@ -2835,7 +2835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>CC:6,CLAN:1,IS:7,Periphery.Deep:7,FS:6,BAN:5,Periphery:7,CS:4,LA:6,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2877,7 +2877,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,CLAN:4,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:4,IS:2,FS:3,Periphery:2,CS:5-,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:1</availability>
 			</model>
@@ -2945,7 +2945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -2966,7 +2966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2983,7 +2983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,DC:6,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3067,7 +3067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3110,7 +3110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3144,7 +3144,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>CC:6,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3247,7 +3247,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,TC:6,Periphery:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3562,7 +3562,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3587,7 +3587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
@@ -3607,7 +3607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:6</availability>
@@ -3631,21 +3631,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,BAN:4,Periphery:4,CS:7,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:3,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:4,PIR:4,General:4,FWL:4,IS:4,Periphery.Deep:6,FS:4,MERC:4,DC:4,Periphery:6</availability>
+				<availability>PIR:4,General:4,IS:4,Periphery.Deep:6,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -3684,7 +3684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3701,7 +3701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,LA:9,IS:8,FWL:10,Periphery.Deep:8,Periphery:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3757,7 +3757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+			<availability>CS:7,CLAN:3,IS:9,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -3888,7 +3888,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:4,FWL:4,NIOPS:8,CJF:8,DC:4</availability>
+			<availability>CC:4,CLAN:8,MERC:3,FS:4,CIR:3,Periphery:2,CS:8,LA:4,FWL:4,NIOPS:8,DC:4</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:5,NIOPS:8</availability>
 			</model>
@@ -3903,7 +3903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3931,7 +3931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -3978,7 +3978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,Clan.IS:3,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
@@ -3988,7 +3988,7 @@
 			<availability>CLAN:1</availability>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>
-			<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
+			<availability>CC:1+,CS:5,CHH:5,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8,CLAN:4,BAN:7</availability>
@@ -4050,7 +4050,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4065,7 +4065,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:2,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,FS:3,TC:3,Periphery:3,DC:4</availability>
+			<availability>CC:2,OA:5,LA:2,CLAN:1,IS:3,FWL:2,MERC:3,Periphery:3,DC:4</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -4076,7 +4076,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4170,7 +4170,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -4239,7 +4239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4250,7 +4250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -4286,7 +4286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:3,CSV:2,CLAN:2,CFM:2,CGS:2,CCO:3,CSA:3,CS:1,CDS:2,CW:2,NIOPS:1,CSJ:2,CJF:2</availability>
+			<availability>CSR:3,CLAN:2,CCO:3,CSA:3,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -4306,7 +4306,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4336,7 +4336,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4350,7 +4350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4402,7 +4402,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4417,7 +4417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+			<availability>CC:4,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,CS:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4449,7 +4449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,TC:2,Periphery:1,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4558,14 +4558,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,TC:2+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,DC:6</availability>
 			</model>
@@ -4599,7 +4599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,TC:6,Periphery:5,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:4,IS:5,Periphery.Deep:5,FS:6,TC:6,Periphery:5,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -4614,7 +4614,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:2-</availability>
 			</model>
@@ -4658,7 +4658,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,CW:7,LA:2,FWL:4,NIOPS:9,DC:1</availability>
+			<availability>CC:3,MOC:2,CLAN:7,FS:2,MERC:2,CIR:1,TC:2,CS:9,OA:2,LA:2,FWL:4,NIOPS:9,DC:1</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -4750,7 +4750,7 @@
 			<availability>IS:2,DC:2</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Union C' unitType='Dropship'>
@@ -4807,7 +4807,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4835,7 +4835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4847,7 +4847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CSA:2,CCC:1,CSR:3,CW:4,CSV:2,CNC:2,CLAN:2,CFM:2,CSJ:5,CJF:2,CB:2</availability>
+			<availability>CCC:1,CSR:3,CW:4,CLAN:2,CSJ:5</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8</availability>
@@ -4872,7 +4872,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -4939,7 +4939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
 			</model>
@@ -4978,7 +4978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:1-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5038,7 +5038,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:1-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>5,5</pctClan>
 			<pctSL>85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -43,8 +42,7 @@
 			<pctSL>100,100,100,60,20</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
 			<weightDistribution era='2865' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2865' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -54,8 +52,7 @@
 			<pctSL>100,100,85,60,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>0,0,0,40,50</pctOmni>
@@ -63,8 +60,7 @@
 			<pctSL>90,90,85,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,25,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,75</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
 			<weightDistribution era='2865' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2865' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -74,8 +70,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,0,25,40</pctOmni>
@@ -93,8 +88,7 @@
 			<pctSL>100,100,80,75,65</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,25,30</pctOmni>
@@ -102,8 +96,7 @@
 			<pctSL>100,100,80,65,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,25,35</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,65</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,20,40</pctOmni>
@@ -111,8 +104,7 @@
 			<pctSL>100,100,85,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
 			<weightDistribution era='2865' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2865' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -122,8 +114,7 @@
 			<pctSL>100,100,75,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG' />
 		<faction key='CNC'>
@@ -132,8 +123,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,40,45</pctOmni>
@@ -141,8 +131,7 @@
 			<pctSL>100,100,80,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='12'>
-				CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
+			<salvage pct='12'>CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,0,25,40</pctOmni>
@@ -150,8 +139,7 @@
 			<pctSL>100,100,85,45,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
+			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>0,0,10,20,40</pctOmni>
@@ -159,8 +147,7 @@
 			<pctSL>90,90,75,45,35</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,0,25,35</pctOmni>
@@ -168,8 +155,7 @@
 			<pctSL>100,100,75,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
+			<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
 			<weightDistribution era='2865' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2865' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -179,8 +165,7 @@
 			<pctSL>90,90,65,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,30,40</pctOmni>
@@ -188,8 +173,7 @@
 			<pctSL>95,95,85,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
+			<salvage pct='10'>CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -368,8 +352,7 @@
 			<pctSL>100,100,90,50,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,20,40</pctOmni>
@@ -377,8 +360,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,10,40</pctOmni>
@@ -386,8 +368,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,20,40</pctOmni>
@@ -395,8 +376,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,15,35</pctOmni>
@@ -404,8 +384,7 @@
 			<pctSL>100,100,90,50,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,15,40</pctOmni>
@@ -413,8 +392,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,15,40</pctOmni>
@@ -422,8 +400,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,15,40</pctOmni>
@@ -431,8 +408,7 @@
 			<pctSL>100,100,90,55,45</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:10,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:10,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CMG:1,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='6'></salvage>
@@ -545,16 +521,14 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -585,8 +559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -761,8 +734,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -796,8 +768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:6,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:6,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -821,8 +792,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -894,8 +864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 			</model>
@@ -945,8 +914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -958,8 +926,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>
-				CC:2+,CHH:8,CLAN:4,FS:2+,MERC:2+,CS:7,CDS:4,LA:2+,CNC:4,FWL:2+,NIOPS:7,CJF:4,DC:2+</availability>
+			<availability>CC:2+,CHH:8,CLAN:4,FS:2+,MERC:2+,CS:7,CDS:4,LA:2+,CNC:4,FWL:2+,NIOPS:7,CJF:4,DC:2+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1005,8 +972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:1</availability>
@@ -1041,8 +1007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1116,8 +1081,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1459,8 +1423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1478,8 +1441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:2,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:2,CGS:8,CS:8,CDS:8,CW:10,LA:2,CBS:10,FWL:2,NIOPS:8,CJF:8,CGB:10,DC:2</availability>
+			<availability>CC:2,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:2,CGS:8,CS:8,CDS:8,CW:10,LA:2,CBS:10,FWL:2,NIOPS:8,CJF:8,CGB:10,DC:2</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -1560,8 +1522,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1648,8 +1609,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:2,FS:4</availability>
@@ -1901,8 +1861,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:7</availability>
 			</model>
@@ -2044,8 +2003,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2074,8 +2032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2124,8 +2081,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
+			<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
 			<model name='GTHA-100'>
 				<availability>General:3,CLAN:2</availability>
 			</model>
@@ -2133,8 +2089,7 @@
 				<availability>CLAN:2,FWL:3,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2159,8 +2114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 			</model>
@@ -2254,8 +2208,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2374,8 +2327,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:3-</availability>
+			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2470,8 +2422,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2497,8 +2448,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2577,8 +2527,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2600,8 +2549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:1,MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,CNC:5,FWL:3,NIOPS:6,DC:2</availability>
+			<availability>CC:1,MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,CNC:5,FWL:3,NIOPS:6,DC:2</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:3,CNC:3</availability>
 			</model>
@@ -2659,8 +2607,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2698,8 +2645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2895,8 +2841,7 @@
 			<availability>CS:1-,IS:3,NIOPS:1-,Periphery:3</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
+			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
 			<model name='C'>
 				<availability>CIH:2,CFM:2,CFM.SmJ:6,CB:4,CGB:2</availability>
 			</model>
@@ -2924,8 +2869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3028,8 +2972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:2</availability>
@@ -3050,8 +2993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3068,8 +3010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3153,8 +3094,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3197,8 +3137,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3232,8 +3171,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3336,8 +3274,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3486,8 +3423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:5,CLAN:6,MERC:4,FS:2,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:2,NIOPS:6,CMG:10,CJF:7,CGB:5,DC:2</availability>
+			<availability>MOC:1,CHH:5,CLAN:6,MERC:4,FS:2,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:2,NIOPS:6,CMG:10,CJF:7,CGB:5,DC:2</availability>
 			<model name='C'>
 				<availability>CIH:4,CMG:8,CJF:4,CGB:4</availability>
 			</model>
@@ -3657,8 +3593,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3703,8 +3638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:6</availability>
@@ -3728,16 +3662,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:2,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3767,8 +3699,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -3784,8 +3715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3802,8 +3732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3915,8 +3844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:8</availability>
@@ -3991,8 +3919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,CLAN:8,MERC:3,FS:2,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:2,FWL:2,NIOPS:8,CJF:8,DC:2</availability>
+			<availability>MOC:2,CC:2,CLAN:8,MERC:3,FS:2,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:2,FWL:2,NIOPS:8,CJF:8,DC:2</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:4,NIOPS:8</availability>
 			</model>
@@ -4007,8 +3934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4036,8 +3962,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4059,8 +3984,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4085,8 +4009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:4-,General:8,Periphery.Deep:8,BAN:5,Periphery:8</availability>
@@ -4158,8 +4081,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4185,8 +4107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4212,8 +4133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -4254,8 +4174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -4273,8 +4192,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+			<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4367,8 +4285,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4435,8 +4352,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-H5'>
 				<roles>interceptor</roles>
 				<availability>General:8,Periphery.Deep:8,FS:8,MERC:8,DC:8,TC:8</availability>
@@ -4480,8 +4396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4526,8 +4441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4542,8 +4456,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+			<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4575,8 +4488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4659,8 +4571,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor Artillery Vehicle' unitType='Tank'>
-			<availability>
-				CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
+			<availability>CC:2+,MOC:1+,CLAN:5,FS:2+,MERC:2+,BAN:5,TC:1+,CS:3,OA:1+,LA:2+,FWL:2+,NIOPS:3,DC:2+</availability>
 			<model name=''>
 				<roles>artillery</roles>
 				<availability>CS:8,General:8,NIOPS:8,BAN:4</availability>
@@ -4693,8 +4604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,DC:6</availability>
 			</model>
@@ -4728,8 +4638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -4744,8 +4653,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:7,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:2-</availability>
 			</model>
@@ -4938,8 +4846,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4967,8 +4874,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5160,8 +5066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:4</availability>
 			</model>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -521,21 +521,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>CLAN:4,IS:3,BAN:5,Periphery:2,CS:6,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+			<availability>CSR:5,CNC:5,CLAN:3,CJF:5</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -559,7 +559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,LA:1+,FWL:1+,NIOPS:7,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -606,7 +606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,IS:7,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
+			<availability>CS:5-,LA:9,IS:7,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -657,7 +657,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -734,7 +734,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,FWL:3,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -761,14 +761,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
+			<availability>MOC:3,OA:3,LA:4,FWL:2,IS:3,FS:4,CIR:3,DC:2,Periphery:2,TC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,CLAN:3-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:6,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CLAN:3-,IS:7,Periphery.Deep:6,CIR:8,Periphery:6,TC:8,CS:8,OA:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -792,7 +792,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>Periphery.Deep:10-,FS:5-,MERC:7-,Periphery:10-,CS:2-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -807,7 +807,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -872,7 +872,7 @@
 				<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -926,7 +926,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:2+,CHH:8,CLAN:4,FS:2+,MERC:2+,CS:7,CDS:4,LA:2+,CNC:4,FWL:2+,NIOPS:7,CJF:4,DC:2+</availability>
+			<availability>CC:2+,CHH:8,CLAN:4,FS:2+,MERC:2+,CS:7,LA:2+,FWL:2+,NIOPS:7,DC:2+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -961,7 +961,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -972,7 +972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,MOC:1,CLAN:2,IS:3,FS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:2,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:1</availability>
@@ -1048,7 +1048,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
+			<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1111,9 +1111,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
+			<availability>CC:3,LA:6,CLAN:3,FWL:4,MERC:3,FS:2,Periphery:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+				<availability>LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:7,CGS:6,BAN:4</availability>
@@ -1280,7 +1280,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+			<availability>CC:6,MOC:3,CS:3-,OA:3,CLAN:2-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1330,7 +1330,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1349,7 +1349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:2,MOC:1,CLAN:2,IS:2,FS:2,BAN:3,TC:2,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:2</availability>
+			<availability>MOC:1,CLAN:2,IS:2,BAN:3,TC:2,CS:6,OA:1,NIOPS:6</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:4</availability>
@@ -1393,7 +1393,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,DC:2,Periphery:2,TC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -1423,7 +1423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1637,7 +1637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:1,CC:2,CS:7,OA:2,CLAN:2,CNC:2,FWL:3,NIOPS:7,FS:2,MERC:2,TC:2</availability>
+			<availability>MOC:1,CC:2,CS:7,OA:2,CLAN:2,FWL:3,NIOPS:7,FS:2,MERC:2,TC:2</availability>
 			<model name='EMP-5A'>
 				<availability>General:8,BAN:2</availability>
 			</model>
@@ -1684,7 +1684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
+			<availability>CDS:3,CLAN:2,CSJ:4,CGB:3</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>CLAN:4,IS:8</availability>
@@ -1695,7 +1695,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -1863,7 +1863,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:7</availability>
+				<availability>LA:7</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2003,7 +2003,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2032,21 +2032,21 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:6,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,CBS:3,CLAN:2,CNC:2,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,CBS:3,CLAN:2,IS:6,NIOPS:4,Periphery.Deep:6,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,LA:3,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>CC:1,LA:3,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2065,7 +2065,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:2,MOC:1,CS:2,OA:1,LA:4,Periphery.MW:2,FWL:5,MERC:2,TC:1,Periphery:2</availability>
+			<availability>CC:2,MOC:1,CS:2,OA:1,LA:4,FWL:5,MERC:2,TC:1,Periphery:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:8,LA:8,FWL:8,Periphery.Deep:8,IS:8,MERC:8,Periphery:8</availability>
@@ -2081,7 +2081,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:2,CLAN:7,IS:1,FS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,CDS:7,LA:1,Periphery.MW:1,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9,DC:1</availability>
+			<availability>MOC:2,CLAN:7,IS:1,CIR:1,MERC:1,TC:1,CS:9,OA:1,Periphery.MW:1,Periphery.ME:1,FWL:3,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:3,CLAN:2</availability>
 			</model>
@@ -2114,7 +2114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 			</model>
@@ -2133,7 +2133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
+			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8,DC:2+</availability>
@@ -2193,7 +2193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CC:2,CLAN:6,IS:2,FS:2,CIR:1,TC:1,CS:7,OA:1,LA:2,CNC:6,FWL:2,NIOPS:7,DC:2</availability>
+			<availability>MOC:1,CLAN:6,IS:2,CIR:1,TC:1,CS:7,OA:1,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2208,7 +2208,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:7,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2311,7 +2311,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
+			<availability>MOC:1+,CLAN:3,IS:1,TC:1+,CS:6,OA:1+,NIOPS:6</availability>
 			<model name='HCT-212'>
 				<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -2327,7 +2327,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:3-</availability>
+			<availability>CC:2-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,DC:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2370,11 +2370,11 @@
 			<availability>MOC:2,CC:1,CS:3,CHH:5,OA:2,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:1,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2392,7 +2392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:1,CFM:10,MERC:1,FS:1,CJF:10,DC:2</availability>
+			<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:1,CFM:10,MERC:1,CJF:10,DC:2</availability>
 			<model name='HGN-732'>
 				<availability>CC:2+,MOC:1+,CS:8,LA:2+,CLAN:6,FWL:2+,IS:1+,NIOPS:8,FS:2+,MERC:1+,BAN:8,DC:2+</availability>
 			</model>
@@ -2448,7 +2448,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2527,7 +2527,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2549,7 +2549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,CNC:5,FWL:3,NIOPS:6,DC:2</availability>
+			<availability>MOC:1,CLAN:5,IS:1,FWL.OH:4,FS:2,CIR:1,TC:1,CS:6,OA:2,LA:2,FWL:3,NIOPS:6,DC:2</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:3,CNC:3</availability>
 			</model>
@@ -2607,7 +2607,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2645,7 +2645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2738,7 +2738,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -2755,7 +2755,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:1,NIOPS:7,FS:6,MERC:1,DC:1</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -2818,7 +2818,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:6,CW:6,CSV:6,CLAN:6,CNC:6,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CLAN:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -2841,7 +2841,7 @@
 			<availability>CS:1-,IS:3,NIOPS:1-,Periphery:3</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,LA:3,NIOPS:6,DC:4</availability>
+			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:4</availability>
 			<model name='C'>
 				<availability>CIH:2,CFM:2,CFM.SmJ:6,CB:4,CGB:2</availability>
 			</model>
@@ -2869,7 +2869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>CC:6,CLAN:1,IS:7,Periphery.Deep:7,FS:6,BAN:5,Periphery:7,CS:4,LA:6,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -2911,7 +2911,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:2,CLAN:3,IS:2,FS:3,Periphery:2,TC:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:3,IS:2,FS:3,Periphery:2,CS:5-,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:1</availability>
 			</model>
@@ -2972,7 +2972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8,CLAN:2</availability>
@@ -2993,7 +2993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,MOC:7,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3010,7 +3010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,DC:6</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3094,7 +3094,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3109,7 +3109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
+			<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,MOC:2,CLAN:4,IS:1+,NIOPS:8,MERC:0,BAN:4,TC:2+</availability>
 			</model>
@@ -3137,7 +3137,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,Periphery.MW:2,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3171,7 +3171,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3274,7 +3274,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3593,7 +3593,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3618,7 +3618,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
@@ -3638,7 +3638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:6</availability>
@@ -3662,14 +3662,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,BAN:4,Periphery:4,CS:7,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,CLAN:2,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:7,Periphery:7</availability>
@@ -3715,7 +3715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3732,7 +3732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,LA:9,IS:8,FWL:10,Periphery.Deep:8,Periphery:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -3919,7 +3919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:2,CC:2,CLAN:8,MERC:3,FS:2,CIR:3,Periphery:2,TC:2,CS:8,OA:2,LA:2,FWL:2,NIOPS:8,CJF:8,DC:2</availability>
+			<availability>CC:2,CLAN:8,MERC:3,FS:2,CIR:3,Periphery:2,CS:8,LA:2,FWL:2,NIOPS:8,DC:2</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:4,NIOPS:8</availability>
 			</model>
@@ -3934,7 +3934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -3962,7 +3962,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4009,7 +4009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:3,CSV:3,CLAN:3,IS:8-,Periphery.Deep:5,CFM:3,FS:8-,CIR:3,CGS:3,Periphery:5,CSA:3,CS:6-,Clan.IS:3,FWL:8-,NIOPS:6-,CJF:3,CB:3</availability>
+			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,Clan.IS:3,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:4-,General:8,Periphery.Deep:8,BAN:5,Periphery:8</availability>
@@ -4019,7 +4019,7 @@
 			<availability>CLAN:1</availability>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>
-			<availability>CC:1+,CS:5,CHH:5,CSR:4,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
+			<availability>CC:1+,CS:5,CHH:5,LA:1+,CLAN:4,FWL:1+,NIOPS:5,FS:1+,CJF:3,DC:1+</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8,CLAN:4,BAN:6</availability>
@@ -4081,7 +4081,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4096,7 +4096,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,OA:5,LA:1,CLAN:1,IS:2,FWL:1,MERC:2,FS:2,Periphery:2,TC:2,DC:4</availability>
+			<availability>OA:5,LA:1,CLAN:1,IS:2,FWL:1,MERC:2,Periphery:2,DC:4</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -4107,7 +4107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:5,FS:5,MERC:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4216,7 +4216,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -4285,7 +4285,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4296,7 +4296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -4332,7 +4332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:3,CSV:2,CLAN:2,CFM:2,CGS:2,CCO:3,CSA:3,CS:1,CDS:2,CW:2,NIOPS:1,CSJ:2,CJF:2</availability>
+			<availability>CSR:3,CLAN:2,CCO:3,CSA:3,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:2</availability>
@@ -4396,7 +4396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4441,7 +4441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4456,7 +4456,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>CC:4,MOC:2,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,TC:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3,DC:1</availability>
+			<availability>CC:4,IS:1,FS:2,MERC:4,CIR:3,Periphery:2,CS:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4488,7 +4488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4597,14 +4597,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:3,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,TC:1+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,DC:6</availability>
 			</model>
@@ -4638,7 +4638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:4,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -4697,7 +4697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
+			<availability>CC:2,MOC:1,CS:9,OA:1,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -4760,7 +4760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
-			<availability>CC:3,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
+			<availability>CC:3,MOC:2,CS:7,OA:4,CLAN:5,FWL:1,NIOPS:7,FS:3,MERC:3,TC:2,DC:3</availability>
 			<model name='TRN-3T'>
 				<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
 			</model>
@@ -4789,7 +4789,7 @@
 			<availability>IS:1,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Union C' unitType='Dropship'>
@@ -4846,7 +4846,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,TC:3-,Periphery:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,FS.CMM:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -4867,14 +4867,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:3,MOC:1,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1,TC:1</availability>
+			<availability>CC:3,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:2-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -4914,7 +4914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8,CLAN:2</availability>
@@ -4981,7 +4981,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
 			</model>
@@ -5020,7 +5020,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:1-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5080,7 +5080,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:1-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>5,5</pctClan>
 			<pctSL>85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -35,8 +34,7 @@
 			<pctSL>100,100,100,90,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,10,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,90,80</pctSL>
-			<salvage pct='5'>
-				CHH:5,CCC:5,CSR:3,CIH:10,CSV:10,CFM:10,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:10,CB:10</salvage>
+			<salvage pct='5'>CHH:5,CCC:5,CSR:3,CIH:10,CSV:10,CFM:10,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:10,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -44,8 +42,7 @@
 			<pctSL>100,100,100,60,20</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
 			<weightDistribution era='2870' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2870' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -55,8 +52,7 @@
 			<pctSL>100,100,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>4,4,5,50,60</pctOmni>
@@ -75,8 +71,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:10,CSR:10,CIH:10,CSV:4,CCO:5,CGS:5,CSA:10,CDS:5,CW:5,CBS:5,CNC:10,CSJ:10,CJF:10,CGB:1,CB:5</salvage>
+			<salvage pct='10'>CCC:5,CHH:10,CSR:10,CIH:10,CSV:4,CCO:5,CGS:5,CSA:10,CDS:5,CW:5,CBS:5,CNC:10,CSJ:10,CJF:10,CGB:1,CB:5</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,10,40,50</pctOmni>
@@ -94,8 +89,7 @@
 			<pctSL>100,100,80,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,30,40</pctOmni>
@@ -103,8 +97,7 @@
 			<pctSL>100,100,75,60,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,30,40</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:3,CIH:5,CSV:3,CFM:10,CCO:2,CGS:5,CSA:5,CDS:8,CW:1,CBS:2,CNC:10,CSJ:5,CJF:8,CGB:7,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:3,CIH:5,CSV:3,CFM:10,CCO:2,CGS:5,CSA:5,CDS:8,CW:1,CBS:2,CNC:10,CSJ:5,CJF:8,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,40,50</pctOmni>
@@ -112,8 +105,7 @@
 			<pctSL>100,100,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CSV:3,CFM:7,CCO:3,CGS:3,CSA:3,CDS:5,CW:10,CBS:3,CNC:7,CSJ:3,CJF:3,CGB:2,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CSV:3,CFM:7,CCO:3,CGS:3,CSA:3,CDS:5,CW:10,CBS:3,CNC:7,CSJ:3,CJF:3,CGB:2,CB:7</salvage>
 			<weightDistribution era='2870' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2870' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -123,8 +115,7 @@
 			<pctSL>100,100,70,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:10,CIH:5,CSV:10,CFM:10,CCO:4,CGS:5,CSA:5,CDS:3,CW:10,CBS:5,CNC:2,CSJ:5,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:10,CIH:5,CSV:10,CFM:10,CCO:4,CGS:5,CSA:5,CDS:3,CW:10,CBS:5,CNC:2,CSJ:5,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>0,0,10,30,50</pctOmni>
@@ -132,8 +123,7 @@
 			<pctSL>100,100,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:8,CSR:10,CIH:3,CSV:1,CFM:3,CCO:10,CGS:3,CSA:5,CDS:2,CW:3,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:8,CSR:10,CIH:3,CSV:1,CFM:3,CCO:10,CGS:3,CSA:5,CDS:2,CW:3,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,50,60</pctOmni>
@@ -141,8 +131,7 @@
 			<pctSL>100,100,75,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:5,CSR:10,CIH:6,CSV:5,CFM:5,CCO:4,CGS:3,CSA:5,CW:3,CNC:5,CSJ:5,CJF:5,CB:10</salvage>
+			<salvage pct='12'>CCC:1,CHH:5,CSR:10,CIH:6,CSV:5,CFM:5,CCO:4,CGS:3,CSA:5,CW:3,CNC:5,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,10,30,50</pctOmni>
@@ -158,8 +147,7 @@
 			<pctSL>80,80,70,40,30</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CIH:2,CSV:4,CFM:3,CCO:5,CGS:1,CSA:1,CDS:3,CW:5,CNC:10,CSJ:2,CJF:3,CB:8</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CIH:2,CSV:4,CFM:3,CCO:5,CGS:1,CSA:1,CDS:3,CW:5,CNC:10,CSJ:2,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,10,40,50</pctOmni>
@@ -167,8 +155,7 @@
 			<pctSL>90,90,70,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
+			<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
 			<weightDistribution era='2870' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2870' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -178,8 +165,7 @@
 			<pctSL>80,80,60,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,40,50</pctOmni>
@@ -187,8 +173,7 @@
 			<pctSL>95,95,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:2,CIH:10,CSR:10,CSV:3,CFM:3,CGS:2,CSA:3,CDS:2,CNC:7,CSJ:7,CJF:7,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:1,CCC:2,CIH:10,CSR:10,CSV:3,CFM:3,CGS:2,CSA:3,CDS:2,CNC:7,CSJ:7,CJF:7,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -367,8 +352,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -376,8 +360,7 @@
 			<pctSL>100,100,85,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,10,50</pctOmni>
@@ -385,8 +368,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -394,8 +376,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,20,50</pctOmni>
@@ -403,8 +384,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,20,50</pctOmni>
@@ -412,8 +392,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -421,8 +400,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.SmJ'>
 			<pctOmni>0,0,0,20,50</pctOmni>
@@ -430,8 +408,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:10,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:10,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='5'></salvage>
@@ -536,16 +513,14 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -576,8 +551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -766,8 +740,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,CSV:2-,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -819,8 +792,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -900,8 +872,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -1003,8 +974,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
+			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 			</model>
@@ -1060,8 +1030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1073,8 +1042,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>
-				CC:1+,CHH:8,CLAN:4,FS:1+,MERC:1+,CS:7,CDS:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:4,DC:1+</availability>
+			<availability>CC:1+,CHH:8,CLAN:4,FS:1+,MERC:1+,CS:7,CDS:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:4,DC:1+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1127,8 +1095,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:1,CC:5,CLAN:2,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>MOC:1,CC:5,CLAN:2,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:1</availability>
@@ -1163,8 +1130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
+			<availability>CC:2,CS:2-,LA:2,Periphery.HR:4,IS:3,FWL:2,NIOPS:2-,FS:9,Periphery.OS:4,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>General:8,FWL:8,Periphery.Deep:8,FS:8,MERC:8,Periphery:8</availability>
@@ -1246,8 +1212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:5,FS:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
@@ -1599,8 +1564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1618,8 +1582,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:1,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:1,CGS:8,CS:8,CDS:8,CW:10,LA:1,CBS:10,FWL:1,NIOPS:8,CJF:8,CGB:10,DC:1</availability>
+			<availability>CC:1,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:1,CGS:8,CS:8,CDS:8,CW:10,LA:1,CBS:10,FWL:1,NIOPS:8,CJF:8,CGB:10,DC:1</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -1732,8 +1695,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,IS:7,Periphery.Deep:9,FS:7-,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1817,8 +1779,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:2,FS:4</availability>
@@ -2090,8 +2051,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:1,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:1,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:8</availability>
 			</model>
@@ -2233,8 +2193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2263,8 +2222,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2339,8 +2297,7 @@
 				<availability>CLAN:2,FWL:3,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2365,8 +2322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 			</model>
@@ -2466,8 +2422,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2586,8 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
+			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2694,8 +2648,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2721,8 +2674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2804,8 +2756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2827,8 +2778,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,CC:1,CLAN:5,IS:1,FWL.OH:3,FS:1,TC:1,CS:6,OA:1,LA:1,CNC:5,FWL:2,NIOPS:6,DC:1</availability>
+			<availability>MOC:1,CC:1,CLAN:5,IS:1,FWL.OH:3,FS:1,TC:1,CS:6,OA:1,LA:1,CNC:5,FWL:2,NIOPS:6,DC:1</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:3,CNC:3</availability>
 			</model>
@@ -2902,8 +2852,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -2941,8 +2890,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -3177,8 +3125,7 @@
 			<availability>CS:1-,IS:3,NIOPS:1-,Periphery:3</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:2,CC:2,CIH:6,CLAN:5,IS:2,CFM:6,MERC:2,CIR:2,CGS:6,BAN:6,TC:2,CS:6,OA:2,LA:2,NIOPS:6,DC:4</availability>
+			<availability>MOC:2,CC:2,CIH:6,CLAN:5,IS:2,CFM:6,MERC:2,CIR:2,CGS:6,BAN:6,TC:2,CS:6,OA:2,LA:2,NIOPS:6,DC:4</availability>
 			<model name='C'>
 				<availability>CIH:4,CFM:3,CFM.SmJ:8,CB:5,CGB:4</availability>
 			</model>
@@ -3215,8 +3162,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3319,8 +3265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3341,8 +3286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3359,8 +3303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3444,8 +3387,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3494,8 +3436,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3529,8 +3470,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3633,8 +3573,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3783,8 +3722,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:5,CLAN:6,MERC:4,FS:1,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:1,NIOPS:6,CJF:7,CGB:5,DC:1</availability>
+			<availability>MOC:1,CHH:5,CLAN:6,MERC:4,FS:1,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:1,NIOPS:6,CJF:7,CGB:5,DC:1</availability>
 			<model name='C'>
 				<availability>CIH:4,CJF:4,CGB:4</availability>
 			</model>
@@ -3968,8 +3906,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4014,8 +3951,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:6</availability>
@@ -4042,16 +3978,14 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
@@ -4081,8 +4015,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
@@ -4098,8 +4031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4116,8 +4048,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4229,8 +4160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4313,8 +4243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:1,CC:2,CLAN:8,MERC:2,FS:2,CIR:2,Periphery:1,TC:1,CS:8,OA:1,LA:2,FWL:2,NIOPS:8,CJF:7,DC:2</availability>
+			<availability>MOC:1,CC:2,CLAN:8,MERC:2,FS:2,CIR:2,Periphery:1,TC:1,CS:8,OA:1,LA:2,FWL:2,NIOPS:8,CJF:7,DC:2</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:4,NIOPS:8</availability>
 			</model>
@@ -4335,8 +4264,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4370,8 +4298,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4393,8 +4320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,LA:2,FWL:8,Periphery.Deep:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4419,8 +4345,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:2,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:8-,CIR:2,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
+			<availability>CC:8-,CCC:2,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:8-,CIR:2,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:4-,General:8,Periphery.Deep:8,BAN:5,Periphery:8</availability>
@@ -4492,8 +4417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4526,8 +4450,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:5,CC:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>MOC:5,CC:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4553,8 +4476,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
 			<model name='SCP-1N'>
 				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -4598,8 +4520,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -4617,8 +4538,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
+			<availability>MOC:2,Periphery.R:5,OA:2,LA:8,FWL:1,Periphery.Deep:4,FS:1,CIR:3,MERC:1,Periphery:4,TC:2,DC:1</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>LA:4,General:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -4721,8 +4641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4795,8 +4714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -4844,8 +4762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4893,8 +4810,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4909,8 +4825,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
+			<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4942,8 +4857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -5033,8 +4947,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='B'>
 				<roles>fire_support</roles>
 				<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
@@ -5088,8 +5001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:2,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:2,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -5123,8 +5035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -5139,8 +5050,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,CS:5-,LA:8,CLAN:4,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6,TC:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:1-</availability>
 			</model>
@@ -5373,8 +5283,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -5402,8 +5311,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5602,8 +5510,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:1-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:1-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
 			<model name='WTH-0'>
 				<availability>TC:2</availability>
 			</model>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -513,21 +513,21 @@
 	</factions>
 	<units>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>CLAN:4,IS:3,BAN:5,Periphery:2,CS:6,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+			<availability>CSR:5,CNC:5,CLAN:3,CJF:5</availability>
 			<model name='(2372)'>
 				<roles>cruiser</roles>
 				<availability>CC:8,IS:8</availability>
@@ -551,7 +551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:5,CW:5,LA:1+,CNC:5,FWL:1+,NIOPS:7,CJF:5,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:5,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,LA:1+,FWL:1+,NIOPS:7,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -598,7 +598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
+			<availability>CC:7,CS:5-,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -649,7 +649,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:10,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -740,7 +740,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CSV:2-,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-D'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -792,7 +792,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CLAN:2-,IS:7,Periphery.Deep:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -872,7 +872,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,Periphery.Deep:10-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>Periphery.Deep:10-,FS:5-,MERC:7-,Periphery:10-,CS:2-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
@@ -899,7 +899,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,FS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -956,7 +956,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:5,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
+			<availability>CHH:8,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -982,7 +982,7 @@
 				<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1030,7 +1030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,DC:9</availability>
+			<availability>CC:9,MOC:8,LA:8,IS:7,FWL:8,Periphery.Deep:7,FS:6,MERC:7,Periphery:7,TC:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1042,7 +1042,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:1+,CHH:8,CLAN:4,FS:1+,MERC:1+,CS:7,CDS:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:4,DC:1+</availability>
+			<availability>CC:1+,CHH:8,CLAN:4,FS:1+,MERC:1+,CS:7,LA:1+,FWL:1+,NIOPS:7,DC:1+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1077,7 +1077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -1095,7 +1095,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:1,CC:5,CLAN:2,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>MOC:1,CC:5,CLAN:2,IS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:2,DC:1</availability>
@@ -1179,7 +1179,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,FWL:4,NIOPS:5,MERC:4,FS:4,CGB:6,DC:4</availability>
+			<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,FS:4,CGB:6</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1244,7 +1244,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:3,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
+				<availability>LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:7,CGS:6,BAN:4</availability>
@@ -1417,7 +1417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:2,CS:3-,OA:2,LA:4,CLAN:1-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+			<availability>CC:6,MOC:2,CS:3-,OA:2,CLAN:1-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1467,7 +1467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,CS:3,LA:7,IS:3,FWL:3,NIOPS:3,FS:3,CIR:3,Periphery:3,TC:3,DC:3</availability>
+			<availability>CS:3,LA:7,IS:3,NIOPS:3,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1486,7 +1486,7 @@
 			</model>
 		</chassis>
 		<chassis name='Confederate' unitType='Dropship'>
-			<availability>CC:1,CS:6,LA:1,CLAN:2,FWL:1,IS:1,NIOPS:6,FS:1,BAN:3,DC:1,TC:1</availability>
+			<availability>CS:6,CLAN:2,IS:1,NIOPS:6,BAN:3,TC:1</availability>
 			<model name='(2602)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -1497,7 +1497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Congress Frigate' unitType='Warship'>
-			<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
+			<availability>CS:2,CW:2,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
 			<model name='(2542)'>
 				<roles>frigate</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -1534,7 +1534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:1,FS:8,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>CLAN:1,IS:8,Periphery.Deep:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -1564,7 +1564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
@@ -1625,7 +1625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,CLAN:3,IS:3,FS:5,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,CLAN:3,IS:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -1675,7 +1675,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CSA:3,CHH:4,CCC:6,CIH:3,CDS:3,CLAN:3,CCO:3,CJF:3,BAN:2,CGB:9,CB:6</availability>
+			<availability>CHH:4,CCC:6,CLAN:3,BAN:2,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -1727,7 +1727,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:5,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5,DC:5</availability>
+			<availability>CC:4,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -1874,7 +1874,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
+			<availability>CDS:3,CLAN:2,CSJ:4,CGB:3</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>IS:8</availability>
@@ -1885,7 +1885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:5,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,FS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2053,7 +2053,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:1,NIOPS:5,CJF:7,CGB:5</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2193,7 +2193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2222,7 +2222,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
+			<availability>MOC:6,CC:4,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,CJF:5,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2239,7 +2239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,TC:3,DC:2</availability>
+			<availability>CC:1,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2289,7 +2289,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CS:9,CDS:7,Periphery.MW:1,CLAN:7,Periphery.ME:1,CNC:7,FWL:3,NIOPS:9</availability>
+			<availability>MOC:1,CS:9,Periphery.MW:1,CLAN:7,Periphery.ME:1,FWL:3,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:2,CLAN:2</availability>
 			</model>
@@ -2297,7 +2297,7 @@
 				<availability>CLAN:2,FWL:3,BAN:3</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:2,CLAN:2,CNC:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
+				<availability>CS:6,CLAN:2,FWL:6,NIOPS:6,Periphery.Deep:6,MERC:6,BAN:4,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
@@ -2322,7 +2322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
 			</model>
@@ -2347,7 +2347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:6,CS:7,CHH:8,CSR:8,CLAN:7,IS:6,FWL:6,NIOPS:7,FS:5,MERC:6,DC:6</availability>
+			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8,DC:2+</availability>
@@ -2407,7 +2407,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hammerhead' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CC:1,CLAN:6,IS:1,FS:1,CIR:1,TC:1,CS:7,OA:1,LA:1,CNC:6,FWL:1,NIOPS:7,DC:1</availability>
+			<availability>MOC:1,CLAN:6,IS:1,CIR:1,TC:1,CS:7,OA:1,NIOPS:7</availability>
 			<model name='HMR-HC'>
 				<availability>IS:8</availability>
 			</model>
@@ -2422,7 +2422,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,FWL.pm:7,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CC:4,FWL.pm:7,Periphery.MW:5,Periphery.ME:5,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2525,7 +2525,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:1+,CLAN:3,IS:1,FS:1,TC:1+,CS:6,OA:1+,LA:1,CNC:3,FWL:1,NIOPS:6,DC:1</availability>
+			<availability>MOC:1+,CLAN:3,IS:1,TC:1+,CS:6,OA:1+,CNC:3,NIOPS:6</availability>
 			<model name='HCT-212'>
 				<availability>LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -2541,7 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,OA:3-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
+			<availability>CC:2-,LA:6-,FWL:2-,Periphery.Deep:4-,FS:6-,MERC:5-,Periphery:3-,DC:2-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2584,11 +2584,11 @@
 			<availability>MOC:1,CC:1,CS:3,CHH:5,OA:1,CLAN:4,FWL:3,NIOPS:3,CGB:5,DC:1,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2674,7 +2674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -2756,7 +2756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2778,7 +2778,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ironsides' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CC:1,CLAN:5,IS:1,FWL.OH:3,FS:1,TC:1,CS:6,OA:1,LA:1,CNC:5,FWL:2,NIOPS:6,DC:1</availability>
+			<availability>MOC:1,CLAN:5,IS:1,FWL.OH:3,TC:1,CS:6,OA:1,FWL:2,NIOPS:6</availability>
 			<model name='IRN-SD1'>
 				<availability>General:8,CLAN:3,CNC:3</availability>
 			</model>
@@ -2852,7 +2852,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -2890,7 +2890,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
+			<availability>MOC:4,OA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>IS:2,FS:5,MERC:2,TC:2</availability>
@@ -2989,7 +2989,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:6,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:7,CGB:7,DC:2+</availability>
+			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3024,7 +3024,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:1,NIOPS:7,FS:6,MERC:1,DC:1</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -3102,7 +3102,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:6,CW:6,CSV:6,CLAN:6,CNC:6,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CLAN:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -3125,7 +3125,7 @@
 			<availability>CS:1-,IS:3,NIOPS:1-,Periphery:3</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:2,CC:2,CIH:6,CLAN:5,IS:2,CFM:6,MERC:2,CIR:2,CGS:6,BAN:6,TC:2,CS:6,OA:2,LA:2,NIOPS:6,DC:4</availability>
+			<availability>MOC:2,CIH:6,CLAN:5,IS:2,CFM:6,MERC:2,CIR:2,CGS:6,BAN:6,TC:2,CS:6,OA:2,NIOPS:6,DC:4</availability>
 			<model name='C'>
 				<availability>CIH:4,CFM:3,CFM.SmJ:8,CB:5,CGB:4</availability>
 			</model>
@@ -3162,7 +3162,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:7,CC:6,CHH:1,CLAN:1,IS:7,Periphery.Deep:7,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>CC:6,CLAN:1,IS:7,Periphery.Deep:7,FS:6,BAN:5,Periphery:7,CS:4,LA:6,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3204,7 +3204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:8,CLAN:3,IS:2,FS:3,TC:2,Periphery:2,CS:5-,OA:2,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
+			<availability>CC:8,CLAN:3,IS:2,FS:3,Periphery:2,CS:5-,LA:3,FWL:1,NIOPS:5-,DC:3</availability>
 			<model name='LTN-G14'>
 				<availability>Periphery:1</availability>
 			</model>
@@ -3265,7 +3265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3286,7 +3286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3303,7 +3303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>MOC:2,Periphery.R:4,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,DC:6</availability>
 			<model name='LCF-R15'>
 				<availability>LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3387,7 +3387,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,IS:9,Periphery.Deep:9,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>LA:6,General:6,Periphery.Deep:6,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3402,7 +3402,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2+,CS:8,LA:5,CLAN:6,IS:4,FWL:4,NIOPS:8,FS:5,TC:3+,DC:5,CGB:6</availability>
+			<availability>MOC:2+,CS:8,LA:5,CLAN:6,IS:4,NIOPS:8,FS:5,TC:3+,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,MOC:1,CLAN:4,NIOPS:8,MERC:0,BAN:4,TC:1+</availability>
 			</model>
@@ -3436,7 +3436,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>Periphery.R:2,LA:2-,Periphery.MW:2,Periphery.HR:1,Periphery.CM:1,IS:2-,Periphery:1</availability>
+			<availability>Periphery.R:2,Periphery.MW:2,IS:2-,Periphery:1</availability>
 			<model name='II-A'>
 				<availability>General:4</availability>
 			</model>
@@ -3470,7 +3470,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,S:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
@@ -3573,7 +3573,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:5,Periphery.Deep:6,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3906,7 +3906,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3931,7 +3931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:3-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,CLAN:3-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
@@ -3951,7 +3951,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:4-,IS:4,Periphery.Deep:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:4,DC:4</availability>
+			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:5-,BAN:6</availability>
@@ -3978,21 +3978,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>CC:6,CHH:7,CLAN:8,IS:4,Periphery.Deep:4,FS:6,BAN:4,Periphery:4,CS:7,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>General:8,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:6,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>PIR:4,General:4,IS:4,Periphery.Deep:6,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4031,7 +4031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,OA:5,LA:8,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,TC:9,DC:6</availability>
+			<availability>CC:6,OA:5,IS:8,FWL:7,Periphery.Deep:9,FS:7,CIR:6,Periphery:9,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4048,7 +4048,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,OA:8,LA:9,IS:8,FWL:10,Periphery.Deep:8,FS:8,CIR:8,Periphery:8,TC:8,DC:8</availability>
+			<availability>CC:9,LA:9,IS:8,FWL:10,Periphery.Deep:8,Periphery:8,TC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4104,7 +4104,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:2,IS:9,FWL:9,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+			<availability>CS:7,CLAN:2,IS:9,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -4243,7 +4243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:1,CC:2,CLAN:8,MERC:2,FS:2,CIR:2,Periphery:1,TC:1,CS:8,OA:1,LA:2,FWL:2,NIOPS:8,CJF:7,DC:2</availability>
+			<availability>CC:2,CLAN:8,MERC:2,FS:2,CIR:2,Periphery:1,CS:8,LA:2,FWL:2,NIOPS:8,CJF:7,DC:2</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:5,CW:5,General:8,CLAN:4,NIOPS:8</availability>
 			</model>
@@ -4264,7 +4264,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,FWL:8,DC:8,TC:8</availability>
 			</model>
@@ -4298,7 +4298,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:5,CW:5,General:8,CLAN:5,CNC:5</availability>
 			</model>
@@ -4345,7 +4345,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:2,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:8-,CIR:2,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
+			<availability>CLAN:2,IS:8-,Periphery.Deep:5,CIR:2,Periphery:5,CS:6-,Clan.IS:2,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>CLAN:4-,General:8,Periphery.Deep:8,BAN:5,Periphery:8</availability>
@@ -4417,7 +4417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,OA:4-,LA:4-,CLAN:5,IS:4-,FWL:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,DC:5-</availability>
+			<availability>CLAN:5,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -4432,7 +4432,7 @@
 			</model>
 		</chassis>
 		<chassis name='Samurai' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CC:1,OA:5,LA:1,CLAN:1,IS:1,FWL:1,MERC:1,FS:1,Periphery:1,TC:1,DC:4</availability>
+			<availability>OA:5,CLAN:1,IS:1,MERC:1,Periphery:1,DC:4</availability>
 			<model name='SL-25'>
 				<roles>ground_support</roles>
 				<availability>OA:8,General:8,DC:8</availability>
@@ -4450,7 +4450,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:5,CC:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4562,7 +4562,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -4641,7 +4641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4652,7 +4652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>IS:8,Periphery.Deep:8,FS:0,Periphery:8</availability>
 			</model>
@@ -4694,7 +4694,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:3,CSV:2,CLAN:2,CFM:2,CGS:2,CCO:3,CSA:3,CS:1,CDS:2,CW:2,NIOPS:1,CSJ:2,CJF:2</availability>
+			<availability>CSR:3,CLAN:2,CCO:3,CSA:3,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -4714,7 +4714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:4,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:4,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -4748,7 +4748,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:3,CLAN:1-,IS:3,FWL:7,NIOPS:4,MERC:4,FS:5,TC:2,DC:6</availability>
+			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:3,FWL:7,NIOPS:4,MERC:4,FS:5,TC:2,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4762,7 +4762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -4810,7 +4810,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:7,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
@@ -4825,7 +4825,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
+			<availability>CC:4,FS:2,MERC:4,CIR:3,Periphery:2,CS:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:8,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -4857,7 +4857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
+			<availability>MOC:2,CC:1,CLAN:6,MERC:4,Periphery.OS:2,FS:8,Periphery:1,TC:2,OA:2,LA:2,Periphery.HR:2,FWL:1,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -4947,7 +4947,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:5,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='B'>
 				<roles>fire_support</roles>
 				<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
@@ -4994,14 +4994,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,General:8,FWL:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:2,TC:1+,CS:7,CDS:7,CW:9,CBS:7,LA:3,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:2,TC:1+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -5035,7 +5035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CLAN:4,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:3</availability>
@@ -5050,7 +5050,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6,TC:6,DC:8</availability>
+			<availability>CC:9,CS:5-,CLAN:4,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6,TC:6</availability>
 			<model name='C'>
 				<availability>CLAN:1-</availability>
 			</model>
@@ -5101,7 +5101,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tomahawk' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:1,CS:9,OA:1,CW:6,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
+			<availability>CC:2,MOC:1,CS:9,OA:1,LA:1,CLAN:6,FWL:2,NIOPS:9,FS:1,MERC:1,TC:1</availability>
 			<model name='THK-43'>
 				<roles>escort</roles>
 				<availability>IS:1</availability>
@@ -5173,7 +5173,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,CS:7,OA:4,CSR:5,CLAN:5,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
+			<availability>CC:2,MOC:2,CS:7,OA:4,CLAN:5,NIOPS:7,FS:2,MERC:2,DC:2,TC:2</availability>
 			<model name='TRN-3T'>
 				<availability>CS:8,OA:1+,CLAN:6,IS:1+,NIOPS:8,BAN:8,Periphery:1+</availability>
 			</model>
@@ -5202,7 +5202,7 @@
 			<availability>IS:1,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
@@ -5283,7 +5283,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:5-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
@@ -5311,7 +5311,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
+			<availability>MOC:5,CC:6,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5323,7 +5323,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CSA:2,CCC:1,CSR:3,CW:4,CSV:2,CNC:2,CLAN:2,CFM:2,CSJ:5,CJF:2,CB:2</availability>
+			<availability>CCC:1,CSR:3,CW:4,CLAN:2,CSJ:5</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8</availability>
@@ -5351,7 +5351,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8</availability>
@@ -5418,7 +5418,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,TC:6,Periphery:6</availability>
+			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
 			<model name='C 3'>
 				<availability>CLAN:3</availability>
 			</model>
@@ -5460,7 +5460,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:1-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:3,Periphery:6</availability>
+			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:3,Periphery:6</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5524,7 +5524,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,DC:7,TC:5</availability>
+			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
 			<model name='WVR-1R'>
 				<availability>FS:1-</availability>
 			</model>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -514,21 +514,21 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>CLAN:4,IS:3,BAN:5,Periphery:2,CS:6,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CSA:3,CCC:3,CIH:3,CSR:5,CDS:3,CBS:3,CSV:3,CNC:5,CLAN:3,CGS:3,CJF:5,CB:3</availability>
+			<availability>CSR:5,CNC:5,CLAN:3,CJF:5</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8</availability>
@@ -548,7 +548,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>MOC:1+,CC:1+,CLAN:4,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:4,CW:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:3,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:4,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,LA:1+,FWL:1+,NIOPS:7,CJF:3,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -595,7 +595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
+			<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -646,7 +646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -701,7 +701,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:1,CC:1,CS:3-,OA:1,HL:1,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,Periphery:3,TC:1</availability>
+			<availability>MOC:1,CC:1,CS:3-,OA:1,HL:1,IS:4,MERC:3,Periphery:3,TC:1</availability>
 			<model name='ASN-21'>
 				<availability>General:8</availability>
 			</model>
@@ -737,7 +737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>CSV:2-,IS:3,FS:5,Periphery:1,CS:4-,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-D'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -782,14 +782,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:5,CLAN:2-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,HL:5,CLAN:2-,IS:7,Periphery.Deep:6,CIR:8,Periphery:7,TC:8,CS:8,OA:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -869,7 +869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:10-,CC:4-,HL:8-,IS:7-,Periphery.Deep:9-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>CC:4-,HL:8-,IS:7-,Periphery.Deep:9-,FS:5-,MERC:7-,Periphery:10-,CS:2-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -912,7 +912,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,HL:4,CLAN:3,IS:5,FS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,HL:4,CLAN:3,IS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -969,7 +969,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:5,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
+			<availability>CHH:8,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -995,7 +995,7 @@
 				<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1056,7 +1056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:8,FWL:8,DC:9</availability>
+			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,MERC:7,Periphery:7,TC:8,LA:8,FWL:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1068,7 +1068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>CC:1+,CHH:7,CLAN:2,FS:1+,MERC:1+,CS:7,CDS:2,LA:1+,CNC:2,FWL:1+,NIOPS:7,CJF:2,DC:1+</availability>
+			<availability>CC:1+,CHH:7,CLAN:2,FS:1+,MERC:1+,CS:7,LA:1+,FWL:1+,NIOPS:7,DC:1+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1103,7 +1103,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -1121,7 +1121,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:1,CC:5,CLAN:1,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>CC:5,CLAN:1,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1156,7 +1156,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1205,7 +1205,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:4,CS:5,CHH:5,LA:4,CLAN:3,IS:3,FWL:3,NIOPS:5,MERC:3,FS:3,CGB:5,DC:3</availability>
+			<availability>CC:4,CS:5,CHH:5,LA:4,CLAN:3,IS:3,NIOPS:5,MERC:3,CGB:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1268,9 +1268,9 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:2,FWL:4,MERC:3,CIR:2,FS:2,Periphery:2,TC:2,DC:3</availability>
+			<availability>CC:2,LA:6,CLAN:2,FWL:4,MERC:3,FS:2,Periphery:2,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+				<availability>HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:7,CGS:6,BAN:4</availability>
@@ -1449,7 +1449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:2,IS:4,FS:6,MERC:4,TC:2,Periphery:2,CS:3-,OA:2,LA:4,FWL:4,NIOPS:3-,DC:4</availability>
+			<availability>CC:6,IS:4,FS:6,MERC:4,Periphery:2,CS:3-,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1499,7 +1499,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>HL:1,IS:3,Periphery:3,CS:3,LA:7,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1529,7 +1529,7 @@
 			</model>
 		</chassis>
 		<chassis name='Congress Frigate' unitType='Warship'>
-			<availability>CS:2,CHH:1,CSR:1,CW:2,CSV:1,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
+			<availability>CS:2,CW:2,CLAN:1,NIOPS:2,CSJ:4,CGS:2,CJF:2</availability>
 			<model name='(2542)'>
 				<roles>frigate</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -1569,7 +1569,7 @@
 			<availability>CSR:2</availability>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>CC:2,MOC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,TC:2,Periphery:2,DC:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,Periphery:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -1599,7 +1599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -1660,7 +1660,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,CLAN:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,CLAN:2,IS:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -1717,7 +1717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CSA:3,CHH:4,CCC:6,CIH:3,CDS:3,CLAN:3,CCO:3,CJF:3,BAN:2,CGB:9,CB:6</availability>
+			<availability>CHH:4,CCC:6,CLAN:3,BAN:2,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -1769,7 +1769,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:3,CLAN:1,IS:5,Periphery.Deep:5,FS:8,MERC:5,Periphery.OS:5,Periphery:4,TC:5,OA:4,LA:5,Periphery.HR:6,DC:5</availability>
+			<availability>CC:4,HL:3,CLAN:1,IS:5,Periphery.Deep:5,FS:8,MERC:5,Periphery.OS:5,Periphery:4,TC:5,Periphery.HR:6</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1934,7 +1934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CSA:2,CIH:2,CSR:2,CDS:3,CSV:2,CLAN:2,CSJ:4,CGS:2,CCO:2,CGB:3,CB:2</availability>
+			<availability>CDS:3,CLAN:2,CSJ:4,CGB:3</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>IS:8</availability>
@@ -1945,7 +1945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:4,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,FS:4,CIR:2,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2119,7 +2119,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,LA:1+,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2256,7 +2256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2282,7 +2282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:2,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,CJF:5,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2292,14 +2292,14 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:2,CNC:2,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:2,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,HL:1,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,TC:3,DC:2</availability>
+			<availability>CC:1,HL:1,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2318,10 +2318,10 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CS:2,OA:1,LA:4,Periphery.MW:2,FWL:5,MERC:1,TC:1,Periphery:1</availability>
+			<availability>CS:2,LA:4,Periphery.MW:2,FWL:5,MERC:1,Periphery:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,HL:6,LA:8,FWL:8,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
@@ -2352,7 +2352,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CS:9,CDS:6,Periphery.MW:1,CLAN:6,Periphery.ME:1,CNC:6,FWL:1,NIOPS:9</availability>
+			<availability>MOC:1,CS:9,Periphery.MW:1,CLAN:6,Periphery.ME:1,FWL:1,NIOPS:9</availability>
 			<model name='GTHA-100'>
 				<availability>General:1,CLAN:1</availability>
 			</model>
@@ -2360,14 +2360,14 @@
 				<availability>CLAN:1,FWL:2,BAN:2</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
+				<availability>CS:6,HL:4,CLAN:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:4,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:4,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2385,7 +2385,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:5,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:5,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:8,TC:7,Periphery:6,CS:4,OA:4,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:5,Periphery:8</availability>
 			</model>
@@ -2416,7 +2416,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:5,CS:7,CHH:7,CSR:7,CLAN:5,IS:5,FWL:5,NIOPS:7,FS:4,MERC:5,DC:5,Periphery:3</availability>
+			<availability>CS:7,CHH:7,CSR:7,CLAN:5,IS:5,NIOPS:7,FS:4,MERC:5,Periphery:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,IS:1+,NIOPS:8,BAN:8,DC:1+</availability>
@@ -2479,7 +2479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:4,CC:4,HL:2,Periphery.Deep:4,MERC:4,Periphery:4,FWL.pm:8,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,FWL:4,MH:5,DC:4</availability>
+			<availability>CC:4,HL:2,Periphery.Deep:4,MERC:4,Periphery:4,FWL.pm:8,Periphery.MW:5,Periphery.ME:5,FWL:4,MH:5,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2601,7 +2601,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>CC:1-,MOC:3-,OA:3-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
+			<availability>CC:1-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,DC:2-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2640,11 +2640,11 @@
 			<availability>CS:3,CHH:5,CLAN:3,FWL:3,NIOPS:3,CGB:5,CB:5</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2704,7 +2704,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
+			<availability>FS.CMM:2,FS.DMM:2,FS:2,MERC:3,FS.CrMM:2,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2730,7 +2730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:3,CLAN:1-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,HL:3,CLAN:1-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2757,7 +2757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>CC:5,MOC:3,HL:3,IS:5,FS:5,MERC:5,CIR:4,TC:4,Periphery:5,OA:4,LA:6,FWL:4,DC:4</availability>
+			<availability>MOC:3,HL:3,IS:5,MERC:5,CIR:4,TC:4,Periphery:5,OA:4,LA:6,FWL:4,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2814,7 +2814,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,HL:1,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,HL:1,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2907,7 +2907,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,HL:3,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,HL:3,IS:5,Periphery.Deep:5,FS:4,Periphery:5,TC:7,CS:4-,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
 			</model>
@@ -2945,7 +2945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,HL:2,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -2956,7 +2956,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,OA:3,HL:1,FS.DMM:5,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FS.DMM:5,IS:2,MERC:4,Periphery.OS:5,Periphery:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3044,7 +3044,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:5,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:6,CGB:6,DC:2+</availability>
+			<availability>CS:6,CLAN:5,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:6,CGB:6,</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3079,7 +3079,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:6,CDS:6,CSV:6,CLAN:5,NIOPS:7,FS:6</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -3177,7 +3177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:5,CW:6,CSV:6,CLAN:5,CNC:5,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:5,CW:6,CSV:6,CLAN:5,CGS:6,CJF:6,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -3193,7 +3193,7 @@
 			<availability>CS:1-,HL:1,IS:3,NIOPS:1-,Periphery:3</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:1,CC:1,CIH:6,CLAN:5,IS:1,CFM:6,CIR:1,MERC:1,CGS:6,BAN:6,TC:1,CS:6,OA:1,LA:1,NIOPS:6,DC:3</availability>
+			<availability>MOC:1,CIH:6,CLAN:5,IS:1,CFM:6,CIR:1,MERC:1,CGS:6,BAN:6,TC:1,CS:6,OA:1,NIOPS:6,DC:3</availability>
 			<model name='C'>
 				<availability>CIH:4,CB:6,CGB:4</availability>
 			</model>
@@ -3230,7 +3230,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:7,CC:6,CHH:1,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>CC:6,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:6,BAN:5,Periphery:7,CS:4,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3272,7 +3272,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:8,CS:5-,OA:2,LA:3,CLAN:3,IS:1,NIOPS:5-,FS:3,TC:2,Periphery:2,DC:3</availability>
+			<availability>CC:8,CS:5-,LA:3,CLAN:3,IS:1,NIOPS:5-,FS:3,Periphery:2,DC:3</availability>
 			<model name='LTN-G15'>
 				<availability>General:8,CLAN:3</availability>
 			</model>
@@ -3326,7 +3326,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CDS:5,CW:5,CBS:5,CSV:5,CLAN:5,CFM:5,CSJ:5,CJF:5,CGB:5,CB:5</availability>
+			<availability>CHH:8,CLAN:5</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:8</availability>
@@ -3339,7 +3339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3360,7 +3360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:5,CLAN:2,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,HL:5,CLAN:2,IS:7,Periphery.Deep:6,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3377,7 +3377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>Periphery.R:4,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,DC:6</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3494,7 +3494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3509,7 +3509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,CLAN:5,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:5</availability>
+			<availability>CLAN:5,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,NIOPS:8,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:3,NIOPS:8,MERC:0,BAN:4</availability>
 			</model>
@@ -3577,7 +3577,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3680,7 +3680,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -3828,7 +3828,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CS:6,CHH:5,OA:1,CDS:5,CBS:6,CLAN:6,NIOPS:6,MERC:4,CJF:6,TC:1,CGB:5</availability>
+			<availability>MOC:1,CS:6,CHH:5,OA:1,CDS:5,CLAN:6,NIOPS:6,MERC:4,TC:1,CGB:5</availability>
 			<model name='C'>
 				<availability>CIH:4,CJF:4,CGB:4</availability>
 			</model>
@@ -4047,7 +4047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:2,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,HL:2,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4069,7 +4069,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,HL:2,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CS:4,HL:2,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,CLAN:2,IS:8,Periphery.Deep:7,MERC:8,BAN:4,Periphery:8</availability>
@@ -4092,7 +4092,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,HL:1,LA:4,CLAN:4-,IS:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
+			<availability>CS:4,HL:1,CLAN:4-,IS:4,NIOPS:4,MERC:4,Periphery:3</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:4-,BAN:5</availability>
@@ -4119,21 +4119,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:4,CC:6,CHH:7,HL:2,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>CC:6,CHH:7,HL:2,CLAN:8,IS:4,Periphery.Deep:4,FS:6,BAN:4,Periphery:4,CS:7,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>HL:4,PIR:4,General:4,IS:4,Periphery.Deep:5,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4172,7 +4172,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4189,7 +4189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,HL:6,IS:8,Periphery.Deep:7,FS:8,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
+			<availability>CC:9,HL:6,IS:8,Periphery.Deep:7,Periphery:8,LA:9,FWL:10</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4238,7 +4238,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:9,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+			<availability>CS:7,HL:2,CLAN:2,IS:9,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -4370,7 +4370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>MOC:1,CC:1,CLAN:7,MERC:1,FS:1,CIR:2,Periphery:1,TC:1,CS:8,OA:1,LA:1,FWL:1,NIOPS:8,CJF:5,DC:1</availability>
+			<availability>CC:1,CLAN:7,MERC:1,FS:1,CIR:2,Periphery:1,CS:8,LA:1,FWL:1,NIOPS:8,CJF:5,DC:1</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:4,CW:4,General:8,CLAN:2,NIOPS:8</availability>
 			</model>
@@ -4391,7 +4391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:4,Periphery.Deep:5,FWL:8,IS:6,Periphery:6,DC:8,TC:8</availability>
 			</model>
@@ -4419,7 +4419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:4,CW:4,General:8,CLAN:4,CNC:4</availability>
 			</model>
@@ -4466,7 +4466,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:2,HL:3,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:8-,CIR:2,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
+			<availability>HL:3,CLAN:2,IS:8-,Periphery.Deep:5,CIR:2,Periphery:5,CS:6-,Clan.IS:2,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>HL:6,CLAN:3-,General:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -4513,7 +4513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:8,CDS:8,CW:6,CBS:7,CSV:5,CLAN:6,CNC:6,CSJ:7,CJF:8</availability>
+			<availability>CHH:7,CSR:8,CDS:8,CBS:7,CSV:5,CLAN:6,CSJ:7,CJF:8</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 			</model>
@@ -4557,7 +4557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
+			<availability>HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:2</availability>
 			</model>
@@ -4599,13 +4599,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:1,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,HL:1,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:5,CC:3,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,HL:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4616,13 +4616,13 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5,CC:6,Periphery.DD:5,HL:3,IS:5,MERC:5,Periphery.OS:5,FS:6,Periphery:5,TC:5,OA:5,LA:5,FWL:5,DC:7</availability>
+			<availability>CC:6,Periphery.DD:5,HL:3,IS:5,MERC:5,FS:6,Periphery:5,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>CC:9,HL:7,LA:9,FWL:9,IS:9,Periphery.Deep:8,FS:9,DC:9,Periphery:9</availability>
+			<availability>HL:7,IS:9,Periphery.Deep:8,Periphery:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4637,7 +4637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,HL:2-,IS:4-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
+			<availability>HL:2-,IS:4-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,NIOPS:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -4723,7 +4723,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5,CGB:2</availability>
+			<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -4802,7 +4802,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4817,7 +4817,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 			</model>
@@ -4851,7 +4851,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>CSR:3,CSV:2,CLAN:2,CFM:2,CGS:2,CCO:3,CSA:3,CS:1,CDS:2,CW:2,NIOPS:1,CSJ:2,CJF:2</availability>
+			<availability>CSR:3,CLAN:2,CCO:3,CSA:3,CS:1,NIOPS:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -4878,7 +4878,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,NIOPS:3,DC:2</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -4912,7 +4912,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:5,CLAN:1-,IS:3,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,CLAN:1-,IS:3,MERC:4,FS:5,Periphery:2,CS:4,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4926,7 +4926,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4971,7 +4971,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,HL:4,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>CS:4-,HL:4,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,BAN:2,Periphery:4</availability>
@@ -4986,7 +4986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
+			<availability>CC:4,FS:2,MERC:4,CIR:3,Periphery:2,CS:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:6,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5018,7 +5018,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,Periphery:1,TC:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -5105,7 +5105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:5,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='B'>
 				<roles>fire_support</roles>
 				<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
@@ -5152,14 +5152,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,FS:1,CS:7,CDS:6,CW:8,CBS:6,LA:2,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
+			<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,FS:1,CS:7,CDS:6,CW:8,CBS:6,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -5193,7 +5193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:2</availability>
@@ -5208,7 +5208,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,HL:4,CLAN:4,IS:8,Periphery.Deep:5,FS:7,MERC:8,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,MH:6,DC:8</availability>
+			<availability>CC:9,HL:4,CLAN:4,IS:8,Periphery.Deep:5,FS:7,MERC:8,Periphery:6,CS:5-,NIOPS:5-</availability>
 			<model name='C'>
 				<availability>CLAN:1-</availability>
 			</model>
@@ -5315,7 +5315,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,FS:4,MERC:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -5444,7 +5444,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:5-,HL:1-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>CC:5-,HL:1-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5496,14 +5496,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:3,MOC:1,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1,TC:1</availability>
+			<availability>CC:3,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:2,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
+			<availability>MOC:5,CC:6,HL:2,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,FS:1</availability>
 			</model>
@@ -5515,7 +5515,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CSA:2,CCC:1,CSR:3,CW:4,CSV:2,CNC:2,CLAN:2,CFM:2,CSJ:5,CJF:2,CB:2</availability>
+			<availability>CCC:1,CSR:3,CW:4,CLAN:2,CSJ:5</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:8,IS:8</availability>
@@ -5555,7 +5555,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:2,CSR:2,CDS:2,CW:2,CLAN:2,NIOPS:1,CGS:2,CGB:2,CB:2</availability>
+			<availability>CS:1,CLAN:2,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8</availability>
@@ -5578,7 +5578,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FWL:7,IS:5,NIOPS:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:8,FS:4</availability>
@@ -5625,7 +5625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,HL:4,LA:9,CLAN:4,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:4,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
 			<model name='C 3'>
 				<availability>CLAN:4</availability>
 			</model>
@@ -5705,7 +5705,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:4,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>Periphery.DD:2,CLAN:1-,IS:3,FS:4,MERC:3,Periphery.OS:2,Periphery:1,CS:3-,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -5716,7 +5716,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,CS:5-,HL:3,LA:7,IS:7,Periphery.Deep:5,FWL:10,NIOPS:5-,FS:8,Periphery:4,TC:5,DC:7</availability>
+			<availability>CS:5-,HL:3,IS:7,Periphery.Deep:5,FWL:10,NIOPS:5-,FS:8,Periphery:4,TC:5</availability>
 			<model name='WVR-6D'>
 				<availability>FS:3</availability>
 			</model>
@@ -5750,7 +5750,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:5,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:3,DC:5,TC:3</availability>
+			<availability>CS:6,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>CS:8,CLAN:4,NIOPS:8,CFM:5,BAN:6</availability>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>5,5</pctClan>
 			<pctSL>85,85</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -35,8 +34,7 @@
 			<pctSL>100,100,100,90,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,10,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,90,80</pctSL>
-			<salvage pct='5'>
-				CHH:5,CCC:5,CSR:3,CIH:10,CSV:10,CFM:10,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:10,CB:10</salvage>
+			<salvage pct='5'>CHH:5,CCC:5,CSR:3,CIH:10,CSV:10,CFM:10,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:10,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -44,8 +42,7 @@
 			<pctSL>100,100,100,60,20</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
 			<weightDistribution era='2900' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2900' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -55,8 +52,7 @@
 			<pctSL>100,100,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>4,4,5,50,60</pctOmni>
@@ -64,8 +60,7 @@
 			<pctSL>85,85,85,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:2,CSR:5,CSV:3,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:10,CSJ:3,CJF:10,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:2,CSR:5,CSV:3,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:10,CSJ:3,CJF:10,CB:7</salvage>
 			<weightDistribution era='2900' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2900' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -75,8 +70,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:10,CSR:10,CIH:10,CSV:4,CCO:5,CGS:5,CSA:10,CDS:5,CW:5,CBS:5,CNC:10,CSJ:10,CJF:10,CGB:1,CB:5</salvage>
+			<salvage pct='10'>CCC:5,CHH:10,CSR:10,CIH:10,CSV:4,CCO:5,CGS:5,CSA:10,CDS:5,CW:5,CBS:5,CNC:10,CSJ:10,CJF:10,CGB:1,CB:5</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,10,40,50</pctOmni>
@@ -94,8 +88,7 @@
 			<pctSL>100,100,80,70,60</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,0,30,40</pctOmni>
@@ -103,8 +96,7 @@
 			<pctSL>100,100,75,60,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,30,40</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CSR:3,CIH:5,CSV:3,CFM:10,CCO:2,CGS:5,CSA:5,CDS:8,CW:1,CBS:2,CNC:10,CSJ:5,CJF:8,CGB:7,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CSR:3,CIH:5,CSV:3,CFM:10,CCO:2,CGS:5,CSA:5,CDS:8,CW:1,CBS:2,CNC:10,CSJ:5,CJF:8,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,40,50</pctOmni>
@@ -112,8 +104,7 @@
 			<pctSL>100,100,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:3,CSV:3,CFM:7,CCO:3,CGS:3,CSA:3,CDS:5,CW:10,CBS:3,CNC:7,CSJ:3,CJF:3,CGB:2,CB:7</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CSV:3,CFM:7,CCO:3,CGS:3,CSA:3,CDS:5,CW:10,CBS:3,CNC:7,CSJ:3,CJF:3,CGB:2,CB:7</salvage>
 			<weightDistribution era='2900' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2900' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -123,8 +114,7 @@
 			<pctSL>90,90,70,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:10,CIH:5,CSV:10,CFM:10,CCO:4,CGS:5,CSA:5,CDS:3,CW:10,CBS:5,CNC:2,CSJ:5,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:10,CIH:5,CSV:10,CFM:10,CCO:4,CGS:5,CSA:5,CDS:3,CW:10,CBS:5,CNC:2,CSJ:5,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>0,0,10,30,50</pctOmni>
@@ -132,8 +122,7 @@
 			<pctSL>100,100,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:8,CSR:10,CIH:3,CSV:1,CFM:3,CCO:10,CGS:3,CSA:5,CDS:2,CW:3,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:8,CSR:10,CIH:3,CSV:1,CFM:3,CCO:10,CGS:3,CSA:5,CDS:2,CW:3,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,50,60</pctOmni>
@@ -141,8 +130,7 @@
 			<pctSL>100,100,75,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:5,CSR:10,CIH:6,CSV:5,CFM:5,CCO:4,CGS:3,CSA:5,CW:3,CNC:5,CSJ:5,CJF:5,CB:10</salvage>
+			<salvage pct='12'>CCC:1,CHH:5,CSR:10,CIH:6,CSV:5,CFM:5,CCO:4,CGS:3,CSA:5,CW:3,CNC:5,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>0,0,10,30,50</pctOmni>
@@ -158,8 +146,7 @@
 			<pctSL>80,80,70,40,30</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CIH:3,CSV:3,CFM:5,CCO:5,CGS:1,CSA:2,CDS:3,CW:5,CNC:10,CSJ:2,CJF:5,CB:8</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CIH:3,CSV:3,CFM:5,CCO:5,CGS:1,CSA:2,CDS:3,CW:5,CNC:10,CSJ:2,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>0,0,10,40,50</pctOmni>
@@ -167,8 +154,7 @@
 			<pctSL>90,90,70,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
+			<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
 			<weightDistribution era='2900' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2900' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -178,8 +164,7 @@
 			<pctSL>80,80,60,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,40,50</pctOmni>
@@ -187,8 +172,7 @@
 			<pctSL>95,95,80,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:2,CIH:10,CSR:10,CSV:3,CFM:3,CGS:2,CSA:3,CDS:2,CNC:7,CSJ:7,CJF:7,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:1,CCC:2,CIH:10,CSR:10,CSV:3,CFM:3,CGS:2,CSA:3,CDS:2,CNC:7,CSJ:7,CJF:7,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -370,8 +354,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -379,8 +362,7 @@
 			<pctSL>100,100,85,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,10,50</pctOmni>
@@ -388,8 +370,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -397,8 +378,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,0,20,50</pctOmni>
@@ -406,8 +386,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,0,20,50</pctOmni>
@@ -415,8 +394,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,0,30,50</pctOmni>
@@ -424,8 +402,7 @@
 			<pctSL>100,100,90,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:4,CCO:4,CGS:5,CSA:10,CDS:2,CW:3,CNC:2,CSJ:3,CFM.P:8,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CC.LL'>
 			<salvage pct='5'></salvage>
@@ -537,16 +514,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
+			<availability>MOC:2,CC:3,CLAN:4,IS:3,FS:3,BAN:5,TC:2,Periphery:2,CS:6,OA:2,LA:3,FWL:2,NIOPS:6,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -573,8 +548,7 @@
 			</model>
 		</chassis>
 		<chassis name='Alacorn Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:1+,CC:1+,CLAN:4,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:4,CW:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:3,DC:1+</availability>
+			<availability>MOC:1+,CC:1+,CLAN:4,MERC:1+,FS:1+,TC:1+,CS:7,OA:1+,CDS:4,CW:4,LA:1+,CNC:4,FWL:1+,NIOPS:7,CJF:3,DC:1+</availability>
 			<model name='Mk III'>
 				<availability>General:1</availability>
 			</model>
@@ -672,8 +646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -764,8 +737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,CSV:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-D'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -817,8 +789,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:5,CLAN:2-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:5,CLAN:2-,IS:7,Periphery.Deep:6,FS:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -898,8 +869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:10-,CC:4-,HL:8-,IS:7-,Periphery.Deep:9-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
+			<availability>MOC:10-,CC:4-,HL:8-,IS:7-,Periphery.Deep:9-,FS:5-,CIR:10-,MERC:7-,TC:10-,Periphery:10-,CS:2-,OA:10-,LA:6-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -942,8 +912,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:6,MOC:6,HL:4,CLAN:3,IS:5,FS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>CC:6,MOC:6,HL:4,CLAN:3,IS:5,FS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1018,8 +987,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,FS:1,MERC:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:2,CNC:9,FWL:4,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
+			<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,FS:1,MERC:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:2,CNC:9,FWL:4,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
 			</model>
@@ -1088,8 +1056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:8,FWL:8,DC:9</availability>
+			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:8,FWL:8,DC:9</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1101,8 +1068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Burke Defense Tank' unitType='Tank'>
-			<availability>
-				CC:1+,CHH:7,CLAN:2,FS:1+,MERC:1+,CS:7,CDS:2,LA:1+,CNC:2,FWL:1+,NIOPS:7,CJF:2,DC:1+</availability>
+			<availability>CC:1+,CHH:7,CLAN:2,FS:1+,MERC:1+,CS:7,CDS:2,LA:1+,CNC:2,FWL:1+,NIOPS:7,CJF:2,DC:1+</availability>
 			<model name=''>
 				<availability>General:8,CLAN:6</availability>
 			</model>
@@ -1155,8 +1121,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:1,CC:5,CLAN:1,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
+			<availability>MOC:1,CC:5,CLAN:1,IS:3,MERC:2,FS:3,CIR:1,Periphery:1,TC:1,CS:2,LA:3,FWL:3,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1191,8 +1156,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1274,8 +1238,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -1523,8 +1486,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				Periphery.R:4,HL:3,LA:9,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,CSJ:2,CIR:4,MERC:4,CGS:2,Periphery:3,TC:6</availability>
+			<availability>Periphery.R:4,HL:3,LA:9,Periphery.CM:4,Periphery.HR:4,Periphery.ME:4,CSJ:2,CIR:4,MERC:4,CGS:2,Periphery:3,TC:6</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1637,8 +1599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
+			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,FWL:3,CJF:4,CGB:4,DC:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -1656,8 +1617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CC:1,CHH:9,CSR:7,CSV:7,CLAN:8,CFM:7,FS:1,CGS:7,CS:8,CDS:7,CW:9,LA:1,CBS:9,FWL:1,NIOPS:8,CJF:7,CGB:9,DC:1</availability>
+			<availability>CC:1,CHH:9,CSR:7,CSV:7,CLAN:8,CFM:7,FS:1,CGS:7,CS:8,CDS:7,CW:9,LA:1,CBS:9,FWL:1,NIOPS:8,CJF:7,CGB:9,DC:1</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -1700,8 +1660,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,CLAN:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:2,CLAN:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -1778,8 +1737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7-,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7-,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
+			<availability>CC:7-,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7-,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9-,FWL:8-,NIOPS:6-,DC:7-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1811,8 +1769,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:3,CLAN:1,IS:5,Periphery.Deep:5,FS:8,MERC:5,Periphery.OS:5,Periphery:4,TC:5,OA:4,LA:5,Periphery.HR:6,DC:5</availability>
+			<availability>MOC:4,CC:4,HL:3,CLAN:1,IS:5,Periphery.Deep:5,FS:8,MERC:5,Periphery.OS:5,Periphery:4,TC:5,OA:4,LA:5,Periphery.HR:6,DC:5</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1851,8 +1808,7 @@
 				<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='Prime'>
 				<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
@@ -1886,8 +1842,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,General:1,FS:4</availability>
@@ -2162,8 +2117,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
+			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:8</availability>
 			</model>
@@ -2302,8 +2256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2329,8 +2282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:2,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,CLAN:6,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:5,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2340,8 +2292,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:4,CBS:3,CLAN:2,CNC:2,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:2,CNC:2,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2409,16 +2360,14 @@
 				<availability>CLAN:1,FWL:2,BAN:2</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
+				<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:3,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:7,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:4,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:4,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2436,8 +2385,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:5,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:5,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:8,TC:7,Periphery:6,CS:4,OA:4,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:3-,Periphery.Deep:7,BAN:5,Periphery:8</availability>
 			</model>
@@ -2531,8 +2479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,HL:2,Periphery.Deep:4,MERC:4,Periphery:4,FWL.pm:8,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,FWL:4,MH:5,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,Periphery.Deep:4,MERC:4,Periphery:4,FWL.pm:8,Periphery.CM:4,Periphery.MW:5,Periphery.ME:5,FWL:4,MH:5,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2654,8 +2601,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:1-,MOC:3-,OA:3-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
+			<availability>CC:1-,MOC:3-,OA:3-,HL:1,LA:6-,FWL:1-,Periphery.Deep:3-,FS:5-,MERC:5-,Periphery:3-,TC:3-,DC:2-</availability>
 			<model name='HCT-213'>
 				<availability>General:8</availability>
 			</model>
@@ -2758,8 +2704,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:2,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2785,8 +2730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:3,CLAN:1-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,CLAN:1-,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2870,8 +2814,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,HL:1,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,HL:1,CLAN:3,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -2964,8 +2907,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:5,HL:3,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
+			<availability>CC:4,MOC:5,HL:3,IS:5,Periphery.Deep:5,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:4,NIOPS:4-,DC:7</availability>
 			<model name=''>
 				<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
 			</model>
@@ -3003,8 +2945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3015,8 +2956,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,OA:3,HL:1,FS.DMM:5,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,OA:3,HL:1,FS.DMM:5,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3253,8 +3193,7 @@
 			<availability>CS:1-,HL:1,IS:3,NIOPS:1-,Periphery:3</availability>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,CIH:6,CLAN:5,IS:1,CFM:6,CIR:1,MERC:1,CGS:6,BAN:6,TC:1,CS:6,OA:1,LA:1,NIOPS:6,DC:3</availability>
+			<availability>MOC:1,CC:1,CIH:6,CLAN:5,IS:1,CFM:6,CIR:1,MERC:1,CGS:6,BAN:6,TC:1,CS:6,OA:1,LA:1,NIOPS:6,DC:3</availability>
 			<model name='C'>
 				<availability>CIH:4,CB:6,CGB:4</availability>
 			</model>
@@ -3291,8 +3230,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:7,CC:6,CHH:1,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:7,CC:6,CHH:1,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:6,CIR:7,BAN:5,Periphery:7,TC:7,CS:4,OA:7,LA:6,CBS:1,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3308,8 +3246,7 @@
 			<availability>CC:3-,LA:8-,IS:6-,FWL:3-,MERC:4-,Periphery:6-,BAN:2,DC:7-</availability>
 			<model name='Angel'>
 				<roles>recon</roles>
-				<availability>
-					CC:2,LA:2-,Periphery.MW:3,Periphery.ME:3,FWL:4,IS:8,MERC:6,Periphery:6,DC:2,BAN:2</availability>
+				<availability>CC:2,LA:2-,Periphery.MW:3,Periphery.ME:3,FWL:4,IS:8,MERC:6,Periphery:6,DC:2,BAN:2</availability>
 			</model>
 			<model name='Comet'>
 				<availability>FS:8</availability>
@@ -3402,8 +3339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:4,CSR:5,CIH:4,CSV:3,CLAN:2,CFM:4,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:2,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3424,8 +3360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:5,CLAN:2,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,HL:5,CLAN:2,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3442,8 +3377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:6</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,DC:2,Periphery:4</availability>
 			</model>
@@ -3560,8 +3494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3644,8 +3577,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3748,8 +3680,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4116,8 +4047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:2,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,CLAN:3,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4139,8 +4069,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,CS:4,HL:2,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>CC:5,MOC:4,CS:4,HL:2,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:4,TC:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,CLAN:2,IS:8,Periphery.Deep:7,MERC:8,BAN:4,Periphery:8</availability>
@@ -4190,24 +4119,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:6,CHH:7,HL:2,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
+			<availability>MOC:4,CC:6,CHH:7,HL:2,CLAN:8,IS:4,Periphery.Deep:4,FS:6,CIR:4,BAN:4,Periphery:4,TC:4,CS:7,OA:4,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:4,General:8,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4230,8 +4156,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:6,LA:6,TC:6</availability>
 			</model>
@@ -4247,8 +4172,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4265,8 +4189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,HL:6,IS:8,Periphery.Deep:7,FS:8,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:6,IS:8,Periphery.Deep:7,FS:8,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4368,8 +4291,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:5,CSV:3,CLAN:2,CFM:3,CGS:5,CCO:3,CSA:3,CS:1,CDS:5,CW:3,NIOPS:1,CSJ:3</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8,CLAN:6</availability>
@@ -4448,8 +4370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
-			<availability>
-				MOC:1,CC:1,CLAN:7,MERC:1,FS:1,CIR:2,Periphery:1,TC:1,CS:8,OA:1,LA:1,FWL:1,NIOPS:8,CJF:5,DC:1</availability>
+			<availability>MOC:1,CC:1,CLAN:7,MERC:1,FS:1,CIR:2,Periphery:1,TC:1,CS:8,OA:1,LA:1,FWL:1,NIOPS:8,CJF:5,DC:1</availability>
 			<model name='PAT-005'>
 				<availability>CS:8,CHH:4,CW:4,General:8,CLAN:2,NIOPS:8</availability>
 			</model>
@@ -4470,8 +4391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:4,Periphery.Deep:5,FWL:8,IS:6,Periphery:6,DC:8,TC:8</availability>
 			</model>
@@ -4499,8 +4419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:4,CW:4,General:8,CLAN:4,CNC:4</availability>
 			</model>
@@ -4522,8 +4441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4548,8 +4466,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:2,HL:3,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:8-,CIR:2,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
+			<availability>CC:8-,CCC:2,HL:3,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:8-,CIR:2,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>HL:6,CLAN:3-,General:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
@@ -4640,8 +4557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:2</availability>
 			</model>
@@ -4689,8 +4605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:5,CC:3,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4701,8 +4616,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,Periphery.DD:5,HL:3,IS:5,MERC:5,Periphery.OS:5,FS:6,Periphery:5,TC:5,OA:5,LA:5,FWL:5,DC:7</availability>
+			<availability>MOC:5,CC:6,Periphery.DD:5,HL:3,IS:5,MERC:5,Periphery.OS:5,FS:6,Periphery:5,TC:5,OA:5,LA:5,FWL:5,DC:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4723,8 +4637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,HL:2-,IS:4-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
+			<availability>CC:4-,HL:2-,IS:4-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -4889,8 +4802,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4966,8 +4878,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
+			<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:2</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -5001,8 +4912,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,CLAN:1-,IS:3,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>MOC:2,CC:5,CLAN:1-,IS:3,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5016,8 +4926,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5062,8 +4971,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,HL:4,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
+			<availability>MOC:6,CS:4-,HL:4,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,BAN:2,Periphery:4</availability>
@@ -5078,8 +4986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
+			<availability>MOC:2,CC:4,FS:2,MERC:4,CIR:3,TC:2,Periphery:2,CS:3,OA:2,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,NIOPS:3</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:6,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5111,8 +5018,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:2,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -5199,8 +5105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:5,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='B'>
 				<roles>fire_support</roles>
 				<availability>CCC:6,CDS:4,CW:6,CNC:5,General:6,CJF:7,CGB:4</availability>
@@ -5247,16 +5152,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,FS:1,CS:7,CDS:6,CW:8,CBS:6,LA:2,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
+			<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,FS:1,CS:7,CDS:6,CW:8,CBS:6,LA:2,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -5290,8 +5193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:8,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:2</availability>
@@ -5306,8 +5208,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:9,HL:4,CLAN:4,IS:8,Periphery.Deep:5,FS:7,MERC:8,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,MH:6,DC:8</availability>
+			<availability>CC:9,HL:4,CLAN:4,IS:8,Periphery.Deep:5,FS:7,MERC:8,Periphery:6,TC:6,CS:5-,LA:8,NIOPS:5-,MH:6,DC:8</availability>
 			<model name='C'>
 				<availability>CLAN:1-</availability>
 			</model>
@@ -5414,8 +5315,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -5544,8 +5444,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:5-,HL:1-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>MOC:3-,CC:5-,HL:1-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5604,8 +5503,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:2,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
+			<availability>MOC:5,CC:6,HL:2,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,CJF:1-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,FS:1</availability>
 			</model>
@@ -5807,8 +5705,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:4,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:4,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -5819,8 +5716,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:7,CS:5-,HL:3,LA:7,IS:7,Periphery.Deep:5,FWL:10,NIOPS:5-,FS:8,Periphery:4,TC:5,DC:7</availability>
+			<availability>CC:7,CS:5-,HL:3,LA:7,IS:7,Periphery.Deep:5,FWL:10,NIOPS:5-,FS:8,Periphery:4,TC:5,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:3</availability>
 			</model>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -6,8 +6,7 @@
 			<pctOmni>0,0</pctOmni>
 			<pctClan>10,10</pctClan>
 			<pctSL>80,80</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -36,8 +35,7 @@
 			<pctSL>100,100,100,80,25</pctSL>
 			<pctClan unitType='Vehicle'>0,0,0,15,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,85,80</pctSL>
-			<salvage pct='5'>
-				CHH:5,CCC:5,CSR:1,CIH:5,CSV:10,CFM:5,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:5,CB:10</salvage>
+			<salvage pct='5'>CHH:5,CCC:5,CSR:1,CIH:5,CSV:10,CFM:5,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
 			<pctOmni>0,0,0,60,80</pctOmni>
@@ -45,8 +43,7 @@
 			<pctSL>90,90,60,40,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:5,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:5,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
 			<weightDistribution era='2950' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='2950' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -56,8 +53,7 @@
 			<pctSL>100,100,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>6,6,7,70,80</pctOmni>
@@ -65,8 +61,7 @@
 			<pctSL>60,60,60,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:7,CSR:3,CSV:5,CFM:2,CGS:2,CSA:7,CDS:2,CW:1,CBS:1,CNC:10,CSJ:3,CJF:7,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:7,CSR:3,CSV:5,CFM:2,CGS:2,CSA:7,CDS:2,CW:1,CBS:1,CNC:10,CSJ:3,CJF:7,CB:7</salvage>
 			<weightDistribution era='2950' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2950' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -76,8 +71,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:10,CCO:1,CGS:10,CSA:10,CDS:1,CW:1,CBS:1,CNC:3,CSJ:8,CJF:10,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:10,CCO:1,CGS:10,CSA:10,CDS:1,CW:1,CBS:1,CNC:3,CSJ:8,CJF:10,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,20,70,80</pctOmni>
@@ -85,8 +79,7 @@
 			<pctSL>70,70,40,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:2,CIH:10,CSV:5,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:5,CNC:8,CSJ:3,CJF:8</salvage>
+			<salvage pct='10'>CHH:10,CCC:2,CIH:10,CSV:5,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:5,CNC:8,CSJ:3,CJF:8</salvage>
 			<weightDistribution era='2950' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2950' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -96,8 +89,7 @@
 			<pctSL>100,100,60,50,40</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>0,0,10,60,70</pctOmni>
@@ -105,8 +97,7 @@
 			<pctSL>90,90,50,40,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,40,50</pctClan>
 			<pctSL unitType='Vehicle'>100,100,60,60,50</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:3,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:7,CW:1,CBS:1,CNC:3,CSJ:3,CJF:3,CGB:10,CB:6</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:3,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:7,CW:1,CBS:1,CNC:3,CSJ:3,CJF:3,CGB:10,CB:6</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,60,80</pctOmni>
@@ -114,8 +105,7 @@
 			<pctSL>90,90,60,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:2,CSV:8,CFM:6,CCO:4,CGS:7,CSA:5,CDS:3,CW:4,CBS:1,CNC:3,CSJ:5,CJF:10,CGB:4,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:2,CSV:8,CFM:6,CCO:4,CGS:7,CSA:5,CDS:3,CW:4,CBS:1,CNC:3,CSJ:5,CJF:10,CGB:4,CB:3</salvage>
 			<weightDistribution era='2950' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='2950' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -125,8 +115,7 @@
 			<pctSL>70,70,40,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:1,CIH:6,CSV:10,CFM:5,CCO:3,CGS:4,CSA:3,CDS:1,CW:3,CBS:1,CNC:1,CSJ:3,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:6,CSV:10,CFM:5,CCO:3,CGS:4,CSA:3,CDS:1,CW:3,CBS:1,CNC:1,CSJ:3,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>5,5,30,60,80</pctOmni>
@@ -134,8 +123,7 @@
 			<pctSL>90,90,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:2,CSR:8,CIH:5,CSV:2,CFM:3,CCO:10,CGS:7,CSA:5,CDS:2,CW:5,CBS:3,CSJ:2,CJF:2,CGB:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:2,CSR:8,CIH:5,CSV:2,CFM:3,CCO:10,CGS:7,CSA:5,CDS:2,CW:5,CBS:3,CSJ:2,CJF:2,CGB:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,70,80</pctOmni>
@@ -143,8 +131,7 @@
 			<pctSL>90,90,50,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:5,CSR:7,CIH:10,CSV:7,CFM:3,CCO:4,CGS:3,CSA:7,CW:3,CNC:3,CSJ:3,CJF:7,CB:7,CGB:1</salvage>
+			<salvage pct='12'>CCC:1,CHH:5,CSR:7,CIH:10,CSV:7,CFM:3,CCO:4,CGS:3,CSA:7,CW:3,CNC:3,CSJ:3,CJF:7,CB:7,CGB:1</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>10,10,25,60,80</pctOmni>
@@ -152,8 +139,7 @@
 			<pctSL>90,90,60,10,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:1,CIH:9,CSV:3,CFM:9,CCO:10,CGS:3,CSA:3,CDS:4,CW:8,CNC:4,CJF:5,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CHH:5,CSR:1,CIH:9,CSV:3,CFM:9,CCO:10,CGS:3,CSA:3,CDS:4,CW:8,CNC:4,CJF:5,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>25,25,50,60,80</pctOmni>
@@ -169,8 +155,7 @@
 			<pctSL>50,50,50,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,40,40</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
 			<weightDistribution era='2950' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2950' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -180,8 +165,7 @@
 			<pctSL>50,50,30,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:4,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:4,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:2</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,10,70,80</pctOmni>
@@ -189,8 +173,7 @@
 			<pctSL>85,85,60,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:5,CIH:10,CSV:5,CFM:3,CCO:1,CGS:2,CSA:3,CDS:2,CNC:8,CSJ:10,CJF:10,CGB:5,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:5,CIH:10,CSV:5,CFM:3,CCO:1,CGS:2,CSA:3,CDS:2,CNC:8,CSJ:10,CJF:10,CGB:5,CB:3</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -385,8 +368,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,3,50,80</pctOmni>
@@ -394,8 +376,7 @@
 			<pctSL>85,85,65,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,10,70</pctOmni>
@@ -403,8 +384,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,3,50,80</pctOmni>
@@ -412,8 +392,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,5,40,80</pctOmni>
@@ -421,8 +400,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,3,40,80</pctOmni>
@@ -430,8 +408,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,5,70,80</pctOmni>
@@ -439,8 +416,7 @@
 			<pctSL>85,85,70,20,10</pctSL>
 			<pctClan unitType='Vehicle'>0,0,30,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,70</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='DC.LV' />
 		<faction key='CC.LL'>
@@ -565,16 +541,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:2,CLAN:3,IS:2,FS:2,BAN:5,TC:2,Periphery:1,CS:6,OA:2,LA:2,FWL:2,NIOPS:6,DC:5</availability>
+			<availability>MOC:2,CC:2,CLAN:3,IS:2,FS:2,BAN:5,TC:2,Periphery:1,CS:6,OA:2,LA:2,FWL:2,NIOPS:6,DC:5</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -706,8 +680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -798,8 +771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,CSV:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,MERC:2</availability>
 			</model>
@@ -854,8 +826,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:6,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -938,8 +909,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:6-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:6-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -985,8 +955,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:6,MOC:6,HL:3,CLAN:2,IS:5,FS:5,Periphery:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
+			<availability>CC:6,MOC:6,HL:3,CLAN:2,IS:5,FS:5,Periphery:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1090,8 +1059,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
+			<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:4,CGS:9,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 			</model>
@@ -1180,8 +1148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:7,FWL:7,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:7,FWL:7,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1257,8 +1224,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:5</availability>
+			<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1293,8 +1259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1373,8 +1338,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:5,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -1592,8 +1556,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>
-				CC:5,MOC:1,IS:4,FS:5,MERC:4,TC:1,Periphery:1,CS:3-,OA:1,LA:4,FWL:4,NIOPS:3-,MH:1,DC:4</availability>
+			<availability>CC:5,MOC:1,IS:4,FS:5,MERC:4,TC:1,Periphery:1,CS:3-,OA:1,LA:4,FWL:4,NIOPS:3-,MH:1,DC:4</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1630,8 +1593,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				HL:3,CIR:4,MERC:4,CGS:1,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CSJ:1</availability>
+			<availability>HL:3,CIR:4,MERC:4,CGS:1,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CSJ:1</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1741,8 +1703,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,CLAN:4,IS:2,CFM:3,MERC:2,CGS:5,Periphery:2,CS:5,CDS:5,CW:5,CBS:5,NIOPS:5,FWL:2,CJF:3,CGB:3,DC:2</availability>
+			<availability>CHH:3,CSR:3,CLAN:4,IS:2,CFM:3,MERC:2,CGS:5,Periphery:2,CS:5,CDS:5,CW:5,CBS:5,NIOPS:5,FWL:2,CJF:3,CGB:3,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -1877,8 +1838,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1910,8 +1870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1949,8 +1908,7 @@
 				<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='Prime'>
 				<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
@@ -1984,8 +1942,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:7,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:1,CLAN:3,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:7,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,FS:4</availability>
@@ -2262,8 +2219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
+			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,LA:8</availability>
 			</model>
@@ -2413,8 +2369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:3,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:3,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2443,8 +2398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:4,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:4,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2454,8 +2408,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2520,16 +2473,14 @@
 				<availability>CLAN:1,BAN:1</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:2,Periphery:6</availability>
+				<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:2,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:6,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2550,8 +2501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:4,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:3,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:4,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:3,LA:9,CNC:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -2652,8 +2602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:6,MH:6,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:6,MH:6,DC:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2870,8 +2819,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:1,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
+			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:1,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2901,8 +2849,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2998,8 +2945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -3092,8 +3038,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:4,FWL:3,NIOPS:4-,DC:6</availability>
+			<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:4,FWL:3,NIOPS:4-,DC:6</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3134,8 +3079,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3146,8 +3090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3322,8 +3265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CIH:5,CSR:5,CSV:5,CLAN:5,CCO:5,CGS:5,BAN:5,CSA:5,CDS:5,CW:5,CBS:5,CSJ:9,CJF:4,CB:5</availability>
+			<availability>CHH:5,CIH:5,CSR:5,CSV:5,CLAN:5,CCO:5,CGS:5,BAN:5,CSA:5,CDS:5,CW:5,CBS:5,CSJ:9,CJF:4,CB:5</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3402,8 +3344,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,CIR:8,BAN:4,TC:8,Periphery:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,CIR:8,BAN:4,TC:8,Periphery:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3512,8 +3453,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:3,CSR:4,CIH:3,CSV:3,CLAN:2,CFM:3,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:1,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CCC:2,CHH:3,CSR:4,CIH:3,CSV:3,CLAN:2,CFM:3,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:1,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3534,8 +3474,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3558,8 +3497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
 			</model>
@@ -3682,8 +3620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3775,8 +3712,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3883,8 +3819,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4272,8 +4207,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4295,8 +4229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:5,MOC:3,CS:4,HL:1,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>CC:5,MOC:3,CS:4,HL:1,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
@@ -4346,24 +4279,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:2,CLAN:8,IS:5,Periphery.Deep:4,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:2,CLAN:8,IS:5,Periphery.Deep:4,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4386,8 +4316,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,BAN:1,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:4,LA:4,TC:4</availability>
 			</model>
@@ -4403,8 +4332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4421,8 +4349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,HL:6,IS:9,Periphery.Deep:7,FS:9,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:6,IS:9,Periphery.Deep:7,FS:9,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4517,8 +4444,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,LA:5,FWL:4,MH:4,DC:5</availability>
+			<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,LA:5,FWL:4,MH:4,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -4547,8 +4473,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:2,CCC:3,CIH:2,CSR:5,CSV:3,CLAN:1,CFM:2,CGS:4,CCO:3,CSA:2,CS:1,CDS:5,CW:2,NIOPS:1,CSJ:2</availability>
+			<availability>CHH:2,CCC:3,CIH:2,CSR:5,CSV:3,CLAN:1,CFM:2,CGS:4,CCO:3,CSA:2,CS:1,CDS:5,CW:2,NIOPS:1,CSJ:2</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -4659,8 +4584,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -4688,8 +4612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:4,CW:4,General:8,CLAN:2,CNC:4</availability>
 			</model>
@@ -4711,8 +4634,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -4740,8 +4662,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:9-,CCC:2,HL:3,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:9-,CIR:1,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
+			<availability>CC:9-,CCC:2,HL:3,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:9-,CIR:1,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>HL:6,CLAN:2-,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
@@ -4829,8 +4750,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
+			<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:1</availability>
 			</model>
@@ -4842,8 +4762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
+			<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -4863,8 +4782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:6,HL:4,IS:6-,Periphery.Deep:4,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:6,HL:4,IS:6-,Periphery.Deep:4,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4883,8 +4801,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:4+,CC:2+,HL:2+,IS:4+,Periphery.Deep:5,MERC:4+,FS:4+,CIR:4+,Periphery:4+,TC:4+,CS:5,OA:4+,LA:4+,FWL:4+,DC:2+</availability>
+			<availability>MOC:4+,CC:2+,HL:2+,IS:4+,Periphery.Deep:5,MERC:4+,FS:4+,CIR:4+,Periphery:4+,TC:4+,CS:5,OA:4+,LA:4+,FWL:4+,DC:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4895,8 +4812,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
+			<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4920,8 +4836,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,HL:2-,IS:3-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
+			<availability>CC:4-,HL:2-,IS:3-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -4998,8 +4913,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:6,OA:2,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:4,TC:2</availability>
+			<availability>MOC:2,Periphery.R:6,OA:2,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:4,TC:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5102,8 +5016,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5179,8 +5092,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
+			<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -5214,8 +5126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5229,8 +5140,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5271,8 +5181,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:8,Periphery:6,DC:6,CGB:1-</availability>
+			<availability>MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:8,Periphery:6,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,BAN:1,Periphery:4</availability>
@@ -5287,8 +5196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,FS:2,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,FS:2,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:5,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5335,8 +5243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -5450,8 +5357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -5501,16 +5407,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,CS:7,CDS:6,CW:8,CBS:6,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
+			<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,CS:7,CDS:6,CW:8,CBS:6,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -5544,8 +5448,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:1</availability>
@@ -5560,8 +5463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:8,CCC:2-,CHH:1-,CSR:2-,HL:3,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:5,TC:5,CS:5-,CSA:1-,LA:8,CBS:2,NIOPS:5-,MH:5,CSJ:1-,CJF:1-,DC:8,CB:2</availability>
+			<availability>CC:8,CCC:2-,CHH:1-,CSR:2-,HL:3,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:5,TC:5,CS:5-,CSA:1-,LA:8,CBS:2,NIOPS:5-,MH:5,CSJ:1-,CJF:1-,DC:8,CB:2</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:2-,CHH:1-,CSR:2-,CBS:2,CSJ:1-,CGS:2-,CJF:1-,CB:2</availability>
 			</model>
@@ -5665,8 +5567,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -5718,8 +5619,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:3,CIH:3,CSR:7,CSV:2,CLAN:4,CCO:3,CDS:2,CW:3,CBS:5,CNC:2,CSJ:3,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:3,CIH:3,CSR:7,CSV:2,CLAN:4,CCO:3,CDS:2,CW:3,CBS:5,CNC:2,CSJ:3,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -5796,8 +5696,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:1-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:1-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5856,8 +5755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,FS:1</availability>
 			</model>
@@ -6033,8 +5931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -6102,8 +5999,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6114,8 +6010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2</availability>
 			</model>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -541,21 +541,21 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:2,CC:2,CLAN:3,IS:2,FS:2,BAN:5,TC:2,Periphery:1,CS:6,OA:2,LA:2,FWL:2,NIOPS:6,DC:5</availability>
+			<availability>MOC:2,CLAN:3,IS:2,BAN:5,TC:2,Periphery:1,CS:6,OA:2,NIOPS:6,DC:5</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CSA:2,CCC:2,CIH:2,CSR:6,CDS:2,CBS:2,CSV:2,CNC:4,CLAN:2,CGS:2,CJF:5,CB:2</availability>
+			<availability>CSR:6,CNC:4,CLAN:2,CJF:5</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8</availability>
@@ -629,7 +629,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
+			<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -648,7 +648,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -680,7 +680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -771,7 +771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>CSV:2-,IS:3,FS:5,Periphery:1,CS:4-,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,MERC:2</availability>
 			</model>
@@ -819,14 +819,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:6,CLAN:2-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:6,CLAN:2-,IS:7,Periphery.Deep:7,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -909,7 +909,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:6-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,MERC:6-,Periphery:9-,CS:2-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -955,7 +955,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,HL:3,CLAN:2,IS:5,FS:5,Periphery:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
+			<availability>CC:6,MOC:6,HL:3,CLAN:2,IS:5,Periphery:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1041,7 +1041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:5,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
+			<availability>CHH:8,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1067,7 +1067,7 @@
 				<availability>CS:4,CLAN:6,NIOPS:4,CGS:7,BAN:3</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1148,7 +1148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:7,FWL:7,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,MERC:7,Periphery:7,TC:8,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1195,7 +1195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cameron Battlecruiser' unitType='Warship'>
-			<availability>CS:1,CHH:1,CCC:1,CSR:2,CW:2,CSV:1,CLAN:1,NIOPS:1,CGS:2,CCO:1,CJF:1,CGB:1</availability>
+			<availability>CS:1,CSR:2,CW:2,CLAN:1,NIOPS:1,CGS:2</availability>
 			<model name='(2688)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -1224,14 +1224,14 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:5</availability>
+			<availability>CC:4,IS:2,MERC:1,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,MERC:8,BAN:6,Periphery:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
@@ -1259,7 +1259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1305,7 +1305,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:3,CS:5,CHH:5,LA:3,CLAN:2,IS:2,FWL:2,NIOPS:5,MERC:2,FS:2,CGB:5,DC:2</availability>
+			<availability>CC:3,CS:5,CHH:5,LA:3,CLAN:2,IS:2,NIOPS:5,MERC:2,CGB:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1372,12 +1372,12 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,OA:2,LA:6,CLAN:1,FWL:4,MERC:3,FS:3,CIR:2,Periphery:2,TC:2,DC:3</availability>
+			<availability>CC:2,LA:6,CLAN:1,FWL:4,MERC:3,FS:3,Periphery:2,DC:3</availability>
 			<model name='CHP-W10'>
 				<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:6,CGS:6,BAN:3</availability>
@@ -1556,7 +1556,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:5,MOC:1,IS:4,FS:5,MERC:4,TC:1,Periphery:1,CS:3-,OA:1,LA:4,FWL:4,NIOPS:3-,MH:1,DC:4</availability>
+			<availability>CC:5,IS:4,FS:5,MERC:4,Periphery:1,CS:3-,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1593,7 +1593,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>HL:3,CIR:4,MERC:4,CGS:1,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CSJ:1</availability>
+			<availability>HL:3,CIR:4,MERC:4,CGS:1,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,CSJ:1</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1673,7 +1673,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -1703,7 +1703,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:4,IS:2,CFM:3,MERC:2,CGS:5,Periphery:2,CS:5,CDS:5,CW:5,CBS:5,NIOPS:5,FWL:2,CJF:3,CGB:3,DC:2</availability>
+			<availability>CHH:3,CSR:3,CLAN:4,IS:2,CFM:3,MERC:2,CGS:5,Periphery:2,CS:5,CDS:5,CW:5,CBS:5,NIOPS:5,CJF:3,CGB:3</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -1761,7 +1761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,IS:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -1818,7 +1818,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CHH:6,CCC:6,CIH:5,CDS:5,CLAN:5,CCO:4,CJF:4,BAN:4,CGB:9,CB:6</availability>
+			<availability>CSA:4,CHH:6,CCC:6,CLAN:5,CCO:4,CJF:4,BAN:4,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -1838,7 +1838,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>MOC:10,HL:7,IS:7,Periphery.Deep:8,CIR:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -1870,7 +1870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,Periphery.HR:6</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1897,7 +1897,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CHH:4,CIH:4,CDS:4,CSV:3,CLAN:4,CFM:5,CSJ:3,CJF:4,CGB:3,CB:4</availability>
+			<availability>CSV:3,CLAN:4,CFM:5,CSJ:3CGB:3</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 			</model>
@@ -2034,7 +2034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CSA:1,CIH:1,CSR:1,CDS:3,CSV:1,CLAN:1,CSJ:3,CGS:1,CCO:1,CGB:3,CB:1</availability>
+			<availability>CDS:3,CLAN:1,CSJ:3,CGB:3</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>IS:8</availability>
@@ -2045,7 +2045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:4,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,FS:4,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2114,7 +2114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>CHH:2,CIH:7,CDS:5,CW:8,CSV:2,CNC:4,CLAN:2,CSJ:4,CJF:6,CGB:2</availability>
+			<availability>CIH:7,CDS:5,CW:8,CNC:4,CLAN:2,CSJ:4,CJF:6</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -2221,7 +2221,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,LA:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2369,7 +2369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:3,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:3,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2398,7 +2398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:4,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,CJF:4,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2408,14 +2408,14 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,HL:1,LA:2,FS.CH:7,FS:6,MERC:2,CIR:4,Periphery:3,TC:3,DC:2</availability>
+			<availability>CC:1,HL:1,LA:2,FS.CH:7,FS:6,MERC:2,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2434,10 +2434,10 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CS:2,OA:1,LA:4,Periphery.MW:1,FWL:5,MERC:1,TC:1,Periphery:1</availability>
+			<availability>CS:2,LA:4,FWL:5,MERC:1,Periphery:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,HL:6,LA:8,FWL:8,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
@@ -2473,14 +2473,14 @@
 				<availability>CLAN:1,BAN:1</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>CS:6,CDS:1,HL:4,CLAN:1,CNC:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:2,Periphery:6</availability>
+				<availability>CS:6,HL:4,CLAN:1,FWL:6,NIOPS:6,Periphery.Deep:5,MERC:6,BAN:2,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:6,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2501,7 +2501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:4,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:3,LA:9,CNC:3,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:4,HL:4,CLAN:3,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:3,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:2-,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -2532,7 +2532,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:4,CS:7,CHH:6,CSR:6,CLAN:4,IS:4,FWL:4,NIOPS:7,FS:3,MERC:4,DC:4,Periphery:3</availability>
+			<availability>CS:7,CHH:6,CSR:6,CLAN:4,IS:4,NIOPS:7,FS:3,MERC:4,Periphery:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2716,7 +2716,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:3-,FS:4-,MERC:5-,Periphery:3-,TC:3-,DC:1-</availability>
+			<availability>HL:1,LA:5-,Periphery.Deep:3-,FS:4-,MERC:5-,Periphery:3-,DC:1-</availability>
 			<model name='HCT-213'>
 				<availability>General:7</availability>
 			</model>
@@ -2755,11 +2755,11 @@
 			<availability>CS:3,CHH:4,CLAN:2,FWL:2,NIOPS:3,CGB:4,CB:4</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -2819,7 +2819,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,OA:2,Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:1,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2,TC:2</availability>
+			<availability>Periphery.HR:2,FS.CMM:2,FS.DMM:2,FS:1,MERC:3,Periphery.OS:2,FS.CrMM:2,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -2849,7 +2849,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,HL:3,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2876,7 +2876,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>CC:6,MOC:4,HL:3,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:5,OA:5,LA:7,FWL:4,DC:5</availability>
+			<availability>CC:6,MOC:4,HL:3,IS:5,MERC:5,CIR:4,Periphery:5,LA:7,FWL:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -2945,7 +2945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,HL:1,CLAN:2,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -3038,7 +3038,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:4,FWL:3,NIOPS:4-,DC:6</availability>
+			<availability>CC:3,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,FWL:3,NIOPS:4-,DC:6</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3079,7 +3079,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:2,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3090,7 +3090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,Periphery:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3178,7 +3178,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2+,CS:6,LA:2+,CLAN:5,IS:2+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:6,CGB:6,DC:2+</availability>
+			<availability>CS:6,CLAN:5,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:6,CGB:6,</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3220,7 +3220,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:5,CDS:5,CSV:5,CLAN:4,NIOPS:7,FS:6</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -3265,7 +3265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CIH:5,CSR:5,CSV:5,CLAN:5,CCO:5,CGS:5,BAN:5,CSA:5,CDS:5,CW:5,CBS:5,CSJ:9,CJF:4,CB:5</availability>
+			<availability>CLAN:5,CSJ:9,CJF:4</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3294,7 +3294,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:5,CW:6,CSV:6,CLAN:5,CNC:5,CGS:6,CJF:6,CGB:6</availability>
+			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CW:6,CSV:6,CLAN:5,CGS:6,CJF:6,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -3344,7 +3344,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,CIR:8,BAN:4,TC:8,Periphery:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,BAN:4,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3440,7 +3440,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CDS:7,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:7,BAN:6,CGB:6,CB:7</availability>
+			<availability>CHH:9,CW:6,CSV:6,CLAN:7,CSJ:6,BAN:6,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:8</availability>
@@ -3453,7 +3453,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:2,CHH:3,CSR:4,CIH:3,CSV:3,CLAN:2,CFM:3,CCO:3,CGS:3,CSA:4,CDS:3,CW:2,CBS:2,CNC:1,CSJ:3,CGB:3,CB:3</availability>
+			<availability>CHH:3,CSR:4,CIH:3,CSV:3,CLAN:2,CFM:3,CCO:3,CGS:3,CSA:4,CDS:3,CNC:1,CSJ:3,CGB:3,CB:3</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3474,7 +3474,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,HL:5,CLAN:1,IS:7,Periphery.Deep:6,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3497,7 +3497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
+			<availability>Periphery.R:4,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,DC:5</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
 			</model>
@@ -3552,7 +3552,7 @@
 			<availability>CC:10,CS:10,LA:10,CLAN:10,FWL:10,IS:9,NIOPS:10,FS:10,DC:10,Periphery:8</availability>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CHH:4,CIH:2,CDS:4,CW:9,CBS:2,CLAN:2,CSJ:4,CCO:4,CJF:4,CB:2</availability>
+			<availability>CSA:4,CHH:4,CDS:4,CW:9,CLAN:2,CSJ:4,CCO:4,CJF:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -3589,7 +3589,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CIH:7,CDS:7,CW:9,CBS:4,CSV:6,CNC:7,CLAN:4,CSJ:5,CJF:8,CGB:4</availability>
+			<availability>CHH:5,CIH:7,CDS:7,CW:9,CSV:6,CNC:7,CLAN:4,CSJ:5,CJF:8</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -3620,7 +3620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3635,7 +3635,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,CLAN:4,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:4,NIOPS:8,DC:5,CGB:4</availability>
+			<availability>CLAN:4,IS:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,NIOPS:8,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:2,NIOPS:8,MERC:0,BAN:3</availability>
 			</model>
@@ -3712,7 +3712,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3819,7 +3819,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4207,7 +4207,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4229,7 +4229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:3,CS:4,HL:1,LA:5,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>CS:4,HL:1,CLAN:3-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,CLAN:1,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
@@ -4252,7 +4252,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:3-,FWL:4,IS:4,NIOPS:4,FS:4,MERC:4,DC:4,Periphery:2</availability>
+			<availability>CS:4,CLAN:3-,IS:4,NIOPS:4,MERC:4,Periphery:2</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,CLAN:2-,BAN:4</availability>
@@ -4286,14 +4286,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>HL:4,PIR:4,General:4,IS:4,Periphery.Deep:5,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4332,7 +4332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,OA:5,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4349,7 +4349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,HL:6,IS:9,Periphery.Deep:7,FS:9,CIR:8,Periphery:8,TC:8,OA:8,LA:9,FWL:10,DC:8</availability>
+			<availability>HL:6,IS:9,Periphery.Deep:7,Periphery:8,FWL:10,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4411,7 +4411,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -4444,7 +4444,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,LA:5,FWL:4,MH:4,DC:5</availability>
+			<availability>CC:4,MOC:7,HL:2,IS:5,MERC:5,TC:5,Periphery:4,CS:6-,OA:5,FWL:4</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -4584,7 +4584,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -4612,7 +4612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:8,Periphery.Deep:9,IS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:4,CW:4,General:8,CLAN:2,CNC:4</availability>
 			</model>
@@ -4662,7 +4662,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:9-,CCC:2,HL:3,CSV:2,CLAN:2,IS:8-,Periphery.Deep:5,CFM:2,FS:9-,CIR:1,CGS:2,Periphery:5,CSA:2,CS:6-,Clan.IS:2,FWL:8-,NIOPS:6-,CJF:2,CB:2</availability>
+			<availability>CC:9-,HL:3,CLAN:2,IS:8-,Periphery.Deep:5,FS:9-,CIR:1,Periphery:5,CS:6-,Clan.IS:2,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>HL:6,CLAN:2-,General:8,Periphery.Deep:7,BAN:3,Periphery:8</availability>
@@ -4706,7 +4706,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CDS:8,CW:8,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:6</availability>
+			<availability>CSR:9,CBS:9,CSV:7,CLAN:8,CSJ:9,CJF:9,BAN:6</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 			</model>
@@ -4750,7 +4750,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:4-,MOC:4-,HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:4-,LA:4-,FWL:4-,DC:5-</availability>
+			<availability>HL:2-,CLAN:4,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8,CLAN:1</availability>
 			</model>
@@ -4762,7 +4762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
+			<availability>CC:8,LA:6,DC.AL:10,IS:7,MERC:7,CIR:7,Periphery:8,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -4782,7 +4782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:6,HL:4,IS:6-,Periphery.Deep:4,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>CC:8-,HL:4,IS:6-,Periphery.Deep:4,FS:7-,Periphery:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4795,13 +4795,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:1,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,HL:1,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:4+,CC:2+,HL:2+,IS:4+,Periphery.Deep:5,MERC:4+,FS:4+,CIR:4+,Periphery:4+,TC:4+,CS:5,OA:4+,LA:4+,FWL:4+,DC:2+</availability>
+			<availability>CC:2+,HL:2+,IS:4+,Periphery.Deep:5,MERC:4+,Periphery:4+,CS:5,DC:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4812,7 +4812,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
+			<availability>CC:8,HL:4,IS:6,Periphery.Deep:4,MERC:6,FS:7,Periphery:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4836,7 +4836,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,HL:2-,IS:3-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
+			<availability>CC:4-,HL:2-,IS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,BAN:1-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -4937,7 +4937,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5,CGB:2</availability>
+			<availability>CS:6-,HL:3,LA:6,CLAN:2,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:3,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -5016,7 +5016,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5031,7 +5031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 			</model>
@@ -5092,7 +5092,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:4</availability>
+			<availability>MOC:2,CC:3,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:2,NIOPS:3,DC:4</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -5126,7 +5126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,IS:2,FS:5,MERC:4,Periphery:2,CS:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5140,7 +5140,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5181,7 +5181,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:8,Periphery:6,DC:6,CGB:1-</availability>
+			<availability>CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:8,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,BAN:1,Periphery:4</availability>
@@ -5196,7 +5196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,FS:2,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,FS:2,MERC:3,CIR:2,Periphery:1,CS:3,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:5,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5217,7 +5217,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -5243,7 +5243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:6,MERC:4,Periphery.OS:2,FS:9,Periphery:1,TC:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,FS.DMM:8</availability>
 			</model>
@@ -5357,7 +5357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:6,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -5407,7 +5407,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -5448,7 +5448,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:3,CLAN:4,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8,CLAN:1</availability>
@@ -5463,7 +5463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,CCC:2-,CHH:1-,CSR:2-,HL:3,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:5,TC:5,CS:5-,CSA:1-,LA:8,CBS:2,NIOPS:5-,MH:5,CSJ:1-,CJF:1-,DC:8,CB:2</availability>
+			<availability>CC:8,CCC:2-,CSR:2-,HL:3,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:5,CS:5-,CBS:2,NIOPS:5-,CB:2</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:2-,CHH:1-,CSR:2-,CBS:2,CSJ:1-,CGS:2-,CJF:1-,CB:2</availability>
 			</model>
@@ -5567,7 +5567,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,FS:4,MERC:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -5577,14 +5577,14 @@
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>CC:6,CS:2,MOC:6,LA:6,FWL:6,IS:6,NIOPS:2,FS:6,MERC:6,DC:6,Periphery:6</availability>
+				<availability>CS:2,IS:6,NIOPS:2,MERC:6,Periphery:6</availability>
 			</model>
 			<model name='TBT-5S'>
-				<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,FWL:4,MERC:4,Periphery:4,TC:4</availability>
+				<availability>MOC:4,HL:2,IS:4,Periphery.Deep:4,MERC:4,Periphery:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
-			<availability>CC:1,MOC:1,CS:7,OA:3,CSR:2,CLAN:2,NIOPS:7,FS:1,MERC:1,DC:1,TC:1</availability>
+			<availability>CC:1,MOC:1,CS:7,OA:3,CLAN:2,NIOPS:7,FS:1,MERC:1,DC:1,TC:1</availability>
 			<model name='TRN-3T'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
 			</model>
@@ -5696,7 +5696,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:1-,CLAN:1-,IS:4-,FS:4-,CIR:3-,Periphery:3-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>CC:6-,HL:1-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5748,14 +5748,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>CC:3,MOC:1,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1,TC:1</availability>
+			<availability>CC:3,CS:5,OA:2,LA:3,FWL:3,IS:2,NIOPS:5,FS:3,DC:3,Periphery:1</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+			<availability>CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,Periphery:4,CS:5-,NIOPS:5-</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,FS:1</availability>
 			</model>
@@ -5767,7 +5767,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CSA:2,CCC:1,CSR:3,CW:4,CSV:2,CNC:2,CLAN:2,CFM:2,CSJ:5,CJF:2,CB:2</availability>
+			<availability>CCC:1,CSR:3,CW:4,CLAN:2,CSJ:5</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>CLAN:6,IS:8</availability>
@@ -5826,7 +5826,7 @@
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
-			<availability>CSA:2,CS:1,CHH:1,CSR:2,CDS:2,CW:1,CLAN:1,NIOPS:1,CGS:1,CGB:1,CB:1</availability>
+			<availability>CSA:2,CS:1,CSR:2,CDS:2,CLAN:1,NIOPS:1</availability>
 			<model name='(2709)'>
 				<roles>cargo</roles>
 				<availability>General:8</availability>
@@ -5849,7 +5849,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FWL:7,IS:5,NIOPS:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:8,FS:4</availability>
@@ -5860,7 +5860,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+			<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 			</model>
@@ -5907,7 +5907,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,HL:4,LA:9,CLAN:4,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:4,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
 			<model name='C 3'>
 				<availability>CLAN:4</availability>
 			</model>
@@ -5931,7 +5931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
+			<availability>HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:8,FWL:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -5999,7 +5999,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,CS:3-,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6010,7 +6010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,CS:5-,FWL:10,NIOPS:5-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2</availability>
 			</model>
@@ -6044,7 +6044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:5,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:2,DC:5,TC:3</availability>
+			<availability>CS:6,CIH:3,CLAN:4,IS:5,NIOPS:6,CFM:5,FS:6,MERC:5,Periphery:2,TC:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>CS:8,CLAN:3,NIOPS:8,CFM:5,BAN:5</availability>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -546,21 +546,21 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:2,CLAN:2,IS:2,FS:2,BAN:5,TC:1,Periphery:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>CLAN:2,IS:2,BAN:5,Periphery:1,CS:6,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>CSA:2,CCC:2,CIH:2,CSR:6,CDS:1,CBS:1,CSV:1,CNC:4,CLAN:1,CGS:2,CJF:5,CB:1</availability>
+			<availability>CSA:2,CCC:2,CIH:2,CSR:6,CNC:4,CLAN:1,CGS:2,CJF:5</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8</availability>
@@ -625,7 +625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,FS:8,Periphery:5,DC:8</availability>
+			<availability>CC:7,CS:5-,HL:3,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,Periphery:5</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>DC:8</availability>
@@ -648,7 +648,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -680,7 +680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -735,7 +735,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:1,CC:1,CS:3-,OA:1,HL:1,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,Periphery:3,TC:1</availability>
+			<availability>MOC:1,CC:1,CS:3-,OA:1,HL:1,IS:4,MERC:3,Periphery:3,TC:1</availability>
 			<model name='ASN-21'>
 				<availability>General:8</availability>
 			</model>
@@ -777,7 +777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,MERC:2,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>CSV:2-,IS:3,FS:5,MERC:2,Periphery:1,CS:4-,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,MERC:2</availability>
 			</model>
@@ -825,14 +825,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>CC:3,MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:6,CLAN:1-,IS:7,Periphery.Deep:7,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -977,7 +977,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:5-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,MERC:6-,Periphery:9-,CS:2-,LA:5-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -1023,7 +1023,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,HL:4,CLAN:2,IS:5,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
+			<availability>CC:6,HL:4,CLAN:2,IS:5,Periphery:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1116,7 +1116,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:4,CLAN:4,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:6</availability>
+			<availability>CHH:7,CLAN:4,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1142,7 +1142,7 @@
 				<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1189,7 +1189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:2,MERC.KH:3,MERC.WD:3,LA:4,FWL:3,FS:6,MERC:2,DC:4,Periphery:2</availability>
+			<availability>CC:4,MERC.KH:3,MERC.WD:3,LA:4,FWL:3,FS:6,MERC:2,DC:4,Periphery:2</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1216,7 +1216,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,LA:2,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,FS:3,Periphery:2</availability>
+			<availability>CC:4,LA:2,FS:3,Periphery:2</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1238,7 +1238,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1314,7 +1314,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
+			<availability>CC:4,IS:2,MERC:1,Periphery:1,CS:2,LA:2,NIOPS:2,DC:4</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1349,7 +1349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1376,7 +1376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
-			<availability>CSA:6,CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
+			<availability>CCC:7,CIH:7,CW:5,CBS:8,CLAN:6,CSJ:7,CJF:5,CGB:5,CB:7</availability>
 			<model name=''>
 				<availability>CLAN:5</availability>
 			</model>
@@ -1395,7 +1395,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:2,CS:5,CHH:4,LA:2,CLAN:1,IS:1,FWL:1,NIOPS:5,MERC:1,FS:1,CGB:4,DC:1</availability>
+			<availability>CC:2,CS:5,CHH:4,LA:2,CLAN:1,IS:1,NIOPS:5,MERC:1,CGB:4</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1471,12 +1471,12 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,OA:2,LA:5,FWL:4,MERC:3,FS:3,CIR:2,TC:2,Periphery:2,DC:3</availability>
+			<availability>CC:2,LA:5,FWL:4,MERC:3,FS:3,Periphery:2,DC:3</availability>
 			<model name='CHP-W10'>
 				<availability>HL:2,FS:8,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:6,LA:8,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:4</availability>
@@ -1486,7 +1486,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:3,CS:4-,OA:2,LA:3,IS:3,FWL:3,FS:3,MERC:3,Periphery:2,DC:3</availability>
+			<availability>CS:4-,IS:3,FWL:3,MERC:3,Periphery:2</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -1715,7 +1715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>Periphery.R:4,MERC.KH:8,HL:3,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CIR:4,MERC:4,Periphery:3,TC:6</availability>
+			<availability>Periphery.R:4,MERC.KH:8,HL:3,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,CIR:4,MERC:4,Periphery:3,TC:6</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -1736,7 +1736,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,HL:1,IS:3,FS:3,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>HL:1,IS:3,Periphery:3,CS:3,LA:7,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1809,7 +1809,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,CIR:2,DC:2,TC:2,Periphery:2</availability>
+			<availability>CC:2,OA:3,LA:2,CLAN:5,FWL:2,FS:8,MERC:3,DC:2,Periphery:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -1842,7 +1842,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
+			<availability>CLAN:3,IS:1,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -1900,7 +1900,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,IS:3,FS:5,CIR:2,TC:2,Periphery:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,IS:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -1969,7 +1969,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CHH:8,CCC:6,CIH:6,CDS:5,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
+			<availability>CSA:4,CHH:8,CCC:6,CIH:6,CLAN:5,CCO:4,CJF:4,BAN:5,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -1989,7 +1989,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>MOC:10,HL:7,IS:7,Periphery.Deep:8,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2021,13 +2021,13 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,Periphery.HR:6</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>CC:4,MOC:5,IS:4,FS:4,MERC:4,CIR:4,TC:4,Periphery:4,OA:5,LA:4,FWL:4,MH:5,DC:4</availability>
+			<availability>MOC:5,IS:4,MERC:4,Periphery:4,OA:5,MH:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2058,7 +2058,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CSA:6,CHH:6,CIH:6,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:5,CB:6</availability>
+			<availability>CSV:5,CLAN:6,CFM:5,CSJ:5,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 			</model>
@@ -2104,7 +2104,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
+			<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,FS:4</availability>
@@ -2193,7 +2193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Essex II Destroyer' unitType='Warship'>
-			<availability>CSA:1,CIH:1,CSR:1,CDS:2,CSV:1,CLAN:1,CSJ:3,CGS:1,CCO:1,CGB:2,CB:1</availability>
+			<availability>CDS:2,CLAN:1,CSJ:3,CGB:2</availability>
 			<model name='(2711)'>
 				<roles>destroyer</roles>
 				<availability>IS:8</availability>
@@ -2204,7 +2204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>CC:5,MOC:3,IS:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,FS:3,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2282,7 +2282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>CHH:3,CIH:7,CDS:5,CW:8,CSV:3,CNC:4,CLAN:3,CSJ:4,CJF:6,CGB:3</availability>
+			<availability>CIH:7,CDS:5,CW:8,CNC:4,CLAN:3,CSJ:4,CJF:6</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -2362,7 +2362,7 @@
 				<availability>CLAN:8,BAN:2</availability>
 			</model>
 			<model name='FFL-4A'>
-				<availability>:0,MERC.WD:8</availability>
+				<availability>MERC.WD:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
@@ -2380,7 +2380,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:8,LA:8</availability>
+				<availability>MERC.KH:8,LA:8</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2518,7 +2518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2541,7 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,NIOPS:6,CJF:3,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2576,7 +2576,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>CC:1,MOC:3,OA:3,HL:1,LA:2,FS.CH:7,FS:6,MERC:1,CIR:4,Periphery:3,TC:3,DC:1</availability>
+			<availability>CC:1,HL:1,LA:2,FS.CH:7,FS:6,MERC:1,CIR:4,Periphery:3,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2595,10 +2595,10 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CS:2,OA:1,LA:4,Periphery.MW:1,FWL:5,MERC:1,TC:1,Periphery:1</availability>
+			<availability>CS:2,LA:4,FWL:5,MERC:1,Periphery:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,HL:6,LA:8,FWL:8,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
@@ -2647,7 +2647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2668,7 +2668,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:3,HL:4,CLAN:2,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:3,HL:4,CLAN:2,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 			</model>
@@ -2702,14 +2702,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:3,CS:7,CHH:5,CSR:5,CLAN:2,IS:3,FWL:3,NIOPS:7,FS:2,MERC:3,DC:3,Periphery:2</availability>
+			<availability>CS:7,CHH:5,CSR:5,CLAN:2,IS:3,NIOPS:7,FS:2,MERC:3,Periphery:2</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -2817,7 +2817,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CS:3,MERC.KH:2,MERC.WD:2,IS:4,MERC:2,DC:4,Periphery:3,TC:2,BAN:2</availability>
+			<availability>CS:3,MERC.KH:2,MERC.WD:2,IS:4,MERC:2,Periphery:3,TC:2,BAN:2</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,TC:7,Periphery:6</availability>
 			</model>
@@ -2883,7 +2883,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
+			<availability>HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:6</availability>
 			</model>
@@ -2926,11 +2926,11 @@
 			<availability>CS:3,CHH:4,CLAN:1,FWL:1,NIOPS:3,CGB:4,CB:3</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -3004,7 +3004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:2,OA:2,Periphery.HR:2,FS.CMM:3,FS.DMM:3,FS:3,MERC:2,Periphery.OS:2,FS.CrMM:3,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:2,FS.CMM:3,FS.DMM:3,FS:3,MERC:2,FS.CrMM:3,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -3034,7 +3034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3064,7 +3064,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:4,CC:6,HL:3,IS:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
+			<availability>MOC:4,CC:6,HL:3,IS:5,MERC:5,CIR:4,Periphery:5,LA:8,FWL:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3127,7 +3127,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -3201,7 +3201,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:3,NIOPS:4-,DC:6</availability>
+			<availability>CC:3,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,LA:5,FWL:3,NIOPS:4-,DC:6</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3257,7 +3257,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:2,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3268,7 +3268,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,Periphery:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3367,7 +3367,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1+,CS:6,LA:1+,CLAN:4,IS:1+,FWL:1+,NIOPS:6,FS:2+,MERC:2+,CGS:5,CGB:5,DC:1+</availability>
+			<availability>CS:6,CLAN:4,IS:1+,NIOPS:6,FS:2+,MERC:2+,CGS:5,CGB:5</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3406,7 +3406,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,CHH:4,CDS:4,CSV:4,CLAN:3,NIOPS:7,FS:6</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -3466,7 +3466,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:6,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:6</availability>
+			<availability>CIH:6,CLAN:7,CCO:5,BAN:7,CSA:5,CW:6,CSJ:9,CJF:5,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3545,7 +3545,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,CIR:8,BAN:3,TC:8,Periphery:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,BAN:3,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3652,7 +3652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CDS:8,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
+			<availability>CHH:9,CDS:8,CW:6,CSV:6,CLAN:7,CSJ:6,CJF:8,BAN:6,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:8</availability>
@@ -3665,7 +3665,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CLAN:1,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CHH:3,CSR:4,CIH:3,CSV:2,CLAN:1,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3686,7 +3686,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:5,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,HL:5,IS:7,Periphery.Deep:6,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3709,7 +3709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
+			<availability>Periphery.R:4,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,DC:5</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
 			</model>
@@ -3801,7 +3801,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:9,CDS:9,CW:9,CBS:5,CSV:8,CNC:9,CLAN:6,CSJ:7,CJF:9,BAN:4,CGB:6</availability>
+			<availability>CIH:9,CDS:9,CW:9,CBS:5,CSV:8,CNC:9,CLAN:6,CSJ:7,CJF:9,BAN:4</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -3832,7 +3832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3856,7 +3856,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,CLAN:3,IS:3,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
+			<availability>CC:4,CLAN:3,IS:3,FS:5,TC:3,Periphery:1,CS:8,LA:5,NIOPS:8,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 			</model>
@@ -3900,7 +3900,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,CSA:3,CDS:3,CW:3,CBS:2,CNC:3,CSJ:8,CJF:3,CGB:3,CB:3</availability>
+			<availability>CSV:2,CLAN:3,CBS:2,CSJ:8</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -3947,7 +3947,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4071,7 +4071,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4124,7 +4124,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
-			<availability>CSA:6,CCC:6,CIH:5,CBS:6,CSV:6,CLAN:6,CFM:6,CGS:6,CCO:6,CB:6</availability>
+			<availability>CIH:5,CLAN:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -4440,7 +4440,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4462,7 +4462,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:4,MOC:3,CS:4,HL:1,LA:5,CLAN:2-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>CC:4,CS:4,HL:1,CLAN:2-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4485,7 +4485,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,CLAN:2-,FWL:4,IS:4,NIOPS:4,FS:4,MERC:4,DC:4,Periphery:1</availability>
+			<availability>CS:4,CLAN:2-,IS:4,NIOPS:4,MERC:4,Periphery:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:3</availability>
@@ -4512,21 +4512,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>MOC:5,CC:6,CHH:7,HL:2,CLAN:8,IS:5,Periphery.Deep:4,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:2,CLAN:8,IS:5,Periphery.Deep:4,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:4,MERC.KH:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>MERC.KH:4,HL:4,PIR:4,General:4,IS:4,Periphery.Deep:5,MERC:4,Periphery:6</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4565,7 +4565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,OA:5,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4589,7 +4589,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>CC:9,MOC:7,HL:5,IS:9,Periphery.Deep:7,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
+			<availability>HL:5,IS:9,Periphery.Deep:7,Periphery:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4651,7 +4651,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -4684,7 +4684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
+			<availability>CC:4,MOC:7,HL:2,IS:5,MERC:5,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,FWL:4</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -4806,7 +4806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSA:9,CSR:6,CDS:6,CW:5,CBS:5,CNC:5,CLAN:5,CFM:6,CSJ:7,CCO:6,CJF:4,CGB:5</availability>
+			<availability>CSA:9,CSR:6,CDS:6,CLAN:5,CFM:6,CSJ:7,CCO:6,CJF:4</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
@@ -4847,9 +4847,9 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
-				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
+				<availability>HL:6,Periphery.Deep:7,IS:8,Periphery:8</availability>
 			</model>
 			<model name='QKD-4H'>
 				<availability>General:4</availability>
@@ -4878,7 +4878,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
 			</model>
@@ -4928,7 +4928,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:9-,CCC:1,HL:3,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,FS:9-,CGS:1,Periphery:5,CSA:1,CS:6-,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
+			<availability>CC:9-,HL:3,CLAN:1,IS:8-,Periphery.Deep:5,FS:9-,Periphery:5,CS:6-,Clan.IS:1,NIOPS:6-</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>HL:6,CLAN:1-,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
@@ -4976,7 +4976,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CDS:9,CW:8,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+			<availability>CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CSJ:9,CJF:9,BAN:8</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 			</model>
@@ -5020,7 +5020,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
+			<availability>CC:3-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,MERC:4-,Periphery:4-,OA:3-,FWL:3-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -5032,7 +5032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
+			<availability>CC:8,LA:6,DC.AL:10,IS:7,MERC:7,CIR:7,Periphery:8,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -5052,7 +5052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:6,HL:4,IS:6-,Periphery.Deep:4,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>CC:8-,HL:4,IS:6-,Periphery.Deep:4,FS:7-,CIR:6,Periphery:6,FWL.MM:10,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5071,7 +5071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:3+,CC:2+,HL:1+,IS:3+,Periphery.Deep:5,MERC:3+,FS:4+,CIR:3+,Periphery:3+,TC:3+,CS:5,OA:3+,LA:4+,FWL:4+,DC:2+</availability>
+			<availability>CC:2+,HL:1+,IS:3+,Periphery.Deep:5,MERC:3+,FS:4+,Periphery:3+,CS:5,LA:4+,FWL:4+,DC:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5082,7 +5082,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
+			<availability>CC:8,HL:4,IS:6,Periphery.Deep:4,MERC:6,FS:7,Periphery:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5180,7 +5180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
+			<availability>MOC:4,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5219,7 +5219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -5298,7 +5298,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5313,7 +5313,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:3,LA:4,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:4,MERC:3,Periphery.OS:3,DC:8,Periphery:2</availability>
 			<model name='SL-15'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 			</model>
@@ -5377,7 +5377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:2,NIOPS:3,DC:5</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -5409,7 +5409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,IS:2,FS:5,MERC:4,Periphery:2,CS:4,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5423,7 +5423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5464,7 +5464,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:9,Periphery:6,DC:6,CGB:1-</availability>
+			<availability>CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:9,Periphery:6,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -5479,7 +5479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,FS:1,MERC:3,CIR:2,Periphery:1,CS:3,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5500,7 +5500,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -5539,7 +5539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,Periphery:1,TC:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,LA:3,FS.DMM:8</availability>
 			</model>
@@ -5659,7 +5659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:6,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -5709,7 +5709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -5750,7 +5750,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -5761,7 +5761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,CCC:2-,CHH:1-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:2,NIOPS:5-,MH:4,CSJ:1-,CJF:1-,DC:8,CB:2</availability>
+			<availability>CCC:2-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:4,CS:5-,CBS:2,NIOPS:5-,CB:2</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:2-,CHH:1-,CSR:2-,CBS:2,CSJ:1-,CGS:2-,CJF:1-,CB:2</availability>
 			</model>
@@ -5861,7 +5861,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,FS:4,MERC:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -5935,7 +5935,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:3,CLAN:4,CCO:3,CDS:4,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CIH:3,CSR:7,CSV:3,CLAN:4,CCO:3,CBS:6,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -6012,7 +6012,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:2-,CLAN:1-,IS:4-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:2-,CLAN:1-,IS:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6071,7 +6071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+			<availability>CC:5,HL:2,IS:4,FS:9,Periphery:4,CS:5-,NIOPS:5-</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,FS:1</availability>
 			</model>
@@ -6086,7 +6086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>CSA:1,CCC:2,CSR:2,CW:3,CSV:1,CNC:1,CLAN:1,CFM:1,CSJ:5,CJF:1,CB:2</availability>
+			<availability>CCC:2,CSR:2,CW:3,CLAN:1,CSJ:5,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>MERC.WD:0,CLAN:2,IS:8</availability>
@@ -6174,7 +6174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FWL:7,IS:5,NIOPS:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:8,FS:4</availability>
@@ -6232,7 +6232,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,HL:4,LA:9,CLAN:3,FWL:9,IS:8,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:3,FWL:9,IS:8,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
 			<model name='C 3'>
 				<availability>CLAN:2</availability>
 			</model>
@@ -6256,7 +6256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
+			<availability>HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:8,FWL:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -6331,7 +6331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,CS:3-,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6342,7 +6342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,CS:5-,FWL:10,NIOPS:5-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2</availability>
 			</model>
@@ -6376,7 +6376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:4,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,FS:5,MERC:4,Periphery:1,DC:5,TC:2</availability>
+			<availability>CS:6,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,FS:5,MERC:4,Periphery:1,DC:5,TC:2</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>CS:8,CLAN:2,NIOPS:8,CFM:4,BAN:4</availability>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -6,8 +6,7 @@
 			<pctOmni>5,5</pctOmni>
 			<pctClan>20,20</pctClan>
 			<pctSL>70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -36,8 +35,7 @@
 			<pctSL>100,100,100,40,20</pctSL>
 			<pctClan unitType='Vehicle'>0,0,5,20,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,80,70</pctSL>
-			<salvage pct='5'>
-				CHH:5,CCC:5,CSR:1,CIH:5,CSV:10,CFM:5,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:5,CB:10</salvage>
+			<salvage pct='5'>CHH:5,CCC:5,CSR:1,CIH:5,CSV:10,CFM:5,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
 			<pctOmni>0,0,5,70,90</pctOmni>
@@ -45,8 +43,7 @@
 			<pctSL>80,80,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:5,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:5,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
 			<weightDistribution era='3019' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='3019' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -56,8 +53,7 @@
 			<pctSL>98,98,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -65,8 +61,7 @@
 			<pctSL>44,44,44,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:7,CSR:3,CSV:5,CFM:2,CGS:2,CSA:7,CDS:2,CW:1,CBS:1,CNC:10,CSJ:3,CJF:7,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:7,CSR:3,CSV:5,CFM:2,CGS:2,CSA:7,CDS:2,CW:1,CBS:1,CNC:10,CSJ:3,CJF:7,CB:7</salvage>
 			<weightDistribution era='3019' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3019' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -76,8 +71,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:10,CCO:1,CGS:10,CSA:10,CDS:1,CW:1,CBS:1,CNC:3,CSJ:8,CJF:10,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:10,CCO:1,CGS:10,CSA:10,CDS:1,CW:1,CBS:1,CNC:3,CSJ:8,CJF:10,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,30,100,100</pctOmni>
@@ -85,8 +79,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:2,CIH:10,CSV:5,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:5,CNC:8,CSJ:3,CJF:8</salvage>
+			<salvage pct='10'>CHH:10,CCC:2,CIH:10,CSV:5,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:5,CNC:8,CSJ:3,CJF:8</salvage>
 			<weightDistribution era='3019' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3019' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -96,8 +89,7 @@
 			<pctSL>98,98,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,20,80,90</pctOmni>
@@ -105,8 +97,7 @@
 			<pctSL>80,80,25,10,0</pctSL>
 			<pctClan unitType='Vehicle'>5,5,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>95,95,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:3,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:7,CW:1,CBS:1,CNC:3,CSJ:3,CJF:3,CGB:10,CB:6</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:3,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:7,CW:1,CBS:1,CNC:3,CSJ:3,CJF:3,CGB:10,CB:6</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -114,8 +105,7 @@
 			<pctSL>80,80,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:2,CSV:8,CFM:6,CCO:4,CGS:7,CSA:5,CDS:3,CW:4,CBS:1,CNC:3,CSJ:5,CJF:10,CGB:4,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:2,CSV:8,CFM:6,CCO:4,CGS:7,CSA:5,CDS:3,CW:4,CBS:1,CNC:3,CSJ:5,CJF:10,CGB:4,CB:3</salvage>
 			<weightDistribution era='3019' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3019' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -125,8 +115,7 @@
 			<pctSL>60,60,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:1,CIH:6,CSV:10,CFM:5,CCO:3,CGS:4,CSA:3,CDS:1,CW:3,CBS:1,CNC:1,CSJ:3,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:6,CSV:10,CFM:5,CCO:3,CGS:4,CSA:3,CDS:1,CW:3,CBS:1,CNC:1,CSJ:3,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>10,10,50,90,100</pctOmni>
@@ -134,8 +123,7 @@
 			<pctSL>80,80,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:2,CSR:8,CIH:5,CSV:2,CFM:3,CCO:10,CGS:7,CSA:5,CDS:2,CW:5,CBS:3,CSJ:2,CJF:2,CGB:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:2,CSR:8,CIH:5,CSV:2,CFM:3,CCO:10,CGS:7,CSA:5,CDS:2,CW:5,CBS:3,CSJ:2,CJF:2,CGB:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -143,8 +131,7 @@
 			<pctSL>60,60,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:5,CSR:7,CIH:10,CSV:7,CFM:3,CCO:4,CGS:3,CSA:7,CW:3,CNC:3,CSJ:3,CJF:7,CB:7,CGB:1</salvage>
+			<salvage pct='12'>CCC:1,CHH:5,CSR:7,CIH:10,CSV:7,CFM:3,CCO:4,CGS:3,CSA:7,CW:3,CNC:3,CSJ:3,CJF:7,CB:7,CGB:1</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -152,8 +139,7 @@
 			<pctSL>60,60,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:5,CSR:1,CIH:9,CSV:3,CFM:9,CCO:10,CGS:3,CSA:3,CDS:4,CW:8,CNC:4,CJF:5,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CHH:5,CSR:1,CIH:9,CSV:3,CFM:9,CCO:10,CGS:3,CSA:3,CDS:4,CW:8,CNC:4,CJF:5,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>40,40,80,100,100</pctOmni>
@@ -169,8 +155,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,50,50</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:3,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
 			<weightDistribution era='3019' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3019' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -180,8 +165,7 @@
 			<pctSL>50,50,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:4,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:4,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:2</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -189,8 +173,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:5,CIH:10,CSV:5,CFM:3,CCO:1,CGS:2,CSA:3,CDS:2,CNC:8,CSJ:10,CJF:10,CGB:5,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:5,CIH:10,CSV:5,CFM:3,CCO:1,CGS:2,CSA:3,CDS:2,CNC:8,CSJ:10,CJF:10,CGB:5,CB:3</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctSL>50,75</pctSL>
@@ -389,8 +372,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,70,100</pctOmni>
@@ -398,8 +380,7 @@
 			<pctSL>70,70,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -407,8 +388,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,70,100</pctOmni>
@@ -416,8 +396,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,50,100</pctOmni>
@@ -425,8 +404,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,50,100</pctOmni>
@@ -434,8 +412,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,15,90,100</pctOmni>
@@ -443,8 +420,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>2,2,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>98,98,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='DC.LV'>
 			<salvage pct='5'></salvage>
@@ -570,16 +546,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,CLAN:2,IS:2,FS:2,BAN:5,TC:1,Periphery:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:2,CLAN:2,IS:2,FS:2,BAN:5,TC:1,Periphery:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -706,8 +680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -804,8 +777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,CSV:2-,IS:3,FS:5,MERC:2,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CC:3,CSV:2-,IS:3,FS:5,MERC:2,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,MERC:2</availability>
 			</model>
@@ -860,8 +832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1006,8 +977,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:5-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:5-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -1053,8 +1023,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:6,MOC:6,HL:4,CLAN:2,IS:5,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
+			<availability>CC:6,MOC:6,HL:4,CLAN:2,IS:5,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1165,8 +1134,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:3,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
+			<availability>CHH:7,CSR:7,CSV:7,CLAN:8,CFM:7,FWL.OH:3,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:2,NIOPS:7,CJF:7,CGB:9</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 			</model>
@@ -1270,8 +1238,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:5,IS:7,Periphery.Deep:6,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1329,8 +1296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:3,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:3,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -1348,8 +1314,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
+			<availability>MOC:1,CC:4,IS:2,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1384,8 +1349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:9,Periphery.OS:4,MERC:3,Periphery:2,CS:2-,LA:2,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1473,8 +1437,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:1,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -1752,8 +1715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				Periphery.R:4,MERC.KH:8,HL:3,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CIR:4,MERC:4,Periphery:3,TC:6</availability>
+			<availability>Periphery.R:4,MERC.KH:8,HL:3,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3,CIR:4,MERC:4,Periphery:3,TC:6</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -1880,8 +1842,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
+			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -2028,8 +1989,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>CC:7,MOC:10,HL:7,IS:7,Periphery.Deep:8,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2061,8 +2021,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2145,8 +2104,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
+			<availability>CC:5,MOC:5,HL:1,CLAN:2,IS:4,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,FS:4</availability>
@@ -2420,8 +2378,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
+			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:8,LA:8</availability>
 			</model>
@@ -2561,8 +2518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2585,8 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:5,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2596,8 +2551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2693,8 +2647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2715,8 +2668,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				CC:7,MOC:3,HL:4,CLAN:2,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>CC:7,MOC:3,HL:4,CLAN:2,IS:9,Periphery.Deep:5,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 			</model>
@@ -2820,8 +2772,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3053,8 +3004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:2,OA:2,Periphery.HR:2,FS.CMM:3,FS.DMM:3,FS:3,MERC:2,Periphery.OS:2,FS.CrMM:3,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:2,OA:2,Periphery.HR:2,FS.CMM:3,FS.DMM:3,FS:3,MERC:2,Periphery.OS:2,FS.CrMM:3,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -3084,8 +3034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3178,19 +3127,16 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -3255,8 +3201,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:3,NIOPS:4-,DC:6</availability>
+			<availability>CC:3,MOC:5,HL:3,IS:4,Periphery.Deep:5,FS:3,CIR:4,Periphery:5,TC:7,CS:4-,OA:5,LA:5,FWL:3,NIOPS:4-,DC:6</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3312,8 +3257,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:2,LA:4,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3324,8 +3268,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,IS:2,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3523,8 +3466,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:6,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:6</availability>
+			<availability>CHH:7,CIH:6,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3603,8 +3545,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,CIR:8,BAN:3,TC:8,Periphery:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,IS:8,Periphery.Deep:7,FS:7,CIR:8,BAN:3,TC:8,Periphery:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3653,8 +3594,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:7,CC:6,HL:2,CLAN:1,IS:3,FS:5,TC:5,Periphery:4,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:2,CLAN:1,IS:3,FS:5,TC:5,Periphery:4,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -3725,8 +3665,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CLAN:1,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CLAN:1,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3747,8 +3686,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:5,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,HL:5,IS:7,Periphery.Deep:6,FS:8,TC:7,Periphery:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3771,8 +3709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
+			<availability>MOC:2,Periphery.R:4,OA:2,HL:3,LA:10,Periphery.MW:3,MERC:5,CIR:3,FS:3,Periphery:2,TC:2,DC:5</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
 			</model>
@@ -3895,8 +3832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>CC:8,MOC:8,HL:7,IS:9,Periphery.Deep:8,FS:9,MERC:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -3964,8 +3900,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,CSA:3,CDS:3,CW:3,CBS:2,CNC:3,CSJ:8,CJF:3,CGB:3,CB:3</availability>
+			<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,CSA:3,CDS:3,CW:3,CBS:2,CNC:3,CSJ:8,CJF:3,CGB:3,CB:3</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -4012,8 +3947,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,IS:5,Periphery.Deep:5,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4137,8 +4071,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4162,8 +4095,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,MERC:3,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,MERC:3,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -4508,8 +4440,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4531,8 +4462,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,CS:4,HL:1,LA:5,CLAN:2-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>CC:4,MOC:3,CS:4,HL:1,LA:5,CLAN:2-,IS:5,Periphery.Deep:4,NIOPS:4,Periphery:3,TC:3,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4582,24 +4512,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:2,CLAN:8,IS:5,Periphery.Deep:4,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:2,CLAN:8,IS:5,Periphery.Deep:4,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:2,IS:4,Periphery.Deep:4,FS:4,CIR:4,FS.CrMM:6,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:6,FS.DMM:6,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:4,MERC.KH:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
+				<availability>CC:4,MERC.KH:4,HL:4,PIR:4,General:4,IS:4,FWL:4,Periphery.Deep:5,FS:4,MERC:4,Periphery:6,DC:4</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4622,8 +4549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:2,LA:2,TC:2</availability>
 			</model>
@@ -4639,8 +4565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,MOC:9,HL:7,IS:8,Periphery.Deep:8,FS:7,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4664,8 +4589,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:7,HL:5,IS:9,Periphery.Deep:7,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
+			<availability>CC:9,MOC:7,HL:5,IS:9,Periphery.Deep:7,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4760,8 +4684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
+			<availability>CC:4,MOC:7,HL:2,IS:5,FS:5,MERC:5,CIR:4,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -4793,8 +4716,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
+			<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -4925,8 +4847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
+			<availability>CC:3,MOC:5,HL:2,IS:5,Periphery.Deep:4,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:7</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -4957,8 +4878,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:7,CIR:8,MERC:8,TC:8,Periphery:10,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
 			</model>
@@ -4980,8 +4900,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:3,CC:5,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,MERC:2,CIR:3,DC:5,Periphery:2,TC:3</availability>
 			<model name='F-100'>
 				<availability>CC:8,HL:6,LA:2,FWL:8,Periphery.Deep:7,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -5009,8 +4928,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:9-,CCC:1,HL:3,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,FS:9-,CGS:1,Periphery:5,CSA:1,CS:6-,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
+			<availability>CC:9-,CCC:1,HL:3,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,FS:9-,CGS:1,Periphery:5,CSA:1,CS:6-,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>HL:6,CLAN:1-,General:8,Periphery.Deep:7,BAN:2,Periphery:8</availability>
@@ -5102,8 +5020,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
+			<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -5115,8 +5032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
+			<availability>CC:8,Periphery.DD:8,LA:6,DC.AL:10,IS:7,FWL:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -5136,8 +5052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:6,HL:4,IS:6-,Periphery.Deep:4,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:6,HL:4,IS:6-,Periphery.Deep:4,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5156,8 +5071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:3+,CC:2+,HL:1+,IS:3+,Periphery.Deep:5,MERC:3+,FS:4+,CIR:3+,Periphery:3+,TC:3+,CS:5,OA:3+,LA:4+,FWL:4+,DC:2+</availability>
+			<availability>MOC:3+,CC:2+,HL:1+,IS:3+,Periphery.Deep:5,MERC:3+,FS:4+,CIR:3+,Periphery:3+,TC:3+,CS:5,OA:3+,LA:4+,FWL:4+,DC:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5168,8 +5082,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
+			<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,IS:6,Periphery.Deep:4,MERC:6,Periphery.OS:6,FS:7,CIR:6,TC:6,Periphery:6,OA:6,LA:6,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5193,8 +5106,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,CS:3-,HL:2-,LA:4-,IS:2-,Periphery.Deep:4-,FWL:4-,NIOPS:3-,FS:3-,MERC:4-,Periphery:4-,DC:4-</availability>
+			<availability>CC:4-,CS:3-,HL:2-,LA:4-,IS:2-,Periphery.Deep:4-,FWL:4-,NIOPS:3-,FS:3-,MERC:4-,Periphery:4-,DC:4-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -5268,8 +5180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
+			<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,CIR:3,FS:1,Periphery:6,TC:7</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5387,8 +5298,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,IS:4,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5467,8 +5377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,Periphery.Deep:4,FS:9,MERC:5,CIR:2,Periphery.OS:4,Periphery:4,TC:2,CS:3,OA:2,LA:2,Periphery.HR:4,NIOPS:3,DC:5</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>FS.CMM:3</availability>
@@ -5500,8 +5409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,MOC:2,IS:2,FS:5,MERC:4,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5515,8 +5423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,CIR:10,TC:10,Periphery:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5557,8 +5464,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:9,Periphery:6,DC:6,CGB:1-</availability>
+			<availability>MOC:6,CS:4-,HL:4,CLAN:1-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:9,Periphery:6,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -5573,8 +5479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5634,8 +5539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:1,Periphery.HR:2,CLAN:5,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,LA:3,FS.DMM:8</availability>
 			</model>
@@ -5755,8 +5659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -5806,16 +5709,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
+			<availability>CC:9,MOC:4,OA:3,HL:1,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2,FS:4,MERC:3,Periphery:3,TC:4</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -5849,8 +5750,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -5861,8 +5761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:8,CCC:2-,CHH:1-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:2,NIOPS:5-,MH:4,CSJ:1-,CJF:1-,DC:8,CB:2</availability>
+			<availability>CC:8,CCC:2-,CHH:1-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:2-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:2,NIOPS:5-,MH:4,CSJ:1-,CJF:1-,DC:8,CB:2</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:2-,CHH:1-,CSR:2-,CBS:2,CSJ:1-,CGS:2-,CJF:1-,CB:2</availability>
 			</model>
@@ -5962,8 +5861,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -6037,8 +5935,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:3,CLAN:4,CCO:3,CDS:4,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:3,CLAN:4,CCO:3,CDS:4,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -6115,8 +6012,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:2-,CLAN:1-,IS:4-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:2-,CLAN:1-,IS:4-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6175,8 +6071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,CC:5,HL:2,IS:4,Periphery.Deep:4,FS:9,CIR:4,Periphery.OS:4,TC:4,Periphery:4,CS:5-,OA:4,LA:4,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,FS:1</availability>
 			</model>
@@ -6361,8 +6256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FS.CH:7,IS:6,Periphery.Deep:4,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -6437,8 +6331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:2,CLAN:1-,IS:3,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6449,8 +6342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:7,HL:3,IS:7,Periphery.Deep:5,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2</availability>
 			</model>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -594,14 +594,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:3,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,OA:4,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:3,CLAN:2,IS:2,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>FRR:3,CLAN:2,IS:2,BAN:5,Periphery:1,CS:6,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -676,7 +676,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>FRR:4,DC:8</availability>
@@ -699,7 +699,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -731,7 +731,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -786,7 +786,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:1,CC:1,HL:1,FRR:4,IS:4,MERC:3,FS:4,Periphery:3,TC:1,CS:3-,OA:1,LA:4,FS.CMM:5</availability>
+			<availability>MOC:1,CC:1,HL:1,IS:4,MERC:3,Periphery:3,TC:1,CS:3-,OA:1,FS.CMM:5</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:2</availability>
 			</model>
@@ -831,7 +831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,FRR:4,CSV:2-,IS:3,CFM:2-:3020,SIC:2-:3020,FS:5,MERC:2,CGS:2-:3020,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>FRR:4,CSV:2-,IS:3,CFM:2-:3020,SIC:2-:3020,FS:5,MERC:2,CGS:2-:3020,Periphery:1,CS:4-,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2:3020,MERC:2</availability>
 			</model>
@@ -879,14 +879,14 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:3,CC:3,OA:3,LA:4,IS:3,FWL:2,SIC:3,FS:4,CIR:3,Periphery:2,TC:3,DC:2</availability>
+			<availability>MOC:3,OA:3,LA:4,IS:3,FWL:2,FS:4,CIR:3,Periphery:2,TC:3,DC:2</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:8,General:8,FS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:6,CLAN:1-,IS:7,Periphery.Deep:7,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1040,7 +1040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:7-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,FS:5-,MERC:6-,Periphery:9-,CS:2-,LA:7-,FWL:5-,NIOPS:2-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -1089,7 +1089,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,HL:4,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
+			<availability>CC:6,HL:4,FRR:4,CLAN:2,IS:5,SIC:6,Periphery:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:4</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1185,7 +1185,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:4,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,CDS:6,CW:6,CBS:4,CJF:6,CGB:6</availability>
+			<availability>CHH:7,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,CDS:6,CW:6,CBS:4,CJF:6,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1211,7 +1211,7 @@
 				<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1229,7 +1229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Blackjack' unitType='Mek'>
-			<availability>MOC:4,CC:5-,OA:4,HL:2,IS:2,SIC:5,MERC:4,FS:6,Periphery:4,TC:4</availability>
+			<availability>CC:5-,HL:2,IS:2,SIC:5,MERC:4,FS:6,Periphery:4</availability>
 			<model name='BJ-1'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1260,7 +1260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CS:5,OA:2-,CDS:6,CLAN:5,IS:2-,NIOPS:5,FWL:2-,DC:2-,Periphery:1</availability>
+			<availability>CS:5,OA:2-,CDS:6,CLAN:5,IS:2-,NIOPS:5,Periphery:1</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -1271,7 +1271,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:2,Periphery:3,MERC.WD:4,LA:6,FWL:4,DA:4,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:2,Periphery:3,MERC.WD:4,LA:6,FWL:4,DA:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1320,7 +1320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>CC:9,MOC:8,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1411,7 +1411,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:1,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
+			<availability>CC:3,FRR:5,IS:2,SIC:3,MERC:1,Periphery:1,CS:2,NIOPS:2,DC:4</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1446,7 +1446,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:2,IS:3,SIC:2,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,SIC:2,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1492,7 +1492,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:2,CS:5,CHH:4,LA:2,CLAN:1,IS:1,FWL:1,NIOPS:5,MERC:1,FS:1,CGB:4,DC:1</availability>
+			<availability>CC:2,CS:5,CHH:4,LA:2,CLAN:1,IS:1,NIOPS:5,MERC:1,CGB:4</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1578,12 +1578,12 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:3,CIR:2,Periphery:2,TC:2,OA:2,LA:7,FWL:4,DC:3</availability>
+			<availability>CC:2,FRR:2,SIC:2,MERC:4,FS:3,CIR:2,Periphery:2,LA:7,FWL:4,DC:3</availability>
 			<model name='CHP-W10'>
 				<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+				<availability>HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:4</availability>
@@ -1781,7 +1781,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:4,CS:3-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:3-,SIC:4,FS:4,MERC:3,DC:3</availability>
+			<availability>CC:4,CS:3-,IS:3,NIOPS:3-,SIC:4,FS:4,MERC:3</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
@@ -1822,7 +1822,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>MERC.KH:8,HL:3,FRR:3,CIR:4,MERC:4,FS:3,Periphery:3,TC:6,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:3,FRR:3,CIR:4,MERC:4,FS:3,Periphery:3,TC:6,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -1847,7 +1847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>HL:1,IS:3,FS:5,Periphery:3,CS:3,LA:7,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1917,7 +1917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
+			<availability>CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,Periphery:2,OA:3,LA:4,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -1950,7 +1950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
+			<availability>CLAN:3,IS:1,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -2014,7 +2014,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,FRR:5,IS:3,SIC:5,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -2110,7 +2110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,HL:7,FRR:7,IS:7,Periphery.Deep:8,SIC:7,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>MOC:10,HL:7,FRR:7,IS:7,Periphery.Deep:8,SIC:7,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2142,13 +2142,13 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,Periphery.HR:6</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>CC:4,MOC:6,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,MERC:6,CIR:5,TC:6,Periphery:6,OA:7,LA:6,FWL:4,MH:7,DC:4</availability>
+			<availability>FRR:4,IS:4,Periphery.Deep:4,FS:5,MERC:6,CIR:5,Periphery:6,OA:7,LA:6,MH:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2188,7 +2188,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CSA:6,CHH:6,CIH:7,CDS:6,CSV:5,CLAN:6,CFM:5,CSJ:5,CJF:6,CGB:9,CB:7</availability>
+			<availability>CIH:7,CSV:5,CLAN:6,CFM:5,CSJ:5,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 			</model>
@@ -2342,7 +2342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,SIC:5,FS:3,CIR:2,TC:3,Periphery:2,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,FS:3,TC:3,Periphery:2,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2500,7 +2500,7 @@
 				<availability>CLAN:8,BAN:2</availability>
 			</model>
 			<model name='FFL-4A'>
-				<availability>:0,MERC.WD:6</availability>
+				<availability>MERC.WD:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
@@ -2518,7 +2518,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:8,LA:8</availability>
+				<availability>MERC.KH:8,LA:8</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
@@ -2656,7 +2656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2679,7 +2679,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:2,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:6,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,NIOPS:6,CJF:3,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2689,7 +2689,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2714,7 +2714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:4,TC:3,Periphery:3,OA:3,LA:3,DC:1</availability>
+			<availability>CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:4,Periphery:3,LA:3,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2733,10 +2733,10 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CS:2,OA:1,LA:4,Periphery.MW:1,FWL:5,MERC:1,TC:1,Periphery:1</availability>
+			<availability>CS:2,LA:4,Periphery.MW:1,FWL:5,MERC:1,Periphery:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,HL:6,LA:8,FWL:8,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
@@ -2785,7 +2785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2806,7 +2806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 			</model>
@@ -2840,14 +2840,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:3,CS:7,CHH:5,CSR:5,CLAN:2,IS:3,FWL:3,NIOPS:7,FS:2,MERC:3,DC:3,Periphery:2</availability>
+			<availability>CS:7,CHH:5,CSR:5,CLAN:2,IS:3,NIOPS:7,FS:2,MERC:3,Periphery:2</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>HL:6,IS:8,FWL:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
+				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -2987,7 +2987,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CS:3,MERC.KH:2,MERC.WD:2,IS:4,FC:4-,MERC:2,DC:4,Periphery:3,TC:2,BAN:2</availability>
+			<availability>CS:3,MERC.KH:2,MERC.WD:2,IS:4,FC:4-,MERC:2,Periphery:3,TC:2,BAN:2</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,TC:7,Periphery:6</availability>
 			</model>
@@ -3053,7 +3053,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
+			<availability>HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:6</availability>
 			</model>
@@ -3096,11 +3096,11 @@
 			<availability>CS:3,CHH:4,CLAN:1,FWL:1,NIOPS:3,CGB:4,CB:3</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:8</availability>
+				<availability>FWL:8</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -3180,7 +3180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:5,OA:2,Periphery.HR:3,FS.CMM:5,FS.DMM:5,FS:5,MERC:2,Periphery.OS:3,FS.CrMM:5,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:5,Periphery.HR:3,FS.CMM:5,FS.DMM:5,FS:5,MERC:2,Periphery.OS:3,FS.CrMM:5,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -3210,7 +3210,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3240,7 +3240,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:4,CC:6,HL:3,FRR:5,IS:5,SIC:6,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
+			<availability>MOC:4,CC:6,HL:3,IS:5,SIC:6,MERC:5,CIR:4,Periphery:5,LA:8,FWL:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3303,7 +3303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>CC:4,MOC:4,HL:1,FRR:4,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -3347,7 +3347,7 @@
 			</model>
 		</chassis>
 		<chassis name='J-27 Ordnance Transport' unitType='Tank'>
-			<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:2,SIC:6,CIR:4,Periphery:2,TC:4</availability>
+			<availability>MOC:4,OA:4,CLAN:6,IS:6,NIOPS:6,MH:2,CIR:4,Periphery:2,TC:4</availability>
 			<model name=''>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
@@ -3377,7 +3377,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:5,MOC:5,CC:3,HL:3,FRR:5,FS.AH:5,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:6</availability>
+			<availability>CC:3,HL:3,IS:5,Periphery.Deep:5,SIC:3,FS:4,Periphery:5,TC:7,CS:4-,LA:6,FWL:3,NIOPS:4-,DC:6</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3430,7 +3430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3456,7 +3456,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,Periphery:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3568,7 +3568,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1+,CLAN:4,IS:1+,MERC:2+,FS:2+,CGS:5,CS:6,DC.GHO:3,LA:1+,FWL:1+,NIOPS:6,CGB:5,DC:1+</availability>
+			<availability>CLAN:4,IS:1+,MERC:2+,FS:2+,CGS:5,CS:6,DC.GHO:3,NIOPS:6,CGB:5</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3607,7 +3607,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:4,CHH:4,CDS:4,CSV:4,CLAN:3,NIOPS:7,FS:6</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
@@ -3667,7 +3667,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
+			<availability>CIH:8,CLAN:7,CCO:5,BAN:7,CSA:5,CW:6,CSJ:9,CJF:5,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3696,7 +3696,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:4,CW:4,CSV:6,CLAN:4,CNC:4,CGS:6,CJF:4,CGB:6</availability>
+			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CSV:6,CLAN:4,CGS:6,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -3746,7 +3746,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3857,7 +3857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CDS:8,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
+			<availability>CHH:9,CDS:8,CW:6,CSV:6,CLAN:7,CSJ:6,CJF:8,BAN:6,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:8</availability>
@@ -3891,7 +3891,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3914,7 +3914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,TC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,DC:4</availability>
+			<availability>HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,Periphery.R:4,LA:10,Periphery.MW:3,DC:4</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
 			</model>
@@ -3969,7 +3969,7 @@
 			<availability>CC:10,CS:10,LA:10,CLAN:10,FWL:10,IS:9,NIOPS:10,FS:10,DC:10,Periphery:8</availability>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CIH:3,CDS:5,CW:9,CBS:3,CLAN:3,CSJ:6,CCO:5,CJF:5,BAN:2,CB:3</availability>
+			<availability>CSA:5,CHH:5,CDS:5,CW:9,CBS:3,CLAN:3,CSJ:6,CCO:5,CJF:5,BAN:2</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -4006,7 +4006,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:9,CDS:9,CW:9,CBS:6,CSV:8,CNC:9,CLAN:6,CSJ:7,CJF:9,BAN:6,CGB:6</availability>
+			<availability>CIH:9,CDS:9,CW:9,CSV:8,CNC:9,CLAN:6,CSJ:7,CJF:9,BAN:6</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -4037,7 +4037,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,SIC:8,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:7,IS:9,Periphery.Deep:8,SIC:8,MERC:9,CIR:8,Periphery:9,CS:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -4061,7 +4061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
+			<availability>CC:4,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,NIOPS:8,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 			</model>
@@ -4098,7 +4098,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:4,CB:3</availability>
+			<availability>CSV:2,CLAN:3,BAN:2,CSA:4,CDS:4,CSJ:8,CJF:4,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -4145,7 +4145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4269,7 +4269,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2,SIC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4419,7 +4419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:4,CLAN:5,MERC:2,Periphery:1,TC:1,CS:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
+			<availability>CHH:4,CLAN:5,MERC:2,Periphery:1,CS:6,CDS:4,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -4639,7 +4639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4661,7 +4661,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:4,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
+			<availability>CC:4,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,CS:4,NIOPS:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4684,7 +4684,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:4,CS:4,LA:4,FRR:4,CLAN:2-,IS:4,FWL:4,NIOPS:4,FS:4,MERC:4,Periphery:1,DC:4</availability>
+			<availability>CS:4,CLAN:2-,IS:4,NIOPS:4,MERC:4,Periphery:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:3</availability>
@@ -4718,14 +4718,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2,CC:2,FRR:5,IS:3,Periphery.Deep:4,SIC:3,FS:4,CIR:3,FS.CrMM:6,Periphery:2,TC:2,CS:6,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,NIOPS:6,DC:3</availability>
+			<availability>CC:2,FRR:5,IS:3,Periphery.Deep:4,FS:4,CIR:3,FS.CrMM:6,Periphery:2,CS:6,LA:4,FS.CMM:6,FS.DMM:6,NIOPS:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,FS:3,MERC:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
+				<availability>MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,MERC:3,Periphery:5,PIR:3,General:3</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4761,7 +4761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:6,FS:8,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:6,CIR:6,Periphery:9,OA:5,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4791,7 +4791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:7,CC:9,HL:5,FRR:8,IS:9,Periphery.Deep:7,SIC:9,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
+			<availability>HL:5,FRR:8,IS:9,Periphery.Deep:7,Periphery:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4820,7 +4820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
-			<availability>CC:8-,LA:3-,FRR:5-,FWL:5-,IS:5-,SIC:8-,FS:5-,MERC:6-,DC:6-</availability>
+			<availability>CC:8-,LA:3-,IS:5-,SIC:8-,MERC:6-,DC:6-</availability>
 			<model name=''>
 				<availability>General:8,DC:6</availability>
 			</model>
@@ -4859,7 +4859,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:6,Periphery:8</availability>
@@ -4892,7 +4892,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
+			<availability>MOC:7,CC:4,HL:2,IS:5,SIC:4,MERC:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,FWL:4</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -5030,7 +5030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:7,CFM:8,CCO:7,BAN:3,CSA:9,CDS:7,CW:7,CBS:7,CNC:7,CSJ:7,CJF:5,CGB:7</availability>
+			<availability>CSR:8,CLAN:7,CFM:8,BAN:3,CSA:9,CJF:5</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
@@ -5071,7 +5071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>CC:3,MOC:5,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:5,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -5109,7 +5109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
 			</model>
@@ -5159,7 +5159,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:9-,CCC:1,HL:3,CSV:1,FRR:8-,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:8-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
+			<availability>CC:9-,HL:3,CLAN:1,IS:8-,Periphery.Deep:5,FS:9-,Periphery:5,CS:6-,Clan.IS:1,NIOPS:6-</availability>
 			<model name='RFL-3C'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>FS:3</availability>
@@ -5217,7 +5217,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CDS:9,CW:8,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+			<availability>CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CSJ:9,CJF:9,BAN:8</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 			</model>
@@ -5261,7 +5261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
+			<availability>CC:3-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,MERC:4-,Periphery:4-,OA:3-,FWL:3-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -5273,7 +5273,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:8,DC.AL:10,FRR:9,IS:7,SIC:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,LA:6,FWL:7,DC:9</availability>
+			<availability>CC:8,DC.AL:10,FRR:9,IS:7,MERC:7,CIR:7,Periphery:8,LA:6,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -5293,7 +5293,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:6,HL:4,FRR:9-,IS:6-,Periphery.Deep:4,SIC:7-,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>CC:8-,HL:4,FRR:9-,IS:6-,Periphery.Deep:4,SIC:7-,FS:7-,Periphery:6,FWL.MM:10,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5316,13 +5316,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:1,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,HL:1,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:3+,CC:2+,HL:1+,FRR:3,IS:3+,Periphery.Deep:5,SIC:2+,MERC:3+,FS:4+,CIR:3+,TC:3+,Periphery:3+,CS:5,OA:3+,LA:4+,FWL:4+,DC:2+</availability>
+			<availability>CC:2+,HL:1+,FRR:3,IS:3+,Periphery.Deep:5,SIC:2+,MERC:3+,FS:4+,Periphery:3+,CS:5,LA:4+,FWL:4+,DC:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5333,7 +5333,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,FRR:10,IS:6,Periphery.Deep:4,SIC:8,MERC:6,Periphery.OS:6,FS:7,CIR:6,Periphery:6,TC:6,OA:6,LA:6,FWL:6,DC:9</availability>
+			<availability>CC:8,HL:4,FRR:10,IS:6,Periphery.Deep:4,SIC:8,MERC:6,FS:7,Periphery:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5342,7 +5342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>CC:9,HL:8,LA:9,FRR:10,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
+			<availability>CC:9,HL:8,LA:9,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5409,7 +5409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,CS:3,HL:1,LA:6,FRR:3,FWL:4,IS:4,SIC:3,FS:4,CIR:3,DC:4,Periphery:3</availability>
+			<availability>CC:3,CS:3,HL:1,LA:6,FRR:3,IS:4,SIC:3,Periphery:3</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -5431,7 +5431,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,Periphery.R:6,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
+			<availability>MOC:4,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5470,7 +5470,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -5549,7 +5549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5564,7 +5564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
+			<availability>Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
 			<model name='SL-15'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 			</model>
@@ -5628,7 +5628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,NIOPS:3,DC:5</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>LA:8,FS.CMM:3</availability>
@@ -5660,7 +5660,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,CS:4,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5674,7 +5674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5715,7 +5715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
+			<availability>HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -5730,7 +5730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,Periphery:1,CS:3,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5751,7 +5751,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -5790,7 +5790,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
+			<availability>FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 			</model>
@@ -5913,7 +5913,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:6,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -5963,7 +5963,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:9,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
+			<availability>MOC:4,CC:9,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6004,7 +6004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -6015,7 +6015,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,CCC:1-,CHH:1-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:1,NIOPS:5-,MH:4,CSJ:1-,FC:8,CJF:1-,DC:8,CB:1</availability>
+			<availability>CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,CS:5-,CBS:1,NIOPS:5-,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,CHH:1-,CSR:2-,CBS:1,CSJ:1-,CGS:1-,CJF:1-,CB:1</availability>
 			</model>
@@ -6118,7 +6118,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,FS:4,MERC:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -6196,7 +6196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CBS:6,CNC:5,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -6273,7 +6273,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,Periphery:4-,TC:3-,CS:4-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6325,14 +6325,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,CS:5,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+			<availability>CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,Periphery:4,CS:5-,LA:5,NIOPS:5-</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 			</model>
@@ -6441,7 +6441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:8,FS:4</availability>
@@ -6452,7 +6452,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+			<availability>CHH:9,CIH:7,CW:7,CSV:7,CLAN:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 			</model>
@@ -6499,7 +6499,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,HL:4,LA:9,CLAN:3,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:3,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
 			<model name='C 3'>
 				<availability>CLAN:1</availability>
 			</model>
@@ -6523,7 +6523,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:4,FS.CH:7,FRR:5,IS:6,Periphery.Deep:4,SIC:8,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
+			<availability>HL:4,FS.CH:7,FRR:5,IS:6,Periphery.Deep:4,SIC:8,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:8,FWL:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -6598,7 +6598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:2,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>Periphery.DD:2,FRR:3,CLAN:1-,IS:2,FS:5,MERC:3,Periphery.OS:2,Periphery:1,CS:3-,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6609,7 +6609,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:7,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>HL:3,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,CS:5-,FWL:10,NIOPS:5-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2</availability>
 			</model>
@@ -6643,7 +6643,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:4,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,MERC:4,FS:5,Periphery:1,DC:5,TC:2</availability>
+			<availability>CS:6,CIH:2,CLAN:3,IS:4,NIOPS:6,CFM:4,MERC:4,FS:5,Periphery:1,DC:5,TC:2</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>CS:8,CLAN:1,NIOPS:8,CFM:4,BAN:4</availability>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -6,8 +6,7 @@
 			<pctOmni>5,5</pctOmni>
 			<pctClan>20,20</pctClan>
 			<pctSL>70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -44,8 +43,7 @@
 			<pctSL>70,70,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
 			<weightDistribution era='3028' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='3028' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -55,8 +53,7 @@
 			<pctSL>96,96,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:3,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:2,CW:7,CBS:2,CNC:10,CSJ:7,CJF:5,CGB:2,CB:3</salvage>
+			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:2,CW:7,CBS:2,CNC:10,CSJ:7,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -64,8 +61,7 @@
 			<pctSL>41,41,41,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:8,CSR:3,CSV:5,CFM:2,CGS:2,CSA:7,CDS:3,CW:1,CBS:1,CNC:10,CSJ:10,CJF:10,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:8,CSR:3,CSV:5,CFM:2,CGS:2,CSA:7,CDS:3,CW:1,CBS:1,CNC:10,CSJ:10,CJF:10,CB:7</salvage>
 			<weightDistribution era='3028' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3028' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -75,8 +71,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:10,CCO:1,CGS:10,CSA:10,CDS:3,CW:1,CBS:1,CNC:3,CSJ:8,CJF:10,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:10,CCO:1,CGS:10,CSA:10,CDS:3,CW:1,CBS:1,CNC:3,CSJ:8,CJF:10,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,30,100,100</pctOmni>
@@ -84,8 +79,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:2,CIH:10,CSV:5,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:5,CNC:8,CSJ:3,CJF:8</salvage>
+			<salvage pct='10'>CHH:10,CCC:2,CIH:10,CSV:5,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:5,CNC:8,CSJ:3,CJF:8</salvage>
 			<weightDistribution era='3028' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3028' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -95,8 +89,7 @@
 			<pctSL>96,96,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CIH:9,CSV:6,CFM:10,CCO:1,CSA:3,CDS:1,CW:1,CNC:5,CSJ:4,CJF:9,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,22,80,90</pctOmni>
@@ -104,8 +97,7 @@
 			<pctSL>80,80,25,10,0</pctSL>
 			<pctClan unitType='Vehicle'>5,5,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>95,95,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:5,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:1,CBS:1,CNC:8,CSJ:10,CJF:5,CGB:10,CB:5</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:5,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:1,CBS:1,CNC:8,CSJ:10,CJF:5,CGB:10,CB:5</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -113,8 +105,7 @@
 			<pctSL>70,70,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:1,CSV:7,CFM:5,CCO:4,CGS:6,CSA:4,CDS:3,CW:4,CBS:1,CNC:4,CSJ:6,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:1,CSV:7,CFM:5,CCO:4,CGS:6,CSA:4,CDS:3,CW:4,CBS:1,CNC:4,CSJ:6,CJF:10,CGB:3,CB:3</salvage>
 			<weightDistribution era='3028' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3028' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -124,8 +115,7 @@
 			<pctSL>60,60,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:1,CIH:8,CSV:10,CFM:5,CCO:4,CGS:4,CSA:3,CDS:3,CW:4,CBS:1,CNC:2,CSJ:4,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:8,CSV:10,CFM:5,CCO:4,CGS:4,CSA:3,CDS:3,CW:4,CBS:1,CNC:2,CSJ:4,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>10,10,50,90,100</pctOmni>
@@ -133,8 +123,7 @@
 			<pctSL>80,80,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:5,CHH:5,CSR:8,CIH:8,CSV:2,CFM:3,CCO:10,CGS:7,CSA:5,CDS:3,CW:5,CBS:3,CSJ:5,CJF:5,CGB:5,CB:10</salvage>
+			<salvage pct='10'>CCC:5,CHH:5,CSR:8,CIH:8,CSV:2,CFM:3,CCO:10,CGS:7,CSA:5,CDS:3,CW:5,CBS:3,CSJ:5,CJF:5,CGB:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -142,8 +131,7 @@
 			<pctSL>20,20,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:2,CSR:10,CIH:8,CSV:4,CFM:4,CCO:3,CGS:2,CSA:6,CW:2,CNC:3,CSJ:6,CJF:8,CB:6</salvage>
+			<salvage pct='12'>CCC:1,CHH:2,CSR:10,CIH:8,CSV:4,CFM:4,CCO:3,CGS:2,CSA:6,CW:2,CNC:3,CSJ:6,CJF:8,CB:6</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -151,8 +139,7 @@
 			<pctSL>50,50,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:7,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:7,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>40,40,80,100,100</pctOmni>
@@ -160,8 +147,7 @@
 			<pctSL>20,20,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:2,CIH:2,CSV:2,CFM:4,CCO:4,CSA:2,CDS:10,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
+			<salvage pct='10'>CHH:1,CCC:2,CIH:2,CSV:2,CFM:4,CCO:4,CSA:2,CDS:10,CW:4,CNC:10,CSJ:2,CJF:2,CB:6</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>20,20,30,100,100</pctOmni>
@@ -169,8 +155,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,50,50</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:4,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:6,CSV:5,CFM:10,CCO:5,CGS:3,CDS:4,CW:1,CNC:4,CSJ:5,CJF:6,CGB:2,CB:4</salvage>
 			<weightDistribution era='3028' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3028' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -180,8 +165,7 @@
 			<pctSL>50,50,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -189,8 +173,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:3,CIH:8,CSV:3,CFM:2,CCO:1,CGS:1,CSA:2,CDS:1,CNC:5,CSJ:7,CJF:10,CGB:3,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:3,CIH:8,CSV:3,CFM:2,CCO:1,CGS:1,CSA:2,CDS:1,CNC:5,CSJ:7,CJF:10,CGB:3,CB:2</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctOmni>0,0</pctOmni>
@@ -423,8 +406,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,75,100</pctOmni>
@@ -432,8 +414,7 @@
 			<pctSL>70,70,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -441,8 +422,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,70,100</pctOmni>
@@ -450,8 +430,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,55,100</pctOmni>
@@ -459,8 +438,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,53,100</pctOmni>
@@ -468,8 +446,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,15,90,100</pctOmni>
@@ -477,8 +454,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>4,4,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>96,96,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='DC.LV'>
 			<salvage pct='6'></salvage>
@@ -618,16 +594,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:3,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:3,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:3,CLAN:2,IS:2,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:2,FRR:3,CLAN:2,IS:2,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -702,8 +676,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>FRR:4,DC:8</availability>
@@ -758,8 +731,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -859,8 +831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,FRR:4,CSV:2-,IS:3,CFM:2-:3020,SIC:2-:3020,FS:5,MERC:2,CGS:2-:3020,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CC:3,FRR:4,CSV:2-,IS:3,CFM:2-:3020,SIC:2-:3020,FS:5,MERC:2,CGS:2-:3020,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2:3020,MERC:2</availability>
 			</model>
@@ -915,8 +886,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1070,8 +1040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:7-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:5-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:7-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -1120,8 +1089,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:6,MOC:6,HL:4,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
+			<availability>CC:6,MOC:6,HL:4,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:6,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1235,8 +1203,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,MERC:1,FS:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9</availability>
+			<availability>CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,MERC:1,FS:1,CGS:9,CS:7,CDS:7,CW:9,CBS:9,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9</availability>
 			<model name='BL-6-KNT'>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
 			</model>
@@ -1304,8 +1271,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:2,Periphery:3,MERC.WD:4,LA:6,FWL:4,DA:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:2,Periphery:3,MERC.WD:4,LA:6,FWL:4,DA:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1354,8 +1320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				CC:9,MOC:8,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
+			<availability>CC:9,MOC:8,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,Periphery:7,TC:8,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1413,8 +1378,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -1447,8 +1411,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
+			<availability>MOC:1,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:1,Periphery:1,TC:1,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:4</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
@@ -1483,8 +1446,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:2,IS:3,SIC:2,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,SIC:2,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1582,8 +1544,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -1861,8 +1822,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:3,FRR:3,CIR:4,MERC:4,FS:3,Periphery:3,TC:6,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:3,FRR:3,CIR:4,MERC:4,FS:3,Periphery:3,TC:6,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -1887,8 +1847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:3,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1958,8 +1917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,FS:8,MERC:3,CIR:2,Periphery:2,TC:2,OA:3,LA:4,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -1992,8 +1950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
+			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -2057,8 +2014,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -2154,8 +2110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,HL:7,FRR:7,IS:7,Periphery.Deep:8,SIC:7,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:7,FRR:7,IS:7,Periphery.Deep:8,SIC:7,FS:7,CIR:9,Periphery:9,TC:10,CS:6-,OA:10,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2187,15 +2142,13 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:6,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,MERC:6,CIR:5,TC:6,Periphery:6,OA:7,LA:6,FWL:4,MH:7,DC:4</availability>
+			<availability>CC:4,MOC:6,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,MERC:6,CIR:5,TC:6,Periphery:6,OA:7,LA:6,FWL:4,MH:7,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2246,8 +2199,7 @@
 				<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='Prime'>
 				<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
@@ -2290,8 +2242,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,TC:4,Periphery:3,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,FS:4</availability>
@@ -2391,8 +2342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,SIC:5,FS:3,CIR:2,TC:3,Periphery:2,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,SIC:5,FS:3,CIR:2,TC:3,Periphery:2,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2488,8 +2438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:5,HL:4,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:6,SIC:5,FS:9</availability>
+			<availability>Periphery.R:5,HL:4,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:6,SIC:5,FS:9</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:9</availability>
@@ -2567,8 +2516,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
+			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:8,LA:8</availability>
 			</model>
@@ -2708,8 +2656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2732,8 +2679,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:2,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:6,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+			<availability>MOC:6,CC:4,HL:2,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:4,FS:8,CIR:6,Periphery:4,TC:6,CS:6,OA:8,LA:6,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2743,8 +2689,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2769,8 +2714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:4,TC:3,Periphery:3,OA:3,LA:3,DC:1</availability>
+			<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:4,TC:3,Periphery:3,OA:3,LA:3,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2841,8 +2785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2863,8 +2806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 			</model>
@@ -2989,8 +2931,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:2,FRR:5,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,FRR:5,Periphery.Deep:4,MERC:5,Periphery:4,FWL.pm:8,Periphery.CM:5,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3239,8 +3180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:5,OA:2,Periphery.HR:3,FS.CMM:5,FS.DMM:5,FS:5,MERC:2,Periphery.OS:3,FS.CrMM:5,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:5,OA:2,Periphery.HR:3,FS.CMM:5,FS.DMM:5,FS:5,MERC:2,Periphery.OS:3,FS.CrMM:5,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -3270,8 +3210,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3301,8 +3240,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:6,HL:3,FRR:5,IS:5,SIC:6,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
+			<availability>MOC:4,CC:6,HL:3,FRR:5,IS:5,SIC:6,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:8,FWL:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3365,19 +3303,16 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				CC:4,MOC:4,HL:1,FRR:4,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>CC:4,MOC:4,HL:1,FRR:4,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:6,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -3442,8 +3377,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:5,MOC:5,CC:3,HL:3,FRR:5,FS.AH:5,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:6</availability>
+			<availability>FS.DLC:5,MOC:5,CC:3,HL:3,FRR:5,FS.AH:5,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:6</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3496,8 +3430,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3523,8 +3456,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3636,8 +3568,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:1+,CLAN:4,IS:1+,MERC:2+,FS:2+,CGS:5,CS:6,DC.GHO:3,LA:1+,FWL:1+,NIOPS:6,CGB:5,DC:1+</availability>
+			<availability>CC:1+,CLAN:4,IS:1+,MERC:2+,FS:2+,CGS:5,CS:6,DC.GHO:3,LA:1+,FWL:1+,NIOPS:6,CGB:5,DC:1+</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3736,8 +3667,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3816,8 +3746,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -3866,8 +3795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:3,SIC:6,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:3,SIC:6,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:2,NIOPS:5-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -3942,8 +3870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -3964,8 +3891,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:8,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3988,8 +3914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,TC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,DC:4</availability>
+			<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,TC:2,Periphery.R:4,OA:2,LA:10,Periphery.MW:3,DC:4</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:2</availability>
 			</model>
@@ -4112,8 +4037,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,SIC:8,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,SIC:8,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:10,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -4137,8 +4061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
+			<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 			</model>
@@ -4175,8 +4098,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:4,CB:3</availability>
+			<availability>CSR:3,CSV:2,CLAN:3,CFM:3,CGS:3,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:4,CB:3</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -4223,8 +4145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4348,8 +4269,7 @@
 			<availability>CC:5,MOC:2,Periphery.CM:2,Periphery.ME:2,SIC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4376,8 +4296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,MERC:3,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,MERC:3,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -4500,8 +4419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:4,CLAN:5,MERC:2,Periphery:1,TC:1,CS:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
+			<availability>MOC:1,CHH:4,CLAN:5,MERC:2,Periphery:1,TC:1,CS:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -4721,8 +4639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4744,8 +4661,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
+			<availability>CC:4,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4795,24 +4711,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:2,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:2,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,FRR:5,IS:3,Periphery.Deep:4,SIC:3,FS:4,CIR:3,FS.CrMM:6,Periphery:2,TC:2,CS:6,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,NIOPS:6,DC:3</availability>
+			<availability>MOC:2,CC:2,FRR:5,IS:3,Periphery.Deep:4,SIC:3,FS:4,CIR:3,FS.CrMM:6,Periphery:2,TC:2,CS:6,OA:2,LA:4,FS.CMM:6,FS.DMM:6,FWL:3,NIOPS:6,DC:3</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,FS:3,MERC:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
+				<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,FS:3,MERC:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4835,8 +4748,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,SIC:3,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,SIC:3,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
@@ -4849,8 +4761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:6,FS:8,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:6,FS:8,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4880,8 +4791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:9,HL:5,FRR:8,IS:9,Periphery.Deep:7,SIC:9,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
+			<availability>MOC:7,CC:9,HL:5,FRR:8,IS:9,Periphery.Deep:7,SIC:9,FS:9,CIR:7,Periphery:7,TC:7,OA:7,LA:9,FWL:9,DC:9</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -4982,8 +4892,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
+			<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:5,FWL:4,MH:4,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -5031,8 +4940,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
+			<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -5163,8 +5071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,MOC:5,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -5202,8 +5109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
 			</model>
@@ -5225,8 +5131,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -5254,8 +5159,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:9-,CCC:1,HL:3,CSV:1,FRR:8-,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:8-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
+			<availability>CC:9-,CCC:1,HL:3,CSV:1,FRR:8-,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:8-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
 			<model name='RFL-3C'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>FS:3</availability>
@@ -5357,8 +5261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
+			<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -5370,8 +5273,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:8,DC.AL:10,FRR:9,IS:7,SIC:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,LA:6,FWL:7,DC:9</availability>
+			<availability>CC:8,Periphery.DD:8,DC.AL:10,FRR:9,IS:7,SIC:7,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:8,LA:6,FWL:7,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -5391,8 +5293,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:6,HL:4,FRR:9-,IS:6-,Periphery.Deep:4,SIC:7-,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:6,HL:4,FRR:9-,IS:6-,Periphery.Deep:4,SIC:7-,Periphery.OS:6,FS:7-,CIR:6,Periphery:6,TC:6,OA:6,FWL.MM:10,LA:6-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5421,8 +5322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:3+,CC:2+,HL:1+,FRR:3,IS:3+,Periphery.Deep:5,SIC:2+,MERC:3+,FS:4+,CIR:3+,TC:3+,Periphery:3+,CS:5,OA:3+,LA:4+,FWL:4+,DC:2+</availability>
+			<availability>MOC:3+,CC:2+,HL:1+,FRR:3,IS:3+,Periphery.Deep:5,SIC:2+,MERC:3+,FS:4+,CIR:3+,TC:3+,Periphery:3+,CS:5,OA:3+,LA:4+,FWL:4+,DC:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5433,8 +5333,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8,Periphery.DD:6,HL:4,FRR:10,IS:6,Periphery.Deep:4,SIC:8,MERC:6,Periphery.OS:6,FS:7,CIR:6,Periphery:6,TC:6,OA:6,LA:6,FWL:6,DC:9</availability>
+			<availability>MOC:6,CC:8,Periphery.DD:6,HL:4,FRR:10,IS:6,Periphery.Deep:4,SIC:8,MERC:6,Periphery.OS:6,FS:7,CIR:6,Periphery:6,TC:6,OA:6,LA:6,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5458,8 +5357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:4-,HL:2-,FRR:3-,IS:2-,Periphery.Deep:4-,SIC:3-,FS:3-,MERC:4-,Periphery:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
+			<availability>CC:4-,HL:2-,FRR:3-,IS:2-,Periphery.Deep:4-,SIC:3-,FS:3-,MERC:4-,Periphery:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,DC:4-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:8,FRR:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -5533,8 +5431,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,Periphery.R:6,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
+			<availability>MOC:4,Periphery.R:6,OA:7,MERC.KH:6,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:3,CIR:3,Periphery:6,TC:7</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5652,8 +5549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:4,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5668,8 +5564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
+			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,CIR:2,Periphery.OS:3,DC:8,Periphery:2,TC:5</availability>
 			<model name='SL-15'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,FS:0,Periphery:8</availability>
 			</model>
@@ -5733,8 +5628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:4,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>LA:8,FS.CMM:3</availability>
@@ -5766,8 +5660,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5781,8 +5674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5823,8 +5715,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
+			<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -5839,8 +5730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -5900,8 +5790,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
+			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 			</model>
@@ -6024,8 +5913,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -6075,16 +5963,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:9,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
+			<availability>MOC:4,CC:9,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -6118,8 +6004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -6130,8 +6015,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:8,CCC:1-,CHH:1-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:1,NIOPS:5-,MH:4,CSJ:1-,FC:8,CJF:1-,DC:8,CB:1</availability>
+			<availability>CC:8,CCC:1-,CHH:1-,CSR:2-,HL:2,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:1,NIOPS:5-,MH:4,CSJ:1-,FC:8,CJF:1-,DC:8,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,CHH:1-,CSR:2-,CBS:1,CSJ:1-,CGS:1-,CJF:1-,CB:1</availability>
 			</model>
@@ -6234,8 +6118,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -6313,8 +6196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -6391,8 +6273,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6444,16 +6325,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>MOC:1,CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
+			<availability>MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:4</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 			</model>
@@ -6644,8 +6523,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:4,FS.CH:7,FRR:5,IS:6,Periphery.Deep:4,SIC:8,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FS.CH:7,FRR:5,IS:6,Periphery.Deep:4,SIC:8,FWL.FWG:7,FS:5,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:6</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -6720,8 +6598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:2,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:2,FS:5,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6732,8 +6609,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:7,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:7,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2</availability>
 			</model>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -640,14 +640,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,FS:5,Periphery:4CS:3,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:3,CLAN:2,IS:2,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>FRR:3,CLAN:2,IS:2,BAN:5,Periphery:1,CS:6,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -725,7 +725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>FRR:4,DC:8</availability>
@@ -752,7 +752,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -784,7 +784,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -839,7 +839,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:1,CC:1,HL:1,FRR:4,IS:4,MERC:3,FS:4,Periphery:3,TC:1,CS:3-,OA:1,LA:4,FS.CMM:5</availability>
+			<availability>MOC:1,CC:1,HL:1,IS:4,MERC:3,Periphery:3,TC:1,CS:3-,OA:1,FS.CMM:5</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:2</availability>
 			</model>
@@ -884,7 +884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,FRR:4,CSV:2-,IS:3,CFM:2,SIC:2,FS:5,MERC:2,CGS:2,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>FRR:4,CSV:2-,IS:3,CFM:2,SIC:2,FS:5,MERC:2,CGS:2,Periphery:1,CS:4-,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -943,7 +943,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:6,CLAN:1-,IS:7,Periphery.Deep:7,CIR:8,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1103,7 +1103,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,MERC:6-,Periphery:9-,CS:2-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -1155,7 +1155,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
+			<availability>CC:6,HL:3,FRR:4,CLAN:2,IS:5,SIC:6,Periphery:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,DC:4</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1254,7 +1254,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:4,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,CDS:6,CW:6,CBS:4,CJF:6,CGB:5</availability>
+			<availability>CHH:7,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,CDS:6,CW:6,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1280,7 +1280,7 @@
 				<availability>CS:4,CLAN:5,NIOPS:4,CGS:7,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1392,7 +1392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>MOC:8,CC:9,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,LA:6,FWL:6,DC:8</availability>
+			<availability>MOC:8,CC:9,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,MERC:7,TC:8,Periphery:7,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1480,7 +1480,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:2,TC:2,Periphery:2,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:6</availability>
+			<availability>CC:3,FRR:5,IS:2,SIC:3,MERC:1,Periphery:2,CS:2,NIOPS:2,MH:1,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SIC:4</availability>
@@ -1519,7 +1519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:2,IS:3,SIC:3,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,LA:8,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1565,7 +1565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:2,CHH:4,CLAN:1,IS:1,SIC:3,MERC:1,FS:1,CS:5,DC.GHO:4,LA:2,FWL:1,NIOPS:5,CGB:4,DC:1</availability>
+			<availability>CC:2,CHH:4,CLAN:1,IS:1,SIC:3,MERC:1,CS:5,DC.GHO:4,LA:2,NIOPS:5,CGB:4</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1651,12 +1651,12 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:4,FS:5,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
+			<availability>CC:2,FRR:2,SIC:2,MERC:4,FS:5,Periphery:2,TC:6,LA:8,FWL:4,DC:3</availability>
 			<model name='CHP-W10'>
 				<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+				<availability>HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:3</availability>
@@ -1895,7 +1895,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>MERC.KH:8,HL:3,FRR:4,CIR:4,MERC:4,FS:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:3,FRR:4,CIR:4,MERC:4,FS:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -1916,7 +1916,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,HL:1,IS:3,FS:5,Periphery:3,CS:3,LA:7,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -1993,7 +1993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
+			<availability>CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,Periphery:2,OA:3,LA:6,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -2026,7 +2026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
+			<availability>CLAN:3,IS:1,MERC:2,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -2090,7 +2090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,FRR:5,IS:3,SIC:5,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -2199,7 +2199,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,SIC:7,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>HL:8,IS:7,Periphery.Deep:9,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2231,7 +2231,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:5,FS:8,MERC:4,Periphery.OS:6,Periphery:4,Periphery.HR:6</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2240,7 +2240,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,FRR:4,IS:4,Periphery.Deep:4,SIC:5,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,OA:7,LA:6,FWL:4,MH:7,DC:4</availability>
+			<availability>IS:4,Periphery.Deep:4,SIC:5,MERC:6,FS:6,CIR:5,Periphery:6,OA:7,LA:6,MH:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2313,7 +2313,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,HL:1,LA:7,FRR:4,FWL:3,IS:3,SIC:2,FS:6,MERC:3,CC.CHG:4,DC:3,Periphery:3</availability>
+			<availability>HL:1,LA:7,FRR:4,IS:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8</availability>
 			</model>
@@ -2443,7 +2443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,FS:3,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2609,7 +2609,7 @@
 				<availability>CLAN:8,BAN:2</availability>
 			</model>
 			<model name='FFL-4A'>
-				<availability>:0,MERC.WD:4</availability>
+				<availability>MERC.WD:4</availability>
 			</model>
 			<model name='FFL-4B'>
 				<availability>MERC.WD:3+</availability>
@@ -2630,7 +2630,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:8,LA:8</availability>
+				<availability>MERC.KH:8,LA:8</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
@@ -2772,7 +2772,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2795,7 +2795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:5,HL:3,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:5,FS:8,CIR:6,Periphery:5,TC:6,CS:6,OA:8,LA:7,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+			<availability>MOC:6,CC:5,HL:3,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:5,FS:8,CIR:6,Periphery:5,TC:6,CS:6,OA:8,LA:7,NIOPS:6,CJF:3,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2809,7 +2809,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2840,7 +2840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:3,TC:3,Periphery:3,OA:3,LA:4,DC:1</availability>
+			<availability>CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,Periphery:3,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2859,10 +2859,10 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CS:2,OA:1,LA:4,Periphery.MW:1,FWL:5,MERC:1,TC:1,Periphery:1</availability>
+			<availability>CS:2,LA:4,Periphery.MW:1,FWL:5,MERC:1,Periphery:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
-				<availability>CC:8,HL:6,LA:8,FWL:8,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,Periphery.Deep:7,IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='GOL-3M'>
 				<roles>fire_support</roles>
@@ -2915,7 +2915,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2939,7 +2939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 			</model>
@@ -2973,7 +2973,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:3,CHH:5,CSR:5,CLAN:1,IS:3,FS:2,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:3,NIOPS:7,DC:3</availability>
+			<availability>CHH:5,CSR:5,CLAN:1,IS:3,FS:2,MERC:3,Periphery:2,CS:7,DC.GHO:6,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
@@ -3213,7 +3213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:3-,OA:3-,HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-,TC:3-</availability>
+			<availability>HL:1,LA:5-,Periphery.Deep:2-,FS:4-,MERC:4-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:6</availability>
 			</model>
@@ -3256,11 +3256,11 @@
 			<availability>CS:3,DC.GHO:5,CHH:4,CLAN:1,FWL:3,NIOPS:3,CGB:4,CB:2</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:6</availability>
+				<availability>FWL:6</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:4</availability>
+				<availability>FWL:4</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -3344,7 +3344,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:6,FS.DMM:6,FS:5,MERC:4,Periphery.OS:3,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:6,Periphery.HR:3,FS.CMM:6,FS.DMM:6,FS:5,MERC:4,Periphery.OS:3,FS.CrMM:6,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -3374,7 +3374,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3407,7 +3407,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3476,7 +3476,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:1,FRR:4,CLAN:1,IS:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:4</availability>
+			<availability>MOC:4,HL:1,CLAN:1,IS:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -3550,7 +3550,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:5</availability>
+			<availability>FS.DLC:6,CC:3,DC.LV:7,HL:3,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,SIC:3,FS:4,Periphery:5,TC:7,CS:4-,LA:6,FWL:3,NIOPS:4-</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3603,7 +3603,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3641,7 +3641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,Periphery:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3771,7 +3771,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1+,CLAN:4,IS:1+,MERC:1,FS:2+,CGS:5,CS:6,DC.GHO:3,LA:1+,FWL:1+,NIOPS:6,CGB:5,DC:1+</availability>
+			<availability>CLAN:4,IS:1+,MERC:1,FS:2+,CGS:5,CS:6,DC.GHO:3,NIOPS:6,CGB:5</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3810,7 +3810,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:5,CHH:4,CDS:4,CSV:4,CLAN:3,NIOPS:7,FS:6,DC:3</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6</availability>
+				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:8,CS:8,DC.SL:4,CLAN:6,NIOPS:8,MERC.SI:8,BAN:7</availability>
@@ -3873,7 +3873,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
+			<availability>CIH:8,CLAN:7,CCO:5,BAN:7,CSA:5,CW:6CSJ:9,CJF:5,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -3902,7 +3902,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:4,CW:4,CSV:6,CLAN:4,CNC:4,CGS:6,CJF:4,CGB:6</availability>
+			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CSV:6,CLAN:4,CGS:6,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -3952,7 +3952,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -4063,7 +4063,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CDS:8,CW:6,CBS:7,CSV:6,CLAN:7,CFM:7,CSJ:6,CJF:8,BAN:6,CGB:6,CB:7</availability>
+			<availability>CHH:9,CDS:8,CW:6,CSV:6,CLAN:7,CSJ:6,CJF:8,BAN:6,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:8</availability>
@@ -4097,7 +4097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4120,7 +4120,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:4</availability>
+			<availability>HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:4</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
 			</model>
@@ -4175,7 +4175,7 @@
 			<availability>CC:10,CS:10,LA:10,CLAN:10,FWL:10,IS:9,NIOPS:10,FS:10,DC:10,Periphery:8</availability>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CIH:4,CDS:6,CW:9,CBS:4,CLAN:5,CSJ:6,CCO:6,CJF:6,BAN:3,CB:4</availability>
+			<availability>CIH:4,CDS:6,CW:9,CBS:4,CLAN:5,CSJ:6,CCO:6,CJF:6,BAN:3,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -4212,7 +4212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:9,CDS:9,CW:9,CBS:6,CSV:8,CNC:9,CLAN:6,CSJ:7,CJF:9,BAN:6,CGB:6</availability>
+			<availability>CIH:9,CDS:9,CW:9,CSV:8,CNC:9,CLAN:6,CSJ:7,CJF:9,BAN:6</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -4243,7 +4243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,SIC:8,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:7,IS:9,Periphery.Deep:8,SIC:8,MERC:9,CIR:8,Periphery:9,CS:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -4267,7 +4267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
+			<availability>CC:4,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,NIOPS:8,DC:5</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 			</model>
@@ -4307,7 +4307,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:5,CB:4</availability>
+			<availability>CSV:3,CLAN:4,BAN:2,CW:3,CBS:3,CNC:3,CSJ:8,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -4364,7 +4364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,Periphery:5,CS:6-,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4488,7 +4488,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4642,7 +4642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:4,CLAN:5,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
+			<availability>CHH:4,CLAN:5,MERC:1,Periphery:1,CS:6,DC.GHO:6,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -4862,7 +4862,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4884,7 +4884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
+			<availability>CC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,CS:4,NIOPS:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4907,7 +4907,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:3,FRR:4,CLAN:2-,IS:3,SIC:3,FS:3,MERC:4,Periphery:1,CS:4,LA:3,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>FRR:4,CLAN:2-,IS:3,MERC:4,Periphery:1,CS:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:3</availability>
@@ -4945,14 +4945,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:4,FS:6,CIR:4,FS.CrMM:7,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:7,FS.DMM:7,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,HL:2,FRR:5,IS:4,Periphery.Deep:4,FS:6,FS.CrMM:7,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:7,FS.DMM:7,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
+				<availability>MERC.KH:3,HL:3,IS:3,Periphery.Deep:6,MERC:3,Periphery:5,PIR:3,General:3</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -4988,7 +4988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:7,FS:9,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:7,FS:9,CIR:6,Periphery:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5018,7 +5018,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8,HL:4,FRR:8,IS:8,Periphery.Deep:6,SIC:8,FS:8,CIR:6,Periphery:6,TC:6,OA:6,LA:8,FWL:8,DC:8</availability>
+			<availability>HL:4,IS:8,Periphery.Deep:6,Periphery:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5086,7 +5086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4,CGB:2</availability>
+			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:7,BAN:6,Periphery:7</availability>
@@ -5131,7 +5131,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:4,DC:5</availability>
+			<availability>MOC:7,CC:4,HL:2,IS:5,SIC:4,MERC:5,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:4</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -5269,7 +5269,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:5,CSA:9,CDS:8,CW:8,CBS:7,CNC:8,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CLAN:8,CCO:7,BAN:5,CSA:9,CBS:7,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
@@ -5310,7 +5310,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -5362,7 +5362,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
 			</model>
@@ -5412,7 +5412,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:8-,CCC:1,HL:3,FRR:8-,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:7-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
+			<availability>HL:3,CLAN:1,IS:8-,Periphery.Deep:5,SIC:7-,FS:9-,Periphery:5,CS:6-,Clan.IS:1,NIOPS:6-</availability>
 			<model name='RFL-3C'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>FS:3</availability>
@@ -5514,7 +5514,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
+			<availability>CC:3-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,MERC:4-,Periphery:4-,OA:3-,FWL:3-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -5551,7 +5551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:9,DC.AL:10,FRR:9,IS:7,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,LA:8,FWL:8,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,DC.AL:10,FRR:9,IS:7,SIC:8,MERC:7,Periphery.OS:9,CIR:7,Periphery:8,LA:8,FWL:8,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -5571,7 +5571,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,SIC:7-,Periphery.OS:8,FS:7-,CIR:7,Periphery:7,TC:6,OA:8,FWL.MM:10,LA:7-,FWL:9-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,Periphery.OS:8,Periphery:7,TC:6,OA:8,FWL.MM:10,FWL:9-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5594,13 +5594,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:1,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,HL:1,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:4,CC:3,HL:2,FRR:3,IS:4,Periphery.Deep:5,SIC:4,MERC:4,FS:5,CIR:5,Periphery:4,TC:4,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>CC:3,HL:2,FRR:3,IS:4,Periphery.Deep:5,MERC:4,FS:5,CIR:5,Periphery:4,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5611,7 +5611,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,OA:8,LA:8,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,SIC:8,MERC:7,Periphery.OS:8,Periphery:7,OA:8,LA:8,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5620,7 +5620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>CC:9,HL:8,LA:9,FRR:10,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
+			<availability>CC:9,HL:8,LA:9,FWL:9,IS:10,Periphery.Deep:9,SIC:9,FS:9,DC:9,Periphery:10</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5635,7 +5635,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:3-,HL:2-,FRR:3-,IS:2-,Periphery.Deep:4-,SIC:3-,FS:2-,MERC:3-,Periphery:4-,CS:3-,LA:2-,FWL:3-,NIOPS:3-,DC:3-</availability>
+			<availability>CC:3-,HL:2-,FRR:3-,IS:2-,Periphery.Deep:4-,SIC:3-,MERC:3-,Periphery:4-,CS:3-,FWL:3-,NIOPS:3-,DC:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:6,FRR:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -5687,7 +5687,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,CS:3,HL:1,LA:6,FRR:3,FWL:4,IS:4,SIC:3,FS:5,CIR:3,DC:4,Periphery:3</availability>
+			<availability>CC:3,CS:3,HL:1,LA:6,FRR:3,IS:4,SIC:3,FS:5,Periphery:3</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -5712,7 +5712,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
+			<availability>MOC:4,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5751,7 +5751,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,BAN:2,Periphery:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
@@ -5839,7 +5839,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:5,NIOPS:3,DC:8</availability>
+			<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,Periphery:2,CS:3,OA:3,FWL:5,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5854,7 +5854,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
 			</model>
@@ -5915,7 +5915,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,NIOPS:3,DC:5</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>LA:8,FS.CMM:3</availability>
@@ -5947,7 +5947,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,CS:4,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5961,7 +5961,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -6008,7 +6008,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
+			<availability>HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -6023,7 +6023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,Periphery:1,CS:3,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -6044,7 +6044,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -6083,7 +6083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,TC:1,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
+			<availability>FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 			</model>
@@ -6203,7 +6203,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:6,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -6256,7 +6256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
+			<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6297,7 +6297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:3,CLAN:3,IS:5,Periphery.Deep:5,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -6308,7 +6308,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:8,CCC:1-,CSR:1-,HL:2,MERC.ELH:3+,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:1,NIOPS:5-,MH:4,CSJ:1-,FC:8,CJF:1-,DC:8,CB:1</availability>
+			<availability>HL:2,MERC.ELH:3+,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,Periphery:4,CS:5-,CBS:1,NIOPS:5-,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,CSR:1-,CBS:1,CSJ:1-,CGS:1-,CJF:1-,CB:1</availability>
 			</model>
@@ -6421,7 +6421,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,FS:4,MERC:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -6482,7 +6482,7 @@
 			<availability>CS:6</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
@@ -6510,7 +6510,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CBS:6,CNC:5,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -6587,7 +6587,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,Periphery:4-,TC:3-,CS:4-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6639,14 +6639,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,CS:5,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,Periphery:4,CS:5-,LA:5,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 			</model>
@@ -6755,7 +6755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:8,FS:4</availability>
@@ -6813,7 +6813,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,HL:4,LA:9,CLAN:3,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:3,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,Periphery:6</availability>
 			<model name='C 3'>
 				<availability>MERC.WD:3</availability>
 			</model>
@@ -6840,7 +6840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,SIC:7,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
+			<availability>HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,SIC:7,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -6915,7 +6915,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:2,SIC:1,FS:4,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,MH:1,DC:6</availability>
+			<availability>Periphery.DD:2,FRR:3,CLAN:1-,IS:2,SIC:1,FS:4,MERC:3,Periphery.OS:2,Periphery:1,CS:3-,FS.CMM:5,NIOPS:3-,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -6938,7 +6938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:3,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,CS:5-,FWL:10,NIOPS:5-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2-</availability>
 			</model>
@@ -6972,7 +6972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:4,CIH:2,CLAN:3,IS:4,CFM:4,MERC:4,FS:5,Periphery:1,TC:2,CS:6,DC.GHO:6,NIOPS:6,DC:5</availability>
+			<availability>CIH:2,CLAN:3,IS:4,CFM:4,MERC:4,FS:5,Periphery:1,TC:2,CS:6,DC.GHO:6,NIOPS:6,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:8,CS:8,NIOPS:8,CFM:4,BAN:4</availability>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -6,8 +6,7 @@
 			<pctOmni>5,5</pctOmni>
 			<pctClan>20,20</pctClan>
 			<pctSL>70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -50,8 +49,7 @@
 			<pctSL>60,60,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
 			<weightDistribution era='3039' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='3039' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -61,8 +59,7 @@
 			<pctSL>94,94,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -70,8 +67,7 @@
 			<pctSL>37,37,37,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:8,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:10,CB:2</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:8,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:10,CB:2</salvage>
 			<weightDistribution era='3039' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3039' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -81,8 +77,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:2,CIH:3,CSV:10,CCO:2,CGS:7,CSA:10,CDS:2,CW:4,CNC:3,CSJ:5,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:2,CIH:3,CSV:10,CCO:2,CGS:7,CSA:10,CDS:2,CW:4,CNC:3,CSJ:5,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -90,8 +85,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:2,CIH:5,CSV:10,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:8,CNC:8,CSJ:2,CJF:8</salvage>
+			<salvage pct='10'>CHH:10,CCC:2,CIH:5,CSV:10,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:8,CNC:8,CSJ:2,CJF:8</salvage>
 			<weightDistribution era='3039' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3039' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -101,8 +95,7 @@
 			<pctSL>94,94,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,25,80,90</pctOmni>
@@ -110,8 +103,7 @@
 			<pctSL>80,80,25,10,0</pctSL>
 			<pctClan unitType='Vehicle'>5,5,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>95,95,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:8,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:8,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -119,8 +111,7 @@
 			<pctSL>60,60,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:4,CSR:1,CSV:8,CFM:5,CCO:7,CGS:8,CSA:8,CDS:9,CW:6,CNC:3,CSJ:7,CJF:10,CGB:5,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CSV:8,CFM:5,CCO:7,CGS:8,CSA:8,CDS:9,CW:6,CNC:3,CSJ:7,CJF:10,CGB:5,CB:2</salvage>
 			<weightDistribution era='3039' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3039' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -130,8 +121,7 @@
 			<pctSL>60,60,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:2,CIH:5,CSV:10,CFM:5,CCO:6,CGS:6,CSA:4,CDS:5,CW:10,CNC:1,CSJ:3,CGB:4,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:2,CIH:5,CSV:10,CFM:5,CCO:6,CGS:6,CSA:4,CDS:5,CW:10,CNC:1,CSJ:3,CGB:4,CB:1</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>10,10,50,90,100</pctOmni>
@@ -139,8 +129,7 @@
 			<pctSL>80,80,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:8,CHH:5,CSR:8,CIH:3,CSV:3,CFM:5,CCO:10,CGS:5,CSA:8,CDS:2,CW:6,CBS:3,CSJ:3,CJF:3,CGB:8,CB:5</salvage>
+			<salvage pct='10'>CCC:8,CHH:5,CSR:8,CIH:3,CSV:3,CFM:5,CCO:10,CGS:5,CSA:8,CDS:2,CW:6,CBS:3,CSJ:3,CJF:3,CGB:8,CB:5</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -148,8 +137,7 @@
 			<pctSL>20,20,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='12'>
-				CCC:3,CHH:10,CSR:10,CIH:10,CSV:6,CFM:10,CCO:8,CGS:3,CSA:10,CW:2,CNC:8,CSJ:10,CJF:8,CB:10</salvage>
+			<salvage pct='12'>CCC:3,CHH:10,CSR:10,CIH:10,CSV:6,CFM:10,CCO:8,CGS:3,CSA:10,CW:2,CNC:8,CSJ:10,CJF:8,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -157,8 +145,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:7,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:7,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>40,40,80,100,100</pctOmni>
@@ -174,8 +161,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,50,50</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
 			<weightDistribution era='3039' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3039' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -185,8 +171,7 @@
 			<pctSL>50,50,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,15,100,100</pctOmni>
@@ -194,8 +179,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:10,CIH:4,CSV:5,CFM:2,CCO:1,CGS:3,CSA:3,CDS:1,CNC:2,CSJ:4,CJF:10,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:10,CIH:4,CSV:5,CFM:2,CCO:1,CGS:3,CSA:3,CDS:1,CNC:2,CSJ:4,CJF:10,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctOmni>0,0</pctOmni>
@@ -466,8 +450,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,80,100</pctOmni>
@@ -475,8 +458,7 @@
 			<pctSL>70,70,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -484,8 +466,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,75,100</pctOmni>
@@ -493,8 +474,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,55,100</pctOmni>
@@ -502,8 +482,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,55,100</pctOmni>
@@ -511,8 +490,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,15,90,100</pctOmni>
@@ -520,8 +498,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>6,6,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>94,94,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='DC.LV'>
 			<salvage pct='6'></salvage>
@@ -663,16 +640,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:3,CLAN:2,IS:2,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:2,FRR:3,CLAN:2,IS:2,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -750,8 +725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>FRR:4,DC:8</availability>
@@ -810,8 +784,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -911,8 +884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,FRR:4,CSV:2-,IS:3,CFM:2,SIC:2,FS:5,MERC:2,CGS:2,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>MOC:1,CC:3,FRR:4,CSV:2-,IS:3,CFM:2,SIC:2,FS:5,MERC:2,CGS:2,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:3,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -971,8 +943,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -1132,8 +1103,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -1185,8 +1155,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:6,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
+			<availability>CC:6,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,SIC:6,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:4</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1303,8 +1272,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,FS:1,MERC:1,CGS:9,DC.GHO:3,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
+			<availability>CHH:7,CSR:7,CSV:7,FRR:1,CLAN:8,CFM:7,FWL.OH:2,FS:1,MERC:1,CGS:9,DC.GHO:3,CS:7,CDS:7,CW:9,CBS:9,LA:1,CNC:9,FWL:1,NIOPS:7,CJF:7,CGB:9,DC:1</availability>
 			<model name='BL-6-KNT'>
 				<availability>DC.GHO:4,CS:8,CLAN:6,NIOPS:8,MERC.SI:8,BAN:6</availability>
 			</model>
@@ -1375,8 +1343,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:2,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DA:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:2,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DA:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1403,8 +1370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,SIC:4,FS:7,CIR:4,Periphery:3</availability>
+			<availability>CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,SIC:4,FS:7,CIR:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1426,8 +1392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:9,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,LA:6,FWL:6,DC:8</availability>
+			<availability>MOC:8,CC:9,HL:5,FRR:8,IS:7,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:7,TC:8,Periphery:7,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1485,8 +1450,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:4,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -1516,8 +1480,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:2,TC:2,Periphery:2,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:6</availability>
+			<availability>MOC:2,CC:3,FRR:5,IS:2,SIC:3,MERC:1,FS:2,CIR:2,TC:2,Periphery:2,CS:2,LA:2,FWL:2,NIOPS:2,MH:1,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SIC:4</availability>
@@ -1556,8 +1519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:2,IS:3,SIC:3,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,SIC:3,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN9-A'>
 				<deployedWith>Trebuchet</deployedWith>
 				<availability>HL:6,LA:8,FRR:8,General:8,FWL:8,Periphery.Deep:7,FS:8,MERC:8,Periphery:8</availability>
@@ -1603,8 +1565,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:2,CHH:4,CLAN:1,IS:1,SIC:3,MERC:1,FS:1,CS:5,DC.GHO:4,LA:2,FWL:1,NIOPS:5,CGB:4,DC:1</availability>
+			<availability>CC:2,CHH:4,CLAN:1,IS:1,SIC:3,MERC:1,FS:1,CS:5,DC.GHO:4,LA:2,FWL:1,NIOPS:5,CGB:4,DC:1</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -1656,8 +1617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:1,FRR:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -1935,8 +1895,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:3,FRR:4,CIR:4,MERC:4,FS:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:3,FRR:4,CIR:4,MERC:4,FS:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -1957,8 +1916,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -2035,8 +1993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:2,CLAN:5,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:6,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -2069,8 +2026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
+			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,MERC:2,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:2</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,NIOPS:0,Periphery:8</availability>
@@ -2085,8 +2041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,CGS:6,CS:8,DC.GHO:4,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
+			<availability>CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,CGS:6,CS:8,DC.GHO:4,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -2135,8 +2090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:2,FRR:5,IS:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -2245,8 +2199,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,SIC:7,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,SIC:7,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2278,8 +2231,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:8,MERC:4,Periphery.OS:6,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:6,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2288,8 +2240,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,FRR:4,IS:4,Periphery.Deep:4,SIC:5,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,OA:7,LA:6,FWL:4,MH:7,DC:4</availability>
+			<availability>MOC:6,CC:4,FRR:4,IS:4,Periphery.Deep:4,SIC:5,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,OA:7,LA:6,FWL:4,MH:7,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2346,8 +2297,7 @@
 				<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='Prime'>
 				<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
@@ -2393,8 +2343,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:4,FS:4</availability>
@@ -2494,8 +2443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -2591,8 +2539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
+			<availability>Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:9</availability>
@@ -2681,8 +2628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
+			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:8,LA:8</availability>
 			</model>
@@ -2826,8 +2772,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -2850,8 +2795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:5,HL:3,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:5,FS:8,CIR:6,Periphery:5,TC:6,CS:6,OA:8,LA:7,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
+			<availability>MOC:6,CC:5,HL:3,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,SIC:5,FS:8,CIR:6,Periphery:5,TC:6,CS:6,OA:8,LA:7,FWL:6,NIOPS:6,CJF:3,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -2865,8 +2809,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -2897,8 +2840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:3,TC:3,Periphery:3,OA:3,LA:4,DC:1</availability>
+			<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,SIC:1,MERC:1,FS:6,CIR:3,TC:3,Periphery:3,OA:3,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -2973,8 +2915,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2998,8 +2939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
 			<model name='GRF-1N'>
 				<availability>HL:6,General:8,CLAN:1-,Periphery.Deep:7,BAN:3,Periphery:8</availability>
 			</model>
@@ -3033,8 +2973,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:3,CHH:5,CSR:5,CLAN:1,IS:3,FS:2,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:3,NIOPS:7,DC:3</availability>
+			<availability>CC:3,CHH:5,CSR:5,CLAN:1,IS:3,FS:2,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:3,NIOPS:7,DC:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8</availability>
@@ -3125,8 +3064,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:2,FRR:6,Periphery.Deep:4,MERC:6,Periphery:4,FWL.pm:8,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:2,FRR:6,Periphery.Deep:4,MERC:6,Periphery:4,FWL.pm:8,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3406,8 +3344,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:6,FS.DMM:6,FS:5,MERC:4,Periphery.OS:3,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:6,FS.DMM:6,FS:5,MERC:4,Periphery.OS:3,FS.CrMM:6,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -3437,8 +3374,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3471,8 +3407,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,OA:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -3541,19 +3476,16 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:1,FRR:4,CLAN:1,IS:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:1,FRR:4,CLAN:1,IS:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:4</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -3597,8 +3529,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					CC:4,MOC:3,FRR:4,SIC:4,FS:4,MERC:3,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,DC:4</availability>
+				<availability>CC:4,MOC:3,FRR:4,SIC:4,FS:4,MERC:3,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -3619,8 +3550,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:5</availability>
+			<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:4-,OA:5,LA:6,FWL:3,NIOPS:4-,DC:5</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -3673,8 +3603,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:5,MERC:2,TC:2,Periphery:2</availability>
@@ -3712,8 +3641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:2,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-D'>
 				<roles>raider</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -3843,8 +3771,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:1+,CLAN:4,IS:1+,MERC:1,FS:2+,CGS:5,CS:6,DC.GHO:3,LA:1+,FWL:1+,NIOPS:6,CGB:5,DC:1+</availability>
+			<availability>CC:1+,CLAN:4,IS:1+,MERC:1,FS:2+,CGS:5,CS:6,DC.GHO:3,LA:1+,FWL:1+,NIOPS:6,CGB:5,DC:1+</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
 			</model>
@@ -3946,8 +3873,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:7,CCO:5,CGS:7,BAN:7,CSA:5,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -4026,8 +3952,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -4076,8 +4001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:4,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:4,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -4152,8 +4076,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CS:6,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CS:6,CSA:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -4174,8 +4097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4198,8 +4120,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:4</availability>
+			<availability>MOC:2,HL:3,FRR:5,SIC:4,MERC:5,CIR:3,FS:5,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:4</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
 			</model>
@@ -4322,8 +4243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,SIC:8,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,SIC:8,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -4347,8 +4267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
+			<availability>CC:4,MOC:1,FRR:5,CLAN:3,IS:3,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:3</availability>
 			<model name='MAD-1R'>
 				<availability>CS:8,CLAN:1,NIOPS:8,MERC:0,BAN:2</availability>
 			</model>
@@ -4388,8 +4307,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:5,CB:4</availability>
+			<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:2,CSA:4,CDS:4,CW:3,CBS:3,CNC:3,CSJ:8,CJF:4,CGB:5,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -4446,8 +4364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,FRR:7,IS:5,Periphery.Deep:5,SIC:6,MERC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:6,NIOPS:6-,DC:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -4571,8 +4488,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -4599,8 +4515,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,MERC:3,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,MERC:3,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -4727,8 +4642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:4,CLAN:5,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
+			<availability>MOC:1,CHH:4,CLAN:5,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:6,OA:1,CDS:4,CBS:5,NIOPS:6,CJF:5,CGB:4,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
@@ -4948,8 +4862,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -4971,8 +4884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
+			<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,SIC:3,Periphery:3,TC:3,CS:4,LA:5,NIOPS:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -4995,8 +4907,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:3,FRR:4,CLAN:2-,IS:3,SIC:3,FS:3,MERC:4,Periphery:1,CS:4,LA:3,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>CC:3,FRR:4,CLAN:2-,IS:3,SIC:3,FS:3,MERC:4,Periphery:1,CS:4,LA:3,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:3</availability>
@@ -5027,24 +4938,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:2,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:2,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:4,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:4,FS:6,CIR:4,FS.CrMM:7,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:7,FS.DMM:7,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:4,FS:6,CIR:4,FS.CrMM:7,Periphery:4,TC:3,CS:6,OA:3,LA:6,FS.CMM:7,FS.DMM:7,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
+				<availability>CC:3,MERC.KH:3,HL:3,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:5,PIR:3,General:3,FWL:3,DC:3</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -5067,8 +4975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,SIC:3,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,SIC:3,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:5,FWL:3,NIOPS:2,DC:10</availability>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,Periphery:8,DC:8</availability>
@@ -5081,8 +4988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:7,FS:9,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,SIC:7,FS:9,CIR:6,Periphery:9,TC:9,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5112,8 +5018,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8,HL:4,FRR:8,IS:8,Periphery.Deep:6,SIC:8,FS:8,CIR:6,Periphery:6,TC:6,OA:6,LA:8,FWL:8,DC:8</availability>
+			<availability>MOC:6,CC:8,HL:4,FRR:8,IS:8,Periphery.Deep:6,SIC:8,FS:8,CIR:6,Periphery:6,TC:6,OA:6,LA:8,FWL:8,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5226,8 +5131,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:4,DC:5</availability>
+			<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:4,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -5275,8 +5179,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
+			<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -5407,8 +5310,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:8,OA:8,HL:6,Periphery.Deep:7,FWL:8,IS:8,Periphery:8,DC:8,TC:8</availability>
 			</model>
@@ -5460,8 +5362,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CLAN:1,CNC:3</availability>
 			</model>
@@ -5483,8 +5384,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -5512,8 +5412,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:8-,CCC:1,HL:3,FRR:8-,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:7-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
+			<availability>CC:8-,CCC:1,HL:3,FRR:8-,CSV:1,CLAN:1,IS:8-,Periphery.Deep:5,CFM:1,SIC:7-,FS:9-,CGS:1,Periphery:5,CS:6-,CSA:1,Clan.IS:1,FWL:8-,NIOPS:6-,CJF:1,CB:1</availability>
 			<model name='RFL-3C'>
 				<roles>fire_support,anti_aircraft</roles>
 				<availability>FS:3</availability>
@@ -5615,8 +5514,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
+			<availability>CC:3-,MOC:4-,HL:2-,CLAN:3,IS:4-,Periphery.Deep:4-,SIC:3-,FS:4-,MERC:4-,Periphery:4-,OA:3-,LA:4-,FWL:3-,DC:5-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -5653,8 +5551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:9,DC.AL:10,FRR:9,IS:7,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,LA:8,FWL:8,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,DC.AL:10,FRR:9,IS:7,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,LA:8,FWL:8,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -5674,8 +5571,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,SIC:7-,Periphery.OS:8,FS:7-,CIR:7,Periphery:7,TC:6,OA:8,FWL.MM:10,LA:7-,FWL:9-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,SIC:7-,Periphery.OS:8,FS:7-,CIR:7,Periphery:7,TC:6,OA:8,FWL.MM:10,LA:7-,FWL:9-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5704,8 +5600,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:4,CC:3,HL:2,FRR:3,IS:4,Periphery.Deep:5,SIC:4,MERC:4,FS:5,CIR:5,Periphery:4,TC:4,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
+			<availability>MOC:4,CC:3,HL:2,FRR:3,IS:4,Periphery.Deep:5,SIC:4,MERC:4,FS:5,CIR:5,Periphery:4,TC:4,CS:5,OA:5,LA:5,FWL:5,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5716,8 +5611,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,OA:8,LA:8,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,OA:8,LA:8,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5741,8 +5635,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:3-,HL:2-,FRR:3-,IS:2-,Periphery.Deep:4-,SIC:3-,FS:2-,MERC:3-,Periphery:4-,CS:3-,LA:2-,FWL:3-,NIOPS:3-,DC:3-</availability>
+			<availability>CC:3-,HL:2-,FRR:3-,IS:2-,Periphery.Deep:4-,SIC:3-,FS:2-,MERC:3-,Periphery:4-,CS:3-,LA:2-,FWL:3-,NIOPS:3-,DC:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:6,FRR:8,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -5801,8 +5694,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
+			<availability>CSV:3,CLAN:4,CFM:5,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:1-,NIOPS:4,CJF:5,CGB:5,DC:1</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -5820,8 +5712,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
+			<availability>MOC:4,Periphery.R:6,MERC.KH:6,OA:7,HL:5,LA:9,Periphery.Deep:4,MH:2,FS:4,CIR:3,Periphery:6,TC:7</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -5948,8 +5839,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:5,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:5,NIOPS:3,DC:8</availability>
+			<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3,OA:3,LA:4,FWL:5,NIOPS:3,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -5964,8 +5854,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:5,IS:7,Periphery.Deep:7,FS:0,Periphery:7</availability>
 			</model>
@@ -6026,8 +5915,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 			<model name='SPR-8H'>
 				<roles>interceptor</roles>
 				<availability>LA:8,FS.CMM:3</availability>
@@ -6059,8 +5947,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>MOC:2,CC:5,FRR:6,IS:2,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -6074,8 +5961,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:5,IS:9,Periphery.Deep:9,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -6122,8 +6008,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
+			<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -6138,8 +6023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
+			<availability>MOC:2,CC:3,SIC:3,FS:1,MERC:3,CIR:2,TC:1,Periphery:1,CS:3,OA:1,LA:3,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2</availability>
 			<model name='F-90'>
 				<availability>CS:8,LA:4,IS:8,FS:8,Periphery:8</availability>
 			</model>
@@ -6199,8 +6083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,TC:1,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
+			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,TC:1,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:3</availability>
 			<model name='STU-K10'>
 				<availability>OA:4,LA:4,FS.DMM:8,SIC:4</availability>
 			</model>
@@ -6320,8 +6203,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,CDS:7,CW:7,CNC:6,CSJ:7,CJF:10,CGB:7,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -6374,16 +6256,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
+			<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:2</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,CS:7,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:3,NIOPS:7,CJF:7,CGB:7</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
@@ -6417,8 +6297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -6429,8 +6308,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:8,CCC:1-,CSR:1-,HL:2,MERC.ELH:3+,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:1,NIOPS:5-,MH:4,CSJ:1-,FC:8,CJF:1-,DC:8,CB:1</availability>
+			<availability>CC:8,CCC:1-,CSR:1-,HL:2,MERC.ELH:3+,CLAN:1-,IS:8,Periphery.Deep:6,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,CSA:1-,LA:8,CBS:1,NIOPS:5-,MH:4,CSJ:1-,FC:8,CJF:1-,DC:8,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,CSR:1-,CBS:1,CSJ:1-,CGS:1-,CJF:1-,CB:1</availability>
 			</model>
@@ -6543,8 +6421,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,FRR:5,IS:5,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,NIOPS:6</availability>
@@ -6633,8 +6510,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -6711,8 +6587,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -6764,16 +6639,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>MOC:1,CC:2,FRR:2,IS:1,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:5</availability>
+			<availability>MOC:4,CC:5,HL:2,FRR:5,IS:4,Periphery.Deep:4,SIC:5,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:5-,DC:5</availability>
 			<model name='VTR-9A'>
 				<availability>CC:1,CS:1,SIC:1,FS:1</availability>
 			</model>
@@ -6967,8 +6840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,SIC:7,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
+			<availability>MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,SIC:7,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -7043,8 +6915,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:2,SIC:1,FS:4,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,MH:1,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:2,SIC:1,FS:4,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:3-,OA:1,FS.CMM:5,NIOPS:3-,MH:1,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -7067,8 +6938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2-</availability>
 			</model>
@@ -7102,8 +6972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:4,CIH:2,CLAN:3,IS:4,CFM:4,MERC:4,FS:5,Periphery:1,TC:2,CS:6,DC.GHO:6,NIOPS:6,DC:5</availability>
+			<availability>CC:4,CIH:2,CLAN:3,IS:4,CFM:4,MERC:4,FS:5,Periphery:1,TC:2,CS:6,DC.GHO:6,NIOPS:6,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:8,CS:8,NIOPS:8,CFM:4,BAN:4</availability>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -835,14 +835,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:2,IS:4,Periphery.Deep:4,Periphery:4,CS:3,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>FRR:3,CLAN:2,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -927,7 +927,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,WOB:4-,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,WOB:4-,SIC:7,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>FRR:4,DC:8</availability>
@@ -973,7 +973,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1005,7 +1005,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1060,7 +1060,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:2-,CC:4-,HL:1,FRR:4,IS:3,WOB:3-,MERC:3,FS:4,Periphery:3,TC:2-,CS:3-,OA:1,LA:3,FS.CMM:5-</availability>
+			<availability>MOC:2-,CC:4-,HL:1,FRR:4,IS:3,WOB:3-,MERC:3,FS:4,Periphery:3,TC:2-,CS:3-,OA:1,FS.CMM:5-</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:2</availability>
 			</model>
@@ -1109,7 +1109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,FRR:4,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:6,CB:2-</availability>
+			<availability>FRR:4,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:6</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -1185,7 +1185,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,WOB:8,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:6,CLAN:1-,IS:7,Periphery.Deep:7,WOB:8,CIR:8,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -1364,7 +1364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:2-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:7-,IS:6-,Periphery.Deep:9-,WOB:2-,FS:7-,MERC:6-,Periphery:9-,CS:2-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:4,General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 			</model>
@@ -1433,7 +1433,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
+			<availability>HL:3,FRR:4,CLAN:2,IS:5,WOB:7-,Periphery:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1539,7 +1539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:4,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,MERC.WD:3,CDS:6,CW:6,CBS:3,CJF:6,CGB:5</availability>
+			<availability>CHH:7,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,MERC.WD:3,CDS:6,CW:6,CBS:3,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1564,7 +1564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:7,FRR:2,CLAN:8,CFM:7,FS:1,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
+			<availability>CHH:7,FRR:2,CLAN:8,CFM:7,FS:1,DC.GHO:3,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
 			<model name='BL-6-KNT'>
 				<availability>DC.GHO:4,CS:6,FRR:3+,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:3+</availability>
 			</model>
@@ -1572,7 +1572,7 @@
 				<availability>CS:5,CLAN:5,FWL:4+,NIOPS:5,WOB:5,CGS:6,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>LA:8,FRR:8,FWL:4,MERC:8,FS:8,DC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1669,7 +1669,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:3,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:3,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1696,7 +1696,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,SIC:4,FS:7,CIR:4,Periphery:3</availability>
+			<availability>LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,CIR:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1718,7 +1718,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>MOC:8,CC:9,HL:4,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:6,TC:8,Periphery:6,LA:6,FWL:6,DC:8</availability>
+			<availability>MOC:8,CC:9,HL:4,FRR:8,IS:6,Periphery.Deep:6,SIC:9,CIR:7,MERC:6,TC:8,Periphery:6,LA:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1830,7 +1830,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,FS:1,CIR:2,TC:2,Periphery:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
+			<availability>CC:3,FRR:5,IS:1,SIC:2,MERC:1,Periphery:2,CS:3,NIOPS:3,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SIC:4</availability>
@@ -1920,7 +1920,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:2+,FS:3+</availability>
 			</model>
@@ -1984,7 +1984,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:4,CHH:3,CLAN:2,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:5,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:4,CHH:3,CLAN:2,IS:2,WOB:5,SIC:3,MERC:2,CS:5,DC.GHO:5,LA:3,NIOPS:5,CGB:3,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -2091,7 +2091,7 @@
 				<availability>HL:2,SIC:8,FS:8,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
+				<availability>HL:6,LA:8,FRR:2,IS:8,Periphery.Deep:7,MERC:8,BAN:3,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:3</availability>
@@ -3208,7 +3208,7 @@
 				<availability>MERC.WD:4,CLAN:8,BAN:1</availability>
 			</model>
 			<model name='FFL-4A'>
-				<availability>:0,MERC.WD:3-</availability>
+				<availability>MERC.WD:3-</availability>
 			</model>
 			<model name='FFL-4B'>
 				<availability>MERC.WD:4+</availability>
@@ -3240,7 +3240,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:6,LA:6</availability>
+				<availability>MERC.KH:6,LA:6</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:8,CS:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8</availability>
@@ -4004,11 +4004,11 @@
 			<availability>CS:3,DC.GHO:5,CHH:3,FWL:4,NIOPS:3,WOB:3,CGB:3,CB:2</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:4</availability>
+				<availability>FWL:4</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:2</availability>
+				<availability>FWL:2</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -4109,7 +4109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:6,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -4145,7 +4145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,WOB:5-,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,WOB:5-,SIC:6,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -4178,7 +4178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4291,7 +4291,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:1,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,HL:1,CLAN:1,IS:4,WOB:4,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -4383,7 +4383,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,WOB:3-,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:3-,OA:5,LA:6,FWL:3,NIOPS:3-,DC:5</availability>
+			<availability>FS.DLC:6,CC:3,DC.LV:7,HL:3,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,WOB:3-,SIC:3,FS:4,Periphery:5,TC:7,CS:3-,LA:6,FWL:3,NIOPS:3-</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -4457,7 +4457,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:6,MERC:2,TC:2,Periphery:2</availability>
@@ -4499,7 +4499,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:3,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,MERC:4,Periphery.OS:5,FS:3,Periphery:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>DC:2+</availability>
@@ -4629,7 +4629,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1,CLAN:4,IS:1,WOB:6,FS:3,MERC:1,CGS:5,DC.GHO:5,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
+			<availability>CLAN:4,IS:1,WOB:6,FS:3,MERC:1,CGS:5,DC.GHO:5,CS:6,NIOPS:6,CGB:5</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,FRR:4+,CLAN:6,NIOPS:8,WOB:8,BAN:8,CB:5,DC:4+</availability>
 			</model>
@@ -4675,7 +4675,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:6,MERC:3,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6,MERC:6,DC:4</availability>
+				<availability>FS:6,MERC:6,DC:4</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:8,CS:8,DC.SL:4,CLAN:6,NIOPS:8,WOB:8,MERC.SI:8,FS:4+,MERC:4+,BAN:7</availability>
@@ -4755,7 +4755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:6,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:4,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:6,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:4,CDS:7,CBS:7,CSJ:9,CJF:5,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -4795,7 +4795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CDS:3,CW:4,CSV:6,CLAN:3,CNC:3,CGS:6,CJF:4,CGB:6</availability>
+			<availability>CSA:6,CHH:6,CIH:6,CSR:6,CW:4,CSV:6,CLAN:3,CGS:6,CJF:4,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -4845,7 +4845,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -4894,7 +4894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,Periphery:4,TC:5,CS:5-,OA:7,FWL:3,NIOPS:5-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -5030,7 +5030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,WOB:4,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,WOB:4,SIC:6,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5056,7 +5056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
+			<availability>HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
 			</model>
@@ -5165,7 +5165,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:9,CSV:8,CLAN:6,BAN:6,MERC.WD:6,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
+			<availability>CIH:9,CSV:8,CLAN:6,BAN:6,MERC.WD:6,CDS:9,CW:9,CNC:9,CSJ:7,CJF:9</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -5196,7 +5196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:7,IS:9,Periphery.Deep:8,WOB:9,MERC:9,CIR:8,Periphery:9,CS:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -5229,7 +5229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:2</availability>
+			<availability>CC:4,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,NIOPS:8,DC:5</availability>
 			<model name='C'>
 				<availability>LA:1+,FS:1+,DC:1+</availability>
 			</model>
@@ -5281,7 +5281,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:5,CB:4</availability>
+			<availability>CSV:3,CLAN:4,BAN:3,MERC.WD:2,CW:3,CSJ:8,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -5347,7 +5347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:5,HL:3,FRR:7,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
+			<availability>HL:3,FRR:7,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,Periphery:5,CS:6-,LA:7,NIOPS:6-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5483,7 +5483,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -5661,7 +5661,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:3,CLAN:4,WOB:4,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:5,OA:1,CDS:3,CBS:4,NIOPS:6,CJF:4,CGB:3,DC:1</availability>
+			<availability>CHH:3,CLAN:4,WOB:4,MERC:1,Periphery:1,CS:6,DC.GHO:5,CDS:3,NIOPS:6,CJF:4,CGB:3,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -5888,7 +5888,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>CC:6,FRR:3,IS:3,SIC:7,MERC:3,FS:7,CIR:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:3</availability>
+			<availability>CC:6,IS:3,SIC:7,MERC:3,FS:7,CIR:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4</availability>
 			<model name=''>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -5910,7 +5910,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:5-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,HL:2,CLAN:2,IS:5,Periphery.Deep:4,WOB:5-,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='ON1-K'>
 				<availability>HL:5,General:7,CLAN:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -5938,7 +5938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,WOB:4,SIC:3,MERC:1+,Periphery:3,TC:3,CS:4,LA:4,NIOPS:4,DC:6</availability>
+			<availability>CC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,WOB:4,SIC:3,MERC:1+,Periphery:3,CS:4,LA:4,NIOPS:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -5964,7 +5964,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:4,LA:2,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>FRR:4,CLAN:2-,IS:2,WOB:3,MERC:4,Periphery:1,CS:4,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:2</availability>
@@ -6005,14 +6005,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:9,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:9,FS.DMM:9,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,FS.CrMM:9,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:9,FS.DMM:9,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:3,MERC.KH:3,HL:2,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:4,PIR:3,General:3,FWL:3,DC:3</availability>
+				<availability>MERC.KH:3,HL:2,IS:3,Periphery.Deep:6,MERC:3,Periphery:4,PIR:3,General:3</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -6056,7 +6056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:9,CIR:6,Periphery:9,TC:9,CS:6-,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:9,CIR:6,Periphery:9,CS:6-,OA:5,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6086,7 +6086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:6,Periphery.Deep:8,WOB:5-,SIC:7,FS:7,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:7,FWL:6,DC:7</availability>
+			<availability>HL:3,IS:6,Periphery.Deep:8,WOB:5-,SIC:7,FS:7,Periphery:5,CS:5-,LA:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -6175,7 +6175,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,WOB:7,Periphery:4,CGB:2</availability>
+			<availability>CS:7,HL:2,CLAN:2,IS:9,FWL:10,NIOPS:7,Periphery.Deep:4,WOB:7,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:6,BAN:6,Periphery:6</availability>
@@ -6223,7 +6223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,WOB:6-,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:5,DC:5</availability>
+			<availability>MOC:7,CC:4,HL:2,IS:5,WOB:6-,SIC:4,MERC:5,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -6271,7 +6271,7 @@
 			</model>
 		</chassis>
 		<chassis name='Po Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:3,WOB:3,SIC:6,MERC:5,Periphery:2,TC:2</availability>
+			<availability>MOC:3,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:3,WOB:3,SIC:6,MERC:5,Periphery:2</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6391,7 +6391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CSA:9,MERC.WD:2,CDS:9,CW:8,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CLAN:8,CCO:7,BAN:7,CSA:9,MERC.WD:2,CDS:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
@@ -6438,7 +6438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:6,OA:6,HL:4,Periphery.Deep:6,FWL:6,IS:6,Periphery:6,DC:6,TC:6</availability>
 			</model>
@@ -6534,7 +6534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:9,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,CLAN:7,Periphery.Deep:9,IS:7,WOB:9,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CNC:3</availability>
 			</model>
@@ -6590,7 +6590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:7-,CS:6-,HL:3,FRR:8-,IS:8-,Periphery.Deep:5,FWL:8-,NIOPS:6-,WOB:6-,SIC:7-,FS:9-,Periphery:5</availability>
+			<availability>CC:7-,CS:6-,HL:3,IS:8-,Periphery.Deep:5,NIOPS:6-,WOB:6-,SIC:7-,FS:9-,Periphery:5</availability>
 			<model name='C'>
 				<availability>CLAN:8,BAN:4</availability>
 			</model>
@@ -6663,7 +6663,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,MERC.WD:6,CSR:9,CDS:9,CW:8,CBS:9,CSV:7,CLAN:8,CNC:8,CSJ:9,CJF:9,BAN:8</availability>
+			<availability>MERC.WD:6,CSR:9,CDS:9,CBS:9,CSV:7,CLAN:8,CSJ:9,CJF:9,BAN:8</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:5,CSV:8,General:6,CSJ:7,CJF:5,CGB:5</availability>
 			</model>
@@ -6717,7 +6717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,MERC:3-,Periphery:3-,OA:2-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -6757,7 +6757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:2,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:2,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -6780,7 +6780,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,WOB:3,SIC:7-,Periphery.OS:8,FS:7-,CIR:7,Periphery:7,TC:6,CS:3,OA:8,FWL.MM:10,CW:3,LA:7-,FWL:9-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,WOB:3,Periphery.OS:8,Periphery:7,TC:6,CS:3,OA:8,FWL.MM:10,CW:3,FWL:9-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6814,13 +6814,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:1,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,HL:1,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:5,CC:4,HL:3,FRR:4,IS:5,Periphery.Deep:5,WOB:5,SIC:6,MERC:5,FS:6,CIR:6,Periphery:5,TC:5,CS:5,OA:6,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,HL:3,FRR:4,IS:5,Periphery.Deep:5,WOB:5,SIC:6,MERC:5,FS:6,CIR:6,Periphery:5,CS:5,OA:6,LA:6,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -6831,7 +6831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,WOB:5-,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,CS:5-,OA:8,LA:8,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,WOB:5-,SIC:8,MERC:7,Periphery.OS:8,Periphery:7,CS:5-,OA:8,LA:8,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6859,7 +6859,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:3-,HL:1-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,FS:1-,MERC:3-,Periphery:3-,CS:2-,LA:1-,FWL:3-,NIOPS:2-,DC:3-</availability>
+			<availability>CC:3-,HL:1-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,MERC:3-,Periphery:3-,CS:2-,FWL:3-,NIOPS:2-,DC:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:4,FRR:8,General:6,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -6914,7 +6914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,HL:1,FRR:3,IS:4,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,FWL:4,DC:4</availability>
+			<availability>CC:3,HL:1,FRR:3,IS:4,WOB:3,SIC:3,FS:5,Periphery:3,CS:3,LA:6</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -6939,7 +6939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,OA:7,LA:9,MH:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -6988,7 +6988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,WOB:6-,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,WOB:6-,BAN:2,Periphery:5</availability>
 			<model name='C'>
 				<availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
 			</model>
@@ -7089,7 +7089,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,WOB:3-,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:8</availability>
+			<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,WOB:3-,SIC:3,MERC:4,Periphery.OS:3,Periphery:2,CS:3-,OA:3,FWL:5,NIOPS:3-,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -7104,7 +7104,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
 			</model>
@@ -7177,7 +7177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,NIOPS:3,DC:5</availability>
 			<model name='SPR-6D'>
 				<availability>FS:4+</availability>
 			</model>
@@ -7219,7 +7219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:4,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>CC:5,FRR:6,IS:2,WOB:4,SIC:5,MERC:4,FS:5,Periphery:2,CS:4,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -7243,7 +7243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:6,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>CC:7,HL:8,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:6,SIC:7,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -7303,7 +7303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:4-,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
+			<availability>HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:4-,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -7322,7 +7322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,CS:3,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:7,LA:4,IS:7,FS:7,Periphery:7</availability>
 			</model>
@@ -7349,7 +7349,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -7392,7 +7392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:4+,FS:6+,MERC:4+</availability>
 			</model>
@@ -7507,7 +7507,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,MERC.WD:3,CDS:6,CW:6,CNC:6,CSJ:7,CJF:10,CGB:6,CB:5</availability>
+			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:6,MERC.WD:3,CSJ:7,CJF:10,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -7572,7 +7572,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -7613,7 +7613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:3,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -7628,7 +7628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>HL:2,CLAN:1-,Periphery.Deep:6,FS:7,CSA:1-,CBS:1,NIOPS:5-,MH:4,CSJ:2-,CB:1,CC:7,CCC:1-,CSR:1-,MERC.ELH:5+,IS:8,WOB:4-,CLAN.IS:1-,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,MERC.WD:1,LA:8,FC:8,CJF:2-,DC:8</availability>
+			<availability>HL:2,CLAN:1-,Periphery.Deep:6,FS:7,CBS:1,NIOPS:5-,CSJ:2-,CB:1,CC:7,MERC.ELH:5+,IS:8,WOB:4-,CLAN.IS:1-,MERC:8,Periphery:4,CS:5-,MERC.WD:1,CJF:2-</availability>
 			<model name='C'>
 				<availability>CCC:1-,CSR:1-,CLAN.IS:1-,FS:1+,CGS:1-,CSA:1-,CBS:1,LA:2+,CSJ:2-,FC:2+,CJF:2-,CB:1,DC:1+</availability>
 			</model>
@@ -7756,7 +7756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:5-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>IS:5,WOB:5-,FS:4,MERC:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,FWL:2+,NIOPS:6,WOB:6,MERC:2+</availability>
@@ -7807,7 +7807,7 @@
 			<availability>CS:6,WOB:5</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
@@ -7854,7 +7854,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:3,CDS:5,CBS:6,CNC:5,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -7942,7 +7942,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,WOB:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,WOB:4-,SIC:6-,Periphery:4-,TC:3-,CS:4-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -8002,7 +8002,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,CS:5,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -8015,7 +8015,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:2,FRR:6,IS:4,Periphery.Deep:4,WOB:5,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:5-,CJF:3,DC:6</availability>
+			<availability>CC:5,HL:2,FRR:6,IS:4,Periphery.Deep:4,WOB:5,SIC:6,FS:9,Periphery:4,CS:5-,LA:6,NIOPS:5-,CJF:3,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -8170,7 +8170,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,MERC.WD:3,CIH:7,CW:7,CSV:7,CLAN:8,CNC:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
+			<availability>CHH:9,MERC.WD:3,CIH:7,CW:7,CSV:7,CLAN:8,CCO:7,CJF:7,BAN:7,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:6,CNC:7,General:6,CSJ:7,CGB:6</availability>
 			</model>
@@ -8233,7 +8233,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,HL:4,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:2+,FS:2+,DC:2+</availability>
 			</model>
@@ -8277,7 +8277,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
+			<availability>HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -8367,7 +8367,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:3,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:2-,OA:1,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
+			<availability>Periphery.DD:2,FRR:3,CLAN:1-,IS:1,WOB:2-,FS:3,MERC:3,Periphery.OS:2,Periphery:1,CS:2-,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -8403,7 +8403,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,WOB:5-,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:3,IS:7,Periphery.Deep:5,WOB:5-,SIC:6,FS:8,Periphery:5,CS:5-,FWL:10,NIOPS:5-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2-</availability>
 			</model>
@@ -8440,7 +8440,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:4,CIH:2,FRR:4,CLAN:3,IS:4,CFM:4,WOB:6,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:6,NIOPS:6,DC:5</availability>
+			<availability>CIH:2,CLAN:3,IS:4,CFM:4,WOB:6,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:6,NIOPS:6,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:8,CS:8,FRR:8,NIOPS:8,WOB:8,CFM:3,FS:4+,MERC:4+,BAN:4,DC:4+</availability>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -6,8 +6,7 @@
 			<pctOmni>5,5</pctOmni>
 			<pctClan>20,20</pctClan>
 			<pctSL>70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS' />
 		<faction key='CC'>
@@ -51,8 +50,7 @@
 			<pctSL>50,50,25,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
+			<salvage pct='10'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
 			<weightDistribution era='3049' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='3049' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -62,8 +60,7 @@
 			<pctSL>92,92,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -71,8 +68,7 @@
 			<pctSL>35,35,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:8,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:10,CB:2</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:8,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:10,CB:2</salvage>
 			<weightDistribution era='3049' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3049' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -82,8 +78,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:2,CIH:3,CSV:10,CCO:2,CGS:7,CSA:10,CDS:2,CW:4,CNC:3,CSJ:5,CJF:7,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:2,CIH:3,CSV:10,CCO:2,CGS:7,CSA:10,CDS:2,CW:4,CNC:3,CSJ:5,CJF:7,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -91,8 +86,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:10,CCC:2,CIH:5,CSV:10,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:8,CNC:8,CSJ:2,CJF:8</salvage>
+			<salvage pct='10'>CHH:10,CCC:2,CIH:5,CSV:10,CFM:3,CGS:2,CCO:1,CSA:5,CDS:1,CW:8,CNC:8,CSJ:2,CJF:8</salvage>
 			<weightDistribution era='3049' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3049' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -102,8 +96,7 @@
 			<pctSL>92,92,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CIH:6,CSV:8,CFM:8,CCO:2,CSA:4,CDS:4,CW:1,CNC:4,CSJ:2,CJF:10,CGB:2,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,30,80,90</pctOmni>
@@ -111,8 +104,7 @@
 			<pctSL>75,75,20,10,0</pctSL>
 			<pctClan unitType='Vehicle'>5,5,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>95,95,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:8,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:8,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,5,90,100</pctOmni>
@@ -120,8 +112,7 @@
 			<pctSL>50,50,25,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='12'>
-				CCC:1,CHH:4,CSR:1,CSV:8,CFM:5,CCO:7,CGS:8,CSA:8,CDS:9,CW:6,CNC:3,CSJ:7,CJF:10,CGB:5,CB:2</salvage>
+			<salvage pct='12'>CCC:1,CHH:4,CSR:1,CSV:8,CFM:5,CCO:7,CGS:8,CSA:8,CDS:9,CW:6,CNC:3,CSJ:7,CJF:10,CGB:5,CB:2</salvage>
 			<weightDistribution era='3049' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3049' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -131,8 +122,7 @@
 			<pctSL>60,60,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:2,CIH:5,CSV:10,CFM:5,CCO:6,CGS:6,CSA:4,CDS:5,CW:10,CNC:1,CSJ:3,CGB:4,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:2,CIH:5,CSV:10,CFM:5,CCO:6,CGS:6,CSA:4,CDS:5,CW:10,CNC:1,CSJ:3,CGB:4,CB:1</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>10,10,50,90,100</pctOmni>
@@ -140,8 +130,7 @@
 			<pctSL>80,80,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:8,CHH:5,CSR:8,CIH:3,CSV:3,CFM:5,CCO:10,CGS:5,CSA:8,CDS:2,CW:6,CBS:3,CSJ:3,CJF:3,CGB:8,CB:5</salvage>
+			<salvage pct='10'>CCC:8,CHH:5,CSR:8,CIH:3,CSV:3,CFM:5,CCO:10,CGS:5,CSA:8,CDS:2,CW:6,CBS:3,CSJ:3,CJF:3,CGB:8,CB:5</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -149,8 +138,7 @@
 			<pctSL>15,15,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='12'>
-				CCC:3,CHH:10,CSR:10,CIH:10,CSV:6,CFM:10,CCO:8,CGS:3,CSA:10,CW:2,CNC:8,CSJ:10,CJF:8,CB:10</salvage>
+			<salvage pct='12'>CCC:3,CHH:10,CSR:10,CIH:10,CSV:6,CFM:10,CCO:8,CGS:3,CSA:10,CW:2,CNC:8,CSJ:10,CJF:8,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -158,8 +146,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:7,CGB:1,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:7,CGB:1,CB:3</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>40,40,80,100,100</pctOmni>
@@ -175,8 +162,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,50,50</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:1,CJF:5,CGB:2,CB:2</salvage>
 			<weightDistribution era='3049' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3049' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -186,8 +172,7 @@
 			<pctSL>50,50,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:6,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,10,100,100</pctOmni>
@@ -195,8 +180,7 @@
 			<pctSL>70,70,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:1,CSR:10,CIH:4,CSV:5,CFM:2,CCO:1,CGS:3,CSA:3,CDS:1,CNC:2,CSJ:4,CJF:10,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:1,CSR:10,CIH:4,CSV:5,CFM:2,CCO:1,CGS:3,CSA:3,CDS:1,CNC:2,CSJ:4,CJF:10,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CS'>
 			<pctOmni>0,0</pctOmni>
@@ -280,8 +264,7 @@
 			<pctOmni>0,0,0,0,0</pctOmni>
 			<pctClan>0,0,0,0,0</pctClan>
 			<pctSL>0,5,12,16,20</pctSL>
-			<salvage pct='6'>
-				MOC:2,CC:10,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:10,CSJ:5,CJF:5,CGB:5,DC:10</salvage>
+			<salvage pct='6'>MOC:2,CC:10,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:10,CSJ:5,CJF:5,CGB:5,DC:10</salvage>
 		</faction>
 		<faction key='MM'>
 			<salvage pct='5'></salvage>
@@ -571,8 +554,7 @@
 			<pctOmni>0</pctOmni>
 			<pctClan>5</pctClan>
 			<pctSL>20</pctSL>
-			<salvage pct='6'>
-				CC:10,MOC:2,FRR:2,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:20,CSJ:5,CJF:5,DC:20,CGB:5</salvage>
+			<salvage pct='6'>CC:10,MOC:2,FRR:2,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:20,CSJ:5,CJF:5,DC:20,CGB:5</salvage>
 		</faction>
 		<faction key='CFM.BG'>
 			<pctOmni>0,0,10,60,100</pctOmni>
@@ -580,8 +562,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,80,100</pctOmni>
@@ -589,8 +570,7 @@
 			<pctSL>68,68,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -598,8 +578,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,75,100</pctOmni>
@@ -607,8 +586,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,60,100</pctOmni>
@@ -616,8 +594,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,60,100</pctOmni>
@@ -625,8 +602,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -634,8 +610,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>8,8,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>92,92,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:8,CSV:6,CCO:4,CGS:7,CSA:10,CDS:4,CW:4,CNC:2,CSJ:5,CFM.P:8,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='DC.LV'>
 			<pctOmni>0</pctOmni>
@@ -860,16 +835,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:2,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:1,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -954,8 +927,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,WOB:4-,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:8,Periphery.Deep:5,WOB:4-,SIC:7,FS:8,Periphery:5,CS:5-,LA:9,FWL:9,NIOPS:5-,DC:8</availability>
 			<model name='ARC-2K'>
 				<roles>fire_support</roles>
 				<availability>FRR:4,DC:8</availability>
@@ -1033,8 +1005,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:8,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1089,8 +1060,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:2-,CC:4-,HL:1,FRR:4,IS:3,WOB:3-,MERC:3,FS:4,Periphery:3,TC:2-,CS:3-,OA:1,LA:3,FS.CMM:5-</availability>
+			<availability>MOC:2-,CC:4-,HL:1,FRR:4,IS:3,WOB:3-,MERC:3,FS:4,Periphery:3,TC:2-,CS:3-,OA:1,LA:3,FS.CMM:5-</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:2</availability>
 			</model>
@@ -1139,8 +1109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,FRR:4,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:6,CB:2-</availability>
+			<availability>MOC:1,CC:3,FRR:4,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:6,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -1216,8 +1185,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,WOB:8,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,CLAN:1-,IS:7,Periphery.Deep:7,WOB:8,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -1396,8 +1364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:2-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:7-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:2-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:2-,OA:9-,LA:8-,FWL:5-,NIOPS:2-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:4,General:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
 			</model>
@@ -1466,8 +1433,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:3,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:8-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:8-,CJF:2,DC:5</availability>
 			<model name='BLR-1D'>
 				<availability>FS:8</availability>
 			</model>
@@ -1553,8 +1519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,HL:1,FRR:7,IS:4,WOB:6-,SIC:7,MERC:6,FS:10,Periphery:3,CS:6-,OA:5,LA:7,PIR:6,DC:8</availability>
+			<availability>CC:6,HL:1,FRR:7,IS:4,WOB:6-,SIC:7,MERC:6,FS:10,Periphery:3,CS:6-,OA:5,LA:7,PIR:6,DC:8</availability>
 			<model name=''>
 				<availability>General:8,DC:8</availability>
 			</model>
@@ -1574,8 +1539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:4,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,MERC.WD:3,CDS:6,CW:6,CBS:3,CJF:6,CGB:5</availability>
+			<availability>CHH:7,CSR:4,CLAN:4,CFM:6,CGS:6,CCO:6,BAN:5,CSA:6,MERC.WD:3,CDS:6,CW:6,CBS:3,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1600,8 +1564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,FRR:2,CLAN:8,CFM:7,FS:1,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
+			<availability>CHH:7,FRR:2,CLAN:8,CFM:7,FS:1,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
 			<model name='BL-6-KNT'>
 				<availability>DC.GHO:4,CS:6,FRR:3+,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,BAN:6,DC:3+</availability>
 			</model>
@@ -1706,8 +1669,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:3,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:3,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1734,8 +1696,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,SIC:4,FS:7,CIR:4,Periphery:3</availability>
+			<availability>CC:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,SIC:4,FS:7,CIR:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1757,8 +1718,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:9,HL:4,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:6,TC:8,Periphery:6,LA:6,FWL:6,DC:8</availability>
+			<availability>MOC:8,CC:9,HL:4,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:6,CIR:7,MERC:6,TC:8,Periphery:6,LA:6,FWL:6,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -1834,8 +1794,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:2,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -1871,8 +1830,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,FS:1,CIR:2,TC:2,Periphery:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
+			<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,FS:1,CIR:2,TC:2,Periphery:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,SIC:4</availability>
@@ -1962,8 +1920,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:2+,FS:3+</availability>
 			</model>
@@ -2027,15 +1984,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:4,CHH:3,CLAN:2,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:5,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:4,CHH:3,CLAN:2,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:5,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CHH:3,WOB:8,SIC:3,FS:3,MERC:3,BAN:4,DC.GHO:6,CS:8,LA:3,NIOPS:8,MERC.SI:8,DC:3,CGB:3</availability>
+				<availability>CHH:3,WOB:8,SIC:3,FS:3,MERC:3,BAN:4,DC.GHO:6,CS:8,LA:3,NIOPS:8,MERC.SI:8,DC:3,CGB:3</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:3+,CS:4,LA:3+,IS:3+,MERC:3+</availability>
@@ -2087,8 +2042,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:1,FRR:3,WOB:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:1,FRR:3,WOB:3,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:4,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:7,HL:5,General:7,FWL:7,Periphery.Deep:7,MERC:7,Periphery:7</availability>
@@ -2397,8 +2351,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:3,FRR:4,FS:5,CIR:4,MERC:5,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:3,FRR:4,FS:5,CIR:4,MERC:5,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -2423,8 +2376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:3,HL:1,FRR:3,IS:3,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:3,HL:1,FRR:3,IS:3,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,TC:3,CS:3,LA:7,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -2513,8 +2465,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,BAN:4,Periphery:8</availability>
 			</model>
@@ -2550,8 +2501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,WOB:5,MERC:1,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:4</availability>
+			<availability>CHH:3,CSR:3,CLAN:3,IS:1,CFM:3,WOB:5,MERC:1,CGS:4,Periphery:1,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,FWL:1,CJF:3,CGB:3,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
@@ -2569,8 +2519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,WOB:8,CGS:6,CS:8,DC.GHO:4,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
+			<availability>CHH:8,CSR:6,CSV:6,CLAN:7,CFM:6,WOB:8,CGS:6,CS:8,DC.GHO:4,CDS:6,CW:8,CBS:8,NIOPS:8,CJF:6,CGB:8</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -2640,8 +2589,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -2763,8 +2711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CCC:6,CIH:6,CLAN:5,CLAN.IS:5,CCO:4,BAN:5,CSA:4,MERC.WD:3,CDS:6,CJF:4,CGB:9,CB:6</availability>
+			<availability>CHH:8,CCC:6,CIH:6,CLAN:5,CLAN.IS:5,CCO:4,BAN:5,CSA:4,MERC.WD:3,CDS:6,CJF:4,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -2791,8 +2738,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,WOB:6-,SIC:8,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,FRR:7,IS:7,Periphery.Deep:9,WOB:6-,SIC:8,FS:9,CIR:9,Periphery:10,TC:9,CS:6-,OA:9,LA:9,FWL:8,NIOPS:6-,DC:7</availability>
 			<model name='(Defensive)'>
 				<availability>IS:2,Periphery:2</availability>
 			</model>
@@ -2827,8 +2773,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:7,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
+			<availability>MOC:4,HL:2,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:7,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:7-,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -2837,8 +2782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,FRR:4,IS:4,Periphery.Deep:4,SIC:5,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,OA:6,LA:6,FWL:4,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:4,FRR:4,IS:4,Periphery.Deep:4,SIC:5,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,OA:6,LA:6,FWL:4,MH:6,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2892,8 +2836,7 @@
 				<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='E'>
 				<availability>CCO:6</availability>
@@ -2912,8 +2855,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,HL:1,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
+			<availability>CC:3,HL:1,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8</availability>
 			</model>
@@ -2946,8 +2888,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:1,FRR:5,CLAN:2,IS:4,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:5-,OA:4,LA:5,FWL:6,NIOPS:5-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:3,FS:3</availability>
@@ -2988,8 +2929,7 @@
 		<chassis name='Emperor' unitType='Mek'>
 			<availability>CS:7,CLAN:1,CNC:1,NIOPS:7,WOB:7</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CS:8,CC:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
+				<availability>CS:8,CC:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
@@ -3054,8 +2994,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
@@ -3158,8 +3097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
+			<availability>Periphery.R:6,HL:5,LA:7,Periphery.HR:6,Periphery.MW:6,Periphery.CM:6,FWL:6,SIC:6,FS:9</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:9</availability>
@@ -3300,8 +3238,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
+			<availability>CHH:4,CSV:6,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:6,LA:6</availability>
 			</model>
@@ -3337,8 +3274,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,OA:4,MERC.WD:3,Periphery.MW:4,Periphery.ME:4,FWL:2,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:5,MOC:4,OA:4,MERC.WD:3,Periphery.MW:4,Periphery.ME:4,FWL:2,CIR:4,Periphery:4,TC:4</availability>
 			<model name='FLE-15'>
 				<availability>MERC.WD:2,FWL:2</availability>
 			</model>
@@ -3452,8 +3388,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:1,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8</availability>
@@ -3476,8 +3411,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:4,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:4,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:8</availability>
@@ -3491,8 +3425,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:4,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -3533,8 +3466,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,WOB:2,SIC:1,MERC:1,FS:6,CIR:3,Periphery:3,TC:3,CS:3-,OA:2,LA:4,DC:1</availability>
+			<availability>MOC:3,CC:1,HL:1,FS.CH:7,FRR:1,WOB:2,SIC:1,MERC:1,FS:6,CIR:3,Periphery:3,TC:3,CS:3-,OA:2,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -3553,8 +3485,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,IS:1,WOB:2:3053,FS:1,MERC:1,TC:1,Periphery:1,CS:2,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>MOC:1,CC:1,IS:1,WOB:2:3053,FS:1,MERC:1,TC:1,Periphery:1,CS:2,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:6,HL:4,LA:8,FWL:6,Periphery.Deep:6,IS:6,MERC:6,Periphery:6</availability>
@@ -3583,14 +3514,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CS:9,CDS:5,Periphery.MW:3,PIR:3,CLAN:5,Periphery.ME:3,CNC:5,FWL:8,NIOPS:9,WOB:9,MERC:4</availability>
+			<availability>CS:9,CDS:5,Periphery.MW:3,PIR:3,CLAN:5,Periphery.ME:3,CNC:5,FWL:8,NIOPS:9,WOB:9,MERC:4</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:8,FWL:8,MH:8,MERC:8</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:3,HL:2,CNC:3,FWL:4,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:4,BAN:1,Periphery:4</availability>
+				<availability>CS:6,CDS:3,HL:2,CNC:3,FWL:4,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:4,BAN:1,Periphery:4</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:5,BAN:2</availability>
@@ -3625,8 +3554,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:4,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3695,8 +3623,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,WOB:4,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:4,CLAN:2,IS:9,Periphery.Deep:5,WOB:4,SIC:7,MERC:9,TC:7,Periphery:6,CS:4,OA:2,LA:9,CNC:2,NIOPS:4,DC:8</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:4+,FRR:4+,FS:4+,MERC:4+,DC:4+</availability>
 			</model>
@@ -3742,8 +3669,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:4</availability>
+			<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:4</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
@@ -3859,8 +3785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4103,8 +4028,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,CS:4-,CDS:2,Periphery.CM:7,CNC:2,IS:4-,Periphery.Deep:6,WOB:4-,SIC:8,MERC:4,Periphery:4</availability>
+			<availability>CC:8,CS:4-,CDS:2,Periphery.CM:7,CNC:2,IS:4-,Periphery.Deep:6,WOB:4-,SIC:8,MERC:4,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4185,8 +4109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:8</availability>
@@ -4222,8 +4145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,WOB:5-,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:5,Periphery.Deep:5,WOB:5-,SIC:6,FS:5,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -4256,8 +4178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4370,19 +4291,16 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:1,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,CC:4,HL:1,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -4444,8 +4362,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -4466,8 +4383,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,WOB:3-,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:3-,OA:5,LA:6,FWL:3,NIOPS:3-,DC:5</availability>
+			<availability>FS.DLC:6,MOC:5,CC:3,DC.LV:7,HL:3,FRR:5,DC.GR:7,FS.AH:6,IS:5,Periphery.Deep:5,WOB:3-,SIC:3,FS:4,CIR:5,Periphery:5,TC:7,CS:3-,OA:5,LA:6,FWL:3,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
@@ -4541,8 +4457,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:2,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:2,FS:6,MERC:2,TC:2,Periphery:2</availability>
@@ -4584,8 +4499,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:3,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:1,FRR:8,IS:2,SIC:3,MERC:4,Periphery.OS:5,FS:3,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>DC:2+</availability>
@@ -4715,8 +4629,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:1,CLAN:4,IS:1,WOB:6,FS:3,MERC:1,CGS:5,DC.GHO:5,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
+			<availability>CC:1,CLAN:4,IS:1,WOB:6,FS:3,MERC:1,CGS:5,DC.GHO:5,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
 			<model name='KGC-000'>
 				<availability>CS:8,CIH:5,FRR:4+,CLAN:6,NIOPS:8,WOB:8,BAN:8,CB:5,DC:4+</availability>
 			</model>
@@ -4842,8 +4755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:7,CLAN:6,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:4,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:6,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:4,CDS:7,CW:6,CBS:7,CSJ:9,CJF:5,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
@@ -4933,8 +4845,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:6,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8</availability>
@@ -4983,8 +4894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:2,FRR:6,CLAN:1,IS:5,WOB:5-,SIC:8,FS:5,Periphery:4,TC:5,CS:5-,OA:7,LA:5,FWL:3,NIOPS:5-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -5099,8 +5009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CS:6,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,CCO:2,CGS:2,CS:6,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -5121,8 +5030,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,WOB:4,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>MOC:7,CC:6,HL:5,FRR:5,IS:7,Periphery.Deep:6,WOB:4,SIC:6,FS:7,Periphery:7,TC:7,CS:4,OA:7,LA:7,FWL:9,NIOPS:4,DC:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5148,8 +5056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
+			<availability>MOC:2,HL:3,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:3</availability>
 			<model name='LCF-R15'>
 				<availability>HL:2,LA:4,General:4,Periphery.Deep:4,MERC:8,Periphery:4,DC:1</availability>
 			</model>
@@ -5258,8 +5165,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CIH:9,CSV:8,CLAN:6,BAN:6,MERC.WD:6,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:6,BAN:6,MERC.WD:6,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:7,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -5290,8 +5196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:7,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:6,General:6,Periphery.Deep:5,FS:6,DC:6,Periphery:6</availability>
 			</model>
@@ -5324,8 +5229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:2</availability>
+			<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:8,LA:5,FWL:3,NIOPS:8,DC:5,CGB:2</availability>
 			<model name='C'>
 				<availability>LA:1+,FS:1+,DC:1+</availability>
 			</model>
@@ -5377,8 +5281,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:5,CB:4</availability>
+			<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:5,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:7</availability>
 			</model>
@@ -5444,8 +5347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:3,FRR:7,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,FRR:7,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -5581,8 +5483,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:4,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -5591,8 +5492,7 @@
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:6,CS:6,MERC.KH:3:3050,MERC.WD:3:3050,LA:5-,IS:5,SIC:6,FC:6,MERC:4,FS:4,Periphery:4</availability>
+			<availability>CC:6,CS:6,MERC.KH:3:3050,MERC.WD:3:3050,LA:5-,IS:5,SIC:6,FC:6,MERC:4,FS:4,Periphery:4</availability>
 			<model name='Crane'>
 				<availability>CC:8-,SIC:8-</availability>
 			</model>
@@ -5610,8 +5510,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:4,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:4,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:4,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -5762,8 +5661,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:3,CLAN:4,WOB:4,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:5,OA:1,CDS:3,CBS:4,NIOPS:6,CJF:4,CGB:3,DC:1</availability>
+			<availability>MOC:1,CHH:3,CLAN:4,WOB:4,MERC:1,Periphery:1,TC:1,CS:6,DC.GHO:5,OA:1,CDS:3,CBS:4,NIOPS:6,CJF:4,CGB:3,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -5990,8 +5888,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,FRR:3,IS:3,SIC:7,MERC:3,FS:7,CIR:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:3</availability>
+			<availability>CC:6,FRR:3,IS:3,SIC:7,MERC:3,FS:7,CIR:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:3</availability>
 			<model name=''>
 				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -6013,8 +5910,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:5-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:5-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:5-,DC:6</availability>
 			<model name='ON1-K'>
 				<availability>HL:5,General:7,CLAN:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -6042,8 +5938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,WOB:4,SIC:3,MERC:1+,Periphery:3,TC:3,CS:4,LA:4,NIOPS:4,DC:6</availability>
+			<availability>CC:3,MOC:3,HL:1,FRR:6,CLAN:2-,IS:5,Periphery.Deep:4,WOB:4,SIC:3,MERC:1+,Periphery:3,TC:3,CS:4,LA:4,NIOPS:4,DC:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,MERC:8,BAN:2,Periphery:8</availability>
@@ -6069,8 +5964,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:4,LA:2,FWL:4,NIOPS:4,DC:4</availability>
+			<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:4,LA:2,FWL:4,NIOPS:4,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:2</availability>
@@ -6104,24 +5998,21 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:2,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:2,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:9,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:9,FS.DMM:9,FWL:6,NIOPS:6,DC:7</availability>
+			<availability>MOC:5,CC:6,HL:4,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:9,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:9,FS.DMM:9,FWL:6,NIOPS:6,DC:7</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:3,MERC.KH:3,HL:2,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:4,PIR:3,General:3,FWL:3,DC:3</availability>
+				<availability>CC:3,MERC.KH:3,HL:2,FRR:3,IS:3,Periphery.Deep:6,SIC:3,MERC:3,FS:3,Periphery:4,PIR:3,General:3,FWL:3,DC:3</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -6144,8 +6035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:2,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,FWL:2,NIOPS:2,DC:10</availability>
+			<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:1,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,FWL:2,NIOPS:2,DC:10</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>DC:4+</availability>
@@ -6166,8 +6056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:9,CIR:6,Periphery:9,TC:9,CS:6-,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:7,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:9,CIR:6,Periphery:9,TC:9,CS:6-,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6197,8 +6086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:3,FRR:6,IS:6,Periphery.Deep:8,WOB:5-,SIC:7,FS:7,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:7,FWL:6,DC:7</availability>
+			<availability>MOC:5,CC:6,HL:3,FRR:6,IS:6,Periphery.Deep:8,WOB:5-,SIC:7,FS:7,CIR:5,Periphery:5,TC:5,CS:5-,OA:5,LA:7,FWL:6,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -6335,8 +6223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,HL:2,FRR:5,IS:5,WOB:6-,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:5,DC:5</availability>
+			<availability>MOC:7,CC:4,HL:2,FRR:5,IS:5,WOB:6-,SIC:4,MERC:5,FS:5,CIR:4,Periphery:4,TC:5,CS:6-,OA:5,MERC.WD:5,LA:4,FWL:4,MH:5,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -6384,15 +6271,13 @@
 			</model>
 		</chassis>
 		<chassis name='Po Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:3,WOB:3,SIC:6,MERC:5,Periphery:2,TC:2</availability>
+			<availability>MOC:3,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:3,WOB:3,SIC:6,MERC:5,Periphery:2,TC:2</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
+			<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CSA:1,CS:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -6506,8 +6391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CSA:9,MERC.WD:2,CDS:9,CW:8,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CSA:9,MERC.WD:2,CDS:9,CW:8,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:7,CSV:8,CNC:8,General:7,CSJ:8,CGB:6</availability>
@@ -6554,8 +6438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:6,OA:6,HL:4,Periphery.Deep:6,FWL:6,IS:6,Periphery:6,DC:6,TC:6</availability>
 			</model>
@@ -6651,8 +6534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:9,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
+			<availability>MOC:8,HL:8,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:9,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9,DC:7</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CNC:3</availability>
 			</model>
@@ -6674,8 +6556,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,WOB:3,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,WOB:3,SIC:4,MERC:2,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>CC:8,HL:6,LA:2,FRR:2,FWL:8,Periphery.Deep:7,SIC:8,MERC:8,DC:2,Periphery:8</availability>
 			</model>
@@ -6709,8 +6590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:7-,CS:6-,HL:3,FRR:8-,IS:8-,Periphery.Deep:5,FWL:8-,NIOPS:6-,WOB:6-,SIC:7-,FS:9-,Periphery:5</availability>
+			<availability>CC:7-,CS:6-,HL:3,FRR:8-,IS:8-,Periphery.Deep:5,FWL:8-,NIOPS:6-,WOB:6-,SIC:7-,FS:9-,Periphery:5</availability>
 			<model name='C'>
 				<availability>CLAN:8,BAN:4</availability>
 			</model>
@@ -6837,8 +6717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,MOC:3-,HL:1-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -6878,8 +6757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:2,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:2,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -6902,8 +6780,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,WOB:3,SIC:7-,Periphery.OS:8,FS:7-,CIR:7,Periphery:7,TC:6,CS:3,OA:8,FWL.MM:10,CW:3,LA:7-,FWL:9-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:5,FRR:9-,IS:7-,Periphery.Deep:5,WOB:3,SIC:7-,Periphery.OS:8,FS:7-,CIR:7,Periphery:7,TC:6,CS:3,OA:8,FWL.MM:10,CW:3,LA:7-,FWL:9-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6943,8 +6820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:5,CC:4,HL:3,FRR:4,IS:5,Periphery.Deep:5,WOB:5,SIC:6,MERC:5,FS:6,CIR:6,Periphery:5,TC:5,CS:5,OA:6,LA:6,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,IS:5,Periphery.Deep:5,WOB:5,SIC:6,MERC:5,FS:6,CIR:6,Periphery:5,TC:5,CS:5,OA:6,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -6955,8 +6831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,WOB:5-,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,CS:5-,OA:8,LA:8,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:5,FRR:10,IS:7,Periphery.Deep:5,WOB:5-,SIC:8,MERC:7,Periphery.OS:8,FS:7,CIR:7,Periphery:7,TC:7,CS:5-,OA:8,LA:8,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6984,8 +6859,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:3-,HL:1-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,FS:1-,MERC:3-,Periphery:3-,CS:2-,LA:1-,FWL:3-,NIOPS:2-,DC:3-</availability>
+			<availability>CC:3-,HL:1-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,FS:1-,MERC:3-,Periphery:3-,CS:2-,LA:1-,FWL:3-,NIOPS:2-,DC:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:4,FRR:8,General:6,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -7047,8 +6921,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:3,CLAN:4,CFM:5,WOB:4,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:2,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
+			<availability>CSV:3,CLAN:4,CFM:5,WOB:4,CGS:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:2,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:6,DC:6</availability>
 			</model>
@@ -7066,8 +6939,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:2,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:4,HL:2,LA:4,Periphery.Deep:4,FS:4,MERC:4,Periphery:4</availability>
@@ -7116,8 +6988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>
-				CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,WOB:6-,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:6-,HL:3,LA:5,CLAN:1,IS:6,NIOPS:6-,Periphery.Deep:5,WOB:6-,BAN:2,Periphery:5,CGB:1</availability>
 			<model name='C'>
 				<availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
 			</model>
@@ -7218,8 +7089,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:5,Periphery.DD:3,FRR:7,IS:4,WOB:3-,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:8</availability>
+			<availability>CC:5,Periphery.DD:3,FRR:7,IS:4,WOB:3-,SIC:3,MERC:4,Periphery.OS:3,FS:4,Periphery:2,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:8</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -7234,8 +7104,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,FS:0,Periphery:6</availability>
 			</model>
@@ -7281,8 +7150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
+			<availability>CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -7309,8 +7177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:5</availability>
 			<model name='SPR-6D'>
 				<availability>FS:4+</availability>
 			</model>
@@ -7352,8 +7219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FRR:6,IS:2,WOB:4,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
+			<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:4,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:4,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:4,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -7377,8 +7243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:8,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:6,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:8,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:6,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:6,OA:10,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -7438,8 +7303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:4-,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
+			<availability>MOC:6,HL:4,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:4-,SIC:9,MERC:9,Periphery:6,CS:4-,NIOPS:4-,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>HL:2,IS:4,Periphery.Deep:4,Periphery:4</availability>
@@ -7458,8 +7322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,FS:1,MERC:5,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:7,LA:4,IS:7,FS:7,Periphery:7</availability>
 			</model>
@@ -7529,8 +7392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:4+,FS:6+,MERC:4+</availability>
 			</model>
@@ -7645,8 +7507,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,MERC.WD:3,CDS:6,CW:6,CNC:6,CSJ:7,CJF:10,CGB:6,CB:5</availability>
+			<availability>CHH:7,CSR:6,CIH:4,CLAN:6,CCO:7,BAN:6,CSA:6,MERC.WD:3,CDS:6,CW:6,CNC:6,CSJ:7,CJF:10,CGB:6,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:7,CNC:6,General:7,CSJ:6,CJF:8,CGB:6</availability>
 			</model>
@@ -7711,16 +7572,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:7,HL:1,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,WOB:7,FS:2,CS:7,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:4,NIOPS:7,CJF:7,CGB:7</availability>
+			<availability>CHH:5,CSV:7,CLAN:6,IS:2,CFM:8,WOB:7,FS:2,CS:7,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:4,NIOPS:7,CJF:7,CGB:7</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,MERC:6,DC:6</availability>
 			</model>
@@ -7754,8 +7613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:8</availability>
@@ -7770,11 +7628,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				HL:2,CLAN:1-,Periphery.Deep:6,FS:7,CSA:1-,CBS:1,NIOPS:5-,MH:4,CSJ:2-,CB:1,CC:7,CCC:1-,CSR:1-,MERC.ELH:5+,IS:8,WOB:4-,CLAN.IS:1-,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,MERC.WD:1,LA:8,FC:8,CJF:2-,DC:8</availability>
+			<availability>HL:2,CLAN:1-,Periphery.Deep:6,FS:7,CSA:1-,CBS:1,NIOPS:5-,MH:4,CSJ:2-,CB:1,CC:7,CCC:1-,CSR:1-,MERC.ELH:5+,IS:8,WOB:4-,CLAN.IS:1-,MERC:8,CGS:1-,Periphery:4,TC:4,CS:5-,MERC.WD:1,LA:8,FC:8,CJF:2-,DC:8</availability>
 			<model name='C'>
-				<availability>
-					CCC:1-,CSR:1-,CLAN.IS:1-,FS:1+,CGS:1-,CSA:1-,CBS:1,LA:2+,CSJ:2-,FC:2+,CJF:2-,CB:1,DC:1+</availability>
+				<availability>CCC:1-,CSR:1-,CLAN.IS:1-,FS:1+,CGS:1-,CSA:1-,CBS:1,LA:2+,CSJ:2-,FC:2+,CJF:2-,CB:1,DC:1+</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:2,MERC:3</availability>
@@ -7900,8 +7756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,FRR:5,IS:5,WOB:5-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:5-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:5-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,FWL:2+,NIOPS:6,WOB:6,MERC:2+</availability>
@@ -7999,8 +7854,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:3,CDS:5,CW:4,CBS:6,CNC:5,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:5,General:5,CCO:4,CJF:6,CGB:6</availability>
 			</model>
@@ -8088,8 +7942,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,WOB:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:2-,FRR:5-,CLAN:1-,IS:4-,WOB:4-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:4-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:8,HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
@@ -8149,8 +8002,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -8163,8 +8015,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:2,FRR:6,IS:4,Periphery.Deep:4,WOB:5,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:5-,CJF:3,DC:6</availability>
+			<availability>MOC:4,CC:5,HL:2,FRR:6,IS:4,Periphery.Deep:4,WOB:5,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:5-,CJF:3,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -8191,8 +8042,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:2,CSR:1,CSV:1,CLAN:1,CFM:1,WOB:1,CSA:1,CS:4,MERC.WD:1,CW:4,CNC:1,CSJ:5,CJF:1,CB:2</availability>
+			<availability>CCC:2,CSR:1,CSV:1,CLAN:1,CFM:1,WOB:1,CSA:1,CS:4,MERC.WD:1,CW:4,CNC:1,CSJ:5,CJF:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>MERC.WD:0,IS:8</availability>
@@ -8383,8 +8233,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:6-,HL:4,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
+			<availability>CS:6-,HL:4,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:2+,FS:2+,DC:2+</availability>
 			</model>
@@ -8428,8 +8277,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
+			<availability>MOC:6,CC:6,HL:4,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:5</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -8519,8 +8367,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:3,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:2-,OA:1,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:2,FRR:3,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:3,MERC:3,Periphery.OS:2,Periphery:1,TC:1,CS:2-,OA:1,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:6,General:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -8556,8 +8403,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,WOB:5-,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:3,FRR:7,IS:7,Periphery.Deep:5,WOB:5-,SIC:6,FS:8,Periphery:5,TC:5,CS:5-,LA:7,FWL:10,NIOPS:5-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:2-</availability>
 			</model>
@@ -8594,8 +8440,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:4,CIH:2,FRR:4,CLAN:3,IS:4,CFM:4,WOB:6,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:6,NIOPS:6,DC:5</availability>
+			<availability>CC:4,CIH:2,FRR:4,CLAN:3,IS:4,CFM:4,WOB:6,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:6,NIOPS:6,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:8,CS:8,FRR:8,NIOPS:8,WOB:8,CFM:3,FS:4+,MERC:4+,BAN:4,DC:4+</availability>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -6,8 +6,7 @@
 			<pctOmni>5,5</pctOmni>
 			<pctClan>20,20</pctClan>
 			<pctSL>70,70</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='CC'>
 			<pctOmni>0,0,0,0,0</pctOmni>
@@ -51,8 +50,7 @@
 			<pctSL>46,46,23,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='6'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
+			<salvage pct='6'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
 			<weightDistribution era='3055' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='3055' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -62,8 +60,7 @@
 			<pctSL>90,90,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -71,8 +68,7 @@
 			<pctSL>32,32,32,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:7,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:10,CB:2</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:7,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:10,CB:2</salvage>
 			<weightDistribution era='3055' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3055' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -82,8 +78,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:3,CSR:2,CIH:3,CSV:10,CCO:2,CGS:7,CSA:10,CDS:2,CW:3,CNC:3,CSJ:3,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:2,CHH:3,CSR:2,CIH:3,CSV:10,CCO:2,CGS:7,CSA:10,CDS:2,CW:3,CNC:3,CSJ:3,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>0,0,35,70,100</pctOmni>
@@ -101,8 +96,7 @@
 			<pctSL>90,90,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CIH:5,CSV:7,CFM:7,CCO:2,CSA:3,CDS:4,CW:1,CNC:3,CSJ:2,CJF:10,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CIH:5,CSV:7,CFM:7,CCO:2,CSA:3,CDS:4,CW:1,CNC:3,CSJ:2,CJF:10,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,30,80,90</pctOmni>
@@ -110,8 +104,7 @@
 			<pctSL>75,75,20,10,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:8,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:8,CSV:4,CFM:5,CCO:1,CGS:3,CSA:3,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,5,90,100</pctOmni>
@@ -119,8 +112,7 @@
 			<pctSL>50,50,25,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:1,CSV:6,CFM:4,CCO:6,CGS:6,CSA:6,CDS:8,CW:5,CNC:2,CSJ:2,CJF:10,CGB:4,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:1,CSV:6,CFM:4,CCO:6,CGS:6,CSA:6,CDS:8,CW:5,CNC:2,CSJ:2,CJF:10,CGB:4,CB:2</salvage>
 			<weightDistribution era='3055' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3055' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -130,8 +122,7 @@
 			<pctSL>50,50,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='20'>
-				CHH:1,CSR:1,CIH:1,CI:1,CSV:1,CFM:1,CCO:2,CGS:1,CSA:1,CDS:2,CW:2,LA:10,CNC:1,CSJ:1,FC:10,CGB:1</salvage>
+			<salvage pct='20'>CHH:1,CSR:1,CIH:1,CI:1,CSV:1,CFM:1,CCO:2,CGS:1,CSA:1,CDS:2,CW:2,LA:10,CNC:1,CSJ:1,FC:10,CGB:1</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>10,10,50,90,100</pctOmni>
@@ -139,8 +130,7 @@
 			<pctSL>80,80,40,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:8,CHH:5,CSR:8,CIH:3,CSV:3,CFM:5,CCO:10,CGS:5,CSA:8,CDS:2,CW:6,CBS:3,CSJ:3,CJF:3,CGB:8,CB:5</salvage>
+			<salvage pct='10'>CCC:8,CHH:5,CSR:8,CIH:3,CSV:3,CFM:5,CCO:10,CGS:5,CSA:8,CDS:2,CW:6,CBS:3,CSJ:3,CJF:3,CGB:8,CB:5</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -148,8 +138,7 @@
 			<pctSL>10,10,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='12'>
-				CCC:3,CHH:10,CSR:10,CIH:10,CSV:6,CFM:10,CCO:8,CGS:3,CSA:10,CW:2,CNC:8,CSJ:10,CJF:9,CB:10</salvage>
+			<salvage pct='12'>CCC:3,CHH:10,CSR:10,CIH:10,CSV:6,CFM:10,CCO:8,CGS:3,CSA:10,CW:2,CNC:8,CSJ:10,CJF:9,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -157,8 +146,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,FRR:3,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:9,CGB:2,DC:5,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:6,CSR:1,CIH:8,CSV:5,FRR:3,CFM:6,CCO:10,CGS:2,CSA:2,CDS:5,CW:8,CBS:2,CNC:5,CJF:9,CGB:2,DC:5,CB:3</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>40,40,80,100,100</pctOmni>
@@ -174,8 +162,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,50,50</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:5,CFM:10,CCO:3,CGS:3,CDS:2,CW:6,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
 			<weightDistribution era='3055' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3055' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -185,8 +172,7 @@
 			<pctSL>50,50,10,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:5,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:6,CFM:4,CCO:3,CGS:3,CSA:5,CDS:5,CW:5,CBS:2,CNC:1,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,85,100</pctOmni>
@@ -290,8 +276,7 @@
 			<pctOmni>0,0,0,0,0</pctOmni>
 			<pctClan>0,0,0,0,4</pctClan>
 			<pctSL>0,10,18,23,31</pctSL>
-			<salvage pct='6'>
-				MOC:2,CC:10,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:10,CSJ:5,CJF:5,CGB:5,DC:10</salvage>
+			<salvage pct='6'>MOC:2,CC:10,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:10,CSJ:5,CJF:5,CGB:5,DC:10</salvage>
 		</faction>
 		<faction key='MM'>
 			<salvage pct='5'></salvage>
@@ -604,8 +589,7 @@
 			<pctOmni>0</pctOmni>
 			<pctClan>10</pctClan>
 			<pctSL>40</pctSL>
-			<salvage pct='6'>
-				CC:10,MOC:2,FRR:2,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:20,CSJ:5,CJF:15,DC:20,CGB:5</salvage>
+			<salvage pct='6'>CC:10,MOC:2,FRR:2,CSV:3,FS:10,TC:2,OA:2,CW:5,LA:10,CNC:3,FWL:20,CSJ:5,CJF:15,DC:20,CGB:5</salvage>
 		</faction>
 		<faction key='CFM.BG'>
 			<pctOmni>0,0,10,60,100</pctOmni>
@@ -613,8 +597,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,85,100</pctOmni>
@@ -622,8 +605,7 @@
 			<pctSL>68,68,25,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -631,8 +613,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,80,100</pctOmni>
@@ -640,8 +621,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,60,100</pctOmni>
@@ -649,8 +629,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,60,100</pctOmni>
@@ -658,8 +637,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -667,8 +645,7 @@
 			<pctSL>68,68,35,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:7,CSV:5,CCO:4,CGS:6,CSA:9,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='FWL.KIS'>
 			<pctOmni>0</pctOmni>
@@ -906,16 +883,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:3,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:3,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -978,8 +953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
+			<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
 			<model name='ANH-1A'>
 				<availability>MERC.KH:1,CLAN:2-,MERC:4</availability>
 			</model>
@@ -1043,8 +1017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:6,HL:4,FRR:6,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7</availability>
+			<availability>CC:6,HL:4,FRR:6,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7</availability>
 			<model name='(Wolf)'>
 				<availability>CWIE:3</availability>
 			</model>
@@ -1125,8 +1098,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1181,8 +1153,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:2-,CC:4-,FRR:2,IS:2,WOB:3-,MERC:2,FS:2,Periphery:2,TC:2-,CS:3-,OA:1,LA:2,FS.CMM:4-</availability>
+			<availability>MOC:2-,CC:4-,FRR:2,IS:2,WOB:3-,MERC:2,FS:2,Periphery:2,TC:2-,CS:3-,OA:1,LA:2,FS.CMM:4-</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:1</availability>
 			</model>
@@ -1231,8 +1202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
+			<availability>MOC:1,CC:3,FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -1327,8 +1297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -1514,8 +1483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 			</model>
@@ -1587,8 +1555,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
 			<model name='BLR-1D'>
 				<availability>FS:6</availability>
 			</model>
@@ -1639,8 +1606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
+			<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6</availability>
 			<model name='A'>
 				<availability>CDS:8,General:7,CGS:3</availability>
 			</model>
@@ -1681,8 +1647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,HL:4,FRR:7,IS:5,WOB:6-,SIC:7,MERC:6,FS:9,Periphery:5,CS:6-,OA:7,LA:7,PIR:6,DC:8</availability>
+			<availability>CC:6,HL:4,FRR:7,IS:5,WOB:6-,SIC:7,MERC:6,FS:9,Periphery:5,CS:6-,OA:7,LA:7,PIR:6,DC:8</availability>
 			<model name=''>
 				<availability>General:8,DC:8</availability>
 			</model>
@@ -1711,8 +1676,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:4,CLAN:3,CFM:6,CGS:6,CCO:6,BAN:5,CWIE:6,CSA:6,MERC.WD:5,CDS:5,CW:6,CBS:3,CJF:6,CGB:5</availability>
+			<availability>CHH:7,CSR:4,CLAN:3,CFM:6,CGS:6,CCO:6,BAN:5,CWIE:6,CSA:6,MERC.WD:5,CDS:5,CW:6,CBS:3,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1761,11 +1725,9 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:7,FRR:3,CLAN:8,CFM:7,FS:1,CWIE:9,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
+			<availability>CHH:7,FRR:3,CLAN:8,CFM:7,FS:1,CWIE:9,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
 			<model name='BL-6-KNT'>
-				<availability>
-					DC.GHO:4,CS:4,OA:2+,FRR:4+,CLAN:6,FWL:3+,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4+</availability>
+				<availability>DC.GHO:4,CS:4,OA:2+,FRR:4+,CLAN:6,FWL:3+,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4+</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
@@ -1892,8 +1854,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:4,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,SIC:5,FS:6,MERC:4,Periphery:3,MERC.WD:5,LA:6,FWL:4,FC:5,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1920,8 +1881,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+			<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -1949,8 +1909,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:9,HL:5,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:5,CIR:7,MERC:6,Periphery:6,TC:8,LA:5,FWL:5,DC:8</availability>
+			<availability>MOC:8,CC:9,HL:5,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:5,CIR:7,MERC:6,Periphery:6,TC:8,LA:5,FWL:5,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -2029,8 +1988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -2066,8 +2024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
+			<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:3,SIC:3</availability>
@@ -2169,8 +2126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:4+,IS:3+,FS:5+</availability>
 			</model>
@@ -2258,15 +2214,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:5,CHH:3,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:5,CHH:3,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
+				<availability>CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
@@ -2321,8 +2275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -2637,8 +2590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -2663,8 +2615,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -2757,8 +2708,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
 			</model>
@@ -2794,8 +2744,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
+			<availability>CHH:3,CSR:3,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
@@ -2813,8 +2762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:8,CSR:6,FRR:2,CSV:6,CLAN:7,CFM:6,WOB:8,CGS:6,CWIE:7,DC.GHO:4,CS:9,CDS:6,CW:8,CBS:8,NIOPS:9,CJF:6,CGB:8</availability>
+			<availability>CHH:8,CSR:6,FRR:2,CSV:6,CLAN:7,CFM:6,WOB:8,CGS:6,CWIE:7,DC.GHO:4,CS:9,CDS:6,CW:8,CBS:8,NIOPS:9,CJF:6,CGB:8</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:7,NIOPS:0</availability>
 			</model>
@@ -2887,8 +2835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -3030,8 +2977,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CCC:6,CIH:6,CLAN:5,CLAN.IS:5,CCO:4,BAN:5,CSA:4,MERC.WD:5,CDS:6,CJF:4,CGB:9,CB:6</availability>
+			<availability>CHH:8,CCC:6,CIH:6,CLAN:5,CLAN.IS:5,CCO:4,BAN:5,CSA:4,MERC.WD:5,CDS:6,CJF:4,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -3061,8 +3007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,FWL:8,NIOPS:6,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,FWL:8,NIOPS:6,DC:7</availability>
 			<model name='(Clan)'>
 				<availability>MERC.WD:6,CLAN:6</availability>
 			</model>
@@ -3100,8 +3045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
+			<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3110,8 +3054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:6,LA:5,FWL:3,MH:6,DC:3</availability>
+			<availability>MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:6,LA:5,FWL:3,MH:6,DC:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3165,8 +3108,7 @@
 				<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='E'>
 				<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
@@ -3185,8 +3127,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
+			<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:7</availability>
 			</model>
@@ -3219,8 +3160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:3,FS:3</availability>
@@ -3262,11 +3202,9 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2,CLAN:1,IS:2,WOB:7,SIC:2,MERC:2,TC:2,CS:7,LA:2,CNC:1,FWL:2,NIOPS:7,DC:2</availability>
+			<availability>CC:2,MOC:2,CLAN:1,IS:2,WOB:7,SIC:2,MERC:2,TC:2,CS:7,LA:2,CNC:1,FWL:2,NIOPS:7,DC:2</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
+				<availability>CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3338,8 +3276,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:2</availability>
 			</model>
@@ -3475,8 +3412,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
+			<availability>Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:9</availability>
@@ -3660,8 +3596,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:4,CSV:6,FRR:2,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4,DC:2</availability>
+			<availability>CHH:4,CSV:6,FRR:2,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4,DC:2</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:5,LA:5</availability>
 			</model>
@@ -3700,8 +3635,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
 			<model name='FLE-15'>
 				<availability>MERC.WD:1,FWL:1</availability>
 			</model>
@@ -3844,8 +3778,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8,WOB:8</availability>
@@ -3872,8 +3805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:6</availability>
@@ -3899,8 +3831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -3911,8 +3842,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:3,CLAN:5,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CW:2,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
+			<availability>CSR:3,CLAN:5,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CW:2,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -3973,8 +3903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
+			<availability>MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -3993,8 +3922,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,IS:1,WOB:2,FS:1,MERC:1,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>MOC:1,CC:1,IS:1,WOB:2,FS:1,MERC:1,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:5,HL:3,LA:8,FWL:5,Periphery.Deep:8,IS:5,MERC:5,Periphery:5</availability>
@@ -4029,14 +3957,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
+			<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
+				<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:5,BAN:2</availability>
@@ -4083,8 +4009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4153,8 +4078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
 			</model>
@@ -4203,8 +4127,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
+			<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
@@ -4332,8 +4255,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4596,8 +4518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
+			<availability>CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4632,8 +4553,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>CC:1,CS:9,LA:5,CLAN:7,NIOPS:9,CFM:8,WOB:9,SIC:1,MERC:2,FS:3,CJF:8,DC:2</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
+				<availability>MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CLAN:5,BAN:2</availability>
@@ -4693,8 +4613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:6</availability>
@@ -4730,8 +4649,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4770,8 +4688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4893,8 +4810,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -4905,11 +4821,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -4971,8 +4885,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -4993,8 +4906,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -5072,8 +4984,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
@@ -5123,8 +5034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>DC:6+</availability>
@@ -5279,8 +5189,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
+			<availability>CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
 			<model name='KGC-000'>
 				<availability>CS:6,CIH:5,FRR:6+,CLAN:6,NIOPS:6,WOB:6,BAN:8,CB:5,DC:6+</availability>
 			</model>
@@ -5412,8 +5321,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -5541,8 +5449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:6</availability>
@@ -5602,8 +5509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -5724,8 +5630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -5746,8 +5651,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:6</availability>
@@ -5804,8 +5708,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
+			<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 			</model>
@@ -5876,8 +5779,7 @@
 			<availability>CC:10,CS:10,LA:10,CLAN:10,FWL:10,IS:9,NIOPS:10,WOB:10,FS:10,DC:10,Periphery:8</availability>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:4,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:8,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
+			<availability>CHH:4,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:8,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -5892,8 +5794,7 @@
 			</model>
 			<model name='E'>
 				<roles>spotter</roles>
-				<availability>
-					CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
+				<availability>CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
 			</model>
 			<model name='H'>
 				<availability>CSA:4</availability>
@@ -5939,8 +5840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CIH:9,CSV:8,CLAN:5,BAN:6,CWIE:9,MERC.WD:8,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:5,BAN:6,CWIE:9,MERC.WD:8,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -5967,8 +5867,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:5,General:6,Periphery.Deep:5,FS:5,DC:5,Periphery:6</availability>
 			</model>
@@ -6004,8 +5903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
+			<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
 			<model name='C'>
 				<availability>LA:2+,FS:2+,DC:2+</availability>
 			</model>
@@ -6061,8 +5959,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
+			<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 			</model>
@@ -6134,8 +6031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
@@ -6283,8 +6179,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -6311,8 +6206,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:5,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:5,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:5,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:5,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -6463,8 +6357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:4,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
+			<availability>MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:4,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -6732,8 +6625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,CDS:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:4</availability>
+			<availability>CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,CDS:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:4</availability>
 			<model name=''>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -6755,14 +6647,12 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='ON1-K'>
 				<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 			<model name='ON1-M'>
-				<availability>
-					CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
+				<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
 			</model>
 			<model name='ON1-M-DC'>
 				<roles>command</roles>
@@ -6795,8 +6685,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
+			<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
@@ -6822,8 +6711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
+			<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:2</availability>
@@ -6857,8 +6745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
@@ -6900,16 +6787,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
+				<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -6932,8 +6817,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,FWL:2,NIOPS:2,DC:10</availability>
+			<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,FWL:2,NIOPS:2,DC:10</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:4+,FRR:6+,FS.DMM:4+,MERC:4+,DC:8+</availability>
@@ -6962,8 +6846,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6993,8 +6876,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
+			<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -7150,8 +7032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
+			<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -7218,15 +7099,13 @@
 			</model>
 		</chassis>
 		<chassis name='Po Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:4,WOB:5,SIC:5,MERC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:4,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:4,WOB:5,SIC:5,MERC:5,Periphery:2,TC:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
+			<availability>CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -7340,8 +7219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
@@ -7388,8 +7266,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
 			</model>
@@ -7521,8 +7398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:9,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,HL:9,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CNC:3</availability>
 			</model>
@@ -7544,8 +7420,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
 			</model>
@@ -7579,8 +7454,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
+			<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
 			</model>
@@ -7672,8 +7546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CSR:9,CSV:7,CLAN:8,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9</availability>
+			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 			</model>
@@ -7730,8 +7603,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -7771,8 +7643,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -7810,8 +7681,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,SIC:7-,Periphery.OS:8,FS:6-,CIR:7,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,LA:7-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,SIC:7-,Periphery.OS:8,FS:6-,CIR:7,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,LA:7-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7851,8 +7721,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -7863,8 +7732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7877,8 +7745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
+			<availability>CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7893,8 +7760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:3-,HL:2-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,MERC:3-,Periphery:3-,CS:2-,FWL:3-,NIOPS:2-,DC:3-</availability>
+			<availability>CC:3-,HL:2-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,MERC:3-,Periphery:3-,CS:2-,FWL:3-,NIOPS:2-,DC:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:2,FRR:8,General:4,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -7960,8 +7826,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:3,CLAN:4,CFM:5,WOB:4,MERC:3,FS:3,CGS:3,CWIE:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:4,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
+			<availability>CSV:3,CLAN:4,CFM:5,WOB:4,MERC:3,FS:3,CGS:3,CWIE:3,CS:4,DC.GHO:5,CDS:3,CW:3,CBS:3,LA:4,NIOPS:4,CJF:5,CGB:5,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:4,DC:4</availability>
 			</model>
@@ -7985,8 +7850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2,DC:3</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2,DC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
@@ -8039,8 +7903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>
-				CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:2,CSV:8,CFM:8,FS:2,CGS:8,DC:2</availability>
 			</model>
@@ -8141,8 +8004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
+			<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -8157,8 +8019,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 			</model>
@@ -8211,8 +8072,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
+			<availability>CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -8239,8 +8099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
+			<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
 			<model name='SPR-6D'>
 				<availability>FRR:4+,FS:6+,MERC:4+</availability>
 			</model>
@@ -8282,8 +8141,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:6</availability>
@@ -8322,8 +8180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -8394,8 +8251,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
+			<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
@@ -8414,8 +8270,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:6,LA:4,IS:6,FS:6,Periphery:6</availability>
 			</model>
@@ -8520,8 +8375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:5+,FS:7+,MERC:5+</availability>
 			</model>
@@ -8665,8 +8519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:5,CIH:4,CLAN:5,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
+			<availability>CHH:5,CSR:5,CIH:4,CLAN:5,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -8734,16 +8587,14 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:5,CSV:7,FRR:3,CLAN:6,IS:2,CFM:8,WOB:7,FS:3,CWIE:7,CS:8,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:5,NIOPS:8,CJF:7,CGB:7</availability>
+			<availability>CHH:5,CSV:7,FRR:3,CLAN:6,IS:2,CFM:8,WOB:7,FS:3,CWIE:7,CS:8,DC.GHO:5,CDS:5,CW:7,CBS:5,CNC:5,FWL:5,NIOPS:8,CJF:7,CGB:7</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,MERC:8,DC:4</availability>
 			</model>
@@ -8786,8 +8637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:6</availability>
@@ -8802,8 +8652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:7,CCC:1-,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:4-,CSA:1-,MERC.WD:2,LA:8,NIOPS:4-,MH:4,FC:8,DC:8,CB:1</availability>
+			<availability>CC:7,CCC:1-,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:4-,CSA:1-,MERC.WD:2,LA:8,NIOPS:4-,MH:4,FC:8,DC:8,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2+,CLAN.IS:1-,FC:2+,FS:1+,CGS:1-,CB:1,DC:1+</availability>
 			</model>
@@ -8946,8 +8795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
+			<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
@@ -9079,8 +8927,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -9175,8 +9022,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:6,HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -9242,8 +9088,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -9266,8 +9111,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
+			<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -9294,8 +9138,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:2,CSR:1,CSV:1,CLAN:1,CFM:1,WOB:1,CWIE:2,CSA:1,CS:4,MERC.WD:1,CW:4,CNC:1,CSJ:5,CJF:1,CB:2</availability>
+			<availability>CCC:2,CSR:1,CSV:1,CLAN:1,CFM:1,WOB:1,CWIE:2,CSA:1,CS:4,MERC.WD:1,CW:4,CNC:1,CSJ:5,CJF:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>MERC.WD:0,IS:8</availability>
@@ -9423,8 +9266,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7</availability>
+			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 			</model>
@@ -9490,8 +9332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
+			<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:3+,FS:3+,DC:3+</availability>
 			</model>
@@ -9535,8 +9376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -9635,8 +9475,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -9672,8 +9511,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:1</availability>
 			</model>
@@ -9719,8 +9557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
+			<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -883,14 +883,14 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,Periphery:4,CS:3,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:3,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:4</availability>
+			<availability>CC:3,FRR:3,CLAN:2,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1017,7 +1017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:6,HL:4,FRR:6,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7</availability>
+			<availability>CC:6,HL:4,FRR:6,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,NIOPS:4-,DC:7</availability>
 			<model name='(Wolf)'>
 				<availability>CWIE:3</availability>
 			</model>
@@ -1098,7 +1098,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1153,7 +1153,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:2-,CC:4-,FRR:2,IS:2,WOB:3-,MERC:2,FS:2,Periphery:2,TC:2-,CS:3-,OA:1,LA:2,FS.CMM:4-</availability>
+			<availability>MOC:2-,CC:4-,IS:2,WOB:3-,MERC:2,Periphery:2,TC:2-,CS:3-,OA:1,FS.CMM:4-</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:1</availability>
 			</model>
@@ -1202,7 +1202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
+			<availability>FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -1297,7 +1297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -1483,7 +1483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:8-,IS:6-,Periphery.Deep:9-,WOB:1-,FS:7-,MERC:6-,Periphery:9-,CS:1-,LA:8-,FWL:5-,NIOPS:1-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 			</model>
@@ -1555,7 +1555,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
+			<availability>HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,Periphery:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-</availability>
 			<model name='BLR-1D'>
 				<availability>FS:6</availability>
 			</model>
@@ -1676,7 +1676,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSR:4,CLAN:3,CFM:6,CGS:6,CCO:6,BAN:5,CWIE:6,CSA:6,MERC.WD:5,CDS:5,CW:6,CBS:3,CJF:6,CGB:5</availability>
+			<availability>CHH:7,CSR:4,CLAN:3,CFM:6,CGS:6,CCO:6,BAN:5,CWIE:6,CSA:6,MERC.WD:5,CDS:5,CW:6,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1725,7 +1725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:7,FRR:3,CLAN:8,CFM:7,FS:1,CWIE:9,DC.GHO:3,OA:1,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,TC:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
+			<availability>CHH:7,FRR:3,CLAN:8,CFM:7,FS:1,CWIE:9,DC.GHO:3,CDS:7,CBS:9,FWL:1,NIOPS:7,CGB:9,CSR:7,CSV:7,WOB:7,FWL.OH:1,MERC:2,CGS:9,Periphery:1,CS:7,CW:9,LA:1,CNC:9,CJF:7,DC:2</availability>
 			<model name='BL-6-KNT'>
 				<availability>DC.GHO:4,CS:4,OA:2+,FRR:4+,CLAN:6,FWL:3+,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4+</availability>
 			</model>
@@ -1733,7 +1733,7 @@
 				<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
+				<availability>LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1843,7 +1843,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CS:5,OA:1-,CDS:5,CLAN:4,IS:2-,NIOPS:5,FWL:2-,WOB:5,DC:2-,Periphery:1</availability>
+			<availability>CS:5,OA:1-,CDS:5,CLAN:4,IS:2-,NIOPS:5,WOB:5,Periphery:1</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
 				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
@@ -1881,7 +1881,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+			<availability>HL:3,CM:6,IS:4,WOB:5,FS:7,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2024,7 +2024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
+			<availability>CC:3,FRR:5,IS:1,SIC:2,MERC:1,Periphery:2,CS:3,NIOPS:3,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:3,SIC:3</availability>
@@ -2126,7 +2126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:4+,IS:3+,FS:5+</availability>
 			</model>
@@ -2214,7 +2214,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CHH:3,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:5,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,CS:5,DC.GHO:6,LA:3,NIOPS:5,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -2236,7 +2236,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
-			<availability>CS:5,FRR:4+,IS:4+,NIOPS:5,WOB:5,SIC:4+,MERC:3+,BAN:4,Periphery:1+</availability>
+			<availability>CS:5,IS:4+,NIOPS:5,WOB:5,MERC:3+,BAN:4,Periphery:1+</availability>
 			<model name=''>
 				<roles>missile_artillery</roles>
 				<availability>General:8</availability>
@@ -2320,12 +2320,12 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
+			<availability>CC:2,FRR:2,SIC:2,MERC:5,FS:6,Periphery:2,TC:6,LA:8,FWL:4,DC:3</availability>
 			<model name='CHP-W10'>
 				<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
+				<availability>HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -2335,7 +2335,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,CS:4-,OA:1,LA:3,IS:3,FWL:6,WOB:4-,FS:2,MERC:3,Periphery:1,DC:4</availability>
+			<availability>CC:4,CS:4-,IS:3,FWL:6,WOB:4-,FS:2,MERC:3,Periphery:1,DC:4</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
 				<availability>General:6</availability>
@@ -2542,7 +2542,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:4,CS:2-,LA:3,FRR:3,IS:3,FWL:3,NIOPS:2-,WOB:2-,SIC:4,FS:4,MERC:3,DC:3</availability>
+			<availability>CC:4,CS:2-,IS:3,NIOPS:2-,WOB:2-,SIC:4,FS:4,MERC:3</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -2590,7 +2590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -2615,7 +2615,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,HL:2,IS:3,WOB:3,FS:4,Periphery:3,CS:3,LA:6,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -2708,7 +2708,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+			<availability>CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,Periphery:2,OA:3,LA:7,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
 			</model>
@@ -2744,7 +2744,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
+			<availability>CLAN:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
@@ -2835,7 +2835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,FRR:5,IS:3,WOB:3,SIC:5,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -2901,7 +2901,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>MERC.WD:4,CDS:5,CW:6,CBS:4,CNC:4,CLAN:4,CSJ:8,CJF:5,BAN:2,CWIE:6,CGB:5,CB:4</availability>
+			<availability>MERC.WD:4,CDS:5,CW:6,CLAN:4,CSJ:8,CJF:5,BAN:2,CWIE:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -3007,7 +3007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,FWL:8,NIOPS:6,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,FWL:8,NIOPS:6</availability>
 			<model name='(Clan)'>
 				<availability>MERC.WD:6,CLAN:6</availability>
 			</model>
@@ -3045,7 +3045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
+			<availability>CC:3,HL:3,IS:4,Periphery.Deep:5,FS:6,MERC:4,Periphery.OS:5,Periphery:4,Periphery.HR:5</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3054,7 +3054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:6,LA:5,FWL:3,MH:6,DC:3</availability>
+			<availability>IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,OA:6,LA:5,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3097,7 +3097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CSA:6,MERC.WD:5,CHH:6,CIH:7,CDS:4,CSV:5,CLAN:5,CFM:5,CSJ:5,CJF:4,CGB:9,CB:7</availability>
+			<availability>CSA:6,MERC.WD:5,CHH:6,CIH:7,CDS:4,CLAN:5,CJF:4,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 			</model>
@@ -3127,7 +3127,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
+			<availability>HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7</availability>
 			<model name=''>
 				<availability>CC:6,General:7</availability>
 			</model>
@@ -3202,9 +3202,9 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:2,MOC:2,CLAN:1,IS:2,WOB:7,SIC:2,MERC:2,TC:2,CS:7,LA:2,CNC:1,FWL:2,NIOPS:7,DC:2</availability>
+			<availability>MOC:2,CLAN:1,IS:2,WOB:7,MERC:2,TC:2,CS:7,NIOPS:7</availability>
 			<model name='EMP-6A'>
-				<availability>CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
+				<availability>CS:8,HL:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,BAN:4,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3276,7 +3276,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,WOB:5,FS:3,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:2</availability>
 			</model>
@@ -3391,7 +3391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>MERC.WD:6,CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CNC:4,CLAN:4,CSJ:4,CJF:6,CWIE:8,CGB:5</availability>
+			<availability>MERC.WD:6,CHH:5,CIH:7,CDS:5,CW:8,CSV:5,CLAN:4,CJF:6,CWIE:8,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -3543,7 +3543,7 @@
 				<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
 			</model>
 			<model name='FFL-4A'>
-				<availability>:0,MERC.WD:2-</availability>
+				<availability>MERC.WD:2-</availability>
 			</model>
 			<model name='FFL-4B'>
 				<availability>MERC.WD:6+</availability>
@@ -3598,7 +3598,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:4,CSV:6,FRR:2,CLAN:5,CFM:6,WOB:5,CGS:4,CS:5,DC.GHO:4,Periphery.R:2,CDS:4,LA:6,CBS:4,NIOPS:5,CJF:6,CGB:4,DC:2</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:5,LA:5</availability>
+				<availability>MERC.KH:5,LA:5</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:8,CS:6,LA:2,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
@@ -3635,7 +3635,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MERC.WD:4,FWL:2,MERC:3,Periphery:4</availability>
 			<model name='FLE-15'>
 				<availability>MERC.WD:1,FWL:1</availability>
 			</model>
@@ -3778,7 +3778,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8,WOB:8</availability>
@@ -3805,7 +3805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,FS:8,Periphery:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:6</availability>
@@ -3831,7 +3831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -3842,7 +3842,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CSR:3,CLAN:5,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CW:2,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
+			<availability>CSR:3,CLAN:5,BAN:3,CWIE:4,MERC.WD:3,CW:2,CSJ:7,CJF:6,CGB:9,CB:6</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -3903,7 +3903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
+			<availability>CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -3922,7 +3922,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CC:1,IS:1,WOB:2,FS:1,MERC:1,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>IS:1,WOB:2,MERC:1,Periphery:1,CS:1,MERC.WD:1,LA:4,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:5,HL:3,LA:8,FWL:5,Periphery.Deep:8,IS:5,MERC:5,Periphery:5</availability>
@@ -3957,7 +3957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
+			<availability>CS:8,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
 			</model>
@@ -4000,7 +4000,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>CS:3,CC:3+,MOC:3+,FWL:6+,IS:3+,MH:3+,WOB:5,FWL.KIS:7+,SIC:3+,FS:3+,MERC:3+,DC:3+</availability>
+			<availability>CS:3,MOC:3+,FWL:6+,IS:3+,MH:3+,WOB:5,FWL.KIS:7+,MERC:3+</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 			</model>
@@ -4009,7 +4009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4078,7 +4078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,NIOPS:3</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
 			</model>
@@ -4255,7 +4255,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4423,7 +4423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
+			<availability>HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:5</availability>
 			</model>
@@ -4490,11 +4490,11 @@
 			<availability>CS:3,DC.GHO:5,CHH:3,FRR:2,FWL:5,NIOPS:3,WOB:3,CGB:3,CB:1</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:2</availability>
+				<availability>FWL:2</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:1</availability>
+				<availability>FWL:1</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -4613,7 +4613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:6,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:6</availability>
@@ -4649,7 +4649,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,Periphery:5,CS:4-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4688,7 +4688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -4810,7 +4810,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -4906,7 +4906,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -4984,7 +4984,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
@@ -5034,7 +5034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,FS.DMM:5,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>DC:6+</availability>
@@ -5189,7 +5189,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
+			<availability>FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,NIOPS:6,CGB:5</availability>
 			<model name='KGC-000'>
 				<availability>CS:6,CIH:5,FRR:6+,CLAN:6,NIOPS:6,WOB:6,BAN:8,CB:5,DC:6+</availability>
 			</model>
@@ -5235,7 +5235,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:5,MERC:4,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6,MERC:6,DC:4</availability>
+				<availability>FS:6,MERC:6,DC:4</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:6,CS:6,DC.SL:4,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,FS:6+,MERC:6+,BAN:7</availability>
@@ -5321,7 +5321,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,CGS:7,BAN:7,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -5371,7 +5371,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CHH:6,CIH:6,CSR:6,CSV:6,CLAN:3,CGS:6,CWIE:3,CSA:6,CDS:3,CW:4,CNC:3,CJF:4,CGB:6</availability>
+			<availability>CHH:6,CIH:6,CSR:6,CSV:6,CLAN:3,CGS:6,CWIE:3,CSA:6,CW:4,CJF:4,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -5449,7 +5449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:6</availability>
@@ -5509,7 +5509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,Periphery:4,TC:5,CS:4-,OA:7,FWL:3,NIOPS:4-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -5605,7 +5605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSV:6,CLAN:5,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
+			<availability>CHH:8,CSV:6,CLAN:5,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:5</availability>
@@ -5651,7 +5651,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
+			<availability>CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,Periphery:7,CS:3,FWL:9,NIOPS:3,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:6</availability>
@@ -5708,7 +5708,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
+			<availability>HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 			</model>
@@ -5867,7 +5867,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:8,IS:9,Periphery.Deep:8,WOB:9,MERC:9,CIR:8,Periphery:9,CS:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:5,General:6,Periphery.Deep:5,FS:5,DC:5,Periphery:6</availability>
 			</model>
@@ -5903,7 +5903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,DC:5,CGB:2</availability>
+			<availability>CC:4,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,NIOPS:7,DC:5</availability>
 			<model name='C'>
 				<availability>LA:2+,FS:2+,DC:2+</availability>
 			</model>
@@ -5959,7 +5959,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>CSR:4,CSV:3,CLAN:4,CFM:4,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
+			<availability>CSV:3,CLAN:4,BAN:3,CWIE:4,MERC.WD:2,CW:3,CBS:4,CSJ:8,CJF:4,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 			</model>
@@ -6031,7 +6031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
+			<availability>HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,Periphery:5,CS:6-,LA:7,NIOPS:6-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
@@ -6179,7 +6179,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,CIR:5,BAN:4,Periphery:6,OA:5,LA:6</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -6357,7 +6357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:4,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
+			<availability>CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,CS:4,DC.GHO:4,CDS:3,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -6558,7 +6558,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>LA:5,FS:5</availability>
 			<model name='NGS-4S'>
-				<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
@@ -6625,7 +6625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,CDS:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4,DC:4</availability>
+			<availability>CC:6,IS:4,SIC:7,MERC:4,FS:7,CIR:4,CDS:4,LA:7,PIR:4,Periphery.ME:4,FWL:9,MH:4</availability>
 			<model name=''>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -6647,7 +6647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>MOC:5,HL:3,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='ON1-K'>
 				<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -6685,7 +6685,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
+			<availability>CC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,CS:4-,NIOPS:4-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
@@ -6711,7 +6711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
+			<availability>FRR:4,CLAN:2-,IS:2,WOB:3,MERC:4,Periphery:1,CS:3,FWL:4,NIOPS:3,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:2</availability>
@@ -6787,7 +6787,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
+			<availability>MOC:5,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,NIOPS:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -6846,7 +6846,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,CIR:6,Periphery:9,CS:8-,OA:5,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6876,9 +6876,9 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
+			<availability>HL:3,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,Periphery:4,CWIE:4,CS:5-,LA:7,DC:7</availability>
 			<model name=''>
-				<roles>recon</roles>
+				<roles>recon</roles>67
 				<availability>General:8</availability>
 			</model>
 			<model name='(3058 Upgrade)'>
@@ -7032,7 +7032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
+			<availability>MOC:6,CC:3,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -7219,7 +7219,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:8,CFM:8,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CLAN:8,CCO:7,BAN:7,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
@@ -7266,7 +7266,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
 			</model>
@@ -7398,7 +7398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:9,FRR:7,CLAN:7,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,HL:9,CLAN:7,Periphery.Deep:9,IS:7,WOB:8,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CNC:3</availability>
 			</model>
@@ -7454,7 +7454,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
+			<availability>CC:7-,CCC:4,HL:4,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,NIOPS:6-,CB:4</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
 			</model>
@@ -7546,7 +7546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9</availability>
+			<availability>CSR:9,CSV:7,CLAN:8,BAN:8,MERC.WD:7,CDS:9,CBS:9,CSJ:9,CJF:9</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 			</model>
@@ -7603,7 +7603,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,MERC:3-,Periphery:3-,OA:2-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -7643,7 +7643,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,CIR:7,Periphery:8,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -7681,7 +7681,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,SIC:7-,Periphery.OS:8,FS:6-,CIR:7,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,LA:7-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,Periphery.OS:8,FS:6-,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7715,13 +7715,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:2,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,OA:3,HL:2,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,MERC:6,CIR:7,Periphery:6,CS:5,OA:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -7732,7 +7732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,Periphery:7,CS:4-,OA:8,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7850,7 +7850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,MH:2,DC:3</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,OA:7,LA:9,MH:2,DC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
@@ -7903,7 +7903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:2,CSV:8,CFM:8,FS:2,CGS:8,DC:2</availability>
 			</model>
@@ -8004,7 +8004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
+			<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,Periphery:1,CS:3-,OA:2,FWL:4,NIOPS:3-,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -8019,7 +8019,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 			</model>
@@ -8141,7 +8141,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,CS:3,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:6</availability>
@@ -8180,7 +8180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
+			<availability>CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,Periphery:10,CS:5,FWL:10,NIOPS:5,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -8251,7 +8251,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
+			<availability>HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
@@ -8270,7 +8270,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,CS:3,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:6,LA:4,IS:6,FS:6,Periphery:6</availability>
 			</model>
@@ -8297,7 +8297,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -8375,7 +8375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:5+,FS:7+,MERC:5+</availability>
 			</model>
@@ -8519,7 +8519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:5,CIH:4,CLAN:5,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
+			<availability>CIH:4,CLAN:5,BAN:5,CWIE:6,MERC.WD:4,CNC:6,CSJ:7,CJF:9</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -8587,7 +8587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -8637,7 +8637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:4,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:6</availability>
@@ -8652,7 +8652,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:7,CCC:1-,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:4-,CSA:1-,MERC.WD:2,LA:8,NIOPS:4-,MH:4,FC:8,DC:8,CB:1</availability>
+			<availability>CC:7,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,Periphery:4,CS:4-,MERC.WD:2,NIOPS:4-,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2+,CLAN.IS:1-,FC:2+,FS:1+,CGS:1-,CB:1,DC:1+</availability>
 			</model>
@@ -8795,7 +8795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
+			<availability>IS:5,WOB:4-,FS:4,MERC:5,Periphery:5,CS:4-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
@@ -8874,7 +8874,7 @@
 			<availability>CS:5,WOB:5</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
@@ -8927,7 +8927,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,MERC.WD:4,CDS:5,CBS:6,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -9022,7 +9022,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,Periphery:4-,TC:3-,CS:3-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:6,HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -9088,7 +9088,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,CS:5,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -9111,7 +9111,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
+			<availability>CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,Periphery:4,CS:4-,LA:6,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -9247,7 +9247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:7,FS:4</availability>
@@ -9266,7 +9266,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7</availability>
+			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CJF:7,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 			</model>
@@ -9332,7 +9332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
+			<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:3+,FS:3+,DC:3+</availability>
 			</model>
@@ -9376,7 +9376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -9475,7 +9475,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -9511,7 +9511,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:4,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,CS:4-,FWL:10,NIOPS:4-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:1</availability>
 			</model>
@@ -9656,7 +9656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:5-,MERC:5,CIR:4,TC:3,Periphery:3,DC:2</availability>
+			<availability>CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:5-,MERC:5,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -900,7 +900,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,CIR:4,Periphery:4,CS:3,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
@@ -923,7 +923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:3,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:4</availability>
+			<availability>CC:3,FRR:3,CLAN:2,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -1062,7 +1062,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:6,HL:4,FRR:6,CLAN:1,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7,CGB:1</availability>
+			<availability>CC:6,HL:4,FRR:6,CLAN:1,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,NIOPS:4-,DC:7</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
 			</model>
@@ -1136,7 +1136,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1168,7 +1168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1223,7 +1223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:2-,CC:4-,FRR:2,IS:2,WOB:3-,MERC:2,FS:2,Periphery:2,TC:2-,CS:3-,OA:1,LA:2,FS.CMM:4-</availability>
+			<availability>MOC:2-,CC:4-,IS:2,WOB:3-,MERC:2,Periphery:2,TC:2-,CS:3-,OA:1,FS.CMM:4-</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:1</availability>
 			</model>
@@ -1272,7 +1272,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:3,FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
+			<availability>FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -1373,7 +1373,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,Periphery:8,CS:8,FWL:10,NIOPS:8</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -1563,7 +1563,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
+			<availability>CC:4-,HL:8-,IS:6-,Periphery.Deep:9-,WOB:1-,FS:7-,MERC:6-,Periphery:9-,CS:1-,LA:8-,FWL:5-,NIOPS:1-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 			</model>
@@ -1641,7 +1641,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
+			<availability>HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,Periphery:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-</availability>
 			<model name='BLR-1D'>
 				<availability>FS:6</availability>
 			</model>
@@ -1829,7 +1829,7 @@
 				<availability>CS:6,CLAN:5,FWL:5+,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
+				<availability>LA:7,FRR:7,FWL:3,MERC:7,FS:7,DC:7</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:8</availability>
@@ -1950,7 +1950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,MERC.WD:5,LA:6,FRR:4,FWL:4,SIC:5,FS:6,MERC:5,DC:4,Periphery:3</availability>
+			<availability>CC:4,MERC.KH:3,MERC.WD:5,LA:6,FRR:4,FWL:4,SIC:5,FS:6,MERC:5,DC:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -1977,7 +1977,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+			<availability>HL:3,CM:6,IS:4,WOB:5,FS:7,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2126,7 +2126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
+			<availability>CC:3,FRR:5,IS:1,SIC:2,MERC:1,Periphery:2,CS:3,NIOPS:3,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:3,SIC:3</availability>
@@ -2170,7 +2170,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CHH:4,CCC:4,CSR:4,CDS:4,CW:4,CLAN:4,CNC:3,CSJ:6,CGS:4,CJF:4,CGB:4</availability>
+			<availability>CLAN:4,CNC:3,CSJ:6</availability>
 			<model name='A'>
 				<availability>General:8</availability>
 			</model>
@@ -2247,7 +2247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:4+,IS:3+,FS:5+</availability>
 			</model>
@@ -2316,7 +2316,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
-			<availability>MOC:3-,CC:3-,OA:3-,HL:2-,LA:3-,IS:2-,FWL:3-,FS:3-,Periphery:3-,TC:3-,DC:3-</availability>
+			<availability>CC:3-,HL:2-,LA:3-,IS:2-,FWL:3-,FS:3-,Periphery:3-,DC:3-</availability>
 			<model name='CLN-7V'>
 				<roles>training</roles>
 				<availability>IS:4,Periphery:2</availability>
@@ -2335,7 +2335,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CHH:3,FRR:2,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:5,CHH:3,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,CS:5,DC.GHO:6,LA:3,NIOPS:5,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -2441,12 +2441,12 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,SIC:2,MERC:5,FS:6,CIR:2,Periphery:2,TC:6,OA:2,LA:8,FWL:4,DC:3</availability>
+			<availability>CC:2,FRR:2,SIC:2,MERC:5,FS:6,Periphery:2,TC:6,LA:8,FWL:4,DC:3</availability>
 			<model name='CHP-W10'>
 				<availability>HL:2,SIC:6,FS:6,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
+				<availability>HL:4,LA:6,FRR:1,IS:6,Periphery.Deep:6,MERC:6,BAN:3,Periphery:6</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -2663,7 +2663,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:3,IS:3,WOB:2-,SIC:4,FS:4,MERC:3,CS:2-,LA:3,FWL:3,NIOPS:2-,DC:3</availability>
+			<availability>CC:4,MOC:1,IS:3,WOB:2-,SIC:4,FS:4,MERC:3,CS:2-,NIOPS:2-</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:6,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -2711,7 +2711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -2736,7 +2736,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,HL:2,IS:3,WOB:3,FS:4,Periphery:3,CS:3,LA:6,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -2829,7 +2829,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+			<availability>CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,Periphery:2,OA:3,LA:7,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
 			</model>
@@ -2885,7 +2885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:3,CSR:3,FRR:2,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
+			<availability>FRR:2,CLAN:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CGB:3,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
@@ -2976,7 +2976,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+			<availability>CC:5,FRR:5,IS:3,WOB:3,SIC:5,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -3045,7 +3045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:4,IS:1+,FS:1+,MERC:1+,BAN:2,CWIE:6,MERC.WD:4,CDS:5,CW:6,CBS:4,LA:1+,CNC:4,CSJ:8,CJF:5,CGB:5,CB:4,DC:1+</availability>
+			<availability>CLAN:4,IS:1+,MERC:1+,BAN:2,CWIE:6,MERC.WD:4,CDS:5,CW:6,CSJ:8,CJF:5,CGB:5</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -3151,7 +3151,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,CNC:3,FWL:8,NIOPS:6,CJF:1,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,CNC:3,FWL:8,NIOPS:6,CJF:1</availability>
 			<model name='(Clan)'>
 				<availability>MERC.WD:6,CLAN:6</availability>
 			</model>
@@ -3195,7 +3195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
+			<availability>CC:3,HL:3,IS:4,Periphery.Deep:5,FS:6,MERC:4,Periphery.OS:5,Periphery:4,Periphery.HR:5</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3256,7 +3256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:7,CSV:5,CLAN:5,IS:1+,CFM:5,CSA:6,MERC.WD:5,CDS:4,CSJ:5,CJF:4,CGB:9,CB:7</availability>
+			<availability>CHH:6,CIH:7,CLAN:5,IS:1+,CSA:6,MERC.WD:5,CDS:4,CJF:4,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 			</model>
@@ -3286,7 +3286,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
+			<availability>HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7</availability>
 			<model name=''>
 				<availability>CC:6,General:7</availability>
 			</model>
@@ -3383,9 +3383,9 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:2,MOC:2,CLAN:1,IS:2,WOB:7,SIC:2,MERC:2,TC:2,CS:7,LA:2,CNC:1,FWL:2,NIOPS:7,DC:2</availability>
+			<availability>MOC:2,CLAN:1,IS:2,WOB:7,MERC:2,TC:2,CS:7,NIOPS:7</availability>
 			<model name='EMP-6A'>
-				<availability>CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
+				<availability>CS:8,HL:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,BAN:4,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3463,7 +3463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,WOB:5,FS:3,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:2,MERC:1</availability>
 			</model>
@@ -3585,7 +3585,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,MERC.KH:1+,CIH:7,CSV:5,CLAN:4,IS:1+,CWIE:8,MERC.WD:6,CDS:5,CW:8,CNC:4,CSJ:4,CJF:6,CGB:5</availability>
+			<availability>CHH:5,MERC.KH:1+,CIH:7,CSV:5,CLAN:4,IS:1+,CWIE:8,MERC.WD:6,CDS:5,CW:8,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -3768,7 +3768,7 @@
 				<availability>MERC.WD:6,CLAN:8,BAN:1</availability>
 			</model>
 			<model name='FFL-4A'>
-				<availability>:0,MERC.WD:2-</availability>
+				<availability>MERC.WD:2-</availability>
 			</model>
 			<model name='FFL-4B'>
 				<availability>MERC.WD:6+</availability>
@@ -3829,7 +3829,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:3,CSV:5,FRR:2,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:4,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:2</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:5,LA:5</availability>
+				<availability>MERC.KH:5,LA:5</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:8,CS:6,LA:2,CLAN:8,NIOPS:6,WOB:6,MERC.SI:8,BAN:8</availability>
@@ -3866,7 +3866,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,Periphery:4</availability>
 			<model name='FLE-15'>
 				<availability>MERC.WD:1,FWL:1</availability>
 			</model>
@@ -4013,7 +4013,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8,WOB:8</availability>
@@ -4040,7 +4040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,FS:8,Periphery:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:6</availability>
@@ -4075,7 +4075,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -4086,7 +4086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CSR:3,CLAN:5,IS:1+,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CW:2,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
+			<availability>CSR:3,CLAN:5,IS:1+,BAN:3,CWIE:4,MERC.WD:3,CW:2,CSJ:7,CJF:6,CGB:9,CB:6</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -4147,7 +4147,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
+			<availability>CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -4166,7 +4166,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CC:1,IS:1,WOB:2,FS:1,MERC:1,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>IS:1,WOB:2,MERC:1,Periphery:1,CS:1,MERC.WD:1,LA:4,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:5,HL:3,LA:8,FWL:5,Periphery.Deep:8,IS:5,MERC:5,Periphery:5</availability>
@@ -4207,7 +4207,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
+			<availability>CS:8,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
 			</model>
@@ -4250,7 +4250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>CC:3+,MOC:3+,IS:3+,WOB:5,FWL.KIS:7+,SIC:3+,FS:3+,MERC:3+,CS:3,Periphery.MW:1,FWL:6+,MH:3+,DC:3+</availability>
+			<availability>MOC:3+,IS:3+,WOB:5,FWL.KIS:7+,MERC:3+,CS:3,Periphery.MW:1,FWL:6+,MH:3+</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 			</model>
@@ -4259,7 +4259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4328,7 +4328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,NIOPS:3</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
 			</model>
@@ -4513,7 +4513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4615,7 +4615,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>MOC:6,OA:5,HL:3,Periphery.CM:5,Periphery.MW:4,Periphery.HR:5,Periphery.ME:5,MH:5,MERC:3,Periphery.OS:4,TC:5,Periphery:4</availability>
+			<availability>MOC:6,OA:5,HL:3,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,MERC:3,TC:5,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4693,7 +4693,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>MOC:3-,OA:3-,HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-,TC:3-</availability>
+			<availability>HL:2,LA:4-,Periphery.Deep:2-,FS:3-,MERC:4-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:5</availability>
 			</model>
@@ -4779,11 +4779,11 @@
 			<availability>CS:3,DC.GHO:5,CHH:3,FRR:2,FWL:5,NIOPS:3,WOB:3,CGB:3,CB:1,DC:2</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
-				<availability>:0,FWL:2</availability>
+				<availability>FWL:2</availability>
 			</model>
 			<model name='HER-1B'>
 				<roles>recon</roles>
-				<availability>:0,FWL:1</availability>
+				<availability>FWL:1</availability>
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
@@ -4912,7 +4912,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:6,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:6</availability>
@@ -4948,7 +4948,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,Periphery:5,CS:4-,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4990,7 +4990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5141,7 +5141,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -5237,7 +5237,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -5299,7 +5299,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>CC:6,MOC:2,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,FS:8,Periphery.OS:1,CIR:2,TC:2,CS:3,OA:1,LA:6,Periphery.CM:1,Periphery.HR:2,Periphery.ME:1,FWL:3,NIOPS:3,MH:2,DC:3</availability>
+			<availability>CC:6,MOC:2,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,FS:8,Periphery.OS:1,CIR:2,TC:2,CS:3,OA:1,LA:6,Periphery.CM:1,Periphery.HR:2,Periphery.ME:1,NIOPS:3,MH:2</availability>
 			<model name='JM6-A'>
 				<roles>anti_aircraft</roles>
 				<availability>FS:2</availability>
@@ -5325,7 +5325,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
@@ -5375,7 +5375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,FS.DMM:5,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:2+,FS:2+,DC:6+</availability>
@@ -5553,7 +5553,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
+			<availability>FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,NIOPS:6,CGB:5</availability>
 			<model name='KGC-000'>
 				<availability>CS:6,CIH:5,FRR:6+,CLAN:6,NIOPS:6,WOB:6,BAN:8,CB:5,DC:6+</availability>
 			</model>
@@ -5599,7 +5599,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:7,CHH:3,CDS:3,CSV:3,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:5,MERC:4,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:6,MERC:6,DC:4</availability>
+				<availability>FS:6,MERC:6,DC:4</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:6,CS:6,DC.SL:4,CLAN:6,NIOPS:6,WOB:6,MERC.SI:6,FS:6+,MERC:6+,BAN:7</availability>
@@ -5691,7 +5691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,IS:1+,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8,DC:1+</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,IS:1+,CGS:7,BAN:7,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8,DC:1+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -5741,7 +5741,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CHH:6,CIH:6,CSR:6,CSV:6,CLAN:3,CGS:6,CWIE:3,CSA:6,CDS:3,CW:4,CNC:3,CJF:4,CGB:6</availability>
+			<availability>CHH:6,CIH:6,CSR:6,CSV:6,CLAN:3,CGS:6,CSA:6,CW:4,CJF:4,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -5768,7 +5768,7 @@
 			</model>
 			<model name='(3055 Upgrade)'>
 				<roles>fire_support</roles>
-				<availability>CC:4,MOC:2,FRR:4,IS:2,SIC:4,FS:6,CIR:2,TC:3,Periphery:2,CS:4,LA:6,FWL:4,DC:4</availability>
+				<availability>CC:4,FRR:4,IS:2,SIC:4,FS:6,TC:3,Periphery:2,CS:4,LA:6,FWL:4,DC:4</availability>
 			</model>
 		</chassis>
 		<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -5819,7 +5819,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:6</availability>
@@ -5885,7 +5885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,Periphery:4,TC:5,CS:4-,OA:7,FWL:3,NIOPS:4-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -5996,7 +5996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSV:6,CLAN:5,IS:1+,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
+			<availability>CHH:8,CSV:6,CLAN:5,IS:1+,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:5</availability>
@@ -6046,7 +6046,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
+			<availability>CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,Periphery:7,CS:3,FWL:9,NIOPS:3,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:6</availability>
@@ -6106,7 +6106,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
+			<availability>HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 			</model>
@@ -6265,7 +6265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:8,IS:9,Periphery.Deep:8,WOB:9,MERC:9,CIR:8,Periphery:9,CS:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:5,General:6,Periphery.Deep:5,FS:5,DC:5,Periphery:6</availability>
 			</model>
@@ -6301,7 +6301,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,SL.2:5,DC:5,CGB:2</availability>
+			<availability>CC:4,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,NIOPS:7,SL.2:5,DC:5</availability>
 			<model name='C'>
 				<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 			</model>
@@ -6366,7 +6366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>CSR:4,CSV:3,CLAN:4,IS:1+,CFM:4,MERC:1+,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
+			<availability>CSV:3,CLAN:4,IS:1+,MERC:1+,BAN:3,MERC.WD:2,CW:3,CSJ:8,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 			</model>
@@ -6438,7 +6438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
+			<availability>HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,Periphery:5,CS:6-,LA:7,NIOPS:6-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
@@ -6770,7 +6770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:2,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
+			<availability>CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,CS:4,DC.GHO:2,CDS:3,CBS:4,NIOPS:4,CGB:3,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -6978,7 +6978,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>LA:5,FS:5,MERC:1</availability>
 			<model name='NGS-4S'>
-				<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:2,FS:2,MERC:2</availability>
@@ -7090,7 +7090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>CC:6,MOC:2,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:2,CDS:4,LA:7,PIR:4,Periphery.ME:4,CNC:2,FWL:9,MH:4,DC:4</availability>
+			<availability>CC:6,MOC:2,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:2,CDS:4,LA:7,PIR:4,Periphery.ME:4,CNC:2,FWL:9,MH:4</availability>
 			<model name=''>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -7112,7 +7112,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>MOC:5,HL:3,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='ON1-K'>
 				<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -7150,7 +7150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
+			<availability>CC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,CS:4-,NIOPS:4-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
@@ -7176,7 +7176,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
+			<availability>FRR:4,CLAN:2-,IS:2,WOB:3,MERC:4,Periphery:1,CS:3,FWL:4,NIOPS:3,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:2</availability>
@@ -7258,7 +7258,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
+			<availability>MOC:5,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,NIOPS:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -7335,7 +7335,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,CDS:2,LA:8,FWL:7,DC:6</availability>
+			<availability>CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,CIR:6,Periphery:9,CS:8-,OA:5,CDS:2,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7365,7 +7365,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
+			<availability>HL:3,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,Periphery:4,CWIE:4,CS:5-,LA:7,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -7489,7 +7489,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:6,HL:3,CLAN:2,IS:9,FWL:10,NIOPS:6,Periphery.Deep:4,WOB:5,Periphery:4,CGB:2</availability>
+			<availability>CS:6,HL:3,CLAN:2,IS:9,FWL:10,NIOPS:6,Periphery.Deep:4,WOB:5,Periphery:4</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:5,BAN:6,Periphery:5</availability>
@@ -7537,7 +7537,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
+			<availability>MOC:6,CC:3,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -7727,7 +7727,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CLAN:8,IS:1+,MERC:1+,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
@@ -7777,7 +7777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
 			</model>
@@ -7929,7 +7929,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:8,HL:9,FRR:7,CLAN:6,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,HL:9,CLAN:6,Periphery.Deep:9,IS:7,WOB:8,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CNC:3</availability>
 			</model>
@@ -7985,7 +7985,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
+			<availability>CC:7-,CCC:4,HL:4,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,NIOPS:6-,CB:4</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
 			</model>
@@ -8087,7 +8087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9,DC:1+</availability>
+			<availability>CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CBS:9,CSJ:9,CJF:9,DC:1+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 			</model>
@@ -8148,7 +8148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,MERC:3-,Periphery:3-,OA:2-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -8188,7 +8188,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:7,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,Periphery:7,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -8232,7 +8232,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,SIC:7-,Periphery.OS:8,FS:6-,CIR:7,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,LA:7-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,Periphery.OS:8,FS:6-,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8316,7 +8316,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,MERC:6,CIR:7,Periphery:6,CS:5,OA:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -8327,7 +8327,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,Periphery:7,CS:4-,OA:8,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8410,7 +8410,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,SIC:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,FWL:4,DC:4</availability>
+			<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,SIC:3,FS:5,Periphery:3,CS:3,LA:6</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -8421,7 +8421,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,MERC:3,FS:3,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,CBS:2,LA:4,NIOPS:4,CJF:4,CGB:4,DC:2</availability>
+			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,MERC:3,FS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,CBS:2,LA:4,NIOPS:4,CJF:4,CGB:4,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:4,DC:4</availability>
 			</model>
@@ -8445,7 +8445,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
@@ -8498,7 +8498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:3,CSV:8,CFM:8,FS:3,CGS:8,DC:3</availability>
 			</model>
@@ -8612,7 +8612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
+			<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,Periphery:1,CS:3-,OA:2,FWL:4,NIOPS:3-,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -8627,7 +8627,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 			</model>
@@ -8707,7 +8707,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
+			<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,NIOPS:3,DC:4</availability>
 			<model name='SPR-6D'>
 				<availability>FRR:4+,FS:6+,MERC:4+</availability>
 			</model>
@@ -8749,7 +8749,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,CS:3,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:6</availability>
@@ -8788,7 +8788,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
+			<availability>CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,Periphery:10,CS:5,LA:9,FWL:10,NIOPS:5,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -8865,7 +8865,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
+			<availability>HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
@@ -8884,7 +8884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,CS:3,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:5,LA:4,IS:5,FS:5,Periphery:5</availability>
 			</model>
@@ -8911,7 +8911,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -8992,7 +8992,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:5+,FS:7+,MERC:5+</availability>
 			</model>
@@ -9145,7 +9145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:5,CIH:4,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
+			<availability>CIH:4,CLAN:5,IS:1+,BAN:5,CWIE:6,MERC.WD:4,CNC:6,CSJ:7,CJF:9</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -9213,7 +9213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -9223,7 +9223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:2,FS:3,CWIE:6,DC.GHO:5,CS:8,OA:2,CDS:4,CW:6,CBS:4,LA:2,CNC:4,FWL:5,NIOPS:8,CJF:6,CGB:6</availability>
+			<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:2,FS:3,CWIE:6,DC.GHO:5,CS:8,OA:2,CDS:4,CW:6,CBS:4,CNC:4,FWL:5,NIOPS:8,CJF:6,CGB:6</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,MERC:8,DC:4</availability>
 			</model>
@@ -9270,7 +9270,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>HL:4,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,FS:6,Periphery:5,TC:6,CS:5-,LA:7,NIOPS:5-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:6</availability>
@@ -9285,7 +9285,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:7,CCC:1-,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:4-,CSA:1-,MERC.WD:4,LA:8,NIOPS:4-,MH:4,DC:8,CB:1</availability>
+			<availability>CC:7,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,Periphery:4,CS:4-,MERC.WD:4,NIOPS:4-,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2+,CLAN.IS:1-,FS:1+,CGS:1-,CB:1,DC:1+</availability>
 			</model>
@@ -9445,7 +9445,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
+			<availability>IS:5,WOB:4-,FS:4,MERC:5,Periphery:5,CS:4-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
@@ -9532,7 +9532,7 @@
 			<availability>CS:5,WOB:5</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
@@ -9585,7 +9585,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CBS:6,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -9686,7 +9686,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,Periphery:4-,TC:3-,CS:3-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:6,HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -9759,7 +9759,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,CS:5,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -9782,7 +9782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
+			<availability>CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,Periphery.OS:4,Periphery:4,CS:4-,LA:6,NIOPS:4-,CJF:4,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -9925,7 +9925,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:7,FRR:4,FWL:7,IS:5,NIOPS:3,WOB:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:7,FS:4</availability>
@@ -9944,7 +9944,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7,DC:1+</availability>
+			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CJF:7,CGB:9,CB:7,DC:1+</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 			</model>
@@ -10010,7 +10010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
+			<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:3+,FS:3+,DC:3+</availability>
 			</model>
@@ -10054,7 +10054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -10153,7 +10153,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -10195,7 +10195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,CNC:1,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:4,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,CS:4-,CNC:1,FWL:10,NIOPS:4-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:1</availability>
 			</model>
@@ -10241,7 +10241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
+			<availability>CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>
@@ -10361,7 +10361,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:5-,MERC:5,CIR:4,TC:3,Periphery:3,DC:2</availability>
+			<availability>CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:5-,MERC:5,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -12,8 +12,7 @@
 			<pctOmni>8,8</pctOmni>
 			<pctClan>26,26</pctClan>
 			<pctSL>64,64</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2,CB:2</salvage>
 		</faction>
 		<faction key='CC'>
 			<pctOmni>0,0,3,4,9</pctOmni>
@@ -62,8 +61,7 @@
 			<pctSL>46,46,23,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='2'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
+			<salvage pct='2'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:5,CGS:3,CSA:4,CDS:5,CW:4,CBS:3,CNC:10,CSJ:5,CJF:4</salvage>
 			<weightDistribution era='3058' unitType='Mek'>3,4,2,1</weightDistribution>
 			<weightDistribution era='3058' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
@@ -73,8 +71,7 @@
 			<pctSL>88,88,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -82,8 +79,7 @@
 			<pctSL>30,30,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:6,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:5,CB:2</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:6,CSR:2,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:5,CB:2</salvage>
 			<weightDistribution era='3058' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3058' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -93,8 +89,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:2,CIH:3,CSV:7,CCO:1,CGS:6,CSA:9,CDS:1,CW:3,CNC:3,CSJ:3,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:2,CIH:3,CSV:7,CCO:1,CGS:6,CSA:9,CDS:1,CW:3,CNC:3,CSJ:3,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>3,3,35,74,100</pctOmni>
@@ -112,8 +107,7 @@
 			<pctSL>90,90,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CIH:4,CSR:0,CSV:4,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1,CB:2</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CIH:4,CSR:0,CSV:4,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,30,80,90</pctOmni>
@@ -121,8 +115,7 @@
 			<pctSL>70,70,17,10,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:1,CIH:7,CSV:2,CFM:4,CCO:1,CGS:3,CSA:2,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
+			<salvage pct='10'>CCC:1,CSR:1,CIH:7,CSV:2,CFM:4,CCO:1,CGS:3,CSA:2,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10,CB:3</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,6,90,100</pctOmni>
@@ -130,8 +123,7 @@
 			<pctSL>48,48,23,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:1,CSV:4,CFM:3,CCO:5,CGS:5,CSA:5,CDS:7,CW:4,CNC:2,CSJ:2,CJF:10,CGB:3,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:1,CSV:4,CFM:3,CCO:5,CGS:5,CSA:5,CDS:7,CW:4,CNC:2,CSJ:2,CJF:10,CGB:3,CB:1</salvage>
 			<weightDistribution era='3058' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3058' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -141,8 +133,7 @@
 			<pctSL>47,47,20,54,0</pctSL>
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='17'>
-				CHH:0,CSR:0,CIH:0,CI:0,CSV:2,CFM:0,CCO:0,CGS:0,CSA:0,CDS:0,CW:6,LA:5,CNC:0,CSJ:0,CGB:0</salvage>
+			<salvage pct='17'>CHH:0,CSR:0,CIH:0,CI:0,CSV:2,CFM:0,CCO:0,CGS:0,CSA:0,CDS:0,CW:6,LA:5,CNC:0,CSJ:0,CGB:0</salvage>
 		</faction>
 		<faction key='CNC'>
 			<pctOmni>10,10,50,78,100</pctOmni>
@@ -150,8 +141,7 @@
 			<pctSL>80,80,40,6,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:2,CSR:3,CIH:1,CSV:1,FRR:1,CFM:2,FS:3,CCO:4,CGS:2,CSA:3,CDS:0,CW:2,CBS:1,LA:3,CSJ:6,CJF:1,CGB:5,CB:2,DC:6</salvage>
+			<salvage pct='10'>CCC:3,CHH:2,CSR:3,CIH:1,CSV:1,FRR:1,CFM:2,FS:3,CCO:4,CGS:2,CSA:3,CDS:0,CW:2,CBS:1,LA:3,CSJ:6,CJF:1,CGB:5,CB:2,DC:6</salvage>
 		</faction>
 		<faction key='CDS'>
 			<pctOmni>0,0,0,90,100</pctOmni>
@@ -159,8 +149,7 @@
 			<pctSL>5,5,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,43,43,43</pctClan>
 			<pctSL unitType='Vehicle'>88,88,57,57,57</pctSL>
-			<salvage pct='12'>
-				CCC:3,CHH:10,CSR:10,CIH:9,CSV:4,CFM:10,CCO:8,CGS:3,CSA:10,CW:1,CNC:8,CSJ:10,CJF:9,CB:10</salvage>
+			<salvage pct='12'>CCC:3,CHH:10,CSR:10,CIH:9,CSV:4,CFM:10,CCO:8,CGS:3,CSA:10,CW:1,CNC:8,CSJ:10,CJF:9,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -168,8 +157,7 @@
 			<pctSL>40,40,20,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:0,CHH:2,CSR:0,CIH:3,CSV:2,FRR:1,CFM:2,CCO:4,CGS:0,CSA:0,CDS:2,CW:3,CBS:0,CNC:6,CJF:4,CGB:3,DC:8,CB:1</salvage>
+			<salvage pct='10'>CCC:0,CHH:2,CSR:0,CIH:3,CSV:2,FRR:1,CFM:2,CCO:4,CGS:0,CSA:0,CDS:2,CW:3,CBS:0,CNC:6,CJF:4,CGB:3,DC:8,CB:1</salvage>
 		</faction>
 		<faction key='CSR'>
 			<pctOmni>40,40,80,100,100</pctOmni>
@@ -177,8 +165,7 @@
 			<pctSL>20,20,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,43,43,43</pctClan>
 			<pctSL unitType='Vehicle'>88,88,57,57,57</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10,CB:3</salvage>
+			<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10,CB:3</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>18,18,27,100,100</pctOmni>
@@ -186,8 +173,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,43,50,50</pctClan>
 			<pctSL unitType='Vehicle'>88,88,57,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:7,CGB:2,CB:2</salvage>
 			<weightDistribution era='3058' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3058' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -197,8 +183,7 @@
 			<pctSL>51,51,7,1,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:0,CHH:0,CSR:0,CIH:2,CFM:1,CCO:1,CGS:1,CSA:2,CDS:2,CW:4,CBS:0,LA:2,CNC:0,CSJ:1,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:0,CHH:0,CSR:0,CIH:2,CFM:1,CCO:1,CGS:1,CSA:2,CDS:2,CW:4,CBS:0,LA:2,CNC:0,CSJ:1,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
 			<pctOmni>0,0,0,88,100</pctOmni>
@@ -619,8 +604,7 @@
 			<pctSL>66,66,32,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,85,100</pctOmni>
@@ -628,8 +612,7 @@
 			<pctSL>66,66,25,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -637,8 +620,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,80,100</pctOmni>
@@ -646,8 +628,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,63,100</pctOmni>
@@ -655,8 +636,7 @@
 			<pctSL>66,66,32,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,62,100</pctOmni>
@@ -664,8 +644,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CFM.S'>
 			<pctOmni>0,0,20,100,100</pctOmni>
@@ -673,8 +652,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>11,11,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='FWL.KIS'>
 			<pctOmni>12</pctOmni>
@@ -922,8 +900,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
@@ -946,8 +923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:3,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:3,FRR:3,CLAN:2,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:2,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -958,8 +934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CCC:2,CIH:2,CSR:4,CSV:1,CGS:2,CWIE:1,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:1,CJF:6,CB:1</availability>
+			<availability>CCC:2,CIH:2,CSR:4,CSV:1,CGS:2,CWIE:1,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:1,CJF:6,CB:1</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8,FWL:8</availability>
@@ -1023,8 +998,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
+			<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:3,CLAN:1,MERC:3,CCO:2,CWIE:2,BAN:2,CGB:2</availability>
 			<model name='ANH-1A'>
 				<availability>MERC.KH:1,CLAN:2-,MERC:4</availability>
 			</model>
@@ -1088,8 +1062,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:6,HL:4,FRR:6,CLAN:1,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7,CGB:1</availability>
+			<availability>CC:6,HL:4,FRR:6,CLAN:1,IS:8,Periphery.Deep:5,WOB:3-,SIC:7,FS:7,Periphery:5,CS:4-,LA:8,FWL:8,NIOPS:4-,DC:7,CGB:1</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:2,MERC.WD:2,CWIE:3</availability>
 			</model>
@@ -1195,8 +1168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1251,8 +1223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:2-,CC:4-,FRR:2,IS:2,WOB:3-,MERC:2,FS:2,Periphery:2,TC:2-,CS:3-,OA:1,LA:2,FS.CMM:4-</availability>
+			<availability>MOC:2-,CC:4-,FRR:2,IS:2,WOB:3-,MERC:2,FS:2,Periphery:2,TC:2-,CS:3-,OA:1,LA:2,FS.CMM:4-</availability>
 			<model name='ASN-101'>
 				<availability>FS.CMM:1</availability>
 			</model>
@@ -1301,8 +1272,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:3,FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
+			<availability>MOC:1,CC:3,FRR:5,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:5,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:4,FWL:4,NIOPS:4-,CSJ:2-,DC:8,CB:2-</availability>
 			<model name='AS7-A'>
 				<availability>CC:2,FWL:2,SIC:2,MERC:2</availability>
 			</model>
@@ -1403,8 +1373,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,CLAN:1-,IS:7,Periphery.Deep:7,WOB:7,FS:7,CIR:8,Periphery:8,TC:8,CS:8,OA:8,LA:7,FWL:10,NIOPS:8,DC:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -1594,8 +1563,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
+			<availability>MOC:9-,CC:4-,HL:8-,FRR:6-,IS:6-,Periphery.Deep:9-,WOB:1-,SIC:6-,FS:7-,CIR:9-,MERC:6-,Periphery:9-,TC:9-,CS:1-,OA:9-,LA:8-,FWL:5-,NIOPS:1-,MH:9-,DC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:3,General:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
 			</model>
@@ -1673,8 +1641,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:2,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:2,DC:5</availability>
 			<model name='BLR-1D'>
 				<availability>FS:6</availability>
 			</model>
@@ -1725,8 +1692,7 @@
 			</model>
 		</chassis>
 		<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6,DC:2+</availability>
+			<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,CB:6,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:8,General:7,CGS:3</availability>
 			</model>
@@ -1767,8 +1733,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,HL:4,FRR:7,IS:5,WOB:6-,SIC:7,MERC:6,FS:9,Periphery:5,CS:6-,OA:7,CDS:2,LA:7,PIR:6,DC:8</availability>
+			<availability>CC:6,HL:4,FRR:7,IS:5,WOB:6-,SIC:7,MERC:6,FS:9,Periphery:5,CS:6-,OA:7,CDS:2,LA:7,PIR:6,DC:8</availability>
 			<model name=''>
 				<availability>General:8,DC:8</availability>
 			</model>
@@ -1804,8 +1769,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CSR:4,CLAN:3,IS:1+,CFM:6,CGS:6,CCO:6,BAN:5,CWIE:6,CSA:6,MERC.WD:5,CDS:5,CW:6,CBS:3,CJF:6,CGB:5</availability>
+			<availability>CHH:7,CSR:4,CLAN:3,IS:1+,CFM:6,CGS:6,CCO:6,BAN:5,CWIE:6,CSA:6,MERC.WD:5,CDS:5,CW:6,CBS:3,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -1857,8 +1821,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:6,FRR:3,CLAN:7,CFM:6,FS:1,CWIE:8,DC.GHO:3,OA:1,CDS:6,CBS:8,FWL:1,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:1,MERC:2,CGS:8,Periphery:1,TC:1,CS:7,CW:8,LA:1,CNC:8,CJF:6,DC:2</availability>
+			<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:1,CWIE:8,DC.GHO:3,OA:1,CDS:6,CBS:8,FWL:1,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:1,MERC:2,CGS:8,Periphery:1,TC:1,CS:7,CW:8,LA:1,CNC:8,CJF:6,DC:2</availability>
 			<model name='BL-6-KNT'>
 				<availability>DC.GHO:4,CS:4,OA:2+,FRR:4,CLAN:6,FWL:3,NIOPS:4,WOB:4,MERC.SI:5,BAN:6,TC:2,DC:4</availability>
 			</model>
@@ -1987,8 +1950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,MERC.WD:5,LA:6,FRR:4,FWL:4,SIC:5,FS:6,MERC:5,DC:4,Periphery:3</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,MERC.WD:5,LA:6,FRR:4,FWL:4,SIC:5,FS:6,MERC:5,DC:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -2015,8 +1977,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+			<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2044,8 +2005,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:9,HL:5,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:5,CIR:7,MERC:6,Periphery:6,TC:8,LA:5,FWL:5,DC:8</availability>
+			<availability>MOC:8,CC:9,HL:5,FRR:8,IS:6,Periphery.Deep:6,SIC:9,FS:5,CIR:7,MERC:6,Periphery:6,TC:8,LA:5,FWL:5,DC:8</availability>
 			<model name=''>
 				<availability>LA:8,General:8,FS:8,MERC:8,DC:8</availability>
 			</model>
@@ -2130,8 +2090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -2149,8 +2108,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:8,MOC:2,LA:3,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:2,SIC:5,FS:5,MERC:3,TC:2,Periphery:1</availability>
+			<availability>CC:8,MOC:2,LA:3,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:2,SIC:5,FS:5,MERC:3,TC:2,Periphery:1</availability>
 			<model name='CTF-1X'>
 				<availability>General:6,Periphery:6</availability>
 			</model>
@@ -2168,8 +2126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
+			<availability>MOC:2,CC:3,FRR:5,IS:1,SIC:2,MERC:1,CIR:2,FS:1,Periphery:2,TC:2,CS:3,LA:1,FWL:1,NIOPS:3,MH:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:3,SIC:3</availability>
@@ -2290,8 +2247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:4+,IS:3+,FS:5+</availability>
 			</model>
@@ -2379,15 +2335,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:5,CHH:3,FRR:2,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:5,CHH:3,FRR:2,CLAN:3,IS:2,WOB:5,SIC:3,MERC:2,FS:2,CS:5,DC.GHO:6,LA:3,FWL:2,NIOPS:5,CGB:3,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CC:2,CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
+				<availability>CC:2,CHH:3,WOB:6,SIC:4,FS:4,MERC:4,BAN:4,DC.GHO:5,CS:6,LA:4,NIOPS:6,MERC.SI:6,DC:4,CGB:3</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:4+,CS:4,LA:4+,IS:4+,MERC:4+</availability>
@@ -2442,8 +2396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:5,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -2758,8 +2711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:3</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:2</availability>
@@ -2784,8 +2736,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>MOC:3,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:3,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:8,FS:6,Periphery:8</availability>
 			</model>
@@ -2878,8 +2829,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:2,CLAN:4,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:2,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,BAN:4,Periphery:6</availability>
 			</model>
@@ -2935,8 +2885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,FRR:2,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
+			<availability>CHH:3,CSR:3,FRR:2,CLAN:3,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:4</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:3,Periphery.Deep:8,NIOPS:0,Periphery:3</availability>
@@ -2954,8 +2903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:5,FRR:3,CSV:6,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
+			<availability>CHH:7,CSR:5,FRR:3,CSV:6,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:7,NIOPS:0</availability>
 			</model>
@@ -3028,8 +2976,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+			<availability>CC:5,MOC:2,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -3098,8 +3045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,IS:1+,FS:1+,MERC:1+,BAN:2,CWIE:6,MERC.WD:4,CDS:5,CW:6,CBS:4,LA:1+,CNC:4,CSJ:8,CJF:5,CGB:5,CB:4,DC:1+</availability>
+			<availability>CLAN:4,IS:1+,FS:1+,MERC:1+,BAN:2,CWIE:6,MERC.WD:4,CDS:5,CW:6,CBS:4,LA:1+,CNC:4,CSJ:8,CJF:5,CGB:5,CB:4,DC:1+</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -3175,8 +3121,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CCC:6,CIH:6,CLAN:5,IS:1+,CLAN.IS:5,MERC:1+,CCO:4,BAN:5,CSA:4,MERC.WD:5,CDS:6,CJF:4,CGB:9,CB:6</availability>
+			<availability>CHH:8,CCC:6,CIH:6,CLAN:5,IS:1+,CLAN.IS:5,MERC:1+,CCO:4,BAN:5,CSA:4,MERC.WD:5,CDS:6,CJF:4,CGB:9,CB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
@@ -3206,8 +3151,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,CNC:3,FWL:8,NIOPS:6,CJF:1,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:9,CNC:3,FWL:8,NIOPS:6,CJF:1,DC:7</availability>
 			<model name='(Clan)'>
 				<availability>MERC.WD:6,CLAN:6</availability>
 			</model>
@@ -3251,8 +3195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
+			<availability>MOC:4,CC:3,HL:3,FRR:4,IS:4,Periphery.Deep:5,SIC:4,FS:6,MERC:4,Periphery.OS:5,Periphery:4,TC:4,OA:4,LA:4,Periphery.HR:5,DC:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:6,CLAN:4,IS:6-,Periphery.Deep:7,Periphery:8</availability>
 			</model>
@@ -3261,8 +3204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:6,LA:5,FWL:3,MH:6,DC:3</availability>
+			<availability>MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:6,LA:5,FWL:3,MH:6,DC:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3314,8 +3256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CIH:7,CSV:5,CLAN:5,IS:1+,CFM:5,CSA:6,MERC.WD:5,CDS:4,CSJ:5,CJF:4,CGB:9,CB:7</availability>
+			<availability>CHH:6,CIH:7,CSV:5,CLAN:5,IS:1+,CFM:5,CSA:6,MERC.WD:5,CDS:4,CSJ:5,CJF:4,CGB:9,CB:7</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CWIE:6,CGB:8</availability>
 			</model>
@@ -3326,8 +3267,7 @@
 				<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7,CB:6</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
 			</model>
 			<model name='E'>
 				<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
@@ -3346,8 +3286,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
+			<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,FS:6,MERC:3,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:7</availability>
 			</model>
@@ -3392,8 +3331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:2,FRR:5,CLAN:2,IS:4,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:3,TC:4,CS:4-,OA:4,LA:5,FWL:6,NIOPS:4-,DC:5</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:3,FS:3</availability>
@@ -3445,11 +3383,9 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2,CLAN:1,IS:2,WOB:7,SIC:2,MERC:2,TC:2,CS:7,LA:2,CNC:1,FWL:2,NIOPS:7,DC:2</availability>
+			<availability>CC:2,MOC:2,CLAN:1,IS:2,WOB:7,SIC:2,MERC:2,TC:2,CS:7,LA:2,CNC:1,FWL:2,NIOPS:7,DC:2</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
+				<availability>CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3527,8 +3463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:2,MERC:1</availability>
 			</model>
@@ -3650,8 +3585,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,MERC.KH:1+,CIH:7,CSV:5,CLAN:4,IS:1+,CWIE:8,MERC.WD:6,CDS:5,CW:8,CNC:4,CSJ:4,CJF:6,CGB:5</availability>
+			<availability>CHH:5,MERC.KH:1+,CIH:7,CSV:5,CLAN:4,IS:1+,CWIE:8,MERC.WD:6,CDS:5,CW:8,CNC:4,CSJ:4,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -3672,8 +3606,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
+			<availability>Periphery.R:5,HL:5,LA:6,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:8</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:9</availability>
@@ -3894,8 +3827,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:3,CSV:5,FRR:2,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:4,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:2</availability>
+			<availability>CHH:3,CSV:5,FRR:2,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:4,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:2</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:5,LA:5</availability>
 			</model>
@@ -3934,8 +3866,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,MERC:3,CIR:4,Periphery:4,TC:4</availability>
 			<model name='FLE-15'>
 				<availability>MERC.WD:1,FWL:1</availability>
 			</model>
@@ -4082,8 +4013,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:8,General:8,FWL:8,WOB:8</availability>
@@ -4110,16 +4040,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:6</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>
-					MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:4,Periphery:2,CS:5,OA:2,LA:5,FWL:7,DC:3</availability>
+				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:4,Periphery:2,CS:5,OA:2,LA:5,FWL:7,DC:3</availability>
 			</model>
 			<model name='GAL-200'>
 				<availability>MOC:3,LA:3,FRR:3,IS:1,DC:3,Periphery:3</availability>
@@ -4147,8 +4075,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:1,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -4159,8 +4086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:3,CLAN:5,IS:1+,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CW:2,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
+			<availability>CSR:3,CLAN:5,IS:1+,BAN:3,CWIE:4,CSA:5,MERC.WD:3,CDS:5,CW:2,CNC:5,CSJ:7,CJF:6,CGB:9,CB:6</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CSJ:4,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -4221,8 +4147,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
+			<availability>MOC:2,CC:1,FS.CH:6,FRR:1,WOB:2,SIC:1,FS:5,CIR:2,Periphery:2,TC:3,CS:3-,OA:1,LA:4,DC:1</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
 				<availability>General:8</availability>
@@ -4241,8 +4166,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,IS:1,WOB:2,FS:1,MERC:1,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>MOC:1,CC:1,IS:1,WOB:2,FS:1,MERC:1,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:5,HL:3,LA:8,FWL:5,Periphery.Deep:8,IS:5,MERC:5,Periphery:5</availability>
@@ -4283,14 +4207,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
+			<availability>CS:8,CDS:5,Periphery.MW:4,PIR:4,CLAN:5,Periphery.ME:4,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:7,FWL:7,MH:7,MERC:7</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
+				<availability>CS:6,CDS:4,HL:3,CNC:4,FWL:5,NIOPS:6,Periphery.Deep:6,WOB:6,MERC:5,BAN:2,Periphery:5</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:5,BAN:2</availability>
@@ -4328,8 +4250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:3+,MOC:3+,IS:3+,WOB:5,FWL.KIS:7+,SIC:3+,FS:3+,MERC:3+,CS:3,Periphery.MW:1,FWL:6+,MH:3+,DC:3+</availability>
+			<availability>CC:3+,MOC:3+,IS:3+,WOB:5,FWL.KIS:7+,SIC:3+,FS:3+,MERC:3+,CS:3,Periphery.MW:1,FWL:6+,MH:3+,DC:3+</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 			</model>
@@ -4338,8 +4259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -4408,8 +4328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
+			<availability>MOC:3,CC:7,HL:5,CLAN:2,IS:8,Periphery.Deep:5,WOB:3,SIC:7,MERC:9,TC:7,Periphery:6,CS:3,OA:2,LA:8,CNC:2,NIOPS:3,DC:8</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:4+,FRR:4+,FS:5+,MERC:4+,DC:5+</availability>
 			</model>
@@ -4461,8 +4380,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
+			<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:4,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:8,MERC.SI:8,BAN:8,DC:8</availability>
@@ -4595,8 +4513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
+			<availability>MOC:6,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:4,WOB:5,MERC:6,Periphery:5,CS:5,FWL.pm:8,LA:5,Periphery.CM:6,Periphery.MW:6,Periphery.ME:6,FWL:8,MH:6,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4662,8 +4579,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:1,DC:4</availability>
+			<availability>Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:1,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>LA:5,TC.PL:6,MERC:5,FS:5,Periphery:5</availability>
@@ -4699,8 +4615,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:6,OA:5,HL:3,Periphery.CM:5,Periphery.MW:4,Periphery.HR:5,Periphery.ME:5,MH:5,MERC:3,Periphery.OS:4,TC:5,Periphery:4</availability>
+			<availability>MOC:6,OA:5,HL:3,Periphery.CM:5,Periphery.MW:4,Periphery.HR:5,Periphery.ME:5,MH:5,MERC:3,Periphery.OS:4,TC:5,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4896,8 +4811,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
+			<availability>CC:8,CS:3-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:3-,SIC:8,MERC:4,Periphery:4,CWIE:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4932,8 +4846,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>CC:1,CS:9,LA:5,CLAN:6,NIOPS:9,CFM:7,WOB:9,SIC:1,MERC:3,FS:4,CJF:7,DC:2</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
+				<availability>MOC:4+,DC.GHO:8,CS:5,LA:4+,CLAN:6,IS:4+,NIOPS:5,WOB:5,MERC.SI:8,MERC:4+,FS:4+,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CLAN:5,BAN:2</availability>
@@ -4999,8 +4912,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:3,FS.CMM:8,FS.DMM:8,FS:5,MERC:5,Periphery.OS:3,FS.CrMM:8,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:6</availability>
@@ -5036,8 +4948,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:4,FRR:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='HBK-4G'>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -5079,8 +4990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -5231,8 +5141,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:5,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:8</availability>
@@ -5243,11 +5152,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -5309,8 +5216,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -5331,8 +5237,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>FS.DLC:6,MOC:4,CC:2,DC.LV:6,HL:4,FRR:5,DC.GR:6,FS.AH:6,IS:5,Periphery.Deep:5,WOB:4-,SIC:2,FS:4,CIR:5,Periphery:5,TC:6,CS:3-,OA:4,LA:6,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -5394,8 +5299,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				CC:6,MOC:2,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,FS:8,Periphery.OS:1,CIR:2,TC:2,CS:3,OA:1,LA:6,Periphery.CM:1,Periphery.HR:2,Periphery.ME:1,FWL:3,NIOPS:3,MH:2,DC:3</availability>
+			<availability>CC:6,MOC:2,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,FS:8,Periphery.OS:1,CIR:2,TC:2,CS:3,OA:1,LA:6,Periphery.CM:1,Periphery.HR:2,Periphery.ME:1,FWL:3,NIOPS:3,MH:2,DC:3</availability>
 			<model name='JM6-A'>
 				<roles>anti_aircraft</roles>
 				<availability>FS:2</availability>
@@ -5421,8 +5325,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:4,MERC:2,TC:2,Periphery:1</availability>
@@ -5472,8 +5375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:2+,FS:2+,DC:6+</availability>
@@ -5651,8 +5553,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
+			<availability>CC:1,FRR:2,CLAN:4,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:5,DC:1</availability>
 			<model name='KGC-000'>
 				<availability>CS:6,CIH:5,FRR:6+,CLAN:6,NIOPS:6,WOB:6,BAN:8,CB:5,DC:6+</availability>
 			</model>
@@ -5790,8 +5691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,IS:1+,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8,DC:1+</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:7,CLAN:5,IS:1+,CCO:5,CGS:7,BAN:7,CSA:5,MERC.WD:6,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,CB:8,DC:1+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -5919,8 +5819,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:6</availability>
@@ -5951,8 +5850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:5,OA:4,HL:2,Periphery.CM:5,Periphery.MW:4,Periphery.HR:5,Periphery.ME:5,MH:5,CIR:4,Periphery.OS:4,TC:6,Periphery:3</availability>
+			<availability>MOC:5,OA:4,HL:2,Periphery.CM:5,Periphery.MW:4,Periphery.HR:5,Periphery.ME:5,MH:5,CIR:4,Periphery.OS:4,TC:6,Periphery:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5987,8 +5885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
+			<availability>MOC:7,CC:6,HL:3,FRR:6,CLAN:1,IS:5,WOB:4-,SIC:8,FS:5,Periphery:4,TC:5,CS:4-,OA:7,LA:5,FWL:3,NIOPS:4-,DC:7</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -6099,8 +5996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CSV:6,CLAN:5,IS:1+,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
+			<availability>CHH:8,CSV:6,CLAN:5,IS:1+,CFM:6,BAN:6,CWIE:6,CDS:6,CW:6,CBS:6,CSJ:6,CJF:6,CGB:5,CB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:5</availability>
@@ -6129,8 +6025,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:2,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2,CB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -6151,8 +6046,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:6,FRR:5,IS:7,Periphery.Deep:6,WOB:6,SIC:5,FS:7,Periphery:7,TC:7,CS:3,OA:7,LA:7,FWL:9,NIOPS:3,DC:6</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>General:6</availability>
@@ -6212,8 +6106,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
+			<availability>MOC:2,HL:4,FRR:5,SIC:4,FS:5,MERC:5,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:10,Periphery.MW:3,DC:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:3,General:3,Periphery.Deep:4,MERC:8,Periphery:3,DC:1</availability>
 			</model>
@@ -6284,8 +6177,7 @@
 			<availability>CC:10,CS:10,LA:10,CLAN:10,FWL:10,IS:9,NIOPS:10,WOB:10,FS:10,DC:10,Periphery:8</availability>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:4,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:8,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
+			<availability>CHH:4,CIH:4,CLAN:5,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:8,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -6300,8 +6192,7 @@
 			</model>
 			<model name='E'>
 				<roles>spotter</roles>
-				<availability>
-					CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
+				<availability>CHH:4,CIH:4,CLAN:5,CFM:4,CCO:6,CWIE:4,CW:4,CBS:4,CNC:4,General:5,CSJ:4,CJF:4,CB:4</availability>
 			</model>
 			<model name='H'>
 				<availability>CSA:4,CCC:3,CDS:3,CSV:3,CNC:3,CLAN:2,General:1</availability>
@@ -6347,8 +6238,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CIH:9,CSV:8,CLAN:5,IS:2+,BAN:6,CWIE:9,MERC.WD:8,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:2+,BAN:6,CWIE:9,MERC.WD:8,CDS:9,CW:9,CBS:6,CNC:9,CSJ:7,CJF:9,CGB:6</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -6375,8 +6265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:5,General:6,Periphery.Deep:5,FS:5,DC:5,Periphery:6</availability>
 			</model>
@@ -6412,8 +6301,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,SL.2:5,DC:5,CGB:2</availability>
+			<availability>CC:4,MOC:1,FRR:5,CLAN:2,IS:3,WOB:7,SIC:4,FS:5,TC:3,Periphery:1,CS:7,LA:5,FWL:3,NIOPS:7,SL.2:5,DC:5,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 			</model>
@@ -6478,8 +6366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:4,CSV:3,CLAN:4,IS:1+,CFM:4,MERC:1+,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
+			<availability>CSR:4,CSV:3,CLAN:4,IS:1+,CFM:4,MERC:1+,CGS:4,BAN:3,CWIE:4,CSA:4,MERC.WD:2,CDS:4,CW:3,CBS:4,CNC:4,CSJ:8,CJF:4,CGB:6,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 			</model>
@@ -6551,8 +6438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:4,FRR:7,CLAN:4,IS:5,Periphery.Deep:5,WOB:6-,SIC:6,MERC:5,FS:4,CIR:5,Periphery:5,TC:5,CS:6-,OA:5,LA:7,FWL:5,NIOPS:6-,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:5,IS:7,Periphery.Deep:7,Periphery:7</availability>
@@ -6700,8 +6586,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -6728,8 +6613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:5,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:5,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:5,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:5,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -6886,8 +6770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:2,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
+			<availability>MOC:1,CHH:3,CLAN:4,WOB:3,MERC:1,Periphery:1,TC:1,CS:4,DC.GHO:2,OA:1,CDS:3,CBS:4,NIOPS:4,CJF:4,CGB:3,DC:1</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -7207,8 +7090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:2,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:2,CDS:4,LA:7,PIR:4,Periphery.ME:4,CNC:2,FWL:9,MH:4,DC:4</availability>
+			<availability>CC:6,MOC:2,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:2,CDS:4,LA:7,PIR:4,Periphery.ME:4,CNC:2,FWL:9,MH:4,DC:4</availability>
 			<model name=''>
 				<availability>HL:5,General:7,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -7230,14 +7112,12 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
+			<availability>MOC:5,CC:5,HL:3,FRR:5,CLAN:2,IS:5,Periphery.Deep:4,WOB:4-,SIC:5,FS:5,CIR:5,Periphery:4,TC:5,CWIE:3,CS:4-,OA:5,CW:3,LA:6,Periphery.MW:6,Periphery.ME:6,FWL:9,NIOPS:4-,DC:6</availability>
 			<model name='ON1-K'>
 				<availability>HL:4,General:6,CLAN:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
 			<model name='ON1-M'>
-				<availability>
-					CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
+				<availability>CS:4+,MOC:3+,Periphery.MW:2+,PIR:2+,Periphery.ME:2+,FWL:6+,IS:3+,WOB:5+,MH:2+,DC:4+</availability>
 			</model>
 			<model name='ON1-M-DC'>
 				<roles>command</roles>
@@ -7270,8 +7150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
+			<availability>CC:3,MOC:3,HL:2,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:4,SIC:3,MERC:3+,Periphery:3,TC:3,CS:4-,LA:4,NIOPS:4-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,MERC:6,BAN:2,Periphery:6</availability>
@@ -7297,8 +7176,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
+			<availability>CC:2,FRR:4,CLAN:2-,IS:2,WOB:3,SIC:2,FS:2,MERC:4,Periphery:1,CS:3,LA:2,FWL:4,NIOPS:3,DC:4</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>General:8,BAN:2</availability>
@@ -7332,8 +7210,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:8,BAN:1</availability>
@@ -7381,16 +7258,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
+			<availability>MOC:5,CC:6,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:6,SIC:4,FS:8,CIR:6,FS.CrMM:8,Periphery:6,TC:5,CS:6,OA:5,LA:8,FS.CMM:8,FS.DMM:8,FWL:6,NIOPS:6,DC:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
+				<availability>CC:2,MERC.KH:2,HL:2,FRR:3,IS:2,Periphery.Deep:6,SIC:3,MERC:2,FS:2,Periphery:4,PIR:2,General:2,FWL:2,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -7413,8 +7288,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:3,FWL:2,NIOPS:2,DC:10</availability>
+			<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,Periphery.OS:5,FS:2,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:3,FWL:2,NIOPS:2,DC:10</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:4+,FRR:6+,CNC:2,FS.DMM:4+,MERC:4+,DC:8+</availability>
@@ -7461,8 +7335,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,CDS:2,LA:8,FWL:7,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:8,FRR:6,IS:8,Periphery.Deep:8,WOB:8-,SIC:8,FS:8,CIR:6,Periphery:9,TC:9,CS:8-,OA:5,CDS:2,LA:8,FWL:7,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7492,8 +7365,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
+			<availability>MOC:4,CC:5,HL:3,FRR:5,IS:5,Periphery.Deep:8,WOB:5-,SIC:6,FS:7,CIR:4,Periphery:4,TC:4,CWIE:4,CS:5-,OA:4,LA:7,FWL:5,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -7665,8 +7537,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
+			<availability>MOC:6,CC:3,CHH:5,HL:3,FRR:4,CLAN:5,IS:5,WOB:6-,SIC:3,FS:4,MERC:5,CIR:4,CWIE:6,TC:5,Periphery:4,CS:6-,OA:5,MERC.WD:5,CDS:6,LA:4,CNC:6,FWL:3,MH:5,DC:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -7733,8 +7604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Po Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:4,WOB:5,SIC:5,MERC:5,Periphery:2,TC:3</availability>
+			<availability>MOC:4,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:4,WOB:5,SIC:5,MERC:5,Periphery:2,TC:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7743,8 +7613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
+			<availability>CCC:2,CHH:1,CSR:5,CIH:1,CSV:2,CFM:1,CCO:2,CGS:4,CWIE:1,CS:1,CSA:1,CDS:5,CW:1,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -7858,8 +7727,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:8,CSA:9,MERC.WD:4,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
@@ -7909,8 +7777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:5,OA:5,HL:3,Periphery.Deep:8,FWL:5,IS:5,Periphery:5,DC:5,TC:5</availability>
 			</model>
@@ -8062,8 +7929,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:8,HL:9,FRR:7,CLAN:6,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
+			<availability>MOC:8,HL:9,FRR:7,CLAN:6,Periphery.Deep:9,IS:7,WOB:8,SIC:7,FS:8,CIR:8,MERC:8,Periphery:10,TC:8,CS:8,OA:8,LA:9,NIOPS:8,DC:7</availability>
 			<model name=''>
 				<availability>CHH:3,CW:3,General:8,CNC:3</availability>
 			</model>
@@ -8085,8 +7951,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,WOB:5,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>CC:6,HL:4,LA:2,FRR:2,FWL:6,Periphery.Deep:6,SIC:6,MERC:6,DC:2,Periphery:6</availability>
 			</model>
@@ -8120,8 +7985,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
+			<availability>CC:7-,CCC:4,HL:4,FRR:8-,CSV:4,IS:8-,Periphery.Deep:5,WOB:6-,CFM:4,SIC:7-,FS:9-,CGS:4,Periphery:5,CS:6-,CSA:4,FWL:8-,NIOPS:6-,CB:4</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:4,DC:2</availability>
 			</model>
@@ -8223,8 +8087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9,DC:1+</availability>
+			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:7,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9,DC:1+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 			</model>
@@ -8285,8 +8148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -8326,8 +8188,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:7,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
+			<availability>CC:8,Periphery.DD:9,FRR:9,DC.AL:10,IS:7,WOB:6-,SIC:8,MERC:7,Periphery.OS:9,FS:7,CIR:7,Periphery:7,CS:6-,LA:8,FWL:8,CJF:3,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -8371,8 +8232,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,SIC:7-,Periphery.OS:8,FS:6-,CIR:7,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,LA:7-,FWL:8-,DC:8-</availability>
+			<availability>MOC:6,CC:8-,Periphery.DD:8,HL:6,FRR:8-,IS:7-,Periphery.Deep:5,WOB:4,SIC:7-,Periphery.OS:8,FS:6-,CIR:7,Periphery:7,TC:6,CS:4,OA:8,CDS:4,FWL.MM:10,CW:3,LA:7-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8456,8 +8316,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -8468,8 +8327,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
+			<availability>MOC:8,CC:8,Periphery.DD:8,HL:6,FRR:10,IS:7,Periphery.Deep:5,WOB:4-,SIC:8,MERC:7,Periphery.OS:8,FS:6,CIR:7,Periphery:7,TC:7,CS:4-,OA:8,LA:7,FWL:6,DC:9</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8482,8 +8340,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
+			<availability>CC:7,HL:7,LA:7,FRR:9,FWL:7,IS:8,Periphery.Deep:8,SIC:7,FS:7,CJF:3,DC:7,Periphery:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8498,8 +8355,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:3-,HL:2-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,MERC:3-,Periphery:3-,CS:2-,LA:1,FWL:3-,NIOPS:2-,DC:3-</availability>
+			<availability>CC:3-,HL:2-,FRR:3-,IS:1-,Periphery.Deep:4-,WOB:2-,SIC:3-,MERC:3-,Periphery:3-,CS:2-,LA:1,FWL:3-,NIOPS:2-,DC:3-</availability>
 			<model name='SCP-1N'>
 				<availability>HL:6,LA:2,FRR:8,General:4,Periphery.Deep:7,MERC:8,Periphery:8</availability>
 			</model>
@@ -8517,8 +8373,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:3,CCC:2,CIH:3,CSR:2,CSV:2,CFM:3,CGS:3,CCO:2,CWIE:2,CSA:3,CW:2,CNC:2,CSJ:3,CJF:7</availability>
+			<availability>CHH:3,CCC:2,CIH:3,CSR:2,CSV:2,CFM:3,CGS:3,CCO:2,CWIE:2,CSA:3,CW:2,CNC:2,CSJ:3,CJF:7</availability>
 			<model name='A'>
 				<availability>General:6</availability>
 			</model>
@@ -8566,8 +8421,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:2,CLAN:3,CFM:4,WOB:4,MERC:3,FS:3,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,CBS:2,LA:4,NIOPS:4,CJF:4,CGB:4,DC:2</availability>
+			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,MERC:3,FS:3,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,CBS:2,LA:4,NIOPS:4,CJF:4,CGB:4,DC:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:4,DC:4</availability>
 			</model>
@@ -8591,8 +8445,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,FS:4,MERC:3,CIR:3,Periphery:6,TC:7,Periphery.R:6,OA:7,LA:9,FWL:1,MH:2,DC:3</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:3,LA:4,Periphery.Deep:4,FS:3,MERC:4,Periphery:3</availability>
@@ -8645,8 +8498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>
-				CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
+			<availability>CS:5-,HL:4,LA:5,CLAN:1,IS:6,NIOPS:5-,Periphery.Deep:5,WOB:5-,BAN:2,Periphery:5,CGB:1</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:3,CSV:8,CFM:8,FS:3,CGS:8,DC:3</availability>
 			</model>
@@ -8760,8 +8612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
+			<availability>CC:4,Periphery.DD:3,FRR:6,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:7</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -8776,8 +8627,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
+			<availability>MOC:2,Periphery.DD:3,OA:5,LA:4,FRR:8,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:8</availability>
 			<model name='SL-15'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,FS:0,Periphery:5</availability>
 			</model>
@@ -8830,8 +8680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
+			<availability>CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -8858,8 +8707,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
+			<availability>MOC:2,CC:2,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:4</availability>
 			<model name='SPR-6D'>
 				<availability>FRR:4+,FS:6+,MERC:4+</availability>
 			</model>
@@ -8901,8 +8749,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:5,FRR:6,IS:2,WOB:3,SIC:5,MERC:4,FS:5,Periphery:2,TC:2,CS:3,OA:2,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:6</availability>
@@ -8941,8 +8788,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
+			<availability>MOC:10,CC:7,HL:9,FRR:7,CLAN:4,IS:9,Periphery.Deep:9,WOB:5,SIC:7,FS:7,CIR:10,Periphery:10,TC:10,CS:5,OA:10,LA:9,FWL:10,NIOPS:5,DC:7</availability>
 			<model name='STK-3F'>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -9019,8 +8865,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
+			<availability>MOC:6,HL:5,FRR:6,CLAN:1-,IS:9,Periphery.Deep:5,WOB:3-,SIC:9,MERC:9,Periphery:6,CS:3-,NIOPS:3-,DC:6,CGB:1-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:3,Periphery.Deep:4,Periphery:3</availability>
@@ -9039,8 +8884,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:8,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:5,LA:4,IS:5,FS:5,Periphery:5</availability>
 			</model>
@@ -9148,8 +8992,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>MOC:1,FRR:3,CLAN:5,SIC:4,MERC:4,Periphery.OS:2,FS:9,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:5+,FS:7+,MERC:5+</availability>
 			</model>
@@ -9302,8 +9145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:5,CIH:4,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
+			<availability>CHH:5,CSR:5,CIH:4,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:5,MERC.WD:4,CDS:5,CW:5,CNC:6,CSJ:7,CJF:9,CGB:5,CB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -9371,8 +9213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:7,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:8,HL:6,General:8,FWL:8,Periphery.Deep:7,MERC:8,Periphery:8</availability>
@@ -9382,8 +9223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:2,FS:3,CWIE:6,DC.GHO:5,CS:8,OA:2,CDS:4,CW:6,CBS:4,LA:2,CNC:4,FWL:5,NIOPS:8,CJF:6,CGB:6</availability>
+			<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:2,FS:3,CWIE:6,DC.GHO:5,CS:8,OA:2,CDS:4,CW:6,CBS:4,LA:2,CNC:4,FWL:5,NIOPS:8,CJF:6,CGB:6</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,MERC:8,DC:4</availability>
 			</model>
@@ -9430,8 +9270,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:3,IS:5,Periphery.Deep:5,WOB:5-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:5-,OA:5,LA:7,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:6</availability>
@@ -9446,8 +9285,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:7,CCC:1-,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:4-,CSA:1-,MERC.WD:4,LA:8,NIOPS:4-,MH:4,DC:8,CB:1</availability>
+			<availability>CC:7,CCC:1-,HL:3,MERC.ELH:7+,CLAN:1-,IS:8,Periphery.Deep:6,WOB:3-,CLAN.IS:1-,FS:7,MERC:8,CGS:1-,Periphery:4,TC:4,CS:4-,CSA:1-,MERC.WD:4,LA:8,NIOPS:4-,MH:4,DC:8,CB:1</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2+,CLAN.IS:1-,FS:1+,CGS:1-,CB:1,DC:1+</availability>
 			</model>
@@ -9607,8 +9445,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
+			<availability>MOC:5,CC:5,FRR:5,IS:5,WOB:4-,SIC:5,FS:4,MERC:5,Periphery:5,TC:5,CS:4-,OA:5,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:6,FWL:3+,NIOPS:6,WOB:6,MERC:3+</availability>
@@ -9748,8 +9585,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:4,CCO:3,CWIE:4,MERC.WD:4,CDS:5,CW:4,CBS:6,CNC:4,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -9850,8 +9686,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:7-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:3-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:6,HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
@@ -9924,8 +9759,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
+			<availability>MOC:1,CC:2,FRR:2,IS:1,WOB:5,SIC:2,FS:2,Periphery:1,TC:1,CS:5,OA:1,LA:2,FWL:2,NIOPS:5,DC:2</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:8</availability>
@@ -9948,8 +9782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
+			<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:4,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:4-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:4-,CJF:4,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -9983,8 +9816,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:2,CSR:1,CSV:1,CLAN:1,CFM:1,WOB:1,CWIE:2,CSA:1,CS:4,MERC.WD:1,CW:4,CNC:1,CSJ:5,CJF:1,CB:2</availability>
+			<availability>CCC:2,CSR:1,CSV:1,CLAN:1,CFM:1,WOB:1,CWIE:2,CSA:1,CS:4,MERC.WD:1,CW:4,CNC:1,CSJ:5,CJF:1,CB:2</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>MERC.WD:0,IS:8</availability>
@@ -10112,8 +9944,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7,DC:1+</availability>
+			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:4,CW:6,CNC:8,CJF:7,CGB:9,CB:7,DC:1+</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 			</model>
@@ -10179,8 +10010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
+			<availability>CS:5-,HL:5,LA:9,CLAN:2,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:5,WOB:5-,TC:6,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:3+,FS:3+,DC:3+</availability>
 			</model>
@@ -10224,8 +10054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 			<model name='H-7'>
 				<availability>HL:5,IS:7,Periphery.Deep:5,Periphery:7</availability>
 			</model>
@@ -10324,8 +10153,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
+			<availability>MOC:1,Periphery.DD:4,HL:4,FRR:2,CLAN:1-,IS:1,WOB:2-,SIC:1,FS:2,MERC:3,Periphery.OS:4,Periphery:5,TC:4,CS:2-,OA:4,FS.CMM:5,NIOPS:2-,MH:3,DC:6</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:4-,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -10367,8 +10195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,CNC:1,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
+			<availability>CC:6,HL:4,FRR:7,IS:7,Periphery.Deep:5,WOB:4-,SIC:6,FS:8,Periphery:5,TC:5,CS:4-,LA:7,CNC:1,FWL:10,NIOPS:4-,MH:4,DC:7</availability>
 			<model name='WVR-6D'>
 				<availability>FS:1</availability>
 			</model>
@@ -10414,8 +10241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
+			<availability>CC:4,CIH:2,FRR:5,CLAN:3,IS:4,CFM:4,WOB:5,FS:5,MERC:4,Periphery:1,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:6,CS:6,FRR:8,NIOPS:6,WOB:6,CFM:3,FS:6+,MERC:6+,BAN:4,DC:4+</availability>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -948,7 +948,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,Periphery:4,CS:3,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
@@ -996,7 +996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,FRR:3,CLAN:3,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>CC:4,FRR:3,CLAN:3,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:6</availability>
@@ -1200,7 +1200,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:5,HL:4,FRR:5,CLAN:1,IS:7,Periphery.Deep:5,WOB:2-,SIC:6,FS:6,Periphery:5,CS:4-,LA:7,FWL:7,NIOPS:4-,DC:6,CGB:1</availability>
+			<availability>HL:4,CLAN:1,IS:7,Periphery.Deep:5,WOB:2-,SIC:6,FS:6,Periphery:5,CS:4-,NIOPS:4-,DC:6</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:4,MERC.WD:4,CWIE:4</availability>
 			</model>
@@ -1277,7 +1277,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1318,7 +1318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1373,7 +1373,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:4-,CC:4-,FRR:1,IS:1,WOB:2-,MERC:1,FS:1,Periphery:2,TC:4-,CS:3-,OA:1,LA:1,FS.CMM:2-</availability>
+			<availability>MOC:4-,CC:4-,IS:1,WOB:2-,MERC:1,Periphery:2,TC:4-,CS:3-,OA:1,LA:1,FS.CMM:2-</availability>
 			<model name='ASN-21'>
 				<availability>General:2</availability>
 			</model>
@@ -1436,7 +1436,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:2,FRR:6,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:3,FWL:3,NIOPS:4-,CSJ:2-,DC:9</availability>
+			<availability>CC:2,FRR:6,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,CW:2-,NIOPS:4-,CSJ:2-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,SIC:2,MERC:1</availability>
 			</model>
@@ -1591,7 +1591,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,FRR:2,IS:2,SIC:2,FS:4,CIR:2,Periphery:1,TC:2,OA:2,LA:4,FWL:2,DC:3</availability>
+			<availability>MOC:2,IS:2,FS:4,CIR:2,Periphery:1,TC:2,OA:2,LA:4,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:4,General:4,FS:4</availability>
@@ -1602,7 +1602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,FWL:9,NIOPS:7</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -1947,7 +1947,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:1,DC:5</availability>
+			<availability>HL:4,FRR:4,CLAN:1,IS:5,WOB:7-,Periphery:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-</availability>
 			<model name='BLR-1D'>
 				<availability>FS:5</availability>
 			</model>
@@ -2056,7 +2056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:5,HL:4,FRR:6,IS:5,WOB:5-,SIC:6,MERC:5,FS:8,Periphery:5,CS:5-,OA:6,CDS:3,LA:6,PIR:5,DC:7</availability>
+			<availability>HL:4,FRR:6,IS:5,WOB:5-,SIC:6,MERC:5,FS:8,Periphery:5,CS:5-,OA:6,CDS:3,LA:6,PIR:5,DC:7</availability>
 			<model name=''>
 				<availability>General:8,DC:8</availability>
 			</model>
@@ -2105,7 +2105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CSR:3,CLAN:2,IS:2+,CFM:5,CGS:5,CCO:5,BAN:5,CWIE:5,CSA:5,MERC.WD:4,CDS:4,CW:5,CBS:2,CJF:5,CGB:4</availability>
+			<availability>CHH:6,CSR:3,CLAN:2,IS:2+,CFM:5,CGS:5,CCO:5,BAN:5,CWIE:5,CSA:5,MERC.WD:4,CDS:4,CW:5,CJF:5,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -2160,7 +2160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:3,CWIE:8,DC.GHO:3,OA:2,CDS:6,CBS:8,FWL:2,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:2,MERC:3,CGS:8,Periphery:2,TC:3,CS:7,CW:8,LA:2,CNC:8,CJF:6,DC:3</availability>
+			<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:3,CWIE:8,DC.GHO:3,CDS:6,CBS:8,FWL:2,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:2,MERC:3,CGS:8,Periphery:2,TC:3,CS:7,CW:8,LA:2,CNC:8,CJF:6,DC:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:2</availability>
 			</model>
@@ -2171,7 +2171,7 @@
 				<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:6,FRR:6,FWL:2,MERC:6,FS:6,DC:6</availability>
+				<availability>LA:6,FRR:6,FWL:2,MERC:6,FS:6,DC:6</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:6</availability>
@@ -2322,7 +2322,7 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>FWL:4,WOB:3</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Blue Flame' unitType='Mek'>
@@ -2360,7 +2360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,SIC:5,FS:6,MERC:6,Periphery:3,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,FR:2,SIC:5,FS:6,MERC:6,Periphery:3,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -2399,7 +2399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+			<availability>HL:3,CM:6,IS:4,WOB:5,FS:7,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2567,7 +2567,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:3,CC:4,FRR:5,IS:1,SIC:2,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:4,DC:6</availability>
+			<availability>MOC:3,CC:4,FRR:5,IS:1,SIC:2,MERC:2,CIR:4,Periphery:2,TC:3,CS:4,NIOPS:4,MH:4,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:2,SIC:2</availability>
@@ -2624,7 +2624,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CCC:4,CSR:4,CLAN:3,CGS:4,CSA:4,CDS:4,CW:3,CNC:4,CSJ:6,CJF:3,CGB:3,DC:2+</availability>
+			<availability>CHH:4,CCC:4,CSR:4,CLAN:3,CGS:4,CSA:4,CDS:4,CNC:4,CSJ:6,DC:2+</availability>
 			<model name='A'>
 				<availability>General:8</availability>
 			</model>
@@ -2832,7 +2832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:6,CHH:3,FRR:4,CLAN:3,IS:4,WOB:5,SIC:3,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:6,CHH:3,CLAN:3,IS:4,WOB:5,SIC:3,MERC:2,CS:5,DC.GHO:6,LA:5,NIOPS:5,CGB:3,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -2958,7 +2958,7 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4+,DC:8</availability>
+				<availability>IS:4+,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
@@ -2967,7 +2967,7 @@
 				<availability>HL:2,SIC:6,FS:5,TC:4,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:2,LA:4,IS:4,Periphery.Deep:8,MERC:4,BAN:3,Periphery:4</availability>
+				<availability>HL:2,LA:4,IS:4,Periphery.Deep:8,MERC:4,BAN:3,Periphery:4</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -3180,7 +3180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:3,MOC:2,FRR:3,IS:2,WOB:1-,SIC:3,FS:3,MERC:2,CS:2-,LA:2,FWL:2,NIOPS:2-,DC:2</availability>
+			<availability>CC:3,MOC:2,FRR:3,IS:2,WOB:1-,SIC:3,FS:3,MERC:2,CS:2-,NIOPS:2-</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:4,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -3267,7 +3267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>MOC:2,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>MOC:2,CC:2,HL:2,IS:3,WOB:3,FS:4,Periphery:3,TC:2,CS:3,LA:6,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6,General:7,FS:6,Periphery:7</availability>
 			</model>
@@ -3379,7 +3379,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
+			<availability>CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
 			</model>
@@ -3587,7 +3587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+			<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:5,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -3672,7 +3672,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:4,IS:2+,FS:2+,MERC:2+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:2+,CNC:5,CSJ:8,CJF:5,CGB:5,DC:2+</availability>
+			<availability>CLAN:4,IS:2+,MERC:2+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CNC:5,CSJ:8,CJF:5,CGB:5</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -3790,7 +3790,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,TC:9,Periphery:10,CS:6,OA:9,LA:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,TC:9,Periphery:10,CS:6,OA:9,LA:8,CNC:5,FWL:8,NIOPS:6,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,SIC:4,FS:4,TC:4,DC:4</availability>
@@ -3841,7 +3841,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:3,FRR:3,IS:3,Periphery.Deep:5,SIC:3,FS:5,MERC:3,Periphery.OS:4,Periphery:4,TC:4,OA:4,LA:3,Periphery.HR:4,DC:3</availability>
+			<availability>CC:4,HL:3,FRR:3,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:4,Periphery.HR:4</availability>
 			<model name='DV-6M'>
 				<availability>HL:5,CLAN:4,IS:5-,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -3958,7 +3958,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,MERC:3,FS:6,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,CC.MAC:4,DC:3</availability>
+			<availability>HL:2,FRR:4,IS:3,WOB:3,SIC:2,MERC:3,FS:6,CC.CHG:4,Periphery:3,CS:3,LA:7,CC.MAC:4</availability>
 			<model name=''>
 				<availability>CC:5,General:6</availability>
 			</model>
@@ -4003,7 +4003,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,CS:3-,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:2,FS:2</availability>
@@ -4082,7 +4082,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:3,MOC:3,CLAN:2,IS:3,WOB:7,SIC:2,MERC:3,TC:3,CS:7,LA:3,CNC:4,FWL:3,NIOPS:7,DC:3</availability>
+			<availability>MOC:3,CLAN:2,IS:3,WOB:7,SIC:2,MERC:3,TC:3,CS:7,CNC:4,NIOPS:7</availability>
 			<model name='EMP-6A'>
 				<availability>CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
 			</model>
@@ -4114,7 +4114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>OA:3,LA:5,Periphery.HR:3,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:3,TC:3,DC:3,Periphery:2</availability>
+			<availability>OA:3,LA:5,Periphery.HR:3,SIC:3,FS:9,MERC:5,Periphery.OS:3,TC:3,DC:3,Periphery:2</availability>
 			<model name='ENF-4R'>
 				<availability>LA:2,General:5,FS:5,TC:5</availability>
 			</model>
@@ -4190,7 +4190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,WOB:5,FS:3,Periphery:2,TC:3,CS:5,LA:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:2,MERC:2</availability>
 			</model>
@@ -4370,7 +4370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>MERC.KH:2+,CHH:5,CIH:7,CSV:5,CLAN:3,IS:2+,CWIE:8,MERC.WD:7,CDS:4,CW:8,CNC:3,CSJ:4,CJF:6,CGB:5</availability>
+			<availability>MERC.KH:2+,CHH:5,CIH:7,CSV:5,CLAN:3,IS:2+,CWIE:8,MERC.WD:7,CDS:4,CW:8,CSJ:4,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -4638,7 +4638,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:4,LA:4</availability>
+				<availability>MERC.KH:4,LA:4</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:6,CS:5,LA:4,CLAN:8,NIOPS:5,WOB:5,MERC.SI:6,BAN:8</availability>
@@ -4678,7 +4678,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:3,MERC:4,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MERC.WD:4,FWL:2,WOB:3,MERC:4,Periphery:4</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:2,CM:4</availability>
@@ -4832,7 +4832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:6,General:8,FWL:6,WOB:6</availability>
@@ -4862,14 +4862,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,FS:8,Periphery:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
+				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,LA:5,FWL:7</availability>
 			</model>
 			<model name='GAL-200'>
 				<availability>MOC:2,LA:2,FRR:2,IS:1,DC:2,Periphery:2</availability>
@@ -5008,7 +5008,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>MOC:1,CC:2,IS:1,WOB:2,FS:2,MERC:2,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>CC:2,IS:1,WOB:2,FS:2,MERC:2,Periphery:1,CS:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:4,HL:2,LA:6,FWL:4,Periphery.Deep:8,IS:4,MERC:4,Periphery:4</availability>
@@ -5117,7 +5117,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>CC:4,MOC:4,IS:3,WOB:5,FWL.KIS:8,SIC:3,FS:4,MERC:4,CS:3,Periphery.MW:2,FWL:7,MH:2,DC:4</availability>
+			<availability>CC:4,MOC:4,IS:3,WOB:5,FWL.KIS:8,FS:4,MERC:4,CS:3,Periphery.MW:2,FWL:7,MH:2,DC:4</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 			</model>
@@ -5126,7 +5126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -5214,7 +5214,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CSA:5,MERC.WD:5,CIH:6,CDS:5,CW:4,CNC:7,CLAN:4,CCO:5,CJF:4,CWIE:4,CGB:4</availability>
+			<availability>CSA:5,MERC.WD:5,CIH:6,CDS:5,CNC:7,CLAN:4,CCO:5</availability>
 			<model name=''>
 				<availability>MERC.WD:6,CLAN:4,CNC:4</availability>
 			</model>
@@ -5229,7 +5229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>MOC:3,CC:6,HL:4,CLAN:1,IS:7,Periphery.Deep:6,WOB:2,SIC:6,MERC:8,TC:6,Periphery:5,CS:2,OA:2,LA:7,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:3,CC:6,HL:4,CLAN:1,IS:7,Periphery.Deep:6,WOB:2,SIC:6,MERC:8,TC:6,Periphery:5,CS:2,OA:2,CNC:2,NIOPS:2</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
 			</model>
@@ -5488,7 +5488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:5,CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:4,WOB:5,MERC:5,Periphery:5,CS:5,FWL.pm:7,LA:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,FWL:7,MH:5,DC:5</availability>
+			<availability>HL:4,FRR:5,IS:5,Periphery.Deep:4,WOB:5,MERC:5,Periphery:5,CS:5,FWL.pm:7,FWL:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5641,7 +5641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>CC:2,MOC:8,HL:4,MERC:4,Periphery.OS:5,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
+			<availability>CC:2,MOC:8,HL:4,MERC:4,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5939,7 +5939,7 @@
 				<availability>LA:3</availability>
 			</model>
 			<model name='HGN-732'>
-				<availability>MOC:6,DC.GHO:8,CS:4,LA:6,CLAN:6,IS:6,NIOPS:4,WOB:4,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
+				<availability>MOC:6,DC.GHO:8,CS:4,CLAN:6,IS:6,NIOPS:4,WOB:4,MERC.SI:8,MERC:6,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CLAN:4,BAN:2</availability>
@@ -6014,7 +6014,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2</availability>
+			<availability>MERC.WD:6,Periphery.HR:4,FS.CMM:9,FS.DMM:9,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:5</availability>
@@ -6056,7 +6056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:4,FRR:6,IS:4,Periphery.Deep:5,WOB:3-,SIC:5,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5,CGB:2-</availability>
+			<availability>MOC:4,CC:5,HL:4,FRR:6,IS:4,Periphery.Deep:5,WOB:3-,SIC:5,Periphery:5,TC:4,CS:4-,OA:4,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -6107,7 +6107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:7</availability>
@@ -6325,7 +6325,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4FWL:6,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:6</availability>
@@ -6424,7 +6424,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:5,MOC:4,CC:2,DC.LV:6,HL:3,FRR:4,DC.GR:6,FS.AH:5,IS:4,Periphery.Deep:5,WOB:4-,SIC:2,FS:3,CIR:4,Periphery:4,TC:6,CS:3-,OA:4,LA:5,FWL:2,NIOPS:3-,DC:4</availability>
+			<availability>FS.DLC:5,CC:2,DC.LV:6,HL:3,DC.GR:6,FS.AH:5,IS:4,Periphery.Deep:5,WOB:4-,SIC:2,FS:3,Periphery:4,TC:6,CS:3-,LA:5,FWL:2,NIOPS:3-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -6492,7 +6492,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,OA:2,LA:5,Periphery.CM:2,Periphery.HR:3,PIR:2,Periphery.ME:2,FWL:3,NIOPS:3,MH:4,DC:3</availability>
+			<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,OA:2,LA:5,Periphery.CM:2,Periphery.HR:3,PIR:2,Periphery.ME:2,NIOPS:3,MH:4</availability>
 			<model name='JM6-A'>
 				<roles>anti_aircraft</roles>
 				<availability>FS:2-</availability>
@@ -6526,7 +6526,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:2,MERC:2,TC:2,Periphery:1</availability>
@@ -6589,7 +6589,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,FS.DMM:5,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:3+,FS:3+,DC:8</availability>
@@ -6790,7 +6790,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:1,FRR:3,CLAN:3,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:4,DC:1</availability>
+			<availability>FRR:3,CLAN:3,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,NIOPS:6,CGB:4</availability>
 			<model name='KGC-000'>
 				<availability>CS:5,FRR:8,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8</availability>
 			</model>
@@ -6843,9 +6843,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,DC.GHO:7,CHH:2,CDS:2,CSV:2,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:4,MERC:5,DC:5</availability>
+			<availability>CS:7,DC.GHO:7,FRR:4,CLAN:2,NIOPS:7,WOB:7,FS:4,MERC:5,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:5,MERC:5,DC:4</availability>
+				<availability>FS:5,MERC:5,DC:4</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:6,CS:5,DC.SL:4,CLAN:6,NIOPS:5,WOB:5,MERC.SI:6,FS:8,MERC:8,BAN:7</availability>
@@ -6957,7 +6957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:4,IS:2+,CCO:4,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,DC:2+</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:4,IS:2+,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,DC:2+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -7132,7 +7132,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5</availability>
@@ -7213,7 +7213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
+			<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,Periphery:4,CS:3-,OA:6,FWL:2,NIOPS:3-,DC:6</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -7365,7 +7365,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CSV:5,CLAN:4,IS:2+,CFM:5,BAN:6,CWIE:6,CDS:4,CW:5,CBS:5,CSJ:5,CJF:5,CGB:4</availability>
+			<availability>CHH:7,CSV:5,CLAN:4,IS:2+,CFM:5,BAN:6,CWIE:6,CW:5,CBS:5,CSJ:5,CJF:5</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:5</availability>
@@ -7415,7 +7415,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:5,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,SIC:5,FS:6,Periphery:7,TC:6,CS:3,OA:6,LA:6,FWL:8,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:5,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,SIC:5,Periphery:7,TC:6,CS:3,OA:6,FWL:8,NIOPS:3</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -7482,7 +7482,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
+			<availability>HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
 			<model name='LCF-R15'>
 				<availability>LA:2,General:2,Periphery.Deep:4,MERC:8,Periphery:2</availability>
 			</model>
@@ -7646,7 +7646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:6,CSJ:7,CJF:9,CGB:5</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:6,CSJ:7,CJF:9</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -7688,7 +7688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:8,IS:9,Periphery.Deep:8,WOB:9,MERC:9,CIR:8,Periphery:9,CS:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:4,General:6,Periphery.Deep:5,FS:4,DC:4,Periphery:6</availability>
 			</model>
@@ -7752,7 +7752,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:1,FRR:4,CLAN:1,IS:3,WOB:7,SIC:4,FS:6,TC:3,Periphery:1,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
+			<availability>CC:4,FRR:4,CLAN:1,IS:3,WOB:7,SIC:4,FS:6,TC:3,Periphery:1,CS:6,LA:5,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:4</availability>
 			</model>
@@ -7823,7 +7823,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>MERC.KH:2,CSR:4,CSV:2,CLAN:3,IS:1+,CFM:6,MERC:1+,CGS:4,BAN:3,CWIE:3,CSA:4,MERC.WD:3,CDS:4,CW:3,CBS:4,CNC:3,CSJ:8,CJF:4,CGB:5</availability>
+			<availability>MERC.KH:2,CSR:4,CSV:2,CLAN:3,IS:1+,CFM:6,MERC:1+,CGS:4,BAN:3,CSA:4,MERC.WD:3,CDS:4,CBS:4,CSJ:8,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 			</model>
@@ -7908,7 +7908,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:4,CC:5,HL:3,FRR:6,CLAN:4,IS:4,Periphery.Deep:5,WOB:5-,SIC:5,MERC:4,FS:3,CIR:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>CC:5,HL:3,FRR:6,CLAN:4,IS:4,Periphery.Deep:5,WOB:5-,SIC:5,MERC:4,FS:3,Periphery:4,CS:5-,LA:6,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
@@ -8593,7 +8593,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>LA:6,FS:6,MERC:2</availability>
 			<model name='NGS-4S'>
-				<availability>:0,HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
+				<availability>HL:6,LA:8,General:8,Periphery.Deep:6,FS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -8731,7 +8731,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:4,CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:4,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:3,FWL:9,MH:4,DC:4</availability>
+			<availability>MOC:4,CC:6,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:4,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:3,FWL:9,MH:4</availability>
 			<model name=''>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -8762,7 +8762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:3,FRR:4,CLAN:1,IS:4,Periphery.Deep:4,WOB:3-,SIC:4,FS:4,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
+			<availability>HL:3,CLAN:1,IS:4,Periphery.Deep:4,WOB:3-,CIR:5,Periphery:4,CWIE:2,CS:4-,CW:2,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:3,General:5,CLAN:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -8812,7 +8812,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>MOC:3,CC:3,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:3,SIC:3,MERC:4,TC:3,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:3,CC:3,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:3,SIC:3,MERC:4,TC:3,Periphery:2,CS:3-,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:3,IS:5,Periphery.Deep:8,MERC:5,BAN:1,Periphery:5</availability>
@@ -8960,7 +8960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:4,CC:5,HL:4,FRR:4,IS:5,Periphery.Deep:4,WOB:6,SIC:3,FS:7,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:5</availability>
+			<availability>MOC:4,HL:4,FRR:4,IS:5,Periphery.Deep:4,WOB:6,SIC:3,FS:7,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
@@ -9041,7 +9041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:8,CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,TC:8,CS:7-,OA:4,CDS:3,LA:6,FWL:6,DC:5</availability>
+			<availability>CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,CS:7-,OA:4,CDS:3,DC:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -9078,7 +9078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:8,WOB:5-,SIC:5,FS:6,CIR:3,Periphery:3,TC:3,CWIE:4,CS:5-,OA:3,LA:6,FWL:4,DC:6</availability>
+			<availability>HL:2,IS:4,Periphery.Deep:8,WOB:5-,SIC:5,FS:6,Periphery:3,CWIE:4,CS:5-,LA:6,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:7</availability>
@@ -9243,7 +9243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:5,HL:4,CLAN:1,IS:9,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:4,Periphery:5,CGB:1</availability>
+			<availability>CS:5,HL:4,CLAN:1,IS:9,NIOPS:5,Periphery.Deep:4,WOB:4,Periphery:5</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:4,BAN:6,Periphery:4</availability>
@@ -9294,7 +9294,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:6,CC:3,CHH:5,HL:2,FRR:4,CLAN:5,IS:4,WOB:5-,SIC:3,FS:4,MERC:4,CIR:3,CWIE:6,TC:4,Periphery:3,CS:5-,OA:4,MERC.WD:5,CDS:6,LA:3,CNC:6,FWL:3,MH:5,DC:4</availability>
+			<availability>MOC:6,CC:3,CHH:5,HL:2,CLAN:5,IS:4,WOB:5-,SIC:3,MERC:4,CWIE:6,TC:4,Periphery:3,CS:5-,OA:4,MERC.WD:5,CDS:6,LA:3,CNC:6,FWL:3,MH:5</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -9522,7 +9522,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:5,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CLAN:8,IS:1+,MERC:1+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:5,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
@@ -9604,7 +9604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,Periphery:4,TC:5,CS:3-,OA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4,OA:4,HL:2,Periphery.Deep:8,FWL:4,IS:4,Periphery:4,DC:4,TC:4</availability>
 			</model>
@@ -9779,7 +9779,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:4</availability>
+				<availability>General:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Red Shift' unitType='Mek'>
@@ -9806,7 +9806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:7,HL:9,FRR:6,CLAN:6,Periphery.Deep:9,IS:6,WOB:7,SIC:6,FS:7,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:8,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,CLAN:6,Periphery.Deep:9,IS:6,WOB:7,FS:7,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:8,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -9868,7 +9868,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,CCC:5,HL:3,FRR:7,CSV:5,IS:7,Periphery.Deep:5,WOB:5,CFM:5,SIC:7-,FS:8,CGS:5,Periphery:4,CS:5,CSA:5,FWL:7,NIOPS:5</availability>
+			<availability>CC:6,CCC:5,HL:3,CSV:5,IS:7,Periphery.Deep:5,WOB:5,CFM:5,SIC:7-,FS:8,CGS:5,Periphery:4,CS:5,CSA:5,NIOPS:5</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:3,DC:2</availability>
 			</model>
@@ -9999,7 +9999,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9,DC:2+</availability>
+			<availability>CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,MERC.WD:8,CDS:9,CBS:9,CNC:8,CSJ:9,CJF:9,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 			</model>
@@ -10071,7 +10071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,MERC:3-,Periphery:3-,OA:2-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -10123,7 +10123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,SIC:7,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
+			<availability>Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,Periphery:6,CS:5-,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -10184,7 +10184,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7-,Periphery.DD:7,HL:5,FRR:8-,IS:6-,Periphery.Deep:4,WOB:4,SIC:6-,Periphery.OS:7,FS:6-,CIR:6,Periphery:6,TC:5,CS:4,OA:7,CDS:5,FWL.MM:9,CW:3,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>MOC:5,CC:7-,Periphery.DD:7,HL:5,FRR:8-,IS:6-,Periphery.Deep:4,WOB:4,Periphery.OS:7,Periphery:6,TC:5,CS:4,OA:7,CDS:5,FWL.MM:9,CW:3,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10290,13 +10290,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,OA:3,HL:2,LA:2,IS:3,FWL:1,FS:1,TC:3,Periphery:3,DC:1</availability>
+			<availability>CC:1,HL:2,LA:2,IS:3,FWL:1,FS:1,Periphery:3,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,MERC:6,FS:6,CIR:7,Periphery:6,CS:5,OA:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -10307,7 +10307,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:7,CC:7,Periphery.DD:7,HL:5,FRR:9,IS:6,Periphery.Deep:4,WOB:4-,SIC:7,MERC:6,Periphery.OS:7,FS:5,CIR:6,Periphery:6,TC:7,CS:4-,OA:7,LA:6,FWL:5,DC:8</availability>
+			<availability>MOC:7,CC:7,Periphery.DD:7,HL:5,FRR:9,IS:6,Periphery.Deep:4,WOB:4-,SIC:7,MERC:6,Periphery.OS:7,FS:5,Periphery:6,TC:7,CS:4-,OA:7,FWL:5,DC:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10416,7 +10416,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:4,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
+			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:4,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -10524,7 +10524,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:4-,HL:5,LA:4,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
+			<availability>CS:4-,HL:5,LA:4,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,DC:4</availability>
 			</model>
@@ -10698,7 +10698,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:4,Periphery.DD:3,FRR:5,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>CC:4,Periphery.DD:3,FRR:5,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,Periphery:1,CS:3-,OA:2,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -10713,7 +10713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
+			<availability>Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
 			</model>
@@ -10802,7 +10802,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,NIOPS:3,DC:3</availability>
 			<model name='SPR-6D'>
 				<availability>FRR:5,FS:8,MERC:5</availability>
 			</model>
@@ -10851,7 +10851,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,SIC:4,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>MOC:2CC:4,FRR:5,IS:1,WOB:2,SIC:4,MERC:3,FS:4,Periphery:2,CS:3,OA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:5</availability>
@@ -10899,7 +10899,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:9,CC:6,HL:9,FRR:6,CLAN:3,IS:8,Periphery.Deep:9,WOB:4,SIC:6,FS:6,CIR:9,Periphery:10,TC:9,CS:5,OA:9,LA:8,FWL:9,NIOPS:5,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:9,FRR:6,CLAN:3,IS:8,Periphery.Deep:9,WOB:4,SIC:6,FS:6,CIR:9,Periphery:10,TC:9,CS:5,OA:9,FWL:9,NIOPS:5,DC:6</availability>
 			<model name='STK-3F'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -11035,7 +11035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,FRR:5,CLAN:1-,IS:8,Periphery.Deep:5,WOB:3-,SIC:8,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>HL:5,FRR:5,CLAN:1-,IS:8,Periphery.Deep:5,WOB:3-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
@@ -11054,7 +11054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,CS:3,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:4,LA:3,IS:4,FS:4,Periphery:4</availability>
 			</model>
@@ -11081,13 +11081,13 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -11177,7 +11177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:2,CLAN:4,SIC:4,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>FRR:2,CLAN:4,SIC:4,MERC:4,Periphery.OS:2,FS:8,Periphery:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:6,FS:8,MERC:6</availability>
 			</model>
@@ -11468,7 +11468,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CSJ:6,CJF:9,CGB:5</availability>
+			<availability>CIH:3,CLAN:5,IS:1+,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CSJ:6,CJF:9</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -11511,7 +11511,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CS:5,DC.GHO:2,CSA:2,CDS:1,CLAN:1,NIOPS:5,WOB:7,CCO:1,CJF:1,CGB:1,DC:1</availability>
+			<availability>CS:5,DC.GHO:2,CSA:2,CLAN:1,NIOPS:5,WOB:7,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:6,CLAN:6,NIOPS:6,BAN:6</availability>
 			</model>
@@ -11536,7 +11536,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -11605,7 +11605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:4-,OA:5,LA:6,FWL:5,NIOPS:4-,DC:5</availability>
+			<availability>HL:4,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,FS:6,Periphery:5,TC:6,CS:4-,LA:6,NIOPS:4-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:5</availability>
@@ -11620,7 +11620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:7,CCC:1-,HL:3,MERC.ELH:8,CLAN:1-,IS:7,Periphery.Deep:6,WOB:2-,CLAN.IS:1-,FS:6,MERC:7,CGS:1-,Periphery:4,TC:4,CS:3-,CSA:1-,MERC.WD:4,LA:7,NIOPS:3-,MH:4,DC:7</availability>
+			<availability>CCC:1-,HL:3,MERC.ELH:8,CLAN:1-,IS:7,Periphery.Deep:6,WOB:2-,CLAN.IS:1-,FS:6,MERC:7,CGS:1-,Periphery:4,CS:3-,CSA:1-,MERC.WD:4,NIOPS:3-</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2+,CLAN.IS:1-,FS:1,CGS:1-,DC:1+</availability>
 			</model>
@@ -11829,7 +11829,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,SIC:4,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3-,DC:4</availability>
+			<availability>MOC:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,FWL:7,NIOPS:3-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
@@ -11968,7 +11968,7 @@
 			<availability>CS:4,WOB:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Turk' unitType='AeroSpaceFighter' omni='Clan'>
@@ -12048,7 +12048,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:3,CCO:3,CWIE:4,MERC.WD:4,CDS:4,CW:4,CBS:6,CNC:3,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CSR:7,CSV:5,CLAN:3,CWIE:4,MERC.WD:4,CDS:4,CW:4,CBS:6,CSJ:4,CJF:7</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -12156,7 +12156,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,SIC:6-,Periphery:4-,TC:3-,CS:3-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:5,HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
@@ -12260,7 +12260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:2,CC:3,FRR:3,IS:1,WOB:5,SIC:2,FS:3,Periphery:1,TC:1,CS:5,OA:1,LA:3,FWL:3,NIOPS:5,DC:3</availability>
+			<availability>MOC:2,CC:3,FRR:3,IS:1,WOB:5,SIC:2,FS:3,Periphery:1,CS:5,LA:3,FWL:3,NIOPS:5,DC:3</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:6</availability>
@@ -12290,7 +12290,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:3,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:3-,CJF:2,DC:6</availability>
+			<availability>CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:3,SIC:6,FS:9,Periphery:4,CS:3-,LA:6,NIOPS:3-,CJF:2,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -12463,7 +12463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>General:6,FS:3</availability>
@@ -12604,7 +12604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name='H-7'>
 				<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
 			</model>
@@ -12756,7 +12756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:6,HL:4,FRR:6,IS:6,Periphery.Deep:5,WOB:3-,SIC:5,FS:7,Periphery:5,TC:5,CS:3-,LA:6,CNC:2,FWL:9,NIOPS:3-,MH:4,DC:6</availability>
+			<availability>HL:4,IS:6,Periphery.Deep:5,WOB:3-,SIC:5,FS:7,Periphery:5,CS:3-,CNC:2,FWL:9,NIOPS:3-,MH:4</availability>
 			<model name='WVR-6D'>
 				<availability>FS:1</availability>
 			</model>
@@ -12804,7 +12804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:4,CIH:2,FRR:5,CLAN:2,IS:4,CFM:3,WOB:4,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
+			<availability>FRR:5,CLAN:2,IS:4,CFM:3,WOB:4,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:4,WOB:3</availability>
@@ -12950,7 +12950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:5-,MERC:5,CIR:4,TC:3,Periphery:3,DC:3</availability>
+			<availability>CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:5-,MERC:5,CIR:4,Periphery:3,DC:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -12,8 +12,7 @@
 			<pctOmni>10,10</pctOmni>
 			<pctClan>30,30</pctClan>
 			<pctSL>60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:2,CSJ:2,CJF:2,CGB:2</salvage>
 		</faction>
 		<faction key='CDP' />
 		<faction key='CC'>
@@ -62,8 +61,7 @@
 			<pctSL>88,88,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2</salvage>
+			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:7,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CSJ:3,CJF:5,CGB:2</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -71,8 +69,7 @@
 			<pctSL>30,30,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:6,CSR:3,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:3</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:6,CSR:3,CSV:2,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:7,CSJ:10,CJF:3</salvage>
 			<weightDistribution era='3060' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='3060' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
@@ -82,8 +79,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:3,CSV:6,CCO:1,CGS:6,CSA:9,CDS:1,CW:3,CNC:3,CSJ:3,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:3,CSV:6,CCO:1,CGS:6,CSA:9,CDS:1,CW:3,CNC:3,CSJ:3,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CGB'>
 			<pctOmni>5,5,36,77,100</pctOmni>
@@ -101,8 +97,7 @@
 			<pctSL>90,90,40,30,10</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:1,CSR:1,CIH:4,CSV:3,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:4,CSV:3,CFM:5,CCO:2,CSA:3,CDS:3,CW:1,CNC:3,CSJ:1,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CHH'>
 			<pctOmni>5,5,30,80,90</pctOmni>
@@ -110,8 +105,7 @@
 			<pctSL>65,65,15,10,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,50,60</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,50,40</pctSL>
-			<salvage pct='10'>
-				CCC:1,CSR:2,CIH:7,CSV:2,CFM:4,CCO:1,CGS:3,CSA:2,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10</salvage>
+			<salvage pct='10'>CCC:1,CSR:2,CIH:7,CSV:2,CFM:4,CCO:1,CGS:3,CSA:2,CDS:3,CW:3,CBS:1,CNC:5,CSJ:8,CJF:3,CGB:10</salvage>
 		</faction>
 		<faction key='CIH'>
 			<pctOmni>0,0,7,90,100</pctOmni>
@@ -119,8 +113,7 @@
 			<pctSL>46,46,23,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:3,CSR:2,CSV:3,CFM:3,CCO:5,CGS:5,CSA:5,CDS:7,CW:4,CNC:2,CSJ:2,CJF:10,CGB:3</salvage>
+			<salvage pct='10'>CCC:1,CHH:3,CSR:2,CSV:3,CFM:3,CCO:5,CGS:5,CSA:5,CDS:7,CW:4,CNC:2,CSJ:2,CJF:10,CGB:3</salvage>
 			<weightDistribution era='3060' unitType='Mek'>5,4,2,1</weightDistribution>
 			<weightDistribution era='3060' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
@@ -146,8 +139,7 @@
 			<pctSL>0,0,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,45,45,45</pctClan>
 			<pctSL unitType='Vehicle'>88,88,55,55,55</pctSL>
-			<salvage pct='12'>
-				CCC:3,CHH:10,CSR:10,CIH:9,CSV:4,CFM:10,CCO:8,CGS:3,CSA:10,CW:1,CNC:8,CSJ:10,CJF:9</salvage>
+			<salvage pct='12'>CCC:3,CHH:10,CSR:10,CIH:9,CSV:4,CFM:10,CCO:8,CGS:3,CSA:10,CW:1,CNC:8,CSJ:10,CJF:9</salvage>
 		</faction>
 		<faction key='CSJ'>
 			<pctOmni>20,20,50,90,100</pctOmni>
@@ -163,8 +155,7 @@
 			<pctSL>20,20,0,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,45,45,45</pctClan>
 			<pctSL unitType='Vehicle'>88,88,55,55,55</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10</salvage>
+			<salvage pct='10'>CHH:1,CCC:2,CIH:3,CSV:7,CFM:7,CCO:7,CGS:2,CSA:3,CDS:3,CW:10,CNC:10,CSJ:1,CJF:10</salvage>
 		</faction>
 		<faction key='CSA'>
 			<pctOmni>18,18,25,100,100</pctOmni>
@@ -172,8 +163,7 @@
 			<pctSL>20,20,5,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,45,50,50</pctClan>
 			<pctSL unitType='Vehicle'>88,88,55,50,50</pctSL>
-			<salvage pct='10'>
-				CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:8,CGB:2</salvage>
+			<salvage pct='10'>CCC:3,CHH:1,CSR:1,CIH:5,CSV:3,CFM:10,CCO:3,CGS:3,CDS:2,CW:5,CNC:5,CSJ:3,CJF:8,CGB:2</salvage>
 		</faction>
 		<faction key='CSV'>
 			<pctOmni>40,40,84,98,100</pctOmni>
@@ -629,8 +619,7 @@
 			<pctSL>66,66,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CFM.FT'>
 			<pctOmni>0,0,5,85,100</pctOmni>
@@ -638,8 +627,7 @@
 			<pctSL>66,66,25,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CFM.Kl'>
 			<pctOmni>0,0,0,15,90</pctOmni>
@@ -647,8 +635,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CFM.MaC'>
 			<pctOmni>0,0,5,80,100</pctOmni>
@@ -656,8 +643,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CFM.MiKr'>
 			<pctOmni>0,0,10,65,100</pctOmni>
@@ -665,8 +651,7 @@
 			<pctSL>66,66,30,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CFM.P'>
 			<pctOmni>0,0,5,64,100</pctOmni>
@@ -674,8 +659,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='CFM.PBG' />
 		<faction key='CFM.S'>
@@ -684,8 +668,7 @@
 			<pctSL>66,66,33,0,0</pctSL>
 			<pctClan unitType='Vehicle'>12,12,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>88,88,60,60,60</pctSL>
-			<salvage pct='10'>
-				CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1</salvage>
+			<salvage pct='10'>CCC:1,CHH:2,CSR:3,CIH:6,CSV:4,CCO:4,CGS:6,CSA:8,CDS:3,CW:3,CNC:2,CSJ:4,CFM.P:8,CJF:10,CGB:1</salvage>
 		</faction>
 		<faction key='FWL.KIS'>
 			<pctOmni>20</pctOmni>
@@ -965,8 +948,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,SIC:4,FS:4,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
@@ -1014,8 +996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:4,FRR:3,CLAN:3,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:4,FRR:3,CLAN:3,IS:2,WOB:6,SIC:2,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:6</availability>
@@ -1026,8 +1007,7 @@
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CCC:2,CIH:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:1,CJF:6</availability>
+			<availability>CCC:2,CIH:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:1,CJF:6</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8,FWL:8</availability>
@@ -1126,8 +1106,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:3,BAN:2,CGB:2</availability>
+			<availability>CSA:2,MERC.KH:4,MERC.WD:6,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:3,BAN:2,CGB:2</availability>
 			<model name='ANH-1A'>
 				<availability>CLAN:1-,MERC:3</availability>
 			</model>
@@ -1221,8 +1200,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:5,HL:4,FRR:5,CLAN:1,IS:7,Periphery.Deep:5,WOB:2-,SIC:6,FS:6,Periphery:5,CS:4-,LA:7,FWL:7,NIOPS:4-,DC:6,CGB:1</availability>
+			<availability>CC:5,HL:4,FRR:5,CLAN:1,IS:7,Periphery.Deep:5,WOB:2-,SIC:6,FS:6,Periphery:5,CS:4-,LA:7,FWL:7,NIOPS:4-,DC:6,CGB:1</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:4,MERC.WD:4,CWIE:4</availability>
 			</model>
@@ -1340,8 +1318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1396,8 +1373,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:4-,CC:4-,FRR:1,IS:1,WOB:2-,MERC:1,FS:1,Periphery:2,TC:4-,CS:3-,OA:1,LA:1,FS.CMM:2-</availability>
+			<availability>MOC:4-,CC:4-,FRR:1,IS:1,WOB:2-,MERC:1,FS:1,Periphery:2,TC:4-,CS:3-,OA:1,LA:1,FS.CMM:2-</availability>
 			<model name='ASN-21'>
 				<availability>General:2</availability>
 			</model>
@@ -1460,8 +1436,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FRR:6,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:3,FWL:3,NIOPS:4-,CSJ:2-,DC:9</availability>
+			<availability>MOC:1,CC:2,FRR:6,CSV:2-,IS:3,WOB:4-,CFM:2,CLAN.IS:2,SIC:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,CW:2-,LA:3,FWL:3,NIOPS:4-,CSJ:2-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,SIC:2,MERC:1</availability>
 			</model>
@@ -1627,8 +1602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-8Q'>
 				<availability>HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -1844,8 +1818,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:8-,CC:3-,HL:8-,FRR:5-,IS:5-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:8-,MERC:5-,Periphery:9-,TC:8-,OA:8-,LA:7-,FWL:4-,MH:8-,DC:4-</availability>
+			<availability>MOC:8-,CC:3-,HL:8-,FRR:5-,IS:5-,Periphery.Deep:9-,SIC:6-,FS:6-,CIR:8-,MERC:5-,Periphery:9-,TC:8-,OA:8-,LA:7-,FWL:4-,MH:8-,DC:4-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:2,General:4,Periphery.Deep:8,MERC:4,Periphery:4</availability>
 			</model>
@@ -1974,8 +1947,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:1,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:7-,SIC:5,FS:5,Periphery:5,TC:5,CS:7-,DC.GHO:6,LA:7,PIR:5,FWL:8,NIOPS:7-,CJF:1,DC:5</availability>
 			<model name='BLR-1D'>
 				<availability>FS:5</availability>
 			</model>
@@ -2037,8 +2009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,DC:3+</availability>
+			<availability>CHH:6,CIH:6,CSV:8,CFM:7,CGS:6,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CSJ:6,CJF:7,CGB:6,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:8,General:7,CGS:3</availability>
 			</model>
@@ -2085,8 +2056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:5,HL:4,FRR:6,IS:5,WOB:5-,SIC:6,MERC:5,FS:8,Periphery:5,CS:5-,OA:6,CDS:3,LA:6,PIR:5,DC:7</availability>
+			<availability>CC:5,HL:4,FRR:6,IS:5,WOB:5-,SIC:6,MERC:5,FS:8,Periphery:5,CS:5-,OA:6,CDS:3,LA:6,PIR:5,DC:7</availability>
 			<model name=''>
 				<availability>General:8,DC:8</availability>
 			</model>
@@ -2135,8 +2105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CSR:3,CLAN:2,IS:2+,CFM:5,CGS:5,CCO:5,BAN:5,CWIE:5,CSA:5,MERC.WD:4,CDS:4,CW:5,CBS:2,CJF:5,CGB:4</availability>
+			<availability>CHH:6,CSR:3,CLAN:2,IS:2+,CFM:5,CGS:5,CCO:5,BAN:5,CWIE:5,CSA:5,MERC.WD:4,CDS:4,CW:5,CBS:2,CJF:5,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -2191,8 +2160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:6,FRR:3,CLAN:7,CFM:6,FS:3,CWIE:8,DC.GHO:3,OA:2,CDS:6,CBS:8,FWL:2,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:2,MERC:3,CGS:8,Periphery:2,TC:3,CS:7,CW:8,LA:2,CNC:8,CJF:6,DC:3</availability>
+			<availability>CHH:6,FRR:3,CLAN:7,CFM:6,FS:3,CWIE:8,DC.GHO:3,OA:2,CDS:6,CBS:8,FWL:2,NIOPS:7,CGB:8,CSR:6,CSV:6,WOB:7,FWL.OH:2,MERC:3,CGS:8,Periphery:2,TC:3,CS:7,CW:8,LA:2,CNC:8,CJF:6,DC:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:2</availability>
 			</model>
@@ -2392,8 +2360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,SIC:5,FS:6,MERC:6,Periphery:3,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,SIC:5,FS:6,MERC:6,Periphery:3,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -2432,8 +2399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
+			<availability>CC:4,HL:3,CM:6,IS:4,WOB:5,SIC:4,FS:7,CIR:4,Periphery:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2461,8 +2427,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:8,HL:4,FRR:7,IS:5,Periphery.Deep:7,SIC:8,FS:4,CIR:6,MERC:5,Periphery:5,TC:7,LA:4,FWL:4,DC:7</availability>
+			<availability>MOC:7,CC:8,HL:4,FRR:7,IS:5,Periphery.Deep:7,SIC:8,FS:4,CIR:6,MERC:5,Periphery:5,TC:7,LA:4,FWL:4,DC:7</availability>
 			<model name=''>
 				<availability>LA:6,General:8,FS:6,MERC:6,DC:6</availability>
 			</model>
@@ -2559,8 +2524,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:2,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -2585,8 +2549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:8,MOC:4,LA:3,Periphery.CM:3,Periphery.HR:3,Periphery.ME:3,MH:3,SIC:5,FS:5,MERC:4,TC:4,Periphery:2</availability>
+			<availability>CC:8,MOC:4,LA:3,Periphery.CM:3,Periphery.HR:3,Periphery.ME:3,MH:3,SIC:5,FS:5,MERC:4,TC:4,Periphery:2</availability>
 			<model name='CTF-1X'>
 				<availability>General:5,Periphery:6</availability>
 			</model>
@@ -2604,8 +2567,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,FRR:5,IS:1,SIC:2,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:4,DC:6</availability>
+			<availability>MOC:3,CC:4,FRR:5,IS:1,SIC:2,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:4,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:2,SIC:2</availability>
@@ -2763,8 +2725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:2,IS:3,WOB:2-,SIC:4,Periphery.OS:4,FS:9,MERC:3,Periphery:2,CS:2-,LA:5,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:6,IS:4,FS:6</availability>
 			</model>
@@ -2871,15 +2832,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:6,CHH:3,FRR:4,CLAN:3,IS:4,WOB:5,SIC:3,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:3,DC:5</availability>
+			<availability>CC:6,CHH:3,FRR:4,CLAN:3,IS:4,WOB:5,SIC:3,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:3,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CC:3,CHH:2,WOB:5,SIC:5,FS:4,MERC:5,BAN:4,DC.GHO:4,CS:5,LA:5,NIOPS:5,MERC.SI:5,DC:4,CGB:2</availability>
+				<availability>CC:3,CHH:2,WOB:5,SIC:5,FS:4,MERC:5,BAN:4,DC.GHO:4,CS:5,LA:5,NIOPS:5,MERC.SI:5,DC:4,CGB:2</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:4,CS:4,LA:4,IS:4,MERC:4</availability>
@@ -2949,8 +2908,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:3,WOB:6,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,SIC:3,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:3,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:3</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:5,HL:3,General:5,FWL:5,Periphery.Deep:8,MERC:5,Periphery:5</availability>
@@ -3281,8 +3239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,FS:5,MERC:5,CIR:4,TC:6,Periphery:3,Periphery.R:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1B'>
 				<roles>recon</roles>
 				<availability>LA:1</availability>
@@ -3310,8 +3267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:3,IS:3,WOB:3,SIC:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,LA:6,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6,General:7,FS:6,Periphery:7</availability>
 			</model>
@@ -3423,8 +3379,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
+			<availability>MOC:2,CC:1,FRR:2,CLAN:3,SIC:2,MERC:4,FS:8,CIR:2,Periphery:2,TC:2,OA:3,LA:7,FWL:1,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,BAN:4,Periphery:5</availability>
 			</model>
@@ -3493,8 +3448,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:3,CSR:3,FRR:4,CLAN:2,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:5</availability>
+			<availability>CHH:3,CSR:3,FRR:4,CLAN:2,CFM:3,WOB:5,CGS:4,CWIE:4,CS:5,DC.GHO:5,CDS:4,CW:4,CBS:4,NIOPS:5,CJF:3,CGB:3,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>IS:1,Periphery.Deep:8,NIOPS:0,Periphery:1</availability>
@@ -3530,8 +3484,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:5,FRR:5,CSV:5,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
+			<availability>CHH:7,CSR:5,FRR:5,CSV:5,CLAN:6,CFM:5,WOB:8,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:8,NIOPS:9,CJF:5,CGB:7</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:5,NIOPS:0</availability>
 			</model>
@@ -3634,8 +3587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+			<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:5,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -3720,8 +3672,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,IS:2+,FS:2+,MERC:2+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:2+,CNC:5,CSJ:8,CJF:5,CGB:5,DC:2+</availability>
+			<availability>CLAN:4,IS:2+,FS:2+,MERC:2+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:2+,CNC:5,CSJ:8,CJF:5,CGB:5,DC:2+</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -3800,8 +3751,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CCC:5,CIH:5,CLAN:4,IS:2+,CLAN.IS:4,MERC:2+,CCO:3,BAN:4,CSA:3,MERC.WD:5,CDS:5,CJF:4,CGB:8</availability>
+			<availability>CHH:7,CCC:5,CIH:5,CLAN:4,IS:2+,CLAN.IS:4,MERC:2+,CCO:3,BAN:4,CSA:3,MERC.WD:5,CDS:5,CJF:4,CGB:8</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -3840,8 +3790,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,TC:9,Periphery:10,CS:6,OA:9,LA:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,SIC:9,FS:9,CIR:9,CWIE:6,TC:9,Periphery:10,CS:6,OA:9,LA:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,SIC:4,FS:4,TC:4,DC:4</availability>
@@ -3892,8 +3841,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:3,FRR:3,IS:3,Periphery.Deep:5,SIC:3,FS:5,MERC:3,Periphery.OS:4,Periphery:4,TC:4,OA:4,LA:3,Periphery.HR:4,DC:3</availability>
+			<availability>MOC:4,CC:4,HL:3,FRR:3,IS:3,Periphery.Deep:5,SIC:3,FS:5,MERC:3,Periphery.OS:4,Periphery:4,TC:4,OA:4,LA:3,Periphery.HR:4,DC:3</availability>
 			<model name='DV-6M'>
 				<availability>HL:5,CLAN:4,IS:5-,Periphery.Deep:7,Periphery:7</availability>
 			</model>
@@ -3905,8 +3853,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:5,FWL:3,MH:5,DC:3</availability>
+			<availability>MOC:5,CC:3,FRR:3,IS:3,SIC:5,MERC:5,FS:5,CIR:4,Periphery:5,TC:5,OA:5,LA:5,FWL:3,MH:5,DC:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3982,8 +3929,7 @@
 				<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
 			</model>
 			<model name='E'>
 				<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
@@ -4012,8 +3958,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,MERC:3,FS:6,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,CC.MAC:4,DC:3</availability>
+			<availability>CC:3,HL:2,FRR:4,IS:3,WOB:3,SIC:2,MERC:3,FS:6,CC.CHG:4,Periphery:3,CS:3,LA:7,FWL:3,CC.MAC:4,DC:3</availability>
 			<model name=''>
 				<availability>CC:5,General:6</availability>
 			</model>
@@ -4058,8 +4003,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:3,IS:3,WOB:3-,SIC:4,FS:5,CIR:4,Periphery:3,TC:3,CS:3-,OA:3,LA:4,FWL:5,NIOPS:3-,DC:4</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:2,FS:2</availability>
@@ -4138,11 +4082,9 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,CLAN:2,IS:3,WOB:7,SIC:2,MERC:3,TC:3,CS:7,LA:3,CNC:4,FWL:3,NIOPS:7,DC:3</availability>
+			<availability>CC:3,MOC:3,CLAN:2,IS:3,WOB:7,SIC:2,MERC:3,TC:3,CS:7,LA:3,CNC:4,FWL:3,NIOPS:7,DC:3</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
+				<availability>CC:8,CS:8,HL:6,LA:8,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:8,FS:8,BAN:4,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -4172,8 +4114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>
-				OA:3,LA:5,Periphery.HR:3,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:3,TC:3,DC:3,Periphery:2</availability>
+			<availability>OA:3,LA:5,Periphery.HR:3,MH:2,SIC:3,FS:9,MERC:5,Periphery.OS:3,TC:3,DC:3,Periphery:2</availability>
 			<model name='ENF-4R'>
 				<availability>LA:2,General:5,FS:5,TC:5</availability>
 			</model>
@@ -4249,8 +4190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,SIC:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:2,MERC:2</availability>
 			</model>
@@ -4430,8 +4370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:2+,CHH:5,CIH:7,CSV:5,CLAN:3,IS:2+,CWIE:8,MERC.WD:7,CDS:4,CW:8,CNC:3,CSJ:4,CJF:6,CGB:5</availability>
+			<availability>MERC.KH:2+,CHH:5,CIH:7,CSV:5,CLAN:3,IS:2+,CWIE:8,MERC.WD:7,CDS:4,CW:8,CNC:3,CSJ:4,CJF:6,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CSJ:5,CJF:7</availability>
 			</model>
@@ -4455,8 +4394,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:5,HL:5,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:7</availability>
+			<availability>Periphery.R:5,HL:5,LA:5,Periphery.HR:5,Periphery.MW:5,Periphery.CM:5,FWL:5,SIC:5,FS:7</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:8</availability>
@@ -4698,8 +4636,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
+			<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:6,CBS:3,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:4,LA:4</availability>
 			</model>
@@ -4741,8 +4678,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:3,MERC:4,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:3,MERC:4,CIR:4,Periphery:4,TC:4</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:2,CM:4</availability>
@@ -4896,8 +4832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,SIC:3,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:6,General:8,FWL:6,WOB:6</availability>
@@ -4927,16 +4862,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:5,SIC:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>
-					MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
+				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:3,CS:5,OA:3,LA:5,FWL:7,DC:3</availability>
 			</model>
 			<model name='GAL-200'>
 				<availability>MOC:2,LA:2,FRR:2,IS:1,DC:2,Periphery:2</availability>
@@ -4973,8 +4906,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:3,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:3,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:6</availability>
@@ -5076,8 +5008,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,IS:1,WOB:2,FS:2,MERC:2,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
+			<availability>MOC:1,CC:2,IS:1,WOB:2,FS:2,MERC:2,TC:1,Periphery:1,CS:1,OA:1,MERC.WD:1,LA:4,Periphery.MW:1,FWL:5</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:4,HL:2,LA:6,FWL:4,Periphery.Deep:8,IS:4,MERC:4,Periphery:4</availability>
@@ -5131,14 +5062,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6</availability>
+			<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:6,FWL:6,MH:6,MERC:6</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
+				<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:4,BAN:2</availability>
@@ -5188,8 +5117,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,IS:3,WOB:5,FWL.KIS:8,SIC:3,FS:4,MERC:4,CS:3,Periphery.MW:2,FWL:7,MH:2,DC:4</availability>
+			<availability>CC:4,MOC:4,IS:3,WOB:5,FWL.KIS:8,SIC:3,FS:4,MERC:4,CS:3,Periphery.MW:2,FWL:7,MH:2,DC:4</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:6,General:6,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 			</model>
@@ -5198,8 +5126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -5302,8 +5229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:3,CC:6,HL:4,CLAN:1,IS:7,Periphery.Deep:6,WOB:2,SIC:6,MERC:8,TC:6,Periphery:5,CS:2,OA:2,LA:7,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:3,CC:6,HL:4,CLAN:1,IS:7,Periphery.Deep:6,WOB:2,SIC:6,MERC:8,TC:6,Periphery:5,CS:2,OA:2,LA:7,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1DS'>
 				<availability>LA:5,FRR:5,FS:7,MERC:5,DC:6</availability>
 			</model>
@@ -5396,8 +5322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:5,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
+			<availability>CC:5,CHH:4,CSR:4,FRR:4,IS:2,WOB:7,FS:5,MERC:3,Periphery:2,DC.GHO:6,CS:7,FWL:5,NIOPS:7,DC:4</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:6,MERC.SI:8,BAN:8,DC:8</availability>
@@ -5563,8 +5488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:4,WOB:5,MERC:5,Periphery:5,CS:5,FWL.pm:7,LA:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,FWL:7,MH:5,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:4,WOB:5,MERC:5,Periphery:5,CS:5,FWL.pm:7,LA:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,FWL:7,MH:5,DC:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5636,8 +5560,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:2,DC:4</availability>
+			<availability>Periphery.R:3,MERC.KH:4,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:2,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>LA:4,TC.PL:6,MERC:4,FS:4,Periphery:4</availability>
@@ -5718,15 +5641,13 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				CC:2,MOC:8,HL:4,MERC:4,Periphery.OS:5,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
+			<availability>CC:2,MOC:8,HL:4,MERC:4,Periphery.OS:5,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2:3062,MOC:2:3062,MERC.KH:2-,MERC.WD:2-,IS:3,FS:3:3062,MERC:2,DC:4-,Periphery:3,TC:2,BAN:2</availability>
+			<availability>CC:2:3062,MOC:2:3062,MERC.KH:2-,MERC.WD:2-,IS:3,FS:3:3062,MERC:2,DC:4-,Periphery:3,TC:2,BAN:2</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,TC:7,Periphery:6</availability>
 			</model>
@@ -5977,8 +5898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,SIC:8,MERC:3,Periphery:3,CWIE:3</availability>
+			<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,SIC:8,MERC:3,Periphery:3,CWIE:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6094,8 +6014,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,MERC.WD:6,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2</availability>
+			<availability>MOC:2,MERC.WD:6,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:5</availability>
@@ -6137,8 +6056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:4,FRR:6,IS:4,Periphery.Deep:5,WOB:3-,SIC:5,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5,CGB:2-</availability>
+			<availability>MOC:4,CC:5,HL:4,FRR:6,IS:4,Periphery.Deep:5,WOB:3-,SIC:5,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -6189,8 +6107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:7,MERC:6,FS:7,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:7</availability>
@@ -6408,8 +6325,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:5</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,SIC:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:5</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:6</availability>
@@ -6420,11 +6336,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -6489,8 +6403,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,FRR:4,WOB:4,SIC:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -6511,8 +6424,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:5,MOC:4,CC:2,DC.LV:6,HL:3,FRR:4,DC.GR:6,FS.AH:5,IS:4,Periphery.Deep:5,WOB:4-,SIC:2,FS:3,CIR:4,Periphery:4,TC:6,CS:3-,OA:4,LA:5,FWL:2,NIOPS:3-,DC:4</availability>
+			<availability>FS.DLC:5,MOC:4,CC:2,DC.LV:6,HL:3,FRR:4,DC.GR:6,FS.AH:5,IS:4,Periphery.Deep:5,WOB:4-,SIC:2,FS:3,CIR:4,Periphery:4,TC:6,CS:3-,OA:4,LA:5,FWL:2,NIOPS:3-,DC:4</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -6580,8 +6492,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,OA:2,LA:5,Periphery.CM:2,Periphery.HR:3,PIR:2,Periphery.ME:2,FWL:3,NIOPS:3,MH:4,DC:3</availability>
+			<availability>CC:5,MOC:3,FRR:5,IS:3,WOB:3,SIC:7,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,OA:2,LA:5,Periphery.CM:2,Periphery.HR:3,PIR:2,Periphery.ME:2,FWL:3,NIOPS:3,MH:4,DC:3</availability>
 			<model name='JM6-A'>
 				<roles>anti_aircraft</roles>
 				<availability>FS:2-</availability>
@@ -6615,8 +6526,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
+			<availability>MOC:4,OA:4,HL:3,LA:5,Periphery.HR:6,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:2,MERC:2,TC:2,Periphery:1</availability>
@@ -6679,8 +6589,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
+			<availability>CC:3,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,SIC:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:3+,FS:3+,DC:8</availability>
@@ -6881,8 +6790,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:1,FRR:3,CLAN:3,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:4,DC:1</availability>
+			<availability>CC:1,FRR:3,CLAN:3,IS:1,WOB:6,FS:4,MERC:2,CGS:5,DC.GHO:6,CS:6,LA:1,FWL:1,NIOPS:6,CGB:4,DC:1</availability>
 			<model name='KGC-000'>
 				<availability>CS:5,FRR:8,CLAN:6,NIOPS:5,WOB:5,BAN:8,DC:8</availability>
 			</model>
@@ -7049,8 +6957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:8,CLAN:4,IS:2+,CCO:4,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,DC:2+</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:4,IS:2+,CCO:4,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CSJ:9,CJF:6,DC:2+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -7225,8 +7132,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,SIC:7,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5</availability>
@@ -7263,8 +7169,7 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:6,OA:5,HL:3,Periphery.CM:6,Periphery.MW:5,Periphery.HR:6,Periphery.ME:6,MH:6,CIR:5,Periphery.OS:5,TC:7,Periphery:4</availability>
+			<availability>MOC:6,OA:5,HL:3,Periphery.CM:6,Periphery.MW:5,Periphery.HR:6,Periphery.ME:6,MH:6,CIR:5,Periphery.OS:5,TC:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7308,8 +7213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
+			<availability>MOC:6,CC:5,HL:3,FRR:5,CLAN:2,IS:4,WOB:3-,SIC:7,FS:4,Periphery:4,TC:4,CS:3-,OA:6,LA:4,FWL:2,NIOPS:3-,DC:6</availability>
 			<model name='LTN-G15'>
 				<availability>General:8</availability>
 			</model>
@@ -7490,8 +7394,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:1,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2</availability>
+			<availability>CCC:1,CHH:3,CSR:4,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:1,MERC.WD:2,CDS:2,CW:1,CBS:1,CNC:3,CSJ:2,CGB:2</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -7512,8 +7415,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:6,CC:5,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,SIC:5,FS:6,Periphery:7,TC:6,CS:3,OA:6,LA:6,FWL:8,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:5,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,SIC:5,FS:6,Periphery:7,TC:6,CS:3,OA:6,LA:6,FWL:8,NIOPS:3,DC:6</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -7580,8 +7482,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
+			<availability>MOC:2,HL:4,FRR:4,SIC:4,FS:5,MERC:4,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:3,LA:9,Periphery.MW:3</availability>
 			<model name='LCF-R15'>
 				<availability>LA:2,General:2,Periphery.Deep:4,MERC:8,Periphery:2</availability>
 			</model>
@@ -7658,8 +7559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:3,CIH:4,CLAN:5,WOB:1:3062,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:9,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6</availability>
+			<availability>CHH:3,CIH:4,CLAN:5,WOB:1:3062,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:9,CDS:6,CW:9,CBS:4,CSJ:6,CJF:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -7746,8 +7646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CIH:9,CSV:8,CLAN:5,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:6,CSJ:7,CJF:9,CGB:5</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:5,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:6,CSJ:7,CJF:9,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -7789,8 +7688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
+			<availability>MOC:8,CC:8,HL:8,FRR:9,IS:9,Periphery.Deep:8,WOB:9,SIC:9,MERC:9,FS:9,CIR:8,Periphery:9,TC:9,CS:9,OA:9,LA:9,FWL:8,NIOPS:9,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:4,General:6,Periphery.Deep:5,FS:4,DC:4,Periphery:6</availability>
 			</model>
@@ -7854,8 +7752,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:1,FRR:4,CLAN:1,IS:3,WOB:7,SIC:4,FS:6,TC:3,Periphery:1,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
+			<availability>CC:4,MOC:1,FRR:4,CLAN:1,IS:3,WOB:7,SIC:4,FS:6,TC:3,Periphery:1,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:4</availability>
 			</model>
@@ -7907,8 +7804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,Periphery.CM:3,Periphery.HR:3,Periphery.ME:2,MH:3,NCR:6,TC:4,Periphery:2</availability>
+			<availability>MOC:4,CC:4,Periphery.CM:3,Periphery.HR:3,Periphery.ME:2,MH:3,NCR:6,TC:4,Periphery:2</availability>
 			<model name='MHL-2L'>
 				<availability>CC:4,MOC:3,TC:3</availability>
 			</model>
@@ -7927,8 +7823,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:2,CSR:4,CSV:2,CLAN:3,IS:1+,CFM:6,MERC:1+,CGS:4,BAN:3,CWIE:3,CSA:4,MERC.WD:3,CDS:4,CW:3,CBS:4,CNC:3,CSJ:8,CJF:4,CGB:5</availability>
+			<availability>MERC.KH:2,CSR:4,CSV:2,CLAN:3,IS:1+,CFM:6,MERC:1+,CGS:4,BAN:3,CWIE:3,CSA:4,MERC.WD:3,CDS:4,CW:3,CBS:4,CNC:3,CSJ:8,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CSJ:6,CGB:5</availability>
 			</model>
@@ -8013,8 +7908,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:4,CC:5,HL:3,FRR:6,CLAN:4,IS:4,Periphery.Deep:5,WOB:5-,SIC:5,MERC:4,FS:3,CIR:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>MOC:4,CC:5,HL:3,FRR:6,CLAN:4,IS:4,Periphery.Deep:5,WOB:5-,SIC:5,MERC:4,FS:3,CIR:4,Periphery:4,TC:4,CS:5-,OA:4,LA:6,FWL:5,NIOPS:5-,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:4,IS:6,Periphery.Deep:6,Periphery:6</availability>
@@ -8173,8 +8067,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2,SIC:4</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,SIC:4,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -8231,8 +8124,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:5,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:5,Periphery:4</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:5,CLAN:5,IS:5,Periphery.Deep:2,NIOPS:5,WOB:5,MERC:5,Periphery:4</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -8288,11 +8180,9 @@
 			</model>
 		</chassis>
 		<chassis name='Minotaur' unitType='ProtoMek'>
-			<availability>
-				CSA:4,CHH:6,CCC:6:3062,CIH:3:3062,CSR:3:3062,CBS:4:3062,CSV:4:3062,CSJ:5,CFM:3:3062,CGS:4</availability>
+			<availability>CSA:4,CHH:6,CCC:6:3062,CIH:3:3062,CSR:3:3062,CBS:4:3062,CSV:4:3062,CSJ:5,CFM:3:3062,CGS:4</availability>
 			<model name=''>
-				<availability>
-					CSA:4,CHH:6,CCC:6:3062,CIH:3:3062,CSR:3:3062,CBS:4:3062,CSV:4:3062,CSJ:8,CFM:3:3062,CGS:4</availability>
+				<availability>CSA:4,CHH:6,CCC:6:3062,CIH:3:3062,CSR:3:3062,CBS:4:3062,CSV:4:3062,CSJ:8,CFM:3:3062,CGS:4</availability>
 			</model>
 			<model name='2'>
 				<availability>CSA:4,CHH:6,CCC:4,CGS:4</availability>
@@ -8841,8 +8731,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:4,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:3,FWL:9,MH:4,DC:4</availability>
+			<availability>MOC:4,CC:6,FRR:4,IS:4,SIC:7,MERC:4,FS:7,CIR:4,TC:4,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:3,FWL:9,MH:4,DC:4</availability>
 			<model name=''>
 				<availability>HL:4,General:6,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -8873,8 +8762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:3,FRR:4,CLAN:1,IS:4,Periphery.Deep:4,WOB:3-,SIC:4,FS:4,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
+			<availability>MOC:4,CC:4,HL:3,FRR:4,CLAN:1,IS:4,Periphery.Deep:4,WOB:3-,SIC:4,FS:4,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:4-,DC:5</availability>
 			<model name='ON1-K'>
 				<availability>HL:3,General:5,CLAN:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -8924,8 +8812,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:3,SIC:3,MERC:4,TC:3,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:3,CC:3,FRR:5,CLAN:2-,IS:4,Periphery.Deep:4,WOB:3,SIC:3,MERC:4,TC:3,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:3,IS:5,Periphery.Deep:8,MERC:5,BAN:1,Periphery:5</availability>
@@ -9018,8 +8905,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,SIC:6,FS:6,CIR:5,BAN:4,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:6,BAN:1</availability>
@@ -9074,16 +8960,14 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:4,CC:5,HL:4,FRR:4,IS:5,Periphery.Deep:4,WOB:6,SIC:3,FS:7,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:5</availability>
+			<availability>MOC:4,CC:5,HL:4,FRR:4,IS:5,Periphery.Deep:4,WOB:6,SIC:3,FS:7,CIR:5,FS.CrMM:7,Periphery:5,TC:4,CS:6,OA:4,LA:7,FS.CMM:7,FS.DMM:7,FWL:5,NIOPS:6,DC:5</availability>
 			<model name='PKR-T5'>
 				<roles>recon,raider</roles>
 				<availability>HL:3,General:8,Periphery.Deep:6,Periphery:5</availability>
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,MERC.KH:2,FRR:2,IS:2,Periphery.Deep:6,SIC:2,MERC:2,FS:2,Periphery:3,PIR:2,General:2,FWL:2,DC:2</availability>
+				<availability>CC:2,MERC.KH:2,FRR:2,IS:2,Periphery.Deep:6,SIC:2,MERC:2,FS:2,Periphery:3,PIR:2,General:2,FWL:2,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -9106,8 +8990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
+			<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:10,WOB:2,SIC:2,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,MERC:5,DC:9</availability>
@@ -9158,8 +9041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:8,CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,TC:8,CS:7-,OA:4,CDS:3,LA:6,FWL:6,DC:5</availability>
+			<availability>MOC:8,CC:5,HL:7,FRR:5,IS:6,Periphery.Deep:8,WOB:7,SIC:7,FS:7,CIR:5,Periphery:8,TC:8,CS:7-,OA:4,CDS:3,LA:6,FWL:6,DC:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -9196,8 +9078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:8,WOB:5-,SIC:5,FS:6,CIR:3,Periphery:3,TC:3,CWIE:4,CS:5-,OA:3,LA:6,FWL:4,DC:6</availability>
+			<availability>MOC:3,CC:4,HL:2,FRR:4,IS:4,Periphery.Deep:8,WOB:5-,SIC:5,FS:6,CIR:3,Periphery:3,TC:3,CWIE:4,CS:5-,OA:3,LA:6,FWL:4,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:7</availability>
@@ -9413,8 +9294,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:6,CC:3,CHH:5,HL:2,FRR:4,CLAN:5,IS:4,WOB:5-,SIC:3,FS:4,MERC:4,CIR:3,CWIE:6,TC:4,Periphery:3,CS:5-,OA:4,MERC.WD:5,CDS:6,LA:3,CNC:6,FWL:3,MH:5,DC:4</availability>
+			<availability>MOC:6,CC:3,CHH:5,HL:2,FRR:4,CLAN:5,IS:4,WOB:5-,SIC:3,FS:4,MERC:4,CIR:3,CWIE:6,TC:4,Periphery:3,CS:5-,OA:4,MERC.WD:5,CDS:6,LA:3,CNC:6,FWL:3,MH:5,DC:4</availability>
 			<model name=''>
 				<availability>HL:6,IS:8,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -9497,8 +9377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Po Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:4,WOB:5,SIC:5,MERC:5,Periphery:2,TC:4</availability>
+			<availability>MOC:5,CC:7,Periphery.CM:3,Periphery.ME:3,FWL:4,WOB:5,SIC:5,MERC:5,Periphery:2,TC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -9507,8 +9386,7 @@
 			</model>
 		</chassis>
 		<chassis name='Potemkin Troop Cruiser' unitType='Warship'>
-			<availability>
-				CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CWIE:1,CSA:1,CS:1,CDS:5,NIOPS:1,CSJ:1</availability>
+			<availability>CHH:1,CCC:2,CIH:1,CSR:5,CSV:2,CFM:1,CGS:4,CCO:2,CWIE:1,CSA:1,CS:1,CDS:5,NIOPS:1,CSJ:1</availability>
 			<model name='(2611)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -9644,8 +9522,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:5,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
+			<availability>CSR:8,CLAN:8,IS:1+,CFM:8,MERC:1+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:5,CDS:9,CW:9,CBS:7,CNC:9,CSJ:7,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CSJ:8,CWIE:6,CGB:5</availability>
@@ -9727,8 +9604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,SIC:3,FS:3,CIR:4,Periphery:4,TC:5,CS:3-,OA:5,LA:5,FWL:8,NIOPS:3-,DC:6</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4,OA:4,HL:2,Periphery.Deep:8,FWL:4,IS:4,Periphery:4,DC:4,TC:4</availability>
 			</model>
@@ -9930,8 +9806,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,HL:9,FRR:6,CLAN:6,Periphery.Deep:9,IS:6,WOB:7,SIC:6,FS:7,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:8,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,FRR:6,CLAN:6,Periphery.Deep:9,IS:6,WOB:7,SIC:6,FS:7,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:8,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -9953,8 +9828,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,WOB:6,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,WOB:6,SIC:4,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,LA:5,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>CC:5,HL:3,LA:2,FRR:2,FWL:5,Periphery.Deep:8,SIC:5,MERC:5,DC:2,Periphery:5</availability>
 			</model>
@@ -9994,8 +9868,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:6,CCC:5,HL:3,FRR:7,CSV:5,IS:7,Periphery.Deep:5,WOB:5,CFM:5,SIC:7-,FS:8,CGS:5,Periphery:4,CS:5,CSA:5,FWL:7,NIOPS:5</availability>
+			<availability>CC:6,CCC:5,HL:3,FRR:7,CSV:5,IS:7,Periphery.Deep:5,WOB:5,CFM:5,SIC:7-,FS:8,CGS:5,Periphery:4,CS:5,CSA:5,FWL:7,NIOPS:5</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:3,DC:2</availability>
 			</model>
@@ -10061,11 +9934,9 @@
 			</model>
 		</chassis>
 		<chassis name='Roc' unitType='ProtoMek'>
-			<availability>
-				CCC:2:3062,CHH:4,CSR:5:3062,CBS:5:3062,CNC:6:3062,CFM:3:3062,CSJ:5,CGS:5,CCO:6,CWIE:6</availability>
+			<availability>CCC:2:3062,CHH:4,CSR:5:3062,CBS:5:3062,CNC:6:3062,CFM:3:3062,CSJ:5,CGS:5,CCO:6,CWIE:6</availability>
 			<model name=''>
-				<availability>
-					CCC:2:3062,CHH:6,CSR:5:3062,CBS:5:3062,CNC:6:3062,CFM:3:3062,CSJ:7,CCO:6,CGS:5,CWIE:6</availability>
+				<availability>CCC:2:3062,CHH:6,CSR:5:3062,CBS:5:3062,CNC:6:3062,CFM:3:3062,CSJ:7,CCO:6,CGS:5,CWIE:6</availability>
 			</model>
 			<model name='2'>
 				<availability>CCC:4,CSR:6,CBS:6,CNC:4,CFM:6,CCO:6,CGS:4</availability>
@@ -10128,8 +9999,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9,DC:2+</availability>
+			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,MERC:1+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CW:8,CBS:9,CNC:8,CSJ:9,CJF:9,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CSJ:7,CJF:5,CGB:3</availability>
 			</model>
@@ -10201,8 +10071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
+			<availability>CC:2-,MOC:3-,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,SIC:2-,FS:3-,MERC:3-,Periphery:3-,OA:2-,LA:3-,FWL:2-,DC:4-</availability>
 			<model name='SB-27'>
 				<availability>General:8</availability>
 			</model>
@@ -10254,8 +10123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,SIC:7,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
+			<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,SIC:7,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -10316,8 +10184,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7-,Periphery.DD:7,HL:5,FRR:8-,IS:6-,Periphery.Deep:4,WOB:4,SIC:6-,Periphery.OS:7,FS:6-,CIR:6,Periphery:6,TC:5,CS:4,OA:7,CDS:5,FWL.MM:9,CW:3,LA:6-,FWL:8-,DC:8-</availability>
+			<availability>MOC:5,CC:7-,Periphery.DD:7,HL:5,FRR:8-,IS:6-,Periphery.Deep:4,WOB:4,SIC:6-,Periphery.OS:7,FS:6-,CIR:6,Periphery:6,TC:5,CS:4,OA:7,CDS:5,FWL.MM:9,CW:3,LA:6-,FWL:8-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10342,17 +10209,14 @@
 			</model>
 		</chassis>
 		<chassis name='Satyr' unitType='ProtoMek'>
-			<availability>
-				CCC:2:3062,CSR:2:3062,CIH:5:3062,CBS:4:3062,CNC:2,CSJ:5,CFM:2:3062,CGS:5,CCO:5,CWIE:5</availability>
+			<availability>CCC:2:3062,CSR:2:3062,CIH:5:3062,CBS:4:3062,CNC:2,CSJ:5,CFM:2:3062,CGS:5,CCO:5,CWIE:5</availability>
 			<model name=''>
 				<roles>recon,raider</roles>
-				<availability>
-					CCC:6:3062,CIH:5:3062,CSR:2:3062,CBS:4:3062,CNC:6,CFM:2:3062,CSJ:8,CCO:5,CGS:5,CWIE:5</availability>
+				<availability>CCC:6:3062,CIH:5:3062,CSR:2:3062,CBS:4:3062,CNC:6,CFM:2:3062,CSJ:8,CCO:5,CGS:5,CWIE:5</availability>
 			</model>
 			<model name='2'>
 				<roles>recon,raider</roles>
-				<availability>
-					CCC:2:3062,CIH:5:3062,CSR:2:3062,CBS:4:3062,CNC:4,CFM:2:3062,CCO:5,CGS:5,CWIE:5</availability>
+				<availability>CCC:2:3062,CIH:5:3062,CSR:2:3062,CBS:4:3062,CNC:4,CFM:2:3062,CCO:5,CGS:5,CWIE:5</availability>
 			</model>
 			<model name='3'>
 				<roles>recon,raider</roles>
@@ -10432,8 +10296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,IS:6,Periphery.Deep:5,WOB:5,SIC:6,MERC:6,FS:6,CIR:7,Periphery:6,TC:6,CS:5,OA:7,LA:6,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -10444,8 +10307,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:7,Periphery.DD:7,HL:5,FRR:9,IS:6,Periphery.Deep:4,WOB:4-,SIC:7,MERC:6,Periphery.OS:7,FS:5,CIR:6,Periphery:6,TC:7,CS:4-,OA:7,LA:6,FWL:5,DC:8</availability>
+			<availability>MOC:7,CC:7,Periphery.DD:7,HL:5,FRR:9,IS:6,Periphery.Deep:4,WOB:4-,SIC:7,MERC:6,Periphery.OS:7,FS:5,CIR:6,Periphery:6,TC:7,CS:4-,OA:7,LA:6,FWL:5,DC:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10458,8 +10320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,HL:6,LA:6,FRR:9,FWL:6,IS:7,Periphery.Deep:7,SIC:6,FS:6,CJF:4,DC:6,Periphery:7</availability>
+			<availability>CC:6,HL:6,LA:6,FRR:9,FWL:6,IS:7,Periphery.Deep:7,SIC:6,FS:6,CJF:4,DC:6,Periphery:7</availability>
 			<model name=''>
 				<availability>General:7</availability>
 			</model>
@@ -10477,8 +10338,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,SIC:2-,MERC:2-,Periphery:3-,CS:2-,LA:2,FWL:2-,NIOPS:2-,DC:2-</availability>
+			<availability>CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,SIC:2-,MERC:2-,Periphery:3-,CS:2-,LA:2,FWL:2-,NIOPS:2-,DC:2-</availability>
 			<model name='SCP-12S'>
 				<availability>LA:4,MERC:2</availability>
 			</model>
@@ -10505,8 +10365,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:3,CCC:3,CIH:3,CSR:3,CSV:3,CFM:3,CGS:3,CCO:4,CWIE:4,CSA:3,CW:4,CNC:3,CSJ:3,CJF:7</availability>
+			<availability>CHH:3,CCC:3,CIH:3,CSR:3,CSV:3,CFM:3,CGS:3,CCO:4,CWIE:4,CSA:3,CW:4,CNC:3,CSJ:3,CJF:7</availability>
 			<model name='A'>
 				<availability>General:6</availability>
 			</model>
@@ -10557,8 +10416,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:4,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
+			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:4,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -10579,8 +10437,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:4,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:2,MH:2,DC:4</availability>
+			<availability>MOC:4,MERC.KH:6,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:4,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:2,MH:2,DC:4</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:3,LA:3,Periphery.Deep:4,FS:2,MERC:3,Periphery:3</availability>
@@ -10667,8 +10524,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>
-				CS:4-,HL:5,LA:4,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
+			<availability>CS:4-,HL:5,LA:4,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,DC:4</availability>
 			</model>
@@ -10842,8 +10698,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:4,Periphery.DD:3,FRR:5,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>CC:4,Periphery.DD:3,FRR:5,IS:3,WOB:3-,SIC:2,MERC:3,Periphery.OS:3,FS:3,Periphery:1,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:8</availability>
@@ -10858,8 +10713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,OA:5,LA:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:2,IS:4,Periphery.Deep:8,FS:0,Periphery:4</availability>
 			</model>
@@ -10921,8 +10775,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sovetskii Soyuz Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
+			<availability>CSR:3,CSV:1,CFM:1,CGS:1,CCO:2,CSA:2,CS:1,MERC.WD:1,CDS:1,CW:1,NIOPS:1,CSJ:1,CJF:1</availability>
 			<model name='(2742)'>
 				<roles>cruiser</roles>
 				<availability>General:8</availability>
@@ -10949,8 +10802,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,SIC:5,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,LA:3,Periphery.HR:4,NIOPS:3,DC:3</availability>
 			<model name='SPR-6D'>
 				<availability>FRR:5,FS:8,MERC:5</availability>
 			</model>
@@ -10999,8 +10851,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:4,FRR:5,IS:1,WOB:2,SIC:4,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,SIC:4,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:5</availability>
@@ -11048,8 +10899,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:9,CC:6,HL:9,FRR:6,CLAN:3,IS:8,Periphery.Deep:9,WOB:4,SIC:6,FS:6,CIR:9,Periphery:10,TC:9,CS:5,OA:9,LA:8,FWL:9,NIOPS:5,DC:6</availability>
+			<availability>MOC:9,CC:6,HL:9,FRR:6,CLAN:3,IS:8,Periphery.Deep:9,WOB:4,SIC:6,FS:6,CIR:9,Periphery:10,TC:9,CS:5,OA:9,LA:8,FWL:9,NIOPS:5,DC:6</availability>
 			<model name='STK-3F'>
 				<availability>HL:3,IS:5,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -11185,8 +11035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,FRR:5,CLAN:1-,IS:8,Periphery.Deep:5,WOB:3-,SIC:8,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>MOC:6,HL:5,FRR:5,CLAN:1-,IS:8,Periphery.Deep:5,WOB:3-,SIC:8,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:2,Periphery.Deep:4,Periphery:2</availability>
@@ -11205,8 +11054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,SIC:5,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:7,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:4,LA:3,IS:4,FS:4,Periphery:4</availability>
 			</model>
@@ -11329,8 +11177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:2,CLAN:4,SIC:4,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
+			<availability>MOC:1,FRR:2,CLAN:4,SIC:4,MERC:4,Periphery.OS:2,FS:8,CIR:1,Periphery:1,TC:1,OA:2,LA:5,Periphery.HR:2,DC:2</availability>
 			<model name='STU-D6'>
 				<availability>LA:6,FS:8,MERC:6</availability>
 			</model>
@@ -11621,8 +11468,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:5,CIH:3,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CSJ:6,CJF:9,CGB:5</availability>
+			<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:1+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CSJ:6,CJF:9,CGB:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CSJ:6,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -11690,8 +11536,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>MOC:4,CC:6,HL:2,SIC:8,MERC:3,FS:4,Periphery:3,TC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:6,HL:4,General:6,FWL:6,Periphery.Deep:6,MERC:6,Periphery:6</availability>
@@ -11704,8 +11549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:3,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
+			<availability>CHH:4,FRR:3,CSV:6,CLAN:5,IS:2,CFM:7,WOB:7,SIC:3,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,MERC:6,DC:2</availability>
 			</model>
@@ -11761,8 +11605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:5,HL:4,FRR:5,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:4-,OA:5,LA:6,FWL:5,NIOPS:4-,DC:5</availability>
+			<availability>MOC:5,CC:5,HL:4,FRR:5,CLAN:2,IS:5,Periphery.Deep:5,WOB:4-,SIC:5,FS:6,CIR:5,Periphery:5,TC:6,CS:4-,OA:5,LA:6,FWL:5,NIOPS:4-,DC:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:5</availability>
@@ -11777,8 +11620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:7,CCC:1-,HL:3,MERC.ELH:8,CLAN:1-,IS:7,Periphery.Deep:6,WOB:2-,CLAN.IS:1-,FS:6,MERC:7,CGS:1-,Periphery:4,TC:4,CS:3-,CSA:1-,MERC.WD:4,LA:7,NIOPS:3-,MH:4,DC:7</availability>
+			<availability>CC:7,CCC:1-,HL:3,MERC.ELH:8,CLAN:1-,IS:7,Periphery.Deep:6,WOB:2-,CLAN.IS:1-,FS:6,MERC:7,CGS:1-,Periphery:4,TC:4,CS:3-,CSA:1-,MERC.WD:4,LA:7,NIOPS:3-,MH:4,DC:7</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2+,CLAN.IS:1-,FS:1,CGS:1-,DC:1+</availability>
 			</model>
@@ -11987,8 +11829,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,FRR:4,IS:4,WOB:3-,SIC:4,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3-,DC:4</availability>
+			<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,SIC:4,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:3-,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
@@ -12207,8 +12048,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:3,CCO:3,CWIE:4,MERC.WD:4,CDS:4,CW:4,CBS:6,CNC:3,CSJ:4,CJF:7,CGB:3</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:3,CCO:3,CWIE:4,MERC.WD:4,CDS:4,CW:4,CBS:6,CNC:3,CSJ:4,CJF:7,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -12316,8 +12156,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,SIC:6-,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>CC:5,HL:3,General:5,Periphery.Deep:8,Periphery:5</availability>
@@ -12421,8 +12260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:3,FRR:3,IS:1,WOB:5,SIC:2,FS:3,Periphery:1,TC:1,CS:5,OA:1,LA:3,FWL:3,NIOPS:5,DC:3</availability>
+			<availability>MOC:2,CC:3,FRR:3,IS:1,WOB:5,SIC:2,FS:3,Periphery:1,TC:1,CS:5,OA:1,LA:3,FWL:3,NIOPS:5,DC:3</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:6</availability>
@@ -12452,8 +12290,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:3,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:3-,CJF:2,DC:6</availability>
+			<availability>MOC:4,CC:5,HL:3,FRR:6,IS:4,Periphery.Deep:4,WOB:3,SIC:6,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:6,Periphery.HR:4,FWL:4,NIOPS:3-,CJF:2,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -12645,8 +12482,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:5,CW:5,CNC:6,CJF:7,CGB:9,DC:1+</availability>
+			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:5,CW:5,CNC:6,CJF:7,CGB:9,DC:1+</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CSJ:7,CGB:4</availability>
 			</model>
@@ -12721,8 +12557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:4-,TC:7,Periphery:6</availability>
+			<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:4-,TC:7,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:3+,FS:3+,DC:3+</availability>
 			</model>
@@ -12769,8 +12604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,SIC:6,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 			<model name='H-7'>
 				<availability>HL:4,IS:6,Periphery.Deep:4,Periphery:6</availability>
 			</model>
@@ -12878,8 +12712,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:3,HL:4,FRR:1,CLAN:1-,FS:1,MERC:3,Periphery.OS:3,Periphery:5,TC:3,CS:2-,OA:3,FS.CMM:4,NIOPS:2-,MH:3,DC:5</availability>
+			<availability>MOC:1,Periphery.DD:3,HL:4,FRR:1,CLAN:1-,FS:1,MERC:3,Periphery.OS:3,Periphery:5,TC:3,CS:2-,OA:3,FS.CMM:4,NIOPS:2-,MH:3,DC:5</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:3,General:2-,Periphery.Deep:8,MERC:5,Periphery:5</availability>
@@ -12923,8 +12756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:6,HL:4,FRR:6,IS:6,Periphery.Deep:5,WOB:3-,SIC:5,FS:7,Periphery:5,TC:5,CS:3-,LA:6,CNC:2,FWL:9,NIOPS:3-,MH:4,DC:6</availability>
+			<availability>CC:6,HL:4,FRR:6,IS:6,Periphery.Deep:5,WOB:3-,SIC:5,FS:7,Periphery:5,TC:5,CS:3-,LA:6,CNC:2,FWL:9,NIOPS:3-,MH:4,DC:6</availability>
 			<model name='WVR-6D'>
 				<availability>FS:1</availability>
 			</model>
@@ -12972,8 +12804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:4,CIH:2,FRR:5,CLAN:2,IS:4,CFM:3,WOB:4,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
+			<availability>CC:4,CIH:2,FRR:5,CLAN:2,IS:4,CFM:3,WOB:4,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:5</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:4,WOB:3</availability>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -935,7 +935,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
@@ -983,7 +983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>CC:4,FRR:3,CLAN:4,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -1275,7 +1275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5-,Periphery.Deep:5,WOB:2-,FS:5-,Periphery:5,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5-,Periphery.Deep:5,WOB:2-,Periphery:5,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:5,MERC.WD:5,CWIE:4</availability>
 			</model>
@@ -1399,7 +1399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,SOC:4,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,SOC:4,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1449,7 +1449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1504,7 +1504,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:4-,CC:4-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:4-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
+			<availability>MOC:4-,CC:4-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:4-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
 			<model name='ASN-21'>
 				<availability>General:2-</availability>
 			</model>
@@ -1590,7 +1590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:2,FRR:6,IS:2+,WOB:4-,CFM:2,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:3,NIOPS:4-,DC:9,CB:2</availability>
+			<availability>CC:2,FRR:6,IS:2+,WOB:4-,CFM:2,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,LA:3,FWL:3,NIOPS:4-,DC:9,CB:2</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -1762,7 +1762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,FWL:9,NIOPS:7</availability>
 			<model name='AWS-10KM'>
 				<availability>FWL:3+,WOB:3,DC:3+</availability>
 			</model>
@@ -2022,7 +2022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:7-,CC:3-,HL:8-,FRR:4-,IS:3-,Periphery.Deep:9-,FS:4-,CIR:7-,MERC:4-,Periphery:9-,TC:7-,OA:7-,LA:6-,FWL:3-,MH:7-,DC:3-</availability>
+			<availability>MOC:7-,HL:8-,FRR:4-,IS:3-,Periphery.Deep:9-,FS:4-,CIR:7-,MERC:4-,Periphery:9-,TC:7-,OA:7-,LA:6-,MH:7-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:2-,General:3-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 			</model>
@@ -2204,7 +2204,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:6,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,Periphery:5,CS:6-,DC.GHO:6,LA:6,PIR:5,FWL:7,NIOPS:6-,DC:4</availability>
 			<model name='BLR-10S'>
 				<availability>LA:4,FS:2</availability>
 			</model>
@@ -2358,7 +2358,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:4,HL:4,FRR:5,IS:4,WOB:4-,MERC:4,FS:7,Periphery:5,CS:4-,OA:5,CDS:5,LA:5,PIR:4,FWL:3,DC:6</availability>
+			<availability>HL:4,FRR:5,IS:4,WOB:4-,MERC:4,FS:7,Periphery:5,CS:4-,CDS:5,LA:5,PIR:4,FWL:3,DC:6</availability>
 			<model name=''>
 				<availability>General:8,DC:6</availability>
 			</model>
@@ -2498,7 +2498,7 @@
 				<availability>CS:6,CLAN:5,FWL:6,NIOPS:6,WOB:6,CGS:6,BAN:2</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:5-,FRR:5-,FWL:2-,MERC:5-,FS:5-,CIR:6,DC:5-</availability>
+				<availability>LA:5-,FRR:5-,FWL:2-,MERC:5-,FS:5-,CIR:6,DC:5-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:4-,TC:4-</availability>
@@ -2643,7 +2643,7 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>FWL:5,WOB:4</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>General:4</availability>
@@ -2705,7 +2705,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -2744,7 +2744,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,CM:6,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+			<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,CM:6,IS:4,WOB:5,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2780,7 +2780,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>MOC:5-,CC:6-,HL:4-,FRR:5-,IS:4-,Periphery.Deep:7,FS:4-,CIR:5-,MERC:4-,TC:6-,Periphery:5-,LA:3-,FWL:3-,DC:5-</availability>
+			<availability>CC:6-,HL:4-,FRR:5-,IS:4-,Periphery.Deep:7,MERC:4-,TC:6-,Periphery:5-,LA:3-,FWL:3-,DC:5-</availability>
 			<model name=''>
 				<availability>LA:5,General:8,FS:5,MERC:5,DC:5</availability>
 			</model>
@@ -2957,7 +2957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:3,CC:4,FRR:5,IS:1,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,DC:6</availability>
+			<availability>MOC:3,CC:4,FRR:5,IS:1,MERC:2,CIR:4,Periphery:2,TC:3,CS:4,NIOPS:4,MH:5,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:2-</availability>
@@ -3026,7 +3026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CW:3,CLAN:3,CNC:5,CGS:6,CJF:3,CGB:3,DC:3+</availability>
+			<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CLAN:3,CNC:5,CGS:6,DC:3+</availability>
 			<model name='A'>
 				<availability>General:8</availability>
 			</model>
@@ -3159,7 +3159,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:1,IS:2,WOB:2-,Periphery.OS:4,FS:9,MERC:2,CDP:2,Periphery:2,CS:2-,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:1,IS:2,WOB:2-,Periphery.OS:4,FS:9,MERC:2,CDP:2,Periphery:2,CS:2-,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:6,IS:4,FS:6</availability>
 			</model>
@@ -3310,7 +3310,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:6,CHH:2,FRR:4,CLAN:2,IS:4,WOB:5,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:2,DC:5</availability>
+			<availability>CC:6,CHH:2,CLAN:2,IS:4,WOB:5,MERC:2,CS:5,DC.GHO:6,LA:5,NIOPS:5,CGB:2,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -3450,16 +3450,16 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4+,DC:8</availability>
+				<availability>IS:4+,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
+			<availability>CC:1,FRR:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,FVC:5,LA:8,FWL:4,DC:2</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:2-,LA:4-,IS:3-,Periphery.Deep:8,MERC:4-,BAN:3,Periphery:4-</availability>
+				<availability>HL:2-,LA:4-,IS:3-,Periphery.Deep:8,MERC:4-,BAN:3,Periphery:4-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -3702,7 +3702,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:3,MOC:2,FRR:2,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,CS:1-,FVC:2,LA:3,FWL:2,NIOPS:1-,DC:2</availability>
+			<availability>CC:3,MOC:2,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,CS:1-,FVC:2,LA:3,NIOPS:1-</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:2-,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -3813,7 +3813,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:2,HL:2,IS:3,WOB:3,FS:4,Periphery:3,TC:2,CS:3,FVC:4,LA:6,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:6-,FVC:4,General:5-,FS:6-,Periphery:5-</availability>
 			</model>
@@ -3949,7 +3949,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
+			<availability>CC:1,FRR:2,CLAN:3,FS:8,MERC:4,Periphery:2,OA:3,LA:7,FWL:1,DC:2</availability>
 			<model name='CSR-V12'>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,BAN:4,Periphery:5-</availability>
 			</model>
@@ -4034,7 +4034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:2,CSR:2,FRR:4,CLAN:2,CFM:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
+			<availability>FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4235,7 +4235,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -4366,7 +4366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,CB:4,DC:3+</availability>
+			<availability>CLAN:4,IS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CNC:5,CJF:5,CGB:5</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -4455,7 +4455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CCC:4,CIH:4,CLAN:4,IS:3+,CLAN.IS:4,MERC:3+,CCO:3,BAN:4,CSA:3,MERC.WD:4,CDS:4,CJF:3,CGB:7,CB:4</availability>
+			<availability>CHH:6,CLAN:4,IS:3+,CLAN.IS:4,MERC:3+,CCO:3,BAN:4,CSA:3,MERC.WD:4,CJF:3,CGB:7</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:3</availability>
@@ -4556,7 +4556,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:6,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:6,CNC:5,FWL:8,NIOPS:6,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,FS:4,CDP:4,TC:4,DC:4</availability>
@@ -4616,7 +4616,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:3,CC:3,HL:2,FRR:3,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:3,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
+			<availability>HL:2,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,FVC:5,Periphery.HR:4</availability>
 			<model name='DV-1S'>
 				<availability>IS:2-</availability>
 			</model>
@@ -4672,7 +4672,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:4-,CC:3-,FRR:2-,IS:3-,MERC:4-,FS:4-,CIR:2,Periphery:5-,TC:5-,OA:3-,LA:4-,FWL:3-,MH:3-,DC:3-</availability>
+			<availability>MOC:4-,FRR:2-,IS:3-,MERC:4-,FS:4-,CIR:2,Periphery:5-,OA:3-,LA:4-,MH:3-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4815,7 +4815,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
+			<availability>HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,CC.MAC:4-</availability>
 			<model name=''>
 				<availability>CC:4-,General:5-</availability>
 			</model>
@@ -4863,7 +4863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,HL:2,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,CS:3-,OA:2,FWL:4,NIOPS:3-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:2-,FS:2-</availability>
@@ -4961,7 +4961,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:3,MOC:4,CLAN:2,IS:4,WOB:7,FS:3,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
+			<availability>CC:3,MOC:4,CLAN:2,IS:4,WOB:7,FS:3,MERC:4,TC:4,CS:7,LA:4,CNC:5,NIOPS:7</availability>
 			<model name='EMP-6A'>
 				<availability>CC:6,CS:8,HL:6,LA:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:6,FS:6,BAN:4,Periphery:8</availability>
 			</model>
@@ -5012,7 +5012,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>CC:2,FS:8,MERC:5,Periphery.OS:3,CDP:3,TC:3,Periphery:2,FVC:7,OA:3,LA:4,Periphery.HR:3,MH:2,DC:2</availability>
+			<availability>CC:2,FS:8,MERC:5,Periphery.OS:3,CDP:3,TC:3,Periphery:2,FVC:7,OA:3,LA:4,Periphery.HR:3,DC:2</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:4-,FS:5-,TC:5-</availability>
 			</model>
@@ -5099,7 +5099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,WOB:5,FS:3,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:4,FS:3,MERC:2</availability>
 			</model>
@@ -5317,7 +5317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>MERC.KH:3+,CHH:4,CIH:6,CSV:4,CLAN:2,IS:3+,CWIE:8,MERC.WD:7,CDS:2,CW:7,CNC:2,CJF:5,CGB:4</availability>
+			<availability>MERC.KH:3+,CHH:4,CIH:6,CSV:4,CLAN:2,IS:3+,CWIE:8,MERC.WD:7,CW:7,CJF:5,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
 			</model>
@@ -5530,7 +5530,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
-			<availability>CC:2-,MOC:2-,Periphery.CM:2-,PIR:2-,Periphery.ME:2-,Periphery:2-</availability>
+			<availability>CC:2-,PIR:2-,Periphery:2-</availability>
 			<model name='FRB-1E (WAM-B)'>
 				<availability>General:4-</availability>
 			</model>
@@ -5624,7 +5624,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:5,CBS:3,FWL:2,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:4-,LA:4-</availability>
+				<availability>MERC.KH:4-,LA:4-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,CS:4,LA:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
@@ -5670,7 +5670,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MERC.WD:4,FWL:2,WOB:4,MERC:4,Periphery:4</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:2,CM:4</availability>
@@ -5851,7 +5851,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:4,General:8,FWL:4,WOB:4</availability>
@@ -5888,7 +5888,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,Periphery:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -5956,7 +5956,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CSR:2,SOC:1,CLAN:5,IS:2+,BAN:4,CWIE:3,CSA:6,MERC.WD:3,CDS:5,CNC:5,CJF:4,CGB:9,CB:4</availability>
+			<availability>CSR:2,SOC:1,CLAN:5,IS:2+,BAN:4,CWIE:3,CSA:6,MERC.WD:3,CJF:4,CGB:9,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -6103,14 +6103,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:3,MOC:2,IS:1,WOB:2,FS:3,MERC:3,TC:2,Periphery:2,CS:1,OA:1,FVC:2,LA:5,Periphery.MW:1,FWL:6,MH:1</availability>
+			<availability>CC:3,IS:1,WOB:2,FS:3,MERC:3,Periphery:2,CS:1,OA:1,FVC:2,LA:5,Periphery.MW:1,FWL:6,MH:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:4-,HL:2-,LA:5-,FWL:4-,Periphery.Deep:8,IS:2-,MERC:4-,Periphery:4-</availability>
 			</model>
 			<model name='GOL-2H'>
 				<roles>fire_support</roles>
-				<availability>Periphery.MW:2,Periphery.CM:2,Periphery.HR:2,Periphery.ME:2,MH:3,Periphery:2</availability>
+				<availability>MH:3,Periphery:2</availability>
 			</model>
 			<model name='GOL-3M'>
 				<roles>fire_support</roles>
@@ -6137,7 +6137,7 @@
 			</model>
 			<model name='GOL-6H'>
 				<roles>fire_support</roles>
-				<availability>Periphery.HR:2,Periphery.CM:2,Periphery.MW:2,Periphery.ME:2,MH:3,Periphery:2</availability>
+				<availability>MH:3,Periphery:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Gorgon' unitType='ProtoMek'>
@@ -6255,7 +6255,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 			</model>
@@ -6376,7 +6376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>MOC:2,CC:5,HL:4,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:5,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:2,HL:4,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,Periphery:5,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1A'>
 				<availability>LA:2-,MERC:2-,TC:2-</availability>
 			</model>
@@ -6733,7 +6733,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:5-,CC:5-,HL:4-,FRR:5-,IS:5-,Periphery.Deep:4,WOB:5-,MERC:5-,Periphery:5-,CS:5-,FWL.pm:6-,LA:5-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,DC:5-</availability>
+			<availability>HL:4-,FRR:5-,IS:5-,Periphery.Deep:4,WOB:5-,MERC:5-,Periphery:5-,CS:5-,FWL.pm:6-,FWL:6-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -6919,7 +6919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>CC:4,MOC:8,HL:4,MERC:4,Periphery.OS:5,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
+			<availability>CC:4,MOC:8,HL:4,MERC:4,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6932,7 +6932,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:1,FS:3,MERC:2,CDP:2,Periphery:3,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:1,MERC:2,CDP:2,Periphery:3,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:5:3068,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7286,7 +7286,7 @@
 				<availability>LA:3</availability>
 			</model>
 			<model name='HGN-732'>
-				<availability>MOC:6,DC.GHO:8,CS:3,LA:6,CLAN:6,IS:6,NIOPS:3,WOB:3,MERC.SI:8,MERC:6,FS:6,BAN:8</availability>
+				<availability>MOC:6,DC.GHO:8,CS:3,CLAN:6,IS:6,NIOPS:3,WOB:3,MERC.SI:8,MERC:6,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CS:4,LA:2,CLAN:4,WOB:4,FS:2,BAN:2</availability>
@@ -7380,7 +7380,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2,MERC.WD:6,FVC:8,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9</availability>
+			<availability>FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,MERC.WD:6,FVC:8,Periphery.HR:4,FS.CMM:9,FS.DMM:9</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:4-</availability>
@@ -7433,7 +7433,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:4,CC:4,HL:4,FRR:6,IS:4-,Periphery.Deep:5,WOB:3-,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4,CGB:2-</availability>
+			<availability>MOC:4,CC:4,HL:4,FRR:6,IS:4-,Periphery.Deep:5,WOB:3-,FS:4,Periphery:5,TC:4,CS:4-,OA:4,LA:4,FWL:7,NIOPS:4-,DC:4,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -7490,7 +7490,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,CIR:5,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6-</availability>
@@ -7755,7 +7755,7 @@
 			<availability>WOB.PM:3-</availability>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -7861,7 +7861,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:5-,FS.AH:4-,IS:4-,Periphery.Deep:5,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,DC:4-</availability>
+			<availability>FS.DLC:4-,CC:2-,DC.LV:5-,HL:3-,DC.GR:5-,FS.AH:4-,IS:4-,Periphery.Deep:5,WOB:3-,FS:3-,Periphery:4-,TC:5-,CS:2-,FWL:2-,NIOPS:2-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8001,7 +8001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,HL:3,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:4,LA:3,Periphery.HR:6</availability>
+			<availability>HL:3,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,FVC:8,LA:3,Periphery.HR:6</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:2-,MERC:2,TC:2,Periphery:1</availability>
@@ -8068,7 +8068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:3-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3-,DC:8</availability>
+			<availability>CC:3-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,FS.DMM:5,FWL:3-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:4+,FS:4+,DC:8</availability>
@@ -8355,7 +8355,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:2,FRR:4,CLAN:3,IS:2,WOB:6,FS:6,MERC:3,CIR:2,CGS:5,DC.GHO:6,CS:6,FVC:5,LA:2,FWL:2,NIOPS:6,CGB:4,DC:2</availability>
+			<availability>FRR:4,CLAN:3,IS:2,WOB:6,FS:6,MERC:3,CIR:2,CGS:5,DC.GHO:6,CS:6,FVC:5,NIOPS:6,CGB:4</availability>
 			<model name='KGC-000'>
 				<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 			</model>
@@ -8422,7 +8422,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:7,CHH:2,CDS:2,CSV:2,FRR:4,CLAN:1,NIOPS:7,WOB:7,FS:3,MERC:5,DC:5</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:5-,MERC:5-,DC:4-</availability>
+				<availability>FS:5-,MERC:5-,DC:4-</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:5,CS:4,DC.SL:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
@@ -8596,7 +8596,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:3,IS:3+,CCO:3,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CJF:6,CB:7,DC:3+</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:3,IS:3+,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CJF:6,CB:7,DC:3+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -8816,7 +8816,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:4</availability>
 			</model>
@@ -8925,7 +8925,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,Periphery:4,CS:3-,OA:6,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:6-</availability>
 			</model>
@@ -9122,7 +9122,7 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CDS:3,CW:4,CBS:5,CSV:5,CLAN:3,IS:3+,CFM:5,CJF:4,BAN:6,CWIE:6,CGB:3</availability>
+			<availability>CHH:7,CW:4,CBS:5,CSV:5,CLAN:3,IS:3+,CFM:5,CJF:4,BAN:6,CWIE:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>General:7,CGB:5</availability>
@@ -9179,7 +9179,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -9267,7 +9267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
+			<availability>Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:2-,General:2-,Periphery.Deep:4,MERC:8-,Periphery:2-</availability>
 			</model>
@@ -9494,7 +9494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CIH:9,CSV:8,CLAN:4,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:5,CJF:9,CGB:4</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:4,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:5,CJF:9</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -9554,7 +9554,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:7,CC:7,HL:7,FRR:9,IS:8,Periphery.Deep:8,WOB:8,MERC:8,FS:8,CIR:7,Periphery:8,TC:8,CS:8,OA:8,LA:8,FWL:7,NIOPS:8,DC:10</availability>
+			<availability>MOC:7,CC:7,HL:7,FRR:9,IS:8,Periphery.Deep:8,WOB:8,MERC:8,CIR:7,Periphery:8,CS:8,FWL:7,NIOPS:8,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:3-,General:6-,Periphery.Deep:5,FS:3-,DC:3-,Periphery:6</availability>
 			</model>
@@ -9642,7 +9642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
+			<availability>CC:4,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:3</availability>
 			</model>
@@ -9863,7 +9863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:2,FRR:5,CLAN:3,IS:3,Periphery.Deep:5,WOB:4-,MERC:3,FS:2,CIR:3,Periphery:3,TC:3,CS:4-,OA:3,LA:5,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>CC:4,HL:2,FRR:5,CLAN:3,IS:3,Periphery.Deep:5,WOB:4-,MERC:3,FS:2,Periphery:3,CS:4-,LA:5,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
@@ -10518,7 +10518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:2,OA:2,LA:5,CM:4,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:2,LA:5,CM:4,WOB:4,FS:4,MERC:4,CIR:4,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10698,7 +10698,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,LA:8,WOB:3,FS:7,MERC:4,CIR:2</availability>
 			<model name='NGS-4S'>
-				<availability>:0,HL:6,LA:6,General:8,Periphery.Deep:6,FS:6,MERC:6,Periphery:8</availability>
+				<availability>HL:6,LA:6,General:8,Periphery.Deep:6,FS:6,MERC:6,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -10896,7 +10896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,TC:5,FVC:7,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:4,FWL:9,MH:5,DC:4</availability>
+			<availability>MOC:6,CC:6,IS:4,MERC:4,FS:7,CIR:4,TC:5,FVC:7,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:4,FWL:9,MH:5</availability>
 			<model name=''>
 				<availability>HL:4,General:5,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -10937,7 +10937,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:3,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
+			<availability>MOC:3,HL:3,FRR:4,CLAN:1,IS:3,Periphery.Deep:4,WOB:3-,CIR:5,Periphery:4,CWIE:2,CS:4-,CW:2,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>HL:3-,General:5-,CLAN:5-,Periphery.Deep:8,Periphery:5-</availability>
 			</model>
@@ -11024,7 +11024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:3-,IS:4-,Periphery.Deep:8,MERC:5-,BAN:1,Periphery:5-</availability>
@@ -11184,7 +11184,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pack Hunter' unitType='Mek'>
-			<availability>CHH:3,CCC:3,MERC.KH:1,CIH:3,CSR:3,CSV:3,CLAN:3,CCO:3,CWIE:7,CSA:3,CDS:3,CW:3,CNC:4</availability>
+			<availability>MERC.KH:1,CLAN:3,CWIE:7,CNC:4</availability>
 			<model name=''>
 				<availability>CW:8,General:8</availability>
 			</model>
@@ -11199,7 +11199,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
+			<availability>MOC:3-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,NIOPS:6</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -11210,7 +11210,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
+				<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,MERC:2,Periphery:3,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -11331,7 +11331,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Air Defense Tank' unitType='Tank'>
-			<availability>CC:5,CS:6,HL:2,LA:7,FRR:4,CNC:4,IS:5,WOB:6,FS:8,DC:6,Periphery:3,CWIE:5</availability>
+			<availability>CS:6,HL:2,LA:7,FRR:4,CNC:4,IS:5,WOB:6,FS:8,DC:6,Periphery:3,CWIE:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11357,7 +11357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:7-,CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,TC:7-,CS:6-,OA:3-,CDS:4,LA:5-,FWL:5-,DC:4-</availability>
+			<availability>CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,CS:6-,OA:3-,CDS:4,DC:4-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11405,7 +11405,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:2,CC:3,FRR:3,IS:3,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:2,TC:2,CWIE:3,CS:5-,OA:2,LA:6,FWL:3,DC:6</availability>
+			<availability>IS:3,Periphery.Deep:8,WOB:5-,FS:6,Periphery:2,CWIE:3,CS:5-,LA:6,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:6</availability>
@@ -11605,7 +11605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:5,HL:5,CLAN:1,IS:9,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:1</availability>
+			<availability>CS:5,HL:5,CLAN:1,IS:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:4-,BAN:6,Periphery:4-</availability>
@@ -11677,7 +11677,7 @@
 			<availability>LA:2-,MERC:3-,TC:3-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:6,CC:3-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:4-,WOB:4-,FS:3-,MERC:4-,CIR:3-,CWIE:6,Periphery:3-,TC:4-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:3-,CNC:6,FWL:2-,MH:5-,DC:4-</availability>
+			<availability>MOC:6,CC:3-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:4-,WOB:4-,FS:3-,MERC:4-,CWIE:6,Periphery:3-,TC:4-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:3-,CNC:6,FWL:2-,MH:5-</availability>
 			<model name=''>
 				<availability>HL:6,IS:6,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -11972,7 +11972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:8,CLAN:8,IS:2+,CFM:8,MERC:2+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:6,CDS:9,CW:9,CBS:7,CNC:9,CJF:6,CGB:7</availability>
+			<availability>CLAN:8,IS:2+,MERC:2+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:6,CDS:9,CW:9,CBS:7,CNC:9,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -12067,7 +12067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,FS:3,CIR:4,CDP:4,Periphery:4,TC:5,CS:3-,OA:5,FVC:4,LA:5,FWL:7,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,FS:3,CDP:4,Periphery:4,TC:5,CS:3-,OA:5,FVC:4,LA:5,FWL:7,NIOPS:3-</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:4-,IS:4-,Periphery:4-,DC:4-,TC:4-</availability>
 			</model>
@@ -12288,7 +12288,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -12329,7 +12329,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:7,HL:9,FRR:5,CLAN:6,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,CLAN:6,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -12405,7 +12405,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:7,Periphery.Deep:5,WOB:5,CFM:6,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CB:6</availability>
+			<availability>CC:6,CCC:6,HL:3,CSV:6,IS:7,Periphery.Deep:5,WOB:5,CFM:6,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,NIOPS:5,CB:6</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:2,DC:2</availability>
 			</model>
@@ -12620,7 +12620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,WOB:3+,MERC:2+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CW:8,CBS:9,CNC:6,CJF:9,DC:3+</availability>
+			<availability>CSR:9,CSV:7,CLAN:8,WOB:3+,MERC:2+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CBS:9,CNC:6,CJF:9,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -12798,7 +12798,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
+			<availability>Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:8-,Periphery:8-</availability>
 			</model>
@@ -12865,7 +12865,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5,CC:6-,Periphery.DD:7,HL:4,FRR:7-,IS:6-,WOB:4,Periphery.OS:7,FS:5-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:5,FWL.MM:8,CW:3,LA:5-,FWL:7-,DC:8-</availability>
+			<availability>Periphery.DD:7,HL:4,FRR:7-,IS:6-,WOB:4,Periphery.OS:7,FS:5-,Periphery:5,CS:4,OA:7,CDS:5,FWL.MM:8,CW:3,LA:5-,FWL:7-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -13011,13 +13011,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:2,CC:1,OA:2,LA:1,IS:2,FWL:1,FS:1,TC:2,Periphery:2,DC:1</availability>
+			<availability>CC:1,OA:2,LA:1,IS:2,FWL:1,FS:1,Periphery:2,DC:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:5,CC:3,HL:5,FRR:4,IS:5,Periphery.Deep:5,WOB:5,MERC:5,FS:5,CIR:6,Periphery:6,TC:5,CS:5,OA:6,LA:5,FWL:4,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:5,FRR:4,IS:5,Periphery.Deep:5,WOB:5,MERC:5,Periphery:6,TC:5,CS:5,FWL:4,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -13031,7 +13031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:6-,CC:6-,Periphery.DD:6-,HL:4-,FRR:7-,IS:5-,WOB:4-,MERC:5-,Periphery.OS:6-,FS:4-,CIR:5-,Periphery:5-,TC:6-,CS:4-,OA:6-,LA:5-,FWL:4-,DC:7-</availability>
+			<availability>MOC:6-,CC:6-,Periphery.DD:6-,HL:4-,FRR:7-,IS:5-,WOB:4-,MERC:5-,Periphery.OS:6-,FS:4-,CIR:5-,Periphery:5-,TC:6-,CS:4-,OA:6-,FWL:4-,DC:7-</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -13160,7 +13160,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,CS:3,HL:2,LA:6,FRR:3,IS:4,FWL:4,WOB:3,FS:5,CIR:3,Periphery:3,DC:4</availability>
+			<availability>CC:3,CS:3,HL:2,LA:6,FRR:3,IS:4,WOB:3,FS:5,Periphery:3</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:8</availability>
@@ -13171,7 +13171,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
+			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:5,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -13223,7 +13223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
+			<availability>MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:3-,LA:3-,Periphery.Deep:4,FS:2-,MERC:3-,Periphery:3-</availability>
@@ -13346,7 +13346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:4-,HL:5,LA:3,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
+			<availability>CS:4-,HL:5,LA:3,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,CB:8,DC:4</availability>
 			</model>
@@ -13575,7 +13575,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,CS:3-,OA:1,FVC:2,FWL:3,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:6</availability>
@@ -13590,7 +13590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
+			<availability>Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 			</model>
@@ -13691,7 +13691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,NIOPS:3,DC:2-</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
 			</model>
@@ -13746,7 +13746,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,CS:3,OA:1,FVC:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:4-</availability>
@@ -13837,7 +13837,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:8,CC:6,HL:9,FRR:6,CLAN:3,IS:7,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:9,CS:5,OA:9,LA:7,FWL:8,NIOPS:5,DC:6</availability>
+			<availability>MOC:8,CC:6,HL:9,FRR:6,CLAN:3,IS:7,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:9,CS:5,OA:9,FWL:8,NIOPS:5,DC:6</availability>
 			<model name='STK-3F'>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 			</model>
@@ -13983,7 +13983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
@@ -14022,7 +14022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,CS:3,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
 			</model>
@@ -14052,7 +14052,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -14064,7 +14064,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14132,7 +14132,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:3,FRR:4,IS:5,WOB:3-,FS:8,MERC:3,CS:3-,FVC:7,CDS:3,LA:5,PIR:3,FWL:3,DC:3</availability>
+			<availability>CC:3,FRR:4,IS:5,WOB:3-,FS:8,MERC:3,CS:3-,FVC:7,CDS:3,PIR:3,FWL:3,DC:3</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -14172,7 +14172,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:5,Periphery.HR:2,DC:1</availability>
+			<availability>FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,Periphery:1,OA:2,FVC:7,LA:5,Periphery.HR:2,DC:1</availability>
 			<model name='STU-D6'>
 				<availability>LA:6,FS:8,MERC:6</availability>
 			</model>
@@ -14558,7 +14558,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:2+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CJF:8,CGB:5,CB:3</availability>
+			<availability>CIH:3,CLAN:5,IS:2+,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CJF:8,CB:3</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -14617,7 +14617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>MOC:2,CLAN:1,WOB:7,CCO:1,Periphery:2,TC:2,CS:5,DC.GHO:2,CSA:2,OA:2,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+			<availability>CLAN:1,WOB:7,Periphery:2,CS:5,DC.GHO:2,CSA:2,NIOPS:5,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
 			</model>
@@ -14645,7 +14645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:6-,FVC:5-,HL:4-,General:5-,FWL:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
@@ -14658,7 +14658,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:4,FRR:2,CSV:6,CLAN:5,IS:3,CFM:7,WOB:7,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,FVC:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
+			<availability>CHH:4,FRR:2,CSV:6,CLAN:5,IS:3,CFM:7,WOB:7,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,FVC:3,CDS:4,CW:6,CBS:4,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
 			<model name='THG-10E'>
 				<availability>FWL:5,MERC:5</availability>
 			</model>
@@ -14735,7 +14735,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,HL:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,CS:4-,OA:4,LA:6,NIOPS:4-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:4-</availability>
@@ -14756,7 +14756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:6,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,CFM:1,FS:6,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:4,LA:6,NIOPS:3-,MH:4,DC:6</availability>
+			<availability>CC:6,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,MERC:6,Periphery:4,CS:3-,FVC:5,MERC.WD:4,NIOPS:3-</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,CFM:1,CLAN.IS:1-,FS:1,CGS:1-,DC:1+,CB:1</availability>
 			</model>
@@ -15023,7 +15023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
+			<availability>MOC:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,FWL:6,NIOPS:3-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
@@ -15033,7 +15033,7 @@
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
+				<availability>CC:3-,CS:2-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
 			</model>
 			<model name='TBT-5S'>
 				<availability>MOC:3-,IS:3-,Periphery.Deep:4,FWL:3-,MERC:3-,CDP:3,Periphery:3-,TC:3-</availability>
@@ -15194,7 +15194,7 @@
 			<availability>CS:4,WOB:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='(Original)'>
 				<roles>apc,urban</roles>
@@ -15292,7 +15292,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:2,CCO:3,CWIE:4,MERC.WD:4,CDS:3,CW:4,CBS:6,CNC:2,CJF:7,CGB:2</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:2,CCO:3,CWIE:4,MERC.WD:4,CDS:3,CW:4,CBS:6,CJF:7</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -15417,7 +15417,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,Periphery:4-,TC:3-,CS:3-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -15599,7 +15599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,CS:5,LA:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:5</availability>
@@ -15636,7 +15636,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,Periphery:4,CS:3-,LA:5,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -15847,7 +15847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:4,CS:3,LA:6,FRR:4,FWL:6,IS:5,NIOPS:3,WOB:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>FVC:3-,General:5-,FS:3-</availability>
@@ -16023,7 +16023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:3,FWL:3</availability>
@@ -16245,7 +16245,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>HL:4,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,CS:3-,CNC:2,FWL:8,NIOPS:3-,MH:4</availability>
 			<model name='WVR-6M'>
 				<roles>recon</roles>
 				<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4-,MH:4</availability>
@@ -16306,7 +16306,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:3,CIH:2,FRR:5,CLAN:2,IS:3,CFM:3,WOB:4-,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:6</availability>
+			<availability>FRR:5,CLAN:2,IS:3,CFM:3,WOB:4-,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:6</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:5,WOB:4</availability>
@@ -16475,7 +16475,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zeus' unitType='Mek'>
-			<availability>HL:5,FRR:4,IS:2,WOB:3,FS:6-,MERC:5,CDP:4,Periphery:4,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
+			<availability>HL:5,FRR:4,IS:2,WOB:3,FS:6-,MERC:5,CDP:4,Periphery:4,Periphery.R:5,LA:10,PIR:4</availability>
 			<model name='ZEU-10WB'>
 				<availability>LA:4,WOB:8</availability>
 			</model>
@@ -16500,7 +16500,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,DC:4</availability>
+			<availability>CC:6,CS:5-,MERC.WD:7,HL:2,FWL:6,WOB:6,MERC:5,CIR:4,Periphery:3,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -12,8 +12,7 @@
 			<pctOmni>10,10</pctOmni>
 			<pctClan>30,30</pctClan>
 			<pctSL>60,60</pctSL>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:1,CJF:2,CGB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:1,CJF:2,CGB:2</salvage>
 		</faction>
 		<faction key='CDP'>
 			<pctClan>0,0,0,0,0</pctClan>
@@ -67,8 +66,7 @@
 			<pctSL>46,46,23,0,0</pctSL>
 			<pctClan unitType='Vehicle'>10,10,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>90,90,60,60,60</pctSL>
-			<salvage pct='6'>
-				CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:6,CGS:3,CSA:10,CDS:5,CW:4,CBS:3,CNC:10,CJF:4</salvage>
+			<salvage pct='6'>CCC:1,CHH:5,CSR:4,CIH:4,CSV:6,CFM:3,CCO:6,CGS:3,CSA:10,CDS:5,CW:4,CBS:3,CNC:10,CJF:4</salvage>
 		</faction>
 		<faction key='CCC'>
 			<pctOmni>0,0,45,100,100</pctOmni>
@@ -76,8 +74,7 @@
 			<pctSL>85,85,60,0,0</pctSL>
 			<pctClan unitType='Vehicle'>15,15,40,40,40</pctClan>
 			<pctSL unitType='Vehicle'>85,85,60,60,60</pctSL>
-			<salvage pct='10'>
-				CHH:2,CIH:3,CSR:3,CSV:10,CFM:5,CGS:2,CCO:10,CSA:6,CDS:3,CW:7,CBS:2,CJF:10,CGB:2</salvage>
+			<salvage pct='10'>CHH:2,CIH:3,CSR:3,CSV:10,CFM:5,CGS:2,CCO:10,CSA:6,CDS:3,CW:7,CBS:2,CJF:10,CGB:2</salvage>
 		</faction>
 		<faction key='CCO'>
 			<pctOmni>8,8,10,90,100</pctOmni>
@@ -938,8 +935,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:4,General:6,Periphery.Deep:5,Periphery:6</availability>
@@ -987,8 +983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -999,8 +994,7 @@
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CCC:2,CIH:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:2,CJF:5</availability>
+			<availability>CCC:2,CIH:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:2,CJF:5</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8,FWL:8</availability>
@@ -1142,8 +1136,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				CSA:2,MERC.KH:4,MERC.WD:8,CHH:2,CSR:2,LA:5,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
+			<availability>CSA:2,MERC.KH:4,MERC.WD:8,CHH:2,CSR:2,LA:5,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
 			<model name='ANH-1A'>
 				<availability>CLAN:1-,MERC:3-</availability>
 			</model>
@@ -1282,8 +1275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:4,HL:4,FRR:4,CLAN:1,IS:5-,Periphery.Deep:5,WOB:2-,FS:5-,Periphery:5,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5-,Periphery.Deep:5,WOB:2-,FS:5-,Periphery:5,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:5,MERC.WD:5,CWIE:4</availability>
 			</model>
@@ -1457,8 +1449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1513,8 +1504,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:4-,CC:4-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:4-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
+			<availability>MOC:4-,CC:4-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:4-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
 			<model name='ASN-21'>
 				<availability>General:2-</availability>
 			</model>
@@ -1600,8 +1590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FRR:6,IS:2+,WOB:4-,CFM:2,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:3,NIOPS:4-,DC:9,CB:2</availability>
+			<availability>MOC:1,CC:2,FRR:6,IS:2+,WOB:4-,CFM:2,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:3,NIOPS:4-,DC:9,CB:2</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -1773,8 +1762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>FWL:3+,WOB:3,DC:3+</availability>
 			</model>
@@ -2034,8 +2022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:7-,CC:3-,HL:8-,FRR:4-,IS:3-,Periphery.Deep:9-,FS:4-,CIR:7-,MERC:4-,Periphery:9-,TC:7-,OA:7-,LA:6-,FWL:3-,MH:7-,DC:3-</availability>
+			<availability>MOC:7-,CC:3-,HL:8-,FRR:4-,IS:3-,Periphery.Deep:9-,FS:4-,CIR:7-,MERC:4-,Periphery:9-,TC:7-,OA:7-,LA:6-,FWL:3-,MH:7-,DC:3-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:2-,General:3-,Periphery.Deep:8,MERC:4-,Periphery:4-</availability>
 			</model>
@@ -2217,8 +2204,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:6,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
+			<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:6,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
 			<model name='BLR-10S'>
 				<availability>LA:4,FS:2</availability>
 			</model>
@@ -2299,8 +2285,7 @@
 			</model>
 		</chassis>
 		<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:6,CIH:6,SOC:6,CSV:8,CFM:7,CGS:6,CCO:4,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CJF:7,CGB:6,DC:3+,CB:6</availability>
+			<availability>CHH:6,CIH:6,SOC:6,CSV:8,CFM:7,CGS:6,CCO:4,CWIE:5,CSA:6,CDS:6,CW:7,CNC:6,CJF:7,CGB:6,DC:3+,CB:6</availability>
 			<model name='A'>
 				<availability>CDS:8,General:7,CGS:3</availability>
 			</model>
@@ -2373,8 +2358,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:4,FRR:5,IS:4,WOB:4-,MERC:4,FS:7,Periphery:5,CS:4-,OA:5,CDS:5,LA:5,PIR:4,FWL:3,DC:6</availability>
+			<availability>CC:4,HL:4,FRR:5,IS:4,WOB:4-,MERC:4,FS:7,Periphery:5,CS:4-,OA:5,CDS:5,LA:5,PIR:4,FWL:3,DC:6</availability>
 			<model name=''>
 				<availability>General:8,DC:6</availability>
 			</model>
@@ -2436,8 +2420,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:3,CLAN:1,IS:3+,CFM:4,CGS:4,CCO:4,BAN:5,CWIE:5,CSA:4,MERC.WD:2,CDS:2,CW:4,CBS:1,CJF:4,CGB:4</availability>
+			<availability>CHH:5,CSR:3,CLAN:1,IS:3+,CFM:4,CGS:4,CCO:4,BAN:5,CWIE:5,CSA:4,MERC.WD:2,CDS:2,CW:4,CBS:1,CJF:4,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
@@ -2504,8 +2487,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:5,FRR:4,CLAN:6,CFM:5,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,FVC:3,CW:7,LA:3,CNC:7,CJF:5,DC:4</availability>
+			<availability>CHH:5,FRR:4,CLAN:6,CFM:5,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,FVC:3,CW:7,LA:3,CNC:7,CJF:5,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:4</availability>
 			</model>
@@ -2723,8 +2705,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:6,FWL:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -2763,8 +2744,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,CM:6,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+			<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,CM:6,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -2800,8 +2780,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:5-,CC:6-,HL:4-,FRR:5-,IS:4-,Periphery.Deep:7,FS:4-,CIR:5-,MERC:4-,TC:6-,Periphery:5-,LA:3-,FWL:3-,DC:5-</availability>
+			<availability>MOC:5-,CC:6-,HL:4-,FRR:5-,IS:4-,Periphery.Deep:7,FS:4-,CIR:5-,MERC:4-,TC:6-,Periphery:5-,LA:3-,FWL:3-,DC:5-</availability>
 			<model name=''>
 				<availability>LA:5,General:8,FS:5,MERC:5,DC:5</availability>
 			</model>
@@ -2926,8 +2905,7 @@
 			</model>
 		</chassis>
 		<chassis name='Carrack Transport' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:1,CSR:3,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
+			<availability>CCC:1,CHH:1,CSR:3,CIH:1,CSV:1,CFM:1,CCO:1,CGS:1,CSA:1,CDS:3,CW:1,CNC:5,CJF:1,CGB:2</availability>
 			<model name='(Clan)'>
 				<roles>cargo</roles>
 				<availability>CLAN:8</availability>
@@ -2952,8 +2930,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:6,MOC:5,WOB:4,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:3,Periphery.CM:4,Periphery.HR:3,Periphery.ME:3,MH:3</availability>
+			<availability>CC:6,MOC:5,WOB:4,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:3,Periphery.CM:4,Periphery.HR:3,Periphery.ME:3,MH:3</availability>
 			<model name='CTF-1X'>
 				<availability>General:5-,Periphery:6-</availability>
 			</model>
@@ -2980,8 +2957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,FRR:5,IS:1,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,DC:6</availability>
+			<availability>MOC:3,CC:4,FRR:5,IS:1,MERC:2,CIR:4,FS:1,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:2-</availability>
@@ -3183,8 +3159,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:1,IS:2,WOB:2-,Periphery.OS:4,FS:9,MERC:2,CDP:2,Periphery:2,CS:2-,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
+			<availability>CC:2,FRR:1,IS:2,WOB:2-,Periphery.OS:4,FS:9,MERC:2,CDP:2,Periphery:2,CS:2-,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:2,DC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:6,IS:4,FS:6</availability>
 			</model>
@@ -3335,15 +3310,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:6,CHH:2,FRR:4,CLAN:2,IS:4,WOB:5,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:2,DC:5</availability>
+			<availability>CC:6,CHH:2,FRR:4,CLAN:2,IS:4,WOB:5,MERC:2,FS:4,CS:5,DC.GHO:6,LA:5,FWL:4,NIOPS:5,CGB:2,DC:5</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CC:3,CHH:2,WOB:4,FS:3,MERC:5,BAN:4,DC.GHO:4-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:3,CGB:2</availability>
+				<availability>CC:3,CHH:2,WOB:4,FS:3,MERC:5,BAN:4,DC.GHO:4-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:3,CGB:2</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:4,CS:4,LA:4,IS:3,MERC:4</availability>
@@ -3420,8 +3393,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:2</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,OA:4,LA:2,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,DC:2</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:5-,HL:3-,General:4-,FWL:5-,Periphery.Deep:8,MERC:5-,Periphery:5-</availability>
@@ -3482,8 +3454,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
+			<availability>MOC:2,CC:1,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:4,DC:2</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:4,FS:4-,CDP:4,TC:4,Periphery:3-</availability>
 			</model>
@@ -3731,8 +3702,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,FRR:2,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,CS:1-,FVC:2,LA:3,FWL:2,NIOPS:1-,DC:2</availability>
+			<availability>CC:3,MOC:2,FRR:2,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,CS:1-,FVC:2,LA:3,FWL:2,NIOPS:1-,DC:2</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:2-,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -3807,8 +3777,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:4,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:4,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:2-,LA:2-,Periphery:2-</availability>
@@ -3844,8 +3813,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:6,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:6,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:6-,FVC:4,General:5-,FS:6-,Periphery:5-</availability>
 			</model>
@@ -4066,8 +4034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:2,CSR:2,FRR:4,CLAN:2,CFM:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
+			<availability>CHH:2,CSR:2,FRR:4,CLAN:2,CFM:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4122,8 +4089,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,CFM:5,WOB:8,CIR:3,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
+			<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,CFM:5,WOB:8,CIR:3,CGS:5,CWIE:7,DC.GHO:4,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:5-,NIOPS:0</availability>
 			</model>
@@ -4269,8 +4235,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
+			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,SL.2:5,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -4309,8 +4274,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>
-				CS:6,MERC.KH:3,MERC.WD:3,HL:2,SOC:3,CLAN:1-,NIOPS:6,WOB:7,MERC:3,TC:4,Periphery:3</availability>
+			<availability>CS:6,MERC.KH:3,MERC.WD:3,HL:2,SOC:3,CLAN:1-,NIOPS:6,WOB:7,MERC:3,TC:4,Periphery:3</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CS:6,WOB:6,TC:3</availability>
@@ -4402,8 +4366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,CB:4,DC:3+</availability>
+			<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,CB:4,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -4492,8 +4455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CCC:4,CIH:4,CLAN:4,IS:3+,CLAN.IS:4,MERC:3+,CCO:3,BAN:4,CSA:3,MERC.WD:4,CDS:4,CJF:3,CGB:7,CB:4</availability>
+			<availability>CHH:6,CCC:4,CIH:4,CLAN:4,IS:3+,CLAN.IS:4,MERC:3+,CCO:3,BAN:4,CSA:3,MERC.WD:4,CDS:4,CJF:3,CGB:7,CB:4</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:3</availability>
@@ -4594,8 +4556,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:6,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,IS:7,Periphery.Deep:9,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,LA:6,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,CS:4,LA:4,FRR:4,IS:2,FWL:4,WOB:4,FS:4,CDP:4,TC:4,DC:4</availability>
@@ -4655,8 +4616,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,HL:2,FRR:3,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:3,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
+			<availability>MOC:3,CC:3,HL:2,FRR:3,IS:3,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:3,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
 			<model name='DV-1S'>
 				<availability>IS:2-</availability>
 			</model>
@@ -4712,8 +4672,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4-,CC:3-,FRR:2-,IS:3-,MERC:4-,FS:4-,CIR:2,Periphery:5-,TC:5-,OA:3-,LA:4-,FWL:3-,MH:3-,DC:3-</availability>
+			<availability>MOC:4-,CC:3-,FRR:2-,IS:3-,MERC:4-,FS:4-,CIR:2,Periphery:5-,TC:5-,OA:3-,LA:4-,FWL:3-,MH:3-,DC:3-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4803,8 +4762,7 @@
 				<availability>CDS:6,CW:7,General:5,CFM:6,CJF:6,CGB:7</availability>
 			</model>
 			<model name='D'>
-				<availability>
-					CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
+				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CWIE:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7</availability>
 			</model>
 			<model name='E'>
 				<availability>CDS:5,CW:5,CBS:3,General:4,CCO:6,CWIE:5</availability>
@@ -4857,8 +4815,7 @@
 			<availability>CIH:4</availability>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
+			<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
 			<model name=''>
 				<availability>CC:4-,General:5-</availability>
 			</model>
@@ -4906,8 +4863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:2-,FS:2-</availability>
@@ -5007,8 +4963,7 @@
 		<chassis name='Emperor' unitType='Mek'>
 			<availability>CC:3,MOC:4,CLAN:2,IS:4,WOB:7,FS:3,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:6,CS:8,HL:6,LA:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:6,FS:6,BAN:4,Periphery:8</availability>
+				<availability>CC:6,CS:8,HL:6,LA:6,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:6,FS:6,BAN:4,Periphery:8</availability>
 			</model>
 			<model name='EMP-6D'>
 				<availability>FS:6</availability>
@@ -5057,8 +5012,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>
-				CC:2,FS:8,MERC:5,Periphery.OS:3,CDP:3,TC:3,Periphery:2,FVC:7,OA:3,LA:4,Periphery.HR:3,MH:2,DC:2</availability>
+			<availability>CC:2,FS:8,MERC:5,Periphery.OS:3,CDP:3,TC:3,Periphery:2,FVC:7,OA:3,LA:4,Periphery.HR:3,MH:2,DC:2</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:4-,FS:5-,TC:5-</availability>
 			</model>
@@ -5145,8 +5099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:4,FS:3,MERC:2</availability>
 			</model>
@@ -5364,8 +5317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:3+,CHH:4,CIH:6,CSV:4,CLAN:2,IS:3+,CWIE:8,MERC.WD:7,CDS:2,CW:7,CNC:2,CJF:5,CGB:4</availability>
+			<availability>MERC.KH:3+,CHH:4,CIH:6,CSV:4,CLAN:2,IS:3+,CWIE:8,MERC.WD:7,CDS:2,CW:7,CNC:2,CJF:5,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:7,CSV:5,CNC:4,General:6,CJF:7</availability>
 			</model>
@@ -5670,8 +5622,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:5,CBS:3,FWL:2,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
+			<availability>CHH:3,CSV:5,FRR:4,CLAN:4,CFM:5,WOB:5,CGS:3,CS:5,DC.GHO:5,Periphery.R:2,CDS:3,LA:5,CBS:3,FWL:2,NIOPS:5,CJF:5,CGB:3,DC:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:4-,LA:4-</availability>
 			</model>
@@ -5719,8 +5670,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4</availability>
+			<availability>CC:6,MOC:4,OA:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:2,CM:4</availability>
@@ -5901,8 +5851,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:4,General:8,FWL:4,WOB:4</availability>
@@ -5939,16 +5888,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>
-					MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
+				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 			</model>
 			<model name='GAL-103'>
 				<roles>recon</roles>
@@ -5998,8 +5945,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:5</availability>
@@ -6010,8 +5956,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:2,SOC:1,CLAN:5,IS:2+,BAN:4,CWIE:3,CSA:6,MERC.WD:3,CDS:5,CNC:5,CJF:4,CGB:9,CB:4</availability>
+			<availability>CSR:2,SOC:1,CLAN:5,IS:2+,BAN:4,CWIE:3,CSA:6,MERC.WD:3,CDS:5,CNC:5,CJF:4,CGB:9,CB:4</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -6158,8 +6103,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,IS:1,WOB:2,FS:3,MERC:3,TC:2,Periphery:2,CS:1,OA:1,FVC:2,LA:5,Periphery.MW:1,FWL:6,MH:1</availability>
+			<availability>CC:3,MOC:2,IS:1,WOB:2,FS:3,MERC:3,TC:2,Periphery:2,CS:1,OA:1,FVC:2,LA:5,Periphery.MW:1,FWL:6,MH:1</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:4-,HL:2-,LA:5-,FWL:4-,Periphery.Deep:8,IS:2-,MERC:4-,Periphery:4-</availability>
@@ -6240,14 +6184,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6-</availability>
+			<availability>CS:8,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:6-</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:5-,FWL:5-,MH:5-,MERC:5-</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
+				<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:4,FWL:4,BAN:2</availability>
@@ -6304,8 +6246,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:3,WOB:5,FWL.KIS:8,FS:5,MERC:5,CS:3,DTA:7,FVC:5,Periphery.MW:3,FWL:7,MH:3,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:3,WOB:5,FWL.KIS:8,FS:5,MERC:5,CS:3,DTA:7,FVC:5,Periphery.MW:3,FWL:7,MH:3,DC:5</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:6,General:4,FWL:8,Periphery.Deep:6,MERC:8,Periphery:8</availability>
 			</model>
@@ -6314,8 +6255,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:6,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 			</model>
@@ -6436,8 +6376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,HL:4,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:5,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:2,CC:5,HL:4,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:5,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1A'>
 				<availability>LA:2-,MERC:2-,TC:2-</availability>
 			</model>
@@ -6586,8 +6525,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:3,CSR:3,FRR:3,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:3</availability>
+			<availability>CC:5,CHH:3,CSR:3,FRR:3,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:6,FWL:5,NIOPS:7,DC:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
@@ -6753,8 +6691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:3,MERC.KH:2:3068,CIH:3,CSV:5,CLAN:2,IS:3+,CLAN.IS:2:3068,MERC:2:3068,CCO:3,CDS:4,CNC:5,CJF:4,CGB:3</availability>
+			<availability>CHH:3,MERC.KH:2:3068,CIH:3,CSV:5,CLAN:2,IS:3+,CLAN.IS:2:3068,MERC:2:3068,CCO:3,CDS:4,CNC:5,CJF:4,CGB:3</availability>
 			<model name='A'>
 				<availability>CSA:8,CSV:8,General:7</availability>
 			</model>
@@ -6796,8 +6733,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:5-,CC:5-,HL:4-,FRR:5-,IS:5-,Periphery.Deep:4,WOB:5-,MERC:5-,Periphery:5-,CS:5-,FWL.pm:6-,LA:5-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,DC:5-</availability>
+			<availability>MOC:5-,CC:5-,HL:4-,FRR:5-,IS:5-,Periphery.Deep:4,WOB:5-,MERC:5-,Periphery:5-,CS:5-,FWL.pm:6-,LA:5-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,DC:5-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -6875,8 +6811,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:2,DC:4</availability>
+			<availability>Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,FS:5,MERC:3,Periphery:2,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:3,LA:3,TC.PL:5,MERC:3,FS:2,Periphery:3</availability>
@@ -6984,8 +6919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				CC:4,MOC:8,HL:4,MERC:4,Periphery.OS:5,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
+			<availability>CC:4,MOC:8,HL:4,MERC:4,Periphery.OS:5,TC:7,Periphery:5,OA:7,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:7</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -6998,8 +6932,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:1,FS:3,MERC:2,CDP:2,Periphery:3,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:1,FS:3,MERC:2,CDP:2,Periphery:3,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:5:3068,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7107,8 +7040,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2-,OA:4,FVC:2,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:2-,CDP:3,TC:2-,Periphery:3-</availability>
+			<availability>MOC:2-,OA:4,FVC:2,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:2-,CDP:3,TC:2-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:4</availability>
 			</model>
@@ -7307,8 +7239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:2,Periphery:2,CWIE:3,CGB:2</availability>
+			<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:2,Periphery:2,CWIE:3,CGB:2</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -7449,8 +7380,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2,MERC.WD:6,FVC:8,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9</availability>
+			<availability>MOC:2,FS:6,MERC:5,Periphery.OS:4,FS.CrMM:9,Periphery:2,TC:2,MERC.WD:6,FVC:8,OA:2,Periphery.HR:4,FS.CMM:9,FS.DMM:9</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:4-</availability>
@@ -7503,8 +7433,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,HL:4,FRR:6,IS:4-,Periphery.Deep:5,WOB:3-,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4,CGB:2-</availability>
+			<availability>MOC:4,CC:4,HL:4,FRR:6,IS:4-,Periphery.Deep:5,WOB:3-,FS:4,CIR:5,Periphery:5,TC:4,CS:4-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -7561,8 +7490,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:6-</availability>
@@ -7827,8 +7755,7 @@
 			<availability>WOB.PM:3-</availability>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -7839,11 +7766,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CLAN:8</availability>
@@ -7915,8 +7840,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,WOB:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,WOB:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -7937,8 +7861,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:5-,FS.AH:4-,IS:4-,Periphery.Deep:5,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,DC:4-</availability>
+			<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:5-,FS.AH:4-,IS:4-,Periphery.Deep:5,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,DC:4-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8037,8 +7960,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:3,CC:5-,FRR:5,IS:2,WOB:3,MERC:3,Periphery.OS:2,FS:8,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:4,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:2,NIOPS:3,MH:4,DC:3</availability>
+			<availability>MOC:3,CC:5-,FRR:5,IS:2,WOB:3,MERC:3,Periphery.OS:2,FS:8,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:4,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:2,NIOPS:3,MH:4,DC:3</availability>
 			<model name='JM6-A'>
 				<roles>anti_aircraft</roles>
 				<availability>FVC:2,FS:2-</availability>
@@ -8079,8 +8001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,HL:3,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:4,LA:3,Periphery.HR:6</availability>
+			<availability>MOC:4,HL:3,IS:4,Periphery.Deep:4,FS:9,MERC:6,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:4,LA:3,Periphery.HR:6</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:2,IS:1,FS:2-,MERC:2,TC:2,Periphery:1</availability>
@@ -8147,8 +8068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:3-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3-,DC:8</availability>
+			<availability>CC:3-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:3-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:4+,FS:4+,DC:8</availability>
@@ -8435,8 +8355,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:2,FRR:4,CLAN:3,IS:2,WOB:6,FS:6,MERC:3,CIR:2,CGS:5,DC.GHO:6,CS:6,FVC:5,LA:2,FWL:2,NIOPS:6,CGB:4,DC:2</availability>
+			<availability>CC:2,FRR:4,CLAN:3,IS:2,WOB:6,FS:6,MERC:3,CIR:2,CGS:5,DC.GHO:6,CS:6,FVC:5,LA:2,FWL:2,NIOPS:6,CGB:4,DC:2</availability>
 			<model name='KGC-000'>
 				<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 			</model>
@@ -8677,8 +8596,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:7,CIH:8,CSR:7,CSV:8,CLAN:3,IS:3+,CCO:3,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CJF:6,CB:7,DC:3+</availability>
+			<availability>CHH:7,CIH:8,CSR:7,CSV:8,CLAN:3,IS:3+,CCO:3,CGS:6,BAN:7,CSA:7,MERC.WD:7,CDS:7,CW:7,CBS:7,CJF:6,CB:7,DC:3+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CIH:6,CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -8898,8 +8816,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:4</availability>
 			</model>
@@ -8946,8 +8863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,OA:5,HL:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,CIR:5,Periphery.OS:5,TC:8,Periphery:4</availability>
+			<availability>MOC:7,OA:5,HL:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,CIR:5,Periphery.OS:5,TC:8,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -9009,8 +8925,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:6-</availability>
 			</model>
@@ -9243,8 +9158,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
-			<availability>
-				CCC:1,CHH:3,CSR:3,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:4,MERC.WD:2,CDS:2,CW:1,CNC:3,CB:1</availability>
+			<availability>CCC:1,CHH:3,CSR:3,CIH:3,CSV:2,CFM:3,WOB:1,CCO:2,CGS:2,CS:5,CSA:4,MERC.WD:2,CDS:2,CW:1,CNC:3,CB:1</availability>
 			<model name='(2662)'>
 				<roles>destroyer</roles>
 				<availability>General:8</availability>
@@ -9265,8 +9179,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -9354,8 +9267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
+			<availability>MOC:2,Periphery.R:4,OA:3,HL:4,LA:8,FRR:4,Periphery.MW:3,FS:5-,MERC:3,CIR:3,TC:2,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>LA:2-,General:2-,Periphery.Deep:4,MERC:8-,Periphery:2-</availability>
 			</model>
@@ -9450,8 +9362,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:2,CIH:4,CLAN:5,WOB:1,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:9,CDS:6,CW:9,CBS:4,CJF:6</availability>
+			<availability>CHH:2,CIH:4,CLAN:5,WOB:1,CCO:6,BAN:3,CWIE:9,CSA:6,MERC.WD:9,CDS:6,CW:9,CBS:4,CJF:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -9583,8 +9494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CIH:9,CSV:8,CLAN:4,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:5,CJF:9,CGB:4</availability>
+			<availability>CHH:6,CIH:9,CSV:8,CLAN:4,IS:3+,BAN:6,CWIE:9,MERC.WD:9,CDS:9,CW:9,CBS:6,CNC:5,CJF:9,CGB:4</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -9644,8 +9554,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:7,HL:7,FRR:9,IS:8,Periphery.Deep:8,WOB:8,MERC:8,FS:8,CIR:7,Periphery:8,TC:8,CS:8,OA:8,LA:8,FWL:7,NIOPS:8,DC:10</availability>
+			<availability>MOC:7,CC:7,HL:7,FRR:9,IS:8,Periphery.Deep:8,WOB:8,MERC:8,FS:8,CIR:7,Periphery:8,TC:8,CS:8,OA:8,LA:8,FWL:7,NIOPS:8,DC:10</availability>
 			<model name=''>
 				<availability>HL:4,LA:3-,General:6-,Periphery.Deep:5,FS:3-,DC:3-,Periphery:6</availability>
 			</model>
@@ -9700,8 +9609,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder II' unitType='Mek'>
-			<availability>
-				CC:3,FRR:4,WOB:2,FS:5,MERC:5,TC:3,CS:3,MERC.WD:6,LA:4,PIR:3,CNC:3,FWL:4,MH:3,SL.2:4,DC:4</availability>
+			<availability>CC:3,FRR:4,WOB:2,FS:5,MERC:5,TC:3,CS:3,MERC.WD:6,LA:4,PIR:3,CNC:3,FWL:4,MH:3,SL.2:4,DC:4</availability>
 			<model name='C'>
 				<availability>MERC.WD:3</availability>
 			</model>
@@ -9734,8 +9642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
+			<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,SL.2:5,DC:4,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:3,LA:3+,CNC:3,FS:3+,CJF:2,DC:3+,CGB:3,CWIE:3</availability>
 			</model>
@@ -9830,8 +9737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:3,TC:4</availability>
 			</model>
@@ -9850,8 +9756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:3,CSR:4,CSV:1,CLAN:2,IS:2+,CFM:8,MERC:2+,CGS:7,BAN:3,CWIE:2,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
+			<availability>MERC.KH:3,CSR:4,CSV:1,CLAN:2,IS:2+,CFM:8,MERC:2+,CGS:7,BAN:3,CWIE:2,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
 			</model>
@@ -9958,8 +9863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:2,FRR:5,CLAN:3,IS:3,Periphery.Deep:5,WOB:4-,MERC:3,FS:2,CIR:3,Periphery:3,TC:3,CS:4-,OA:3,LA:5,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:3,CC:4,HL:2,FRR:5,CLAN:3,IS:3,Periphery.Deep:5,WOB:4-,MERC:3,FS:2,CIR:3,Periphery:3,TC:3,CS:4-,OA:3,LA:5,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
@@ -10141,8 +10045,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -10203,8 +10106,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:5,SOC:4,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,WOB:5,MERC:5,Periphery:6</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:5,SOC:4,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,WOB:5,MERC:5,Periphery:6</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -10994,8 +10896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,TC:5,FVC:7,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:4,FWL:9,MH:5,DC:4</availability>
+			<availability>MOC:6,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,TC:5,FVC:7,CDS:5,LA:7,PIR:4,Periphery.ME:4,CNC:4,FWL:9,MH:5,DC:4</availability>
 			<model name=''>
 				<availability>HL:4,General:5,Periphery.Deep:6,Periphery:6</availability>
 			</model>
@@ -11036,8 +10937,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:3,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
+			<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:3,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:4,CWIE:2,CS:4-,OA:4,CW:2,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>HL:3-,General:5-,CLAN:5-,Periphery.Deep:8,Periphery:5-</availability>
 			</model>
@@ -11124,8 +11024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:3-,IS:4-,Periphery.Deep:8,MERC:5-,BAN:1,Periphery:5-</availability>
@@ -11239,8 +11138,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5,BAN:1</availability>
@@ -11286,8 +11184,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pack Hunter' unitType='Mek'>
-			<availability>
-				CHH:3,CCC:3,MERC.KH:1,CIH:3,CSR:3,CSV:3,CLAN:3,CCO:3,CWIE:7,CSA:3,CDS:3,CW:3,CNC:4</availability>
+			<availability>CHH:3,CCC:3,MERC.KH:1,CIH:3,CSR:3,CSV:3,CLAN:3,CCO:3,CWIE:7,CSA:3,CDS:3,CW:3,CNC:4</availability>
 			<model name=''>
 				<availability>CW:8,General:8</availability>
 			</model>
@@ -11302,8 +11199,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
+			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -11314,8 +11210,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
+				<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -11338,8 +11233,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:9,WOB:4,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
+			<availability>CC:2,Periphery.DD:5,FS.RR:5,HL:2,FRR:9,WOB:4,MERC:5,FS:2,Periphery.OS:5,Periphery:3,CS:2,LA:2,FS.DMM:5,CNC:5,FWL:2,NIOPS:2,DC:10</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:5,FRR:6,CNC:4,FS.DMM:5,WOB:6,MERC:5,DC:6</availability>
@@ -11463,8 +11357,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:7-,CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,TC:7-,CS:6-,OA:3-,CDS:4,LA:5-,FWL:5-,DC:4-</availability>
+			<availability>MOC:7-,CC:4-,HL:6-,FRR:4-,IS:5-,Periphery.Deep:7-,WOB:6-,FS:6-,CIR:4-,Periphery:7-,TC:7-,CS:6-,OA:3-,CDS:4,LA:5-,FWL:5-,DC:4-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11512,8 +11405,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:2,CC:3,FRR:3,IS:3,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:2,TC:2,CWIE:3,CS:5-,OA:2,LA:6,FWL:3,DC:6</availability>
+			<availability>MOC:2,CC:3,FRR:3,IS:3,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:2,TC:2,CWIE:3,CS:5-,OA:2,LA:6,FWL:3,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:6</availability>
@@ -11785,8 +11677,7 @@
 			<availability>LA:2-,MERC:3-,TC:3-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:6,CC:3-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:4-,WOB:4-,FS:3-,MERC:4-,CIR:3-,CWIE:6,Periphery:3-,TC:4-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:3-,CNC:6,FWL:2-,MH:5-,DC:4-</availability>
+			<availability>MOC:6,CC:3-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:4-,WOB:4-,FS:3-,MERC:4-,CIR:3-,CWIE:6,Periphery:3-,TC:4-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:3-,CNC:6,FWL:2-,MH:5-,DC:4-</availability>
 			<model name=''>
 				<availability>HL:6,IS:6,Periphery.Deep:6,Periphery:8</availability>
 			</model>
@@ -12081,8 +11972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:8,CLAN:8,IS:2+,CFM:8,MERC:2+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:6,CDS:9,CW:9,CBS:7,CNC:9,CJF:6,CGB:7</availability>
+			<availability>CSR:8,CLAN:8,IS:2+,CFM:8,MERC:2+,CCO:7,BAN:7,CWIE:9,CSA:9,MERC.WD:6,CDS:9,CW:9,CBS:7,CNC:9,CJF:6,CGB:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -12177,8 +12067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,FS:3,CIR:4,CDP:4,Periphery:4,TC:5,CS:3-,OA:5,FVC:4,LA:5,FWL:7,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:3,HL:3,FRR:7,IS:5,Periphery.Deep:4,WOB:3-,FS:3,CIR:4,CDP:4,Periphery:4,TC:5,CS:3-,OA:5,FVC:4,LA:5,FWL:7,NIOPS:3-,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:4-,IS:4-,Periphery:4-,DC:4-,TC:4-</availability>
 			</model>
@@ -12440,8 +12329,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,HL:9,FRR:5,CLAN:6,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,FRR:5,CLAN:6,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -12467,8 +12355,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:5,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,FVC:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
+			<availability>MOC:3,CC:5,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,FVC:3,LA:4,Periphery.MW:3,Periphery.ME:3,FWL:8,DC:5</availability>
 			<model name='F-100'>
 				<availability>
 					CC:4-,FVC:5-,HL:3-,LA:2,FRR:2,FWL:5-,Periphery.Deep:8,MERC:5-,DC:2,Periphery:5-</availability>
@@ -12518,8 +12405,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:7,Periphery.Deep:5,WOB:5,CFM:6,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CB:6</availability>
+			<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:7,Periphery.Deep:5,WOB:5,CFM:6,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CB:6</availability>
 			<model name='C'>
 				<availability>LA:2,CLAN:8,FS:2,BAN:2,DC:2</availability>
 			</model>
@@ -12734,8 +12620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:8,CSR:9,CSV:7,CLAN:8,WOB:3+,MERC:2+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CW:8,CBS:9,CNC:6,CJF:9,DC:3+</availability>
+			<availability>CHH:8,CSR:9,CSV:7,CLAN:8,WOB:3+,MERC:2+,BAN:8,CWIE:8,MERC.WD:8,CDS:9,CW:8,CBS:9,CNC:6,CJF:9,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -12770,8 +12655,7 @@
 				<availability>CDS:5,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
 			<model name='TC'>
-				<availability>
-					MERC.WD:2:3062,SOC:1:3062,CLAN.IS:2,WOB:1:3068,MERC:1:3062,CLAN.HW:1:3062,DC:1:3062</availability>
+				<availability>MERC.WD:2:3062,SOC:1:3062,CLAN.IS:2,WOB:1:3068,MERC:1:3062,CLAN.HW:1:3062,DC:1:3062</availability>
 			</model>
 			<model name='Z'>
 				<availability>SOC:10,CCO:4</availability>
@@ -12840,8 +12724,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:2,MOC:2,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:2,MERC:2,Periphery:3-,OA:2-,LA:2,FWL:2-,DC:4</availability>
+			<availability>CC:2,MOC:2,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:2,MERC:2,Periphery:3-,OA:2-,LA:2,FWL:2-,DC:4</availability>
 			<model name='SB-27'>
 				<availability>General:6-</availability>
 			</model>
@@ -12915,8 +12798,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
+			<availability>CC:7,Periphery.DD:8,FRR:8,DC.AL:10,IS:7,WOB:5-,MERC:7,Periphery.OS:8,FS:6,CIR:6,Periphery:6,CS:5-,LA:7,FWL:7,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:8-,Periphery:8-</availability>
 			</model>
@@ -12983,8 +12865,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:6-,Periphery.DD:7,HL:4,FRR:7-,IS:6-,WOB:4,Periphery.OS:7,FS:5-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:5,FWL.MM:8,CW:3,LA:5-,FWL:7-,DC:8-</availability>
+			<availability>MOC:5,CC:6-,Periphery.DD:7,HL:4,FRR:7-,IS:6-,WOB:4,Periphery.OS:7,FS:5-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:5,FWL.MM:8,CW:3,LA:5-,FWL:7-,DC:8-</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -13136,8 +13017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:5,CC:3,HL:5,FRR:4,IS:5,Periphery.Deep:5,WOB:5,MERC:5,FS:5,CIR:6,Periphery:6,TC:5,CS:5,OA:6,LA:5,FWL:4,DC:3</availability>
+			<availability>MOC:5,CC:3,HL:5,FRR:4,IS:5,Periphery.Deep:5,WOB:5,MERC:5,FS:5,CIR:6,Periphery:6,TC:5,CS:5,OA:6,LA:5,FWL:4,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -13151,8 +13031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:6-,CC:6-,Periphery.DD:6-,HL:4-,FRR:7-,IS:5-,WOB:4-,MERC:5-,Periphery.OS:6-,FS:4-,CIR:5-,Periphery:5-,TC:6-,CS:4-,OA:6-,LA:5-,FWL:4-,DC:7-</availability>
+			<availability>MOC:6-,CC:6-,Periphery.DD:6-,HL:4-,FRR:7-,IS:5-,WOB:4-,MERC:5-,Periphery.OS:6-,FS:4-,CIR:5-,Periphery:5-,TC:6-,CS:4-,OA:6-,LA:5-,FWL:4-,DC:7-</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -13168,8 +13047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,FVC:6,HL:6,LA:6,FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
+			<availability>CC:6,FVC:6,HL:6,LA:6,FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -13190,8 +13068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2-,CS:2-,HL:2-,LA:3,FRR:2-,Periphery.Deep:4-,FWL:2-,NIOPS:2-,WOB:2-,MERC:2-,Periphery:3-,DC:2-</availability>
+			<availability>CC:2-,CS:2-,HL:2-,LA:3,FRR:2-,Periphery.Deep:4-,FWL:2-,NIOPS:2-,WOB:2-,MERC:2-,Periphery:3-,DC:2-</availability>
 			<model name='SCP-12C'>
 				<availability>WOB:4</availability>
 			</model>
@@ -13228,8 +13105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scytha' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:3,CCC:4,CIH:3,CSR:4,CSV:4,CLAN:3,CFM:3,CGS:3,CCO:5,CWIE:5,CSA:3,CW:5,CNC:4,CJF:7</availability>
+			<availability>CHH:3,CCC:4,CIH:3,CSR:4,CSV:4,CLAN:3,CFM:3,CGS:3,CCO:5,CWIE:5,CSA:3,CW:5,CNC:4,CJF:7</availability>
 			<model name='A'>
 				<availability>General:6</availability>
 			</model>
@@ -13295,8 +13171,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
+			<availability>CSV:2,CLAN:3,CFM:4,WOB:4,FS:4,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:5,CDS:2,CW:2,LA:6,CBS:2,NIOPS:4,CJF:4,CGB:4,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -13348,8 +13223,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
+			<availability>MOC:4,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,LA:8,FWL:3-,MH:2,DC:4-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:3-,LA:3-,Periphery.Deep:4,FS:2-,MERC:3-,Periphery:3-</availability>
@@ -13448,8 +13322,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				CHH:6,FRR:2,CLAN:5,FS:2,MERC:2,CWIE:6,CS:2,CDS:6,CW:4,LA:2,CNC:6,FWL:2,CJF:4,DC:2,CGB:6</availability>
+			<availability>CHH:6,FRR:2,CLAN:5,FS:2,MERC:2,CWIE:6,CS:2,CDS:6,CW:4,LA:2,CNC:6,FWL:2,CJF:4,DC:2,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:4</availability>
 			</model>
@@ -13473,8 +13346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>
-				CS:4-,HL:5,LA:3,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
+			<availability>CS:4-,HL:5,LA:3,CLAN:1,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,BAN:3,Periphery:6,CGB:1</availability>
 			<model name='C'>
 				<availability>CSA:8,CCC:8,LA:4,CSV:8,CFM:8,FS:4,CGS:8,CB:8,DC:4</availability>
 			</model>
@@ -13703,8 +13575,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:6</availability>
@@ -13719,8 +13590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:2,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 			</model>
@@ -13821,8 +13691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3,DC:2-</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,FRR:5,PIR:2+,FS:8,MERC:5,CDP:2+,TC:2+</availability>
 			</model>
@@ -13877,8 +13746,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,OA:1,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:4-</availability>
@@ -13969,8 +13837,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:8,CC:6,HL:9,FRR:6,CLAN:3,IS:7,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:9,CS:5,OA:9,LA:7,FWL:8,NIOPS:5,DC:6</availability>
+			<availability>MOC:8,CC:6,HL:9,FRR:6,CLAN:3,IS:7,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:9,CS:5,OA:9,LA:7,FWL:8,NIOPS:5,DC:6</availability>
 			<model name='STK-3F'>
 				<availability>HL:3-,IS:5-,Periphery.Deep:8,Periphery:5-</availability>
 			</model>
@@ -14116,8 +13983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:2-,Periphery.Deep:4,Periphery:2-</availability>
@@ -14156,8 +14022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:4-,LA:3-,IS:4-,FS:4-,Periphery:4-</availability>
 			</model>
@@ -14307,8 +14172,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:5,Periphery.HR:2,DC:1</availability>
+			<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:5,Periphery.HR:2,DC:1</availability>
 			<model name='STU-D6'>
 				<availability>LA:6,FS:8,MERC:6</availability>
 			</model>
@@ -14694,8 +14558,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:5,CIH:3,CLAN:5,IS:2+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CJF:8,CGB:5,CB:3</availability>
+			<availability>CHH:5,CSR:5,CIH:3,CLAN:5,IS:2+,CCO:5,BAN:5,CWIE:6,CSA:4,MERC.WD:4,CDS:5,CW:5,CNC:5,CJF:8,CGB:5,CB:3</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -14754,8 +14617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>
-				MOC:2,CLAN:1,WOB:7,CCO:1,Periphery:2,TC:2,CS:5,DC.GHO:2,CSA:2,OA:2,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+			<availability>MOC:2,CLAN:1,WOB:7,CCO:1,Periphery:2,TC:2,CS:5,DC.GHO:2,CSA:2,OA:2,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
 			</model>
@@ -14783,8 +14645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:6-,FVC:5-,HL:4-,General:5-,FWL:6-,Periphery.Deep:6-,MERC:6-,Periphery:6-</availability>
@@ -14797,8 +14658,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:4,FRR:2,CSV:6,CLAN:5,IS:3,CFM:7,WOB:7,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,FVC:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
+			<availability>CHH:4,FRR:2,CSV:6,CLAN:5,IS:3,CFM:7,WOB:7,FS:4,CWIE:6,DC.GHO:6,CS:8,OA:3,FVC:3,CDS:4,CW:6,CBS:4,LA:3,CNC:4,FWL:6,NIOPS:8,CJF:6,CGB:6</availability>
 			<model name='THG-10E'>
 				<availability>FWL:5,MERC:5</availability>
 			</model>
@@ -14875,8 +14735,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:4-</availability>
@@ -14897,8 +14756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:6,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,CFM:1,FS:6,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:4,LA:6,NIOPS:3-,MH:4,DC:6</availability>
+			<availability>CC:6,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,CFM:1,FS:6,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:4,LA:6,NIOPS:3-,MH:4,DC:6</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,CFM:1,CLAN.IS:1-,FS:1,CGS:1-,DC:1+,CB:1</availability>
 			</model>
@@ -15165,8 +15023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,FRR:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
+			<availability>MOC:4,CC:4,FRR:4,IS:4,WOB:3-,FS:3,MERC:4,Periphery:5,TC:4,CS:3-,OA:4,LA:4,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:3</availability>
@@ -15176,8 +15033,7 @@
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
+				<availability>CC:3-,CS:2-,MOC:6-,LA:3-,FWL:2-,IS:6-,NIOPS:2-,WOB:2-,FS:3-,MERC:6-,DC:3-,Periphery:6-</availability>
 			</model>
 			<model name='TBT-5S'>
 				<availability>MOC:3-,IS:3-,Periphery.Deep:4,FWL:3-,MERC:3-,CDP:3,Periphery:3-,TC:3-</availability>
@@ -15436,8 +15292,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:2,CCO:3,CWIE:4,MERC.WD:4,CDS:3,CW:4,CBS:6,CNC:2,CJF:7,CGB:2</availability>
+			<availability>CCC:9,CHH:4,CIH:3,CSR:7,CSV:5,CLAN:2,CCO:3,CWIE:4,MERC.WD:4,CDS:3,CW:4,CBS:6,CNC:2,CJF:7,CGB:2</availability>
 			<model name='A'>
 				<availability>CHH:6,CIH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -15562,8 +15417,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -15745,8 +15599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:5</availability>
@@ -15783,8 +15636,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -15844,8 +15696,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
-			<availability>
-				CCC:2,CSR:1,CSV:1,CFM:1,WOB:1,CCO:1,CWIE:2,CS:3,CSA:2,MERC.WD:1,CW:2,CNC:1,FWL:1,CJF:1</availability>
+			<availability>CCC:2,CSR:1,CSV:1,CFM:1,WOB:1,CCO:1,CWIE:2,CS:3,CSA:2,MERC.WD:1,CW:2,CNC:1,FWL:1,CJF:1</availability>
 			<model name='Mk 39'>
 				<roles>corvette</roles>
 				<availability>MERC.WD:0,IS:8</availability>
@@ -16023,8 +15874,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:6,CW:4,CNC:4,CJF:7,CGB:9,DC:2+</availability>
+			<availability>CHH:9,CIH:7,CSV:7,CLAN:8,CCO:7,BAN:7,CWIE:7,MERC.WD:6,CW:4,CNC:4,CJF:7,CGB:9,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 			</model>
@@ -16099,8 +15949,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
+			<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:2+,FS:2+,DC:2+</availability>
 			</model>
@@ -16174,8 +16023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:3,FWL:3</availability>
@@ -16316,8 +16164,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:3,HL:3,MERC:3,Periphery.OS:3,Periphery:4,TC:3,CS:2-,OA:3,FVC:3,FS.CMM:4,NIOPS:2-,MH:3,DC:4</availability>
+			<availability>MOC:1,Periphery.DD:3,HL:3,MERC:3,Periphery.OS:3,Periphery:4,TC:3,CS:2-,OA:3,FVC:3,FS.CMM:4,NIOPS:2-,MH:3,DC:4</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>HL:2,Periphery.Deep:8,MERC:4,Periphery:4</availability>
@@ -16398,8 +16245,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
 			<model name='WVR-6M'>
 				<roles>recon</roles>
 				<availability>Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4-,MH:4</availability>
@@ -16460,8 +16306,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:3,CIH:2,FRR:5,CLAN:2,IS:3,CFM:3,WOB:4-,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:6</availability>
+			<availability>CC:3,CIH:2,FRR:5,CLAN:2,IS:3,CFM:3,WOB:4-,FS:6,MERC:4,TC:2,DC.GHO:6,CS:5,NIOPS:5,DC:6</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:5,WOB:4</availability>
@@ -16630,8 +16475,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zeus' unitType='Mek'>
-			<availability>
-				HL:5,FRR:4,IS:2,WOB:3,FS:6-,MERC:5,CDP:4,Periphery:4,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
+			<availability>HL:5,FRR:4,IS:2,WOB:3,FS:6-,MERC:5,CDP:4,Periphery:4,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
 			<model name='ZEU-10WB'>
 				<availability>LA:4,WOB:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -12,8 +12,7 @@
 			<pctClan>30</pctClan>
 			<pctSL>60</pctSL>
 			<techMargin>1</techMargin>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CSV:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:1,CJF:2,CGB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CSV:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:1,CJF:2,CGB:2</salvage>
 		</faction>
 		<faction key='CDP'>
 			<pctClan>0,0,0,0,5</pctClan>
@@ -751,8 +750,7 @@
 			<pctSL>75</pctSL>
 			<omniMargin>1</omniMargin>
 			<techMargin>1</techMargin>
-			<salvage pct='6'>
-				MOC:2,CC:8,FRR:1,WOB:20,FS:8,TC:2,OA:2,CW:5,LA:8,CNC:3,FWL:14,CJF:7,CGB:5,DC:11</salvage>
+			<salvage pct='6'>MOC:2,CC:8,FRR:1,WOB:20,FS:8,TC:2,OA:2,CW:5,LA:8,CNC:3,FWL:14,CJF:7,CGB:5,DC:11</salvage>
 		</faction>
 		<faction key='FWL.KIS'>
 			<pctOmni>35</pctOmni>
@@ -1174,8 +1172,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:3,General:5,Periphery.Deep:6,Periphery:5</availability>
@@ -1223,8 +1220,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -1235,8 +1231,7 @@
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
-			<availability>
-				CCC:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:2,CJF:5</availability>
+			<availability>CCC:2,CSR:5,CSV:1,CGS:2,CWIE:2,CSA:2,CS:3,MERC.WD:1,CDS:1,CBS:1,CNC:5,FWL:2,CJF:5</availability>
 			<model name='(2582)'>
 				<roles>cruiser</roles>
 				<availability>CS:8,FWL:8</availability>
@@ -1404,8 +1399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				CSA:2,MERC.KH:3,MERC.WD:8,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
+			<availability>CSA:2,MERC.KH:3,MERC.WD:8,CHH:2,CSR:2,LA:4,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CGB:2</availability>
 			<model name='ANH-1A'>
 				<availability>CLAN:1-,MERC:2-</availability>
 			</model>
@@ -1556,8 +1550,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:4,HL:3,FRR:4,CLAN:1,IS:4-,Periphery.Deep:5,WOB:2-,FS:4-,Periphery:4,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
+			<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:4-,Periphery.Deep:5,WOB:2-,FS:4-,Periphery:4,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:6,MERC.WD:6,CWIE:2</availability>
 			</model>
@@ -1745,8 +1738,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1811,8 +1803,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
+			<availability>MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
 			<model name='ASN-21'>
 				<availability>General:1-</availability>
 			</model>
@@ -1898,8 +1889,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FRR:6,IS:2+,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:2,NIOPS:4-,DC:9</availability>
+			<availability>MOC:1,CC:2,FRR:6,IS:2+,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:2,NIOPS:4-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -2078,8 +2068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,FWL:4,WOB:4,DC:4</availability>
 			</model>
@@ -2361,8 +2350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:7-,CC:2-,HL:8-,FRR:3-,IS:2-,Periphery.Deep:9-,FS:2-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,OA:7-,FVC:3-,LA:5-,FWL:3-,MH:7-,DC:2-</availability>
+			<availability>MOC:7-,CC:2-,HL:8-,FRR:3-,IS:2-,Periphery.Deep:9-,FS:2-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,OA:7-,FVC:3-,LA:5-,FWL:3-,MH:7-,DC:2-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:2-,General:2-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 			</model>
@@ -2553,8 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
+			<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
 			<model name='BLR-10S'>
 				<availability>LA:5,FS:3</availability>
 			</model>
@@ -2635,8 +2622,7 @@
 			</model>
 		</chassis>
 		<chassis name='Batu' unitType='AeroSpaceFighter' omni='Clan'>
-			<availability>
-				CHH:6,SOC:6,CSV:8,CGS:6,CCO:4,CWIE:4,CSA:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CGB:6,DC:2+</availability>
+			<availability>CHH:6,SOC:6,CSV:8,CGS:6,CCO:4,CWIE:4,CSA:6,CDS:6,CW:7,CNC:6,CSL:6,CJF:7,CGB:6,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:8,General:7,CGS:3</availability>
 			</model>
@@ -2712,8 +2698,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:5,Periphery:4,CS:4-,OA:4,CDS:5,LA:4,PIR:3,CNC:3,FWL:2,DC:5</availability>
+			<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:5,Periphery:4,CS:4-,OA:4,CDS:5,LA:4,PIR:3,CNC:3,FWL:2,DC:5</availability>
 			<model name=''>
 				<availability>FVC:3,CDS:3,General:8,DC:4</availability>
 			</model>
@@ -2858,14 +2843,12 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:5,FRR:4,CLAN:6,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:7,LA:3,CNC:7,RCM:5,CJF:5,DC:4</availability>
+			<availability>CHH:5,FRR:4,CLAN:6,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:7,LA:3,CNC:7,RCM:5,CJF:5,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:6</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					FRR:6,CLAN:6,WOB:4,BAN:6,TC:4,Periphery:4,DC.GHO:4,CS:4,OA:4,FWL:6,NIOPS:4,MERC.SI:3,DC:6</availability>
+				<availability>FRR:6,CLAN:6,WOB:4,BAN:6,TC:4,Periphery:4,DC.GHO:4,CS:4,OA:4,FWL:6,NIOPS:4,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>DTA:6,CS:6,LA:4,CLAN:5,FWL:6,NIOPS:6,MERC:4,FS:4,CGS:6,BAN:2,DC:4</availability>
@@ -3096,8 +3079,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3145,8 +3127,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+			<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3185,8 +3166,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:4-,HL:3-,FRR:3-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,FWL:1-,DC:3-</availability>
+			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,FWL:1-,DC:3-</availability>
 			<model name=''>
 				<availability>LA:4,General:8,FS:4,MERC:4,DC:4</availability>
 			</model>
@@ -3339,8 +3319,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:2,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
+			<availability>CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:2,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
 			<model name='CTF-1X'>
 				<availability>General:4-,Periphery:5-</availability>
 			</model>
@@ -3367,8 +3346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,FRR:5,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,RCM:2,DC:6</availability>
+			<availability>MOC:3,CC:4,FRR:5,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,FWL:1,NIOPS:4,MH:5,RCM:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:1-</availability>
@@ -3570,8 +3548,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,FRR:1,IS:1,WOB:2-,Periphery.OS:4,FS:8,MERC:2,CDP:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:4,DC:1</availability>
+			<availability>CC:2,FRR:1,IS:1,WOB:2-,Periphery.OS:4,FS:8,MERC:2,CDP:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:4,DC:1</availability>
 			<model name='CN10-B'>
 				<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
 			</model>
@@ -3703,15 +3680,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:5,CHH:2,FRR:4,IS:3,WOB:5,FS:3,MERC:2,DC.GHO:5,CS:5,DTA:2,FVC:2,LA:4,FWL:3,NIOPS:5,RCM:2,CGB:2,DC:4</availability>
+			<availability>CC:5,CHH:2,FRR:4,IS:3,WOB:5,FS:3,MERC:2,DC.GHO:5,CS:5,DTA:2,FVC:2,LA:4,FWL:3,NIOPS:5,RCM:2,CGB:2,DC:4</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CC:2,CHH:2,WOB:4,FS:2,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:2,CGB:2</availability>
+				<availability>CC:2,CHH:2,WOB:4,FS:2,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:2,CGB:2</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:4,CS:4,LA:4,IS:2,MERC:4</availability>
@@ -3792,12 +3767,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,OA:4,FVC:2,LA:2-,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,RCM:10,DC:2-</availability>
+			<availability>MOC:5,CC:3,HL:2,FRR:3,WOB:6,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,OA:4,FVC:2,LA:2-,Periphery.MW:4,Periphery.ME:4,FWL:10,NIOPS:3,RCM:10,DC:2-</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
-				<availability>
-					CC:4-,DTA:2-,HL:2-,General:2-,Periphery.Deep:8,FWL:4-,MERC:4-,RCM:2-,Periphery:4-</availability>
+				<availability>CC:4-,DTA:2-,HL:2-,General:2-,Periphery.Deep:8,FWL:4-,MERC:4-,RCM:2-,Periphery:4-</availability>
 			</model>
 			<model name='F-11'>
 				<availability>CC:2,MOC:2,DTA:8,FRR:6,Periphery.MW:2,PIR:2,FWL:8,WOB:8,MERC:6,RCM:8</availability>
@@ -3855,8 +3828,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
+			<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
 			</model>
@@ -4111,8 +4083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,FRR:1,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,FWL:1,NIOPS:1-,MH:2,RCM:2,DC:2</availability>
+			<availability>CC:3,MOC:2,FRR:1,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,FWL:1,NIOPS:1-,MH:2,RCM:2,DC:2</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -4191,8 +4162,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:3-,LA:3-,Periphery:3-</availability>
@@ -4232,8 +4202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:5-,FVC:4-,General:3-,FS:5-,Periphery:3-</availability>
 			</model>
@@ -4466,8 +4435,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
+			<availability>CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4525,8 +4493,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,WOB:8,CIR:4,CGS:5,CWIE:7,DC.GHO:3,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
+			<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,WOB:8,CIR:4,CGS:5,CWIE:7,DC.GHO:3,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:4-,NIOPS:0</availability>
 			</model>
@@ -4675,8 +4642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -4731,8 +4697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>
-				CS:6,MERC.KH:4,MERC.WD:4,HL:3,SOC:3,CLAN:1-,NIOPS:6,WOB:7,MERC:4,TC:4,Periphery:4</availability>
+			<availability>CS:6,MERC.KH:4,MERC.WD:4,HL:3,SOC:3,CLAN:1-,NIOPS:6,WOB:7,MERC:4,TC:4,Periphery:4</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CS:6,WOB:6,TC:4</availability>
@@ -4834,8 +4799,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -4930,8 +4894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CCC:3,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CDS:3,CJF:3,CGB:6</availability>
+			<availability>CHH:5,CCC:3,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CDS:3,CJF:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -5028,8 +4991,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,IS:7,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,FVC:8,LA:5,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,IS:7,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,FVC:8,LA:5,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,FWL:4,DC:4</availability>
@@ -5092,8 +5054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:2,CC:2,HL:2,FRR:3,IS:2,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:2,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
+			<availability>MOC:2,CC:2,HL:2,FRR:3,IS:2,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:2,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
 			<model name='DV-1S'>
 				<availability>IS:3-</availability>
 			</model>
@@ -5149,8 +5110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:2-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:4-,OA:2-,LA:3-,FWL:2-,MH:2-,DC:2-</availability>
+			<availability>MOC:3-,CC:2-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:4-,OA:2-,LA:3-,FWL:2-,MH:2-,DC:2-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5293,8 +5253,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
+			<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
 			<model name=''>
 				<availability>CC:3-,General:4-</availability>
 			</model>
@@ -5345,8 +5304,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:1-,FS:1-</availability>
@@ -5476,8 +5434,7 @@
 		<chassis name='Emperor' unitType='Mek'>
 			<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
+				<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
 			<model name='EMP-6D'>
 				<availability>FS:8</availability>
@@ -5541,8 +5498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>
-				CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:2,LA:2,Periphery.HR:2,MH:2,DC:1</availability>
+			<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:2,LA:2,Periphery.HR:2,MH:2,DC:1</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
 			</model>
@@ -5632,8 +5588,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:5,FS:4,MERC:2</availability>
 			</model>
@@ -5891,8 +5846,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:4,HL:4,LA:5-,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3-,FS:6-</availability>
+			<availability>Periphery.R:4,HL:4,LA:5-,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3-,FS:6-</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:5</availability>
@@ -6205,8 +6159,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:2,CSV:4,FRR:4,CLAN:3,WOB:5,CGS:2,CS:5,DC.GHO:5,Periphery.R:1,CDS:2,LA:4,CBS:2,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
+			<availability>CHH:2,CSV:4,FRR:4,CLAN:3,WOB:5,CGS:2,CS:5,DC.GHO:5,Periphery.R:1,CDS:2,LA:4,CBS:2,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:2-,LA:2-</availability>
 			</model>
@@ -6254,8 +6207,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,RCM:3,Periphery:4,TC:4</availability>
+			<availability>CC:6,MOC:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,RCM:3,Periphery:4,TC:4</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:1</availability>
@@ -6265,8 +6217,7 @@
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,RCM:4-,Periphery:6-,TC:4-</availability>
+				<availability>MOC:4-,CC:4-,FVC:4-,OA:4-,HL:4-,FWL:4-,WOB:4-,MERC:5-,RCM:4-,Periphery:6-,TC:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:3</availability>
@@ -6441,8 +6392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:3-,General:8,FWL:2-,WOB:4-</availability>
@@ -6488,16 +6438,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>
-					MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
+				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,FWL:7,DC:4</availability>
 			</model>
 			<model name='GAL-103'>
 				<roles>recon</roles>
@@ -6553,8 +6501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:5</availability>
@@ -6727,8 +6674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,HL:2,IS:1,WOB:2,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,Periphery.MW:2,FWL:6,MH:2</availability>
+			<availability>CC:4,MOC:3,HL:2,IS:1,WOB:2,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,Periphery.MW:2,FWL:6,MH:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:3-,LA:4-,FWL:3-,Periphery.Deep:8,IS:1-,MERC:3-,Periphery:3-</availability>
@@ -6812,14 +6758,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				CS:8,DTA:7,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5-</availability>
+			<availability>CS:8,DTA:7,CDS:5,Periphery.MW:5,PIR:5,CLAN:4,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,WOB:9,MERC:5-</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
+				<availability>CS:6,CDS:4,HL:4,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>CLAN:4,FWL:5,BAN:2</availability>
@@ -6879,8 +6823,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:2,WOB:5,FWL.KIS:8,FS:5,MERC:5,CS:3,DTA:7,FVC:5,Periphery.MW:4,Periphery.ME:2,FWL:7,MH:4,RCM:7,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:2,WOB:5,FWL.KIS:8,FS:5,MERC:5,CS:3,DTA:7,FVC:5,Periphery.MW:4,Periphery.ME:2,FWL:7,MH:4,RCM:7,DC:5</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:4,General:2,FWL:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 			</model>
@@ -6889,8 +6832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -7020,8 +6962,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1A'>
 				<availability>LA:3-,MERC:3-,TC:3-</availability>
 			</model>
@@ -7173,8 +7114,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:3,CSR:3,FRR:2,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:4,FWL:5,NIOPS:7,DC:2</availability>
+			<availability>CC:5,CHH:3,CSR:3,FRR:2,IS:1,WOB:7,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:4,FWL:5,NIOPS:7,DC:2</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
@@ -7346,8 +7286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hankyu (Arctic Cheetah)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:3,MERC.KH:2,CDS:4,CSV:5,CNC:5,CLAN:2,IS:3+,CLAN.IS:2,MERC:2,CJF:4,CCO:3,CGB:3</availability>
+			<availability>CHH:3,MERC.KH:2,CDS:4,CSV:5,CNC:5,CLAN:2,IS:3+,CLAN.IS:2,MERC:2,CJF:4,CCO:3,CGB:3</availability>
 			<model name='A'>
 				<availability>CSA:8,CSV:8,General:7</availability>
 			</model>
@@ -7389,8 +7328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				MOC:5-,CC:5-,HL:3-,FRR:5-,Periphery.Deep:4,IS:4-,WOB:4-,MERC:5-,Periphery:4-,CS:4-,DTA:5,FWL.pm:6-,LA:4-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,RCM:5,DC:5-</availability>
+			<availability>MOC:5-,CC:5-,HL:3-,FRR:5-,Periphery.Deep:4,IS:4-,WOB:4-,MERC:5-,Periphery:4-,CS:4-,DTA:5,FWL.pm:6-,LA:4-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,RCM:5,DC:5-</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -7474,8 +7412,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,WOB:4,FS:5,MERC:3,Periphery:2,DC:4</availability>
+			<availability>Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,FRR:3,Periphery.MW:3,WOB:4,FS:5,MERC:3,Periphery:2,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:2-,LA:2-,TC.PL:4-,MERC:2-,FS:2-,Periphery:2-</availability>
@@ -7593,8 +7530,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				CC:3,MOC:6,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:6,Periphery:5,OA:6,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
+			<availability>CC:3,MOC:6,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:6,Periphery:5,OA:6,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7613,8 +7549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7736,8 +7671,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2-,OA:5,FVC:3,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
+			<availability>MOC:2-,OA:5,FVC:3,CSR:4,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:4</availability>
 			</model>
@@ -7942,8 +7876,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CGB:2</availability>
+			<availability>CC:8,CS:2-,CDS:3,Periphery.CM:7,CNC:3,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CGB:2</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -8000,8 +7933,7 @@
 				<availability>LA:2</availability>
 			</model>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
+				<availability>MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CS:5,LA:3,CLAN:4,WOB:5,FS:3,BAN:2</availability>
@@ -8109,8 +8041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:4,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
+			<availability>MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:4,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:3-</availability>
@@ -8166,8 +8097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:3,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
+			<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:3,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -8224,8 +8154,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:4-</availability>
@@ -8498,8 +8427,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -8510,11 +8438,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,SOC:5,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,SOC:5,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>SOC:4,CLAN:8</availability>
@@ -8595,8 +8521,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,WOB:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,WOB:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -8617,8 +8542,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:4-,FS.AH:4-,Periphery.Deep:5,IS:4-,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,DTA:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,RCM:2-,DC:4-</availability>
+			<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:4-,FS.AH:4-,Periphery.Deep:5,IS:4-,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,DTA:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,RCM:2-,DC:4-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8668,8 +8592,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jackal' unitType='Mek'>
-			<availability>
-				MOC:5,CC:2,DTA:6,FVC:2,Periphery.MW:4,Periphery.ME:4,IS:1,FWL:6,WOB:6,MH:5,FS:2,MERC:6</availability>
+			<availability>MOC:5,CC:2,DTA:6,FVC:2,Periphery.MW:4,Periphery.ME:4,IS:1,FWL:6,WOB:6,MH:5,FS:2,MERC:6</availability>
 			<model name='JA-KL-1532'>
 				<availability>HL:6,General:2,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 			</model>
@@ -8724,8 +8647,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4-,FRR:5,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
+			<availability>MOC:3,CC:4-,FRR:5,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
@@ -8766,8 +8688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,HL:3,IS:2,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:2,LA:2,Periphery.HR:5</availability>
+			<availability>MOC:4,HL:3,IS:2,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:2,LA:2,Periphery.HR:5</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -8837,8 +8758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:2-,DC:8</availability>
+			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:2-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:5,FS:5,DC:6</availability>
@@ -9138,8 +9058,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:3,FRR:4,CLAN:3,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:5,LA:3,FWL:3,NIOPS:6,CGB:4,DC:3</availability>
+			<availability>CC:3,FRR:4,CLAN:3,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:5,LA:3,FWL:3,NIOPS:6,CGB:4,DC:3</availability>
 			<model name='KGC-000'>
 				<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 			</model>
@@ -9399,8 +9318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CSR:6,CSV:7,CLAN:2,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5,DC:3+</availability>
+			<availability>CHH:6,CSR:6,CSV:7,CLAN:2,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5,DC:3+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -9639,8 +9557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FWL:3,WOB:6</availability>
 			</model>
@@ -9687,8 +9604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:2,HL:3,CIR:5,Periphery.OS:5,TC:8,Periphery:4,OA:5,FVC:2,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
+			<availability>MOC:7,CC:2,HL:3,CIR:5,Periphery.OS:5,TC:8,Periphery:4,OA:5,FVC:2,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -9750,8 +9666,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:5-</availability>
 			</model>
@@ -10019,8 +9934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10108,8 +10022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
+			<availability>MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
 			<model name='LCF-R15'>
 				<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:6-,Periphery:2-</availability>
 			</model>
@@ -10347,8 +10260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSV:6,CLAN:2,IS:2+,BAN:5,CWIE:8,MERC.WD:8,CDS:8,CW:8,CBS:5,CNC:4,CJF:8,CGB:2</availability>
+			<availability>CHH:5,CSV:6,CLAN:2,IS:2+,BAN:5,CWIE:8,MERC.WD:8,CDS:8,CW:8,CBS:5,CNC:4,CJF:8,CGB:2</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -10406,8 +10318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,FWL:6,NIOPS:7,DC:9</availability>
+			<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,FWL:6,NIOPS:7,DC:9</availability>
 			<model name=''>
 				<availability>HL:3,LA:2-,General:4-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 			</model>
@@ -10468,8 +10379,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder II' unitType='Mek'>
-			<availability>
-				CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,PIR:4,CNC:2,FWL:5,MH:4,DC:5</availability>
+			<availability>CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,PIR:4,CNC:2,FWL:5,MH:4,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:4</availability>
 			</model>
@@ -10496,8 +10406,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:3,CGB:2</availability>
+			<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:3,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 			</model>
@@ -10598,8 +10507,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,TC:4</availability>
 			</model>
@@ -10621,8 +10529,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:2,CSR:3,CSV:1,CLAN:1,IS:2+,MERC:2+,CGS:7,BAN:2,CWIE:1,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
+			<availability>MERC.KH:2,CSR:3,CSV:1,CLAN:1,IS:2+,MERC:2+,CGS:7,BAN:2,CWIE:1,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
 			</model>
@@ -10732,8 +10639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:2,LA:4,FWL:2,NIOPS:2-,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:2,LA:4,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
@@ -10915,8 +10821,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -10985,8 +10890,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:5,SOC:4,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,WOB:5,MERC:5,Periphery:6</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:5,SOC:4,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,WOB:5,MERC:5,Periphery:6</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -11234,8 +11138,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,DC.GHO:2,CS:4,CDS:1,CBS:1,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
+			<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,DC.GHO:2,CS:4,CDS:1,CBS:1,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -11841,8 +11744,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
+			<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
 			<model name=''>
 				<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -11886,8 +11788,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:3,CW:2,LA:2,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
+			<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:3,CW:2,LA:2,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>HL:2-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -11956,8 +11857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:2-,IS:2-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
@@ -12080,8 +11980,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:4,BAN:1</availability>
@@ -12155,8 +12054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
+			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12167,8 +12065,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
+				<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -12209,8 +12106,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,FS.DMM:5,CNC:3,FWL:1,NIOPS:2,DC:9</availability>
+			<availability>CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,FS.DMM:5,CNC:3,FWL:1,NIOPS:2,DC:9</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:4,FVC:2,FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
@@ -12299,8 +12195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5-,CC:2-,HL:4-,FRR:2-,IS:4-,Periphery.Deep:9,WOB:4-,FS:5-,CIR:3-,Periphery:5-,TC:5-,CS:4-,OA:2-,CDS:2,LA:4-,FWL:4-,DC:2-</availability>
+			<availability>MOC:5-,CC:2-,HL:4-,FRR:2-,IS:4-,Periphery.Deep:9,WOB:4-,FS:5-,CIR:3-,Periphery:5-,TC:5-,CS:4-,OA:2-,CDS:2,LA:4-,FWL:4-,DC:2-</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>
@@ -12364,8 +12259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:1,CC:2,FRR:2,IS:2,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:2,CS:5-,OA:1,LA:6,FWL:2,DC:6</availability>
+			<availability>MOC:1,CC:2,FRR:2,IS:2,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:2,CS:5-,OA:1,LA:6,FWL:2,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:4</availability>
@@ -12647,8 +12541,7 @@
 			<availability>LA:2-,MERC:3-,TC:3-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:4,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:2-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
+			<availability>MOC:4,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:2-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
 			<model name=''>
 				<availability>HL:4,IS:4,Periphery.Deep:4,Periphery:6</availability>
 			</model>
@@ -12962,8 +12855,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:7,CLAN:7,IS:2+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
+			<availability>CSR:7,CLAN:7,IS:2+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -13060,8 +12952,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,HL:3,FRR:7,Periphery.Deep:4,IS:4,WOB:3-,FS:4,CIR:3,CDP:4,Periphery:4,TC:4,CS:3-,DTA:6,OA:4,FVC:4,LA:4,FWL:7,NIOPS:3-,RCM:5,DC:5</availability>
+			<availability>MOC:4,CC:3,HL:3,FRR:7,Periphery.Deep:4,IS:4,WOB:3-,FS:4,CIR:3,CDP:4,Periphery:4,TC:4,CS:3-,DTA:6,OA:4,FVC:4,LA:4,FWL:7,NIOPS:3-,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
 			</model>
@@ -13350,8 +13241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -13377,11 +13267,9 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,RCM:8,DC:4</availability>
+			<availability>MOC:3,CC:4,FRR:5,WOB:6,MERC:2,FS:3,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:2,Periphery.MW:3,Periphery.ME:3,FWL:8,RCM:8,DC:4</availability>
 			<model name='F-100'>
-				<availability>
-					CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
+				<availability>CC:2-,FVC:4-,HL:2-,LA:1,FRR:1,FWL:4-,Periphery.Deep:8,MERC:4-,DC:1,Periphery:4-</availability>
 			</model>
 			<model name='F-100a'>
 				<availability>CC:2-,FWL:4-,MERC:4-</availability>
@@ -13428,8 +13316,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CJF:4</availability>
+			<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CJF:4</availability>
 			<model name='C'>
 				<availability>LA:1,CLAN:8,FS:1,BAN:2,DC:1</availability>
 			</model>
@@ -13653,8 +13540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CSR:7,CSV:6,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:7,CW:6,CBS:8,CNC:4,CJF:7,DC:3+</availability>
+			<availability>CHH:6,CSR:7,CSV:6,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:7,CW:6,CBS:8,CNC:4,CJF:7,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -13770,8 +13656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
+			<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:5-</availability>
 			</model>
@@ -13845,8 +13730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:5,CS:5-,LA:6,FWL:6,CJF:4,DC:9</availability>
+			<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:5,CS:5-,LA:6,FWL:6,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:6-,Periphery:6-</availability>
 			</model>
@@ -13913,8 +13797,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:4-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,FWL:6-,DC:8-</availability>
+			<availability>MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:4-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,FWL:6-,DC:8-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -14066,8 +13949,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:4,CC:2,HL:4,FRR:3,IS:4,Periphery.Deep:5,WOB:4,MERC:4,FS:4,CIR:5,Periphery:5,TC:4,CS:3,OA:5,LA:4,FWL:3,DC:2</availability>
+			<availability>MOC:4,CC:2,HL:4,FRR:3,IS:4,Periphery.Deep:5,WOB:4,MERC:4,FS:4,CIR:5,Periphery:5,TC:4,CS:3,OA:5,LA:4,FWL:3,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -14085,8 +13967,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,FWL:3-,DC:6-</availability>
+			<availability>MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,FWL:3-,DC:6-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -14102,8 +13983,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,FVC:6,HL:6,LA:6,FRR:8,IS:7,Periphery.Deep:7,FWL:6,FS:6,CJF:4,Periphery:7,DC:6</availability>
+			<availability>CC:6,FVC:6,HL:6,LA:6,FRR:8,IS:7,Periphery.Deep:7,FWL:6,FS:6,CJF:4,Periphery:7,DC:6</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -14124,8 +14004,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,MERC:2-,Periphery:3-,CS:2-,LA:3,FWL:2-,NIOPS:2-,RCM:2-,DC:2-</availability>
+			<availability>CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,MERC:2-,Periphery:3-,CS:2-,LA:3,FWL:2-,NIOPS:2-,RCM:2-,DC:2-</availability>
 			<model name='SCP-12C'>
 				<availability>WOB:4</availability>
 			</model>
@@ -14244,8 +14123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CSV:2,CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
+			<availability>CSV:2,CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,FVC:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -14300,8 +14178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
+			<availability>MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
@@ -14412,8 +14289,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				CHH:6,FRR:3,CLAN:4,IS:1,FS:3,MERC:3,CWIE:6,DTA:3,CS:3,CDS:6,CW:4,LA:3,CNC:6,FWL:3,RCM:3,CJF:2,DC:3,CGB:6</availability>
+			<availability>CHH:6,FRR:3,CLAN:4,IS:1,FS:3,MERC:3,CWIE:6,DTA:3,CS:3,CDS:6,CW:4,LA:3,CNC:6,FWL:3,RCM:3,CJF:2,DC:3,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:2</availability>
 			</model>
@@ -14664,8 +14540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:5-</availability>
@@ -14684,8 +14559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 			</model>
@@ -14785,8 +14659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
 			</model>
@@ -14837,8 +14710,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:2-</availability>
@@ -14933,8 +14805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,FWL:8,NIOPS:5,DC:5</availability>
+			<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,FWL:8,NIOPS:5,DC:5</availability>
 			<model name='STK-3F'>
 				<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -15095,8 +14966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
@@ -15147,8 +15017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
 			</model>
@@ -15261,8 +15130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>
-				CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+			<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -15305,8 +15173,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:4,Periphery.HR:2,DC:1</availability>
+			<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:4,Periphery.HR:2,DC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,FS:6,MERC:6</availability>
 			</model>
@@ -15720,8 +15587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:4,CLAN:4,IS:2+,CCO:4,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:4,CW:4,CNC:4,CJF:6,CGB:4</availability>
+			<availability>CHH:5,CSR:4,CLAN:4,IS:2+,CCO:4,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:4,CW:4,CNC:4,CJF:6,CGB:4</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -15780,8 +15646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>
-				MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+			<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
 			</model>
@@ -15809,8 +15674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:4-,FVC:4-,HL:3-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:5-</availability>
@@ -15823,8 +15687,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:3,CSV:6,CLAN:4,IS:3,WOB:7,FS:3,CWIE:5,DC.GHO:5,CS:8,DTA:2,OA:4,FVC:2,CDS:3,CW:5,CBS:3,LA:2,CNC:3,FWL:5,NIOPS:8,RCM:2,CJF:5,CGB:5</availability>
+			<availability>CHH:3,CSV:6,CLAN:4,IS:3,WOB:7,FS:3,CWIE:5,DC.GHO:5,CS:8,DTA:2,OA:4,FVC:2,CDS:3,CW:5,CBS:3,LA:2,CNC:3,FWL:5,NIOPS:8,RCM:2,CJF:5,CGB:5</availability>
 			<model name='THG-10E'>
 				<availability>FWL:4-,MERC:4-</availability>
 			</model>
@@ -15907,8 +15770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:4-</availability>
@@ -15929,8 +15791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:6,MERC.KH:2,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:2,LA:6,NIOPS:3-,MH:4,DC:6</availability>
+			<availability>CC:6,MERC.KH:2,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:2,LA:6,NIOPS:3-,MH:4,DC:6</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,FS:2,CGS:1-,DC:1</availability>
 			</model>
@@ -16232,8 +16093,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:3,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
+			<availability>MOC:3,CC:3,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:3,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:4</availability>
@@ -16243,8 +16103,7 @@
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:2-,CS:2-,MOC:6-,LA:2-,FWL:2-,IS:4-,NIOPS:2-,WOB:2-,FS:2-,MERC:4-,DC:2-,Periphery:6-</availability>
+				<availability>CC:2-,CS:2-,MOC:6-,LA:2-,FWL:2-,IS:4-,NIOPS:2-,WOB:2-,FS:2-,MERC:4-,DC:2-,Periphery:6-</availability>
 			</model>
 			<model name='TBT-5S'>
 				<availability>MOC:2-,IS:2-,Periphery.Deep:4,FWL:2-,MERC:2-,CDP:2,Periphery:2-,TC:2-</availability>
@@ -16529,8 +16388,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:8,CHH:3,CSR:6,CSV:4,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:2,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
+			<availability>CCC:8,CHH:3,CSR:6,CSV:4,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:2,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
 			<model name='A'>
 				<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -16658,8 +16516,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -16860,8 +16717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:4</availability>
@@ -16898,8 +16754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -17219,8 +17074,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
+			<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:1+,FS:1+,DC:1+</availability>
 			</model>
@@ -17294,8 +17148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -17447,8 +17300,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:2,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
+			<availability>MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:2,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
@@ -17516,8 +17368,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolfhound' unitType='Mek'>
-			<availability>
-				MOC:4,MERC.KH:7,FRR:5,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,MERC.WD:5,FVC:3,LA:7,FWL:3,MH:4</availability>
+			<availability>MOC:4,MERC.KH:7,FRR:5,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,MERC.WD:5,FVC:3,LA:7,FWL:3,MH:4</availability>
 			<model name='WLF-1'>
 				<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
 			</model>
@@ -17545,8 +17396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
 			<model name='WVR-1R'>
 				<availability>CC:2-,FWL:2-,FS:2-,MERC:2,RCM:2,DC:2-</availability>
 			</model>
@@ -17622,8 +17472,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:3,FRR:5,CLAN:2,IS:3,WOB:4-,FS:7,MERC:5,DC.GHO:5,CS:5,DTA:3,FVC:3,NIOPS:5,RCM:3,DC:6</availability>
+			<availability>CC:3,FRR:5,CLAN:2,IS:3,WOB:4-,FS:7,MERC:5,DC.GHO:5,CS:5,DTA:3,FVC:3,NIOPS:5,RCM:3,DC:6</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:5,WOB:4</availability>
@@ -17804,8 +17653,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zeus' unitType='Mek'>
-			<availability>
-				HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:2,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
+			<availability>HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:2,TC:4,Periphery.R:5,LA:10,PIR:4,MH:4</availability>
 			<model name='ZEU-10WB'>
 				<availability>LA:4,WOB:8</availability>
 			</model>
@@ -17830,8 +17678,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:6,HL:2,IS:2,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:4</availability>
+			<availability>MOC:3,CC:6,HL:2,IS:2,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -1172,7 +1172,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:3,General:5,Periphery.Deep:6,Periphery:5</availability>
@@ -1220,7 +1220,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>CC:4,FRR:3,CLAN:4,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -1550,7 +1550,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:4-,Periphery.Deep:5,WOB:2-,FS:4-,Periphery:4,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
+			<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:4-,Periphery.Deep:5,WOB:2-,Periphery:4,CS:4-,LA:6,FWL:6,NIOPS:4-,DC:5</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:6,MERC.WD:6,CWIE:2</availability>
 			</model>
@@ -1681,7 +1681,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,SOC:4,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,SOC:4,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1738,7 +1738,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1803,7 +1803,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
+			<availability>MOC:3-,CC:3-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,FS.CMM:1-</availability>
 			<model name='ASN-21'>
 				<availability>General:1-</availability>
 			</model>
@@ -1889,7 +1889,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:2,FRR:6,IS:2+,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:3,FWL:2,NIOPS:4-,DC:9</availability>
+			<availability>CC:2,FRR:6,IS:2+,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,LA:3,FWL:2,NIOPS:4-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -2057,7 +2057,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,OA:2,LA:4,FRR:2,IS:2,FWL:3,FS:4,CIR:2,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,OA:2,LA:4,IS:2,FWL:3,FS:4,CIR:2,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:2-,General:4,FS:2-</availability>
@@ -2068,7 +2068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,FWL:9,NIOPS:7</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,FWL:4,WOB:4,DC:4</availability>
 			</model>
@@ -2350,7 +2350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:7-,CC:2-,HL:8-,FRR:3-,IS:2-,Periphery.Deep:9-,FS:2-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,OA:7-,FVC:3-,LA:5-,FWL:3-,MH:7-,DC:2-</availability>
+			<availability>MOC:7-,HL:8-,FRR:3-,IS:2-,Periphery.Deep:9-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,OA:7-,FVC:3-,LA:5-,FWL:3-,MH:7-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:2-,General:2-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 			</model>
@@ -2541,7 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,Periphery:5,CS:6-,DC.GHO:5,LA:6,PIR:5,FWL:7,NIOPS:6-,DC:4</availability>
 			<model name='BLR-10S'>
 				<availability>LA:5,FS:3</availability>
 			</model>
@@ -2698,7 +2698,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:5,Periphery:4,CS:4-,OA:4,CDS:5,LA:4,PIR:3,CNC:3,FWL:2,DC:5</availability>
+			<availability>HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:5,Periphery:4,CS:4-,CDS:5,LA:4,PIR:3,CNC:3,FWL:2,DC:5</availability>
 			<model name=''>
 				<availability>FVC:3,CDS:3,General:8,DC:4</availability>
 			</model>
@@ -2843,7 +2843,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:5,FRR:4,CLAN:6,FS:5,CDP:3,CWIE:7,DC.GHO:3,OA:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:7,LA:3,CNC:7,RCM:5,CJF:5,DC:4</availability>
+			<availability>CHH:5,FRR:4,CLAN:6,FS:5,CDP:3,CWIE:7,DC.GHO:3,CDS:5,CBS:7,FWL:3,NIOPS:7,CGB:7,CSR:5,CSV:5,WOB:7,FWL.OH:3,MERC:4,CGS:7,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:7,LA:3,CNC:7,RCM:5,CJF:5,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:6</availability>
 			</model>
@@ -2854,7 +2854,7 @@
 				<availability>DTA:6,CS:6,LA:4,CLAN:5,FWL:6,NIOPS:6,MERC:4,FS:4,CGS:6,BAN:2,DC:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:4-,FRR:4-,FWL:1-,MERC:4-,FS:4-,CIR:6,DC:4-</availability>
+				<availability>LA:4-,FRR:4-,FWL:1-,MERC:4-,FS:4-,CIR:6,DC:4-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:2-,TC:2-</availability>
@@ -3002,7 +3002,7 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>DTA:6,FWL:6,WOB:4</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>General:4,RCM:0</availability>
@@ -3079,7 +3079,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3127,7 +3127,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+			<availability>HL:3,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3166,7 +3166,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,FWL:1-,DC:3-</availability>
+			<availability>MOC:3-,CC:4-,HL:3-,IS:3-,Periphery.Deep:7,MERC:3-,TC:3-,Periphery:4-,LA:2-,FWL:1-</availability>
 			<model name=''>
 				<availability>LA:4,General:8,FS:4,MERC:4,DC:4</availability>
 			</model>
@@ -3411,7 +3411,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CW:2,CLAN:2,CNC:5,CGS:6,CJF:2,CGB:2,DC:3+</availability>
+			<availability>CSA:5,CHH:5,CCC:5,CSR:5,CDS:5,CLAN:2,CNC:5,CGS:6,DC:3+</availability>
 			<model name='A'>
 				<availability>General:8</availability>
 			</model>
@@ -3548,7 +3548,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>CC:2,FRR:1,IS:1,WOB:2-,Periphery.OS:4,FS:8,MERC:2,CDP:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:4,DC:1</availability>
+			<availability>CC:2,IS:1,WOB:2-,Periphery.OS:4,FS:8,MERC:2,CDP:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,Periphery.HR:4,FWL:2,NIOPS:2-,MH:4</availability>
 			<model name='CN10-B'>
 				<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
 			</model>
@@ -3680,7 +3680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CHH:2,FRR:4,IS:3,WOB:5,FS:3,MERC:2,DC.GHO:5,CS:5,DTA:2,FVC:2,LA:4,FWL:3,NIOPS:5,RCM:2,CGB:2,DC:4</availability>
+			<availability>CC:5,CHH:2,FRR:4,IS:3,WOB:5,MERC:2,DC.GHO:5,CS:5,DTA:2,FVC:2,LA:4,NIOPS:5,RCM:2,CGB:2,DC:4</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -3824,16 +3824,16 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
+			<availability>FRR:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,FVC:5,LA:8,FWL:3,DC:1,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:4,FS:2-,CDP:4,TC:4,Periphery:2-</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:2-,LA:3-,IS:2-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
+				<availability>HL:2-,LA:3-,IS:2-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -4083,7 +4083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:3,MOC:2,FRR:1,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,FWL:1,NIOPS:1-,MH:2,RCM:2,DC:2</availability>
+			<availability>CC:3,FRR:1,IS:2,WOB:1-,FS:3,MERC:2,CDP:2,Periphery:2,CS:1-,FVC:2,LA:3,FWL:1,NIOPS:1-,MH:2,RCM:2</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -4202,7 +4202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:2,HL:2,IS:3,WOB:3,FS:4,Periphery:3,TC:2,CS:3,FVC:4,LA:5,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:5-,FVC:4-,General:3-,FS:5-,Periphery:3-</availability>
 			</model>
@@ -4435,7 +4435,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
+			<availability>FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,NIOPS:5,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4493,7 +4493,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CHH:7,CSR:5,FRR:6,CSV:5,CLAN:6,WOB:8,CIR:4,CGS:5,CWIE:7,DC.GHO:3,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
+			<availability>CHH:7,CSR:5,CSV:5,CLAN:6,WOB:8,CIR:4,CGS:5,CWIE:7,DC.GHO:3,CS:9,CDS:5,CW:7,CBS:7,NIOPS:9,CJF:5,CGB:7</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:4-,NIOPS:0</availability>
 			</model>
@@ -4532,7 +4532,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CSR:5,CDS:4,CW:4,CBS:5,CSV:8,CLAN:3,CNC:4,CCO:3,CJF:4,CWIE:4,CGB:4</availability>
+			<availability>CHH:4,CSR:5,CDS:4,CW:4,CBS:5,CSV:8,CLAN:3,CNC:4,CJF:4,CWIE:4,CGB:4</availability>
 			<model name='A'>
 				<availability>General:5</availability>
 			</model>
@@ -4642,7 +4642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -4697,7 +4697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CS:6,MERC.KH:4,MERC.WD:4,HL:3,SOC:3,CLAN:1-,NIOPS:6,WOB:7,MERC:4,TC:4,Periphery:4</availability>
+			<availability>CS:6,MERC.KH:4,MERC.WD:4,HL:3,SOC:3,CLAN:1-,NIOPS:6,WOB:7,MERC:4,Periphery:4</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CS:6,WOB:6,TC:4</availability>
@@ -4799,7 +4799,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:4,IS:3+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,IS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CNC:5,CJF:5,CGB:5</availability>
 			<model name='A'>
 				<availability>CW:5,CSV:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -4894,7 +4894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CCC:3,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CDS:3,CJF:3,CGB:6</availability>
+			<availability>CHH:5,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -4991,7 +4991,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,IS:7,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,FVC:8,LA:5,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,Periphery.Deep:9,IS:7,WOB:6,FS:9,CIR:9,CWIE:6,Periphery:10,TC:9,CS:6,OA:9,FVC:8,LA:5,CNC:5,FWL:8,NIOPS:6,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,FWL:4,DC:4</availability>
@@ -5054,7 +5054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:2,CC:2,HL:2,FRR:3,IS:2,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:2,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
+			<availability>MOC:2,HL:2,FRR:3,IS:2,Periphery.Deep:5,FS:5,MERC:3,Periphery.OS:4,Periphery:3,OA:2,FVC:5,LA:3,Periphery.HR:4,DC:3</availability>
 			<model name='DV-1S'>
 				<availability>IS:3-</availability>
 			</model>
@@ -5110,7 +5110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:3-,CC:2-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:4-,OA:2-,LA:3-,FWL:2-,MH:2-,DC:2-</availability>
+			<availability>MOC:3-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,OA:2-,LA:3-,MH:2-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5253,7 +5253,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,FWL:3-,CC.MAC:4-,DC:3-</availability>
+			<availability>HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:4-,Periphery:3-,CS:3,FVC:5-,LA:7,CC.MAC:4-</availability>
 			<model name=''>
 				<availability>CC:3-,General:4-</availability>
 			</model>
@@ -5304,7 +5304,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,HL:2,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,CS:3-,OA:2,FWL:4,NIOPS:3-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:1-,FS:1-</availability>
@@ -5432,7 +5432,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,CNC:5,NIOPS:7</availability>
 			<model name='EMP-6A'>
 				<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
@@ -5498,7 +5498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:2,LA:2,Periphery.HR:2,MH:2,DC:1</availability>
+			<availability>CC:1,FS:7,MERC:4,CDP:2,Periphery:2,FVC:7LA:2,DC:1</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
 			</model>
@@ -5588,7 +5588,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,WOB:5,FS:3,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:5,FS:4,MERC:2</availability>
 			</model>
@@ -6161,7 +6161,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:2,CSV:4,FRR:4,CLAN:3,WOB:5,CGS:2,CS:5,DC.GHO:5,Periphery.R:1,CDS:2,LA:4,CBS:2,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:2-,LA:2-</availability>
+				<availability>MERC.KH:2-,LA:2-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,CS:4,LA:8,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
@@ -6207,7 +6207,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,MERC.WD:4,Periphery.MW:4,Periphery.ME:4,FWL:2,WOB:4,MERC:4,CIR:4,RCM:3,Periphery:4,TC:4</availability>
+			<availability>CC:6,MERC.WD:4,FWL:2,WOB:4,MERC:4,RCM:3,Periphery:4</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:1</availability>
@@ -6392,7 +6392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:3-,General:8,FWL:2-,WOB:4-</availability>
@@ -6438,7 +6438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,Periphery:6,CS:6,OA:8,LA:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -6518,7 +6518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,SOC:1,CLAN:5,CNC:5,IS:2+,CJF:4,BAN:4,CWIE:2,CGB:9</availability>
+			<availability>CSA:6,MERC.WD:1,CSR:1,SOC:1,CLAN:5,IS:2+,CJF:4,BAN:4,CWIE:2,CGB:9</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CSV:4,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -6674,7 +6674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:4,MOC:3,HL:2,IS:1,WOB:2,FS:3,MERC:4,TC:3,Periphery:3,CS:1,OA:2,FVC:2,LA:5,Periphery.MW:2,FWL:6,MH:2</availability>
+			<availability>CC:4,HL:2,IS:1,WOB:2,FS:3,MERC:4,Periphery:3,CS:1,OA:2,FVC:2,LA:5,Periphery.MW:2,FWL:6,MH:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:3-,LA:4-,FWL:3-,Periphery.Deep:8,IS:1-,MERC:3-,Periphery:3-</availability>
@@ -6832,7 +6832,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6,TC:6</availability>
+			<availability>CS:4-,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -6941,7 +6941,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CSA:6,MERC.WD:5,CDS:6,CW:3,CNC:7,CLAN:3,CCO:6,CJF:3,CWIE:4,CGB:3,DC:4</availability>
+			<availability>CSA:6,MERC.WD:5,CDS:6,CNC:7,CLAN:3,CCO:6,CWIE:4,DC:4</availability>
 			<model name=''>
 				<availability>MERC.WD:6,CLAN:2-,CNC:4</availability>
 			</model>
@@ -7328,7 +7328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>MOC:5-,CC:5-,HL:3-,FRR:5-,Periphery.Deep:4,IS:4-,WOB:4-,MERC:5-,Periphery:4-,CS:4-,DTA:5,FWL.pm:6-,LA:4-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,RCM:5,DC:5-</availability>
+			<availability>MOC:5-,CC:5-,HL:3-,FRR:5-,Periphery.Deep:4,IS:4-,WOB:4-,MERC:5-,Periphery:4-,CS:4-,DTA:5,FWL.pm:6-,Periphery.CM:5-,Periphery.MW:5-,Periphery.ME:5-,FWL:6-,MH:5-,RCM:5,DC:5-</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -7530,7 +7530,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>CC:3,MOC:6,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:6,Periphery:5,OA:6,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
+			<availability>CC:3,MOC:6,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:6,Periphery:5,OA:6,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7549,7 +7549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7925,7 +7925,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>MOC:1,CC:2,CS:9,LA:6,CLAN:5,IS:1,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6,DC:1</availability>
+			<availability>MOC:1,CC:2,CS:9,LA:6,CLAN:5,IS:1,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6</availability>
 			<model name='HGN-641-X-2'>
 				<availability>CS:1</availability>
 			</model>
@@ -7933,7 +7933,7 @@
 				<availability>LA:2</availability>
 			</model>
 			<model name='HGN-732'>
-				<availability>MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
+				<availability>MOC:6,CC:3,CLAN:6,IS:6,WOB:3,MERC:6,BAN:8,DC.GHO:8,CS:3,FWL:3,NIOPS:3,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CS:5,LA:3,CLAN:4,WOB:5,FS:3,BAN:2</availability>
@@ -8041,7 +8041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:4,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
+			<availability>FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,MERC.WD:4,FVC:8,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:3-</availability>
@@ -8097,7 +8097,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:3,LA:5,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
+			<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:3,LA:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -8154,7 +8154,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,MERC:6,CIR:5,Periphery:6,CS:5-,LA:8,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:4-</availability>
@@ -8427,7 +8427,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -8542,7 +8542,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:4-,MOC:4-,CC:2-,DC.LV:5-,HL:3-,FRR:4-,DC.GR:4-,FS.AH:4-,Periphery.Deep:5,IS:4-,WOB:3-,FS:3-,CIR:4-,Periphery:4-,TC:5-,CS:2-,DTA:2-,OA:4-,LA:4-,FWL:2-,NIOPS:2-,RCM:2-,DC:4-</availability>
+			<availability>FS.DLC:4-,CC:2-,DC.LV:5-,HL:3-,DC.GR:4-,FS.AH:4-,Periphery.Deep:5,IS:4-,WOB:3-,FS:3-,Periphery:4-,TC:5-,CS:2-,DTA:2-,FWL:2-,NIOPS:2-,RCM:2-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8647,7 +8647,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:3,CC:4-,FRR:5,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
+			<availability>MOC:3,CC:4-,FRR:5,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,NIOPS:3,MH:4,DC:3</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
@@ -8688,7 +8688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,HL:3,IS:2,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:2,LA:2,Periphery.HR:5</availability>
+			<availability>HL:3,IS:2,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,FVC:8,OA:2,Periphery.HR:5</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -8758,7 +8758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,FS.DMM:5,FWL:2-,DC:8</availability>
+			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,FS.DMM:5,FWL:2-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:5,FS:5,DC:6</availability>
@@ -9058,7 +9058,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:3,FRR:4,CLAN:3,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:5,LA:3,FWL:3,NIOPS:6,CGB:4,DC:3</availability>
+			<availability>FRR:4,CLAN:3,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:5,NIOPS:6,CGB:4</availability>
 			<model name='KGC-000'>
 				<availability>CS:4,FRR:8,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 			</model>
@@ -9131,7 +9131,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:6,CHH:1,CDS:1,CSV:1,FRR:4,NIOPS:7,WOB:7,FS:3,MERC:5,DC:4</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:4-,MERC:4-,DC:2-</availability>
+				<availability>FS:4-,MERC:4-,DC:2-</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:4,CS:4,DC.SL:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
@@ -9318,7 +9318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CSR:6,CSV:7,CLAN:2,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5,DC:3+</availability>
+			<availability>CHH:6,CSR:6,CSV:7,CLAN:2,IS:3+,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5,DC:3+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CDS:7,CW:4,CSV:6,General:5,CWIE:4,CGB:4</availability>
@@ -9557,7 +9557,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,BAN:2,Periphery:8,CS:4,LA:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FWL:3,WOB:6</availability>
 			</model>
@@ -9666,7 +9666,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,Periphery:4,TC:4,CS:3-,OA:6,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:5-</availability>
 			</model>
@@ -9934,7 +9934,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,FWL:7,NIOPS:3</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10022,7 +10022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:4,FRR:3,FS:3,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:2,FVC:2,LA:8,Periphery.MW:3</availability>
+			<availability>HL:4,FRR:3,FS:3,MERC:2,CIR:3,Periphery:2,Periphery.R:4,FVC:2,LA:8,Periphery.MW:3</availability>
 			<model name='LCF-R15'>
 				<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:6-,Periphery:2-</availability>
 			</model>
@@ -10260,7 +10260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSV:6,CLAN:2,IS:2+,BAN:5,CWIE:8,MERC.WD:8,CDS:8,CW:8,CBS:5,CNC:4,CJF:8,CGB:2</availability>
+			<availability>CHH:5,CSV:6,CLAN:2,IS:2+,BAN:5,CWIE:8,MERC.WD:8,CDS:8,CW:8,CBS:5,CNC:4,CJF:8</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CSV:5,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -10318,7 +10318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,FWL:6,NIOPS:7,DC:9</availability>
+			<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,CIR:6,Periphery:7,CS:7,FWL:6,NIOPS:7,DC:9</availability>
 			<model name=''>
 				<availability>HL:3,LA:2-,General:4-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 			</model>
@@ -10406,7 +10406,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:3,CGB:2</availability>
+			<availability>CC:4,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,FWL:3,NIOPS:6,DC:3,CGB:2</availability>
 			<model name='C'>
 				<availability>CW:2,LA:2+,CNC:2,FS:2+,CJF:1,DC:2+,CGB:2,CWIE:2</availability>
 			</model>
@@ -10529,7 +10529,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>MERC.KH:2,CSR:3,CSV:1,CLAN:1,IS:2+,MERC:2+,CGS:7,BAN:2,CWIE:1,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
+			<availability>MERC.KH:2,CSR:3,CLAN:1,IS:2+,MERC:2+,CGS:7,BAN:2,CWIE:1,CSA:3,MERC.WD:4,CDS:6,CW:3,CBS:4,CNC:3,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,CSV:6,General:5,CGB:5</availability>
 			</model>
@@ -10639,7 +10639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:2,CC:2,FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:2,LA:4,FWL:2,NIOPS:2-,DC:2</availability>
+			<availability>CC:2FRR:4,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,CS:2-,LA:4,NIOPS:2-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:2-,IS:4-,Periphery.Deep:8,Periphery:4-</availability>
@@ -11138,7 +11138,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,DC.GHO:2,CS:4,CDS:1,CBS:1,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
+			<availability>FRR:3,CLAN:1,WOB:3,MERC:2,DC.GHO:2,CS:4,NIOPS:1,DC:2</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:6,NIOPS:8,WOB:8,BAN:8</availability>
@@ -11328,7 +11328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,OA:2,LA:5,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:4,LA:5,WOB:4,FS:4,MERC:4,CIR:4,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11533,7 +11533,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,LA:8,WOB:3,FS:7,MERC:5,CIR:2</availability>
 			<model name='NGS-4S'>
-				<availability>:0,HL:6,LA:5,General:8,Periphery.Deep:6,FS:5,MERC:5,Periphery:8</availability>
+				<availability>HL:6,LA:5,General:8,Periphery.Deep:6,FS:5,MERC:5,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -11744,7 +11744,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
+			<availability>MOC:7,CC:6,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5</availability>
 			<model name=''>
 				<availability>HL:3,General:4,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -12054,7 +12054,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
+			<availability>MOC:3-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,FS.CMM:7-,FS.DMM:7-,NIOPS:6</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12065,7 +12065,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,FWL:1,MERC:2,FS:1,Periphery:3,DC:2</availability>
+				<availability>CC:2,MERC.KH:1,FRR:2,PIR:2,General:2,IS:1,Periphery.Deep:6,MERC:2,Periphery:3,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -12195,7 +12195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:5-,CC:2-,HL:4-,FRR:2-,IS:4-,Periphery.Deep:9,WOB:4-,FS:5-,CIR:3-,Periphery:5-,TC:5-,CS:4-,OA:2-,CDS:2,LA:4-,FWL:4-,DC:2-</availability>
+			<availability>CC:2-,HL:4-,FRR:2-,IS:4-,Periphery.Deep:9,WOB:4-,CIR:3-,Periphery:5-,CS:4-,OA:2-,CDS:2,DC:2-</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>
@@ -12259,7 +12259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:1,CC:2,FRR:2,IS:2,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:2,CS:5-,OA:1,LA:6,FWL:2,DC:6</availability>
+			<availability>IS:2,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,CWIE:2,CS:5-,LA:6,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:4</availability>
@@ -12469,7 +12469,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:5,HL:5,CLAN:1,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6,CGB:1</availability>
+			<availability>CS:5,HL:5,CLAN:1,IS:8,FWL:9,NIOPS:5,Periphery.Deep:4,WOB:3,Periphery:6</availability>
 			<model name='PXH-1'>
 				<roles>recon</roles>
 				<availability>General:3-,BAN:6,Periphery:3-</availability>
@@ -12541,7 +12541,7 @@
 			<availability>LA:2-,MERC:3-,TC:3-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:4,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:2-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
+			<availability>MOC:4,CC:1-,CHH:5,HL:2-,CLAN:5,IS:3-,WOB:4-,MERC:3-,CWIE:6,Periphery:3-,CS:4-,OA:4-,MERC.WD:5,CDS:6,LA:2-,CNC:5,FWL:2-,MH:5-</availability>
 			<model name=''>
 				<availability>HL:4,IS:4,Periphery.Deep:4,Periphery:6</availability>
 			</model>
@@ -12855,7 +12855,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CSR:7,CLAN:7,IS:2+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
+			<availability>CLAN:7,IS:2+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CSV:8,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -12952,7 +12952,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:4,CC:3,HL:3,FRR:7,Periphery.Deep:4,IS:4,WOB:3-,FS:4,CIR:3,CDP:4,Periphery:4,TC:4,CS:3-,DTA:6,OA:4,FVC:4,LA:4,FWL:7,NIOPS:3-,RCM:5,DC:5</availability>
+			<availability>CC:3,HL:3,FRR:7,Periphery.Deep:4,IS:4,WOB:3-,CIR:3,CDP:4,Periphery:4,CS:3-,DTA:6,FVC:4,FWL:7,NIOPS:3-,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4-,OA:4-,HL:2-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
 			</model>
@@ -13194,7 +13194,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13241,7 +13241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -13316,7 +13316,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,CCC:6,HL:3,FRR:7,CSV:6,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CJF:4</availability>
+			<availability>CCC:6,HL:3,FRR:7,CSV:6,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,FWL:7,NIOPS:5,CJF:4</availability>
 			<model name='C'>
 				<availability>LA:1,CLAN:8,FS:1,BAN:2,DC:1</availability>
 			</model>
@@ -13540,7 +13540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,CSR:7,CSV:6,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:7,CW:6,CBS:8,CNC:4,CJF:7,DC:3+</availability>
+			<availability>CSR:7,CLAN:6,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:7,CBS:8,CNC:4,CJF:7,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,CSV:8,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -13730,7 +13730,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:5,CS:5-,LA:6,FWL:6,CJF:4,DC:9</availability>
+			<availability>Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:5,CS:5-,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:6-,Periphery:6-</availability>
 			</model>
@@ -13797,7 +13797,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:4-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,FWL:6-,DC:8-</availability>
+			<availability>Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:4-,Periphery:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,FWL:6-,DC:8-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -13943,13 +13943,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:1,CC:1,OA:1,LA:1,IS:1,FWL:1,FS:1,TC:1,Periphery:1,DC:1</availability>
+			<availability>IS:1,Periphery:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:4,CC:2,HL:4,FRR:3,IS:4,Periphery.Deep:5,WOB:4,MERC:4,FS:4,CIR:5,Periphery:5,TC:4,CS:3,OA:5,LA:4,FWL:3,DC:2</availability>
+			<availability>MOC:4,CC:2,HL:4,FRR:3,IS:4,Periphery.Deep:5,WOB:4,MERC:4,Periphery:5,TC:4,CS:3,FWL:3,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -13967,7 +13967,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,FWL:3-,DC:6-</availability>
+			<availability>CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,FS:3-,Periphery:5-,CS:4-,OA:6-,FWL:3-,DC:6-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -14112,7 +14112,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,CS:3,HL:2,LA:6,FRR:3,IS:4,FWL:4,WOB:3,FS:5,CIR:3,Periphery:3,DC:4</availability>
+			<availability>CC:3,CS:3,HL:2,LA:6,FRR:3,IS:4,WOB:3,FS:5,Periphery:3</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:6</availability>
@@ -14123,7 +14123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:2,CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
+			<availability>CSV:2,CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,LA:6,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,FVC:8,LA:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -14178,7 +14178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
+			<availability>MOC:4,CC:2,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,OA:7,FVC:3,LA:8,FWL:3-,MH:2,DC:3-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
@@ -14289,7 +14289,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CHH:6,FRR:3,CLAN:4,IS:1,FS:3,MERC:3,CWIE:6,DTA:3,CS:3,CDS:6,CW:4,LA:3,CNC:6,FWL:3,RCM:3,CJF:2,DC:3,CGB:6</availability>
+			<availability>CHH:6,FRR:3,CLAN:4,IS:1,FS:3,MERC:3,CWIE:6,DTA:3,CS:3,CDS:6,LA:3,CNC:6,FWL:3,RCM:3,CJF:2,DC:3,CGB:6</availability>
 			<model name=''>
 				<availability>CLAN:2</availability>
 			</model>
@@ -14540,7 +14540,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,FWL:3,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,CS:3-,OA:1,FVC:2,FWL:3,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:5-</availability>
@@ -14559,7 +14559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
+			<availability>Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,OA:5,FVC:4,LA:1,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:2-,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 			</model>
@@ -14659,7 +14659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,Periphery.HR:4,NIOPS:3</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:2,FRR:5,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
 			</model>
@@ -14710,7 +14710,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,CS:3,FVC:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:2-</availability>
@@ -14805,7 +14805,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,FWL:8,NIOPS:5,DC:5</availability>
+			<availability>MOC:6,CC:5,HL:9,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,FWL:8,NIOPS:5,DC:5</availability>
 			<model name='STK-3F'>
 				<availability>HL:2-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -14966,7 +14966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
@@ -15017,7 +15017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,TC:1,CS:3,DTA:6,OA:1,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
+			<availability>MOC:2,CC:5,IS:3,WOB:3,MERC:5,FS:1,CIR:2,Periphery:1,CS:3,DTA:6,LA:5,Periphery.MW:2,Periphery.ME:2,FWL:6,NIOPS:3,MH:2,RCM:6,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:3-,LA:2-,IS:4-,FS:3-,Periphery:4-</availability>
 			</model>
@@ -15047,7 +15047,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -15059,7 +15059,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15130,7 +15130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+			<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,PIR:3,CNC:4,FWL:3,DC:2</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -15173,7 +15173,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:4,Periphery.HR:2,DC:1</availability>
+			<availability>FRR:2,CLAN:4,MERC:4,Periphery.OS:2,FS:7,Periphery:1,OA:2,FVC:7,LA:4,Periphery.HR:2,DC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,FS:6,MERC:6</availability>
 			</model>
@@ -15587,7 +15587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:4,CLAN:4,IS:2+,CCO:4,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:4,CW:4,CNC:4,CJF:6,CGB:4</availability>
+			<availability>CHH:5,CLAN:4,IS:2+,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CJF:6</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -15646,7 +15646,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+			<availability>CLAN:1,WOB:7,Periphery:1,CS:5,DC.GHO:1,NIOPS:5,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:5,CLAN:6,NIOPS:5,BAN:6</availability>
 			</model>
@@ -15674,7 +15674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:4-,FVC:4-,HL:3-,General:2-,FWL:4-,Periphery.Deep:8,MERC:4-,Periphery:5-</availability>
@@ -15770,7 +15770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,HL:4,CLAN:2,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,CS:4-,OA:4,LA:6,NIOPS:4-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:4-</availability>
@@ -15791,7 +15791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:6,MERC.KH:2,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:2,LA:6,NIOPS:3-,MH:4,DC:6</availability>
+			<availability>MERC.KH:2,HL:3,MERC.ELH:8,CLAN:1,IS:6,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,CS:3-,FVC:5,MERC.WD:2,NIOPS:3-</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,FS:2,CGS:1-,DC:1</availability>
 			</model>
@@ -16093,7 +16093,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:3,CC:3,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:3,LA:3,Periphery.MW:5,Periphery.ME:5,FWL:6,NIOPS:3-,DC:4</availability>
+			<availability>MOC:3,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:3,FWL:6,NIOPS:3-,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,FWL:3,NIOPS:5,WOB:5,MERC:4</availability>
@@ -16275,7 +16275,7 @@
 			<availability>CS:4,WOB:4,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 			<model name='(C3)'>
 				<roles>apc,urban,spotter</roles>
@@ -16388,7 +16388,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:8,CHH:3,CSR:6,CSV:4,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:2,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
+			<availability>CCC:8,CHH:3,CSR:6,CSV:4,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:2,CW:3,CBS:5,CJF:6</availability>
 			<model name='A'>
 				<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -16516,7 +16516,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,Periphery:4-,TC:3-,CS:3-,OA:3-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -16717,7 +16717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,CS:5,LA:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:4</availability>
@@ -16754,7 +16754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,Periphery:4,CS:3-,LA:5,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -16968,7 +16968,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:3,CS:3,MOC:5,LA:6,FRR:4,IS:4,FWL:6,NIOPS:3,WOB:3,CIR:5,Periphery:5,TC:5</availability>
+			<availability>CC:3,CS:3,LA:6,FRR:4,IS:4,FWL:6,NIOPS:3,WOB:3,Periphery:5</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>FVC:3-,General:4-,FS:2-</availability>
@@ -16999,7 +16999,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,MERC.WD:6,CW:2,CSV:6,CLAN:6,CNC:2,CCO:6,CJF:6,BAN:6,CWIE:6,CGB:7,DC:2+</availability>
+			<availability>CHH:7,MERC.WD:6,CW:2,CLAN:6,CNC:2,BAN:6,CWIE:6,CGB:7,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 			</model>
@@ -17148,7 +17148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -17300,7 +17300,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:2,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
+			<availability>MOC:1,MERC:2,Periphery:2,CS:1-,FVC:3,FS.CMM:3,NIOPS:1-,DC:3</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
@@ -17396,7 +17396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,HL:4,FRR:5,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>HL:4,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,CS:3-,CNC:2,FWL:8,NIOPS:3-,MH:4</availability>
 			<model name='WVR-1R'>
 				<availability>CC:2-,FWL:2-,FS:2-,MERC:2,RCM:2,DC:2-</availability>
 			</model>
@@ -17472,7 +17472,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:3,FRR:5,CLAN:2,IS:3,WOB:4-,FS:7,MERC:5,DC.GHO:5,CS:5,DTA:3,FVC:3,NIOPS:5,RCM:3,DC:6</availability>
+			<availability>FRR:5,CLAN:2,IS:3,WOB:4-,FS:7,MERC:5,DC.GHO:5,CS:5,DTA:3,FVC:3,NIOPS:5,RCM:3,DC:6</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:5,WOB:4</availability>
@@ -17678,7 +17678,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,HL:2,IS:2,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:4</availability>
+			<availability>CC:6,HL:2,IS:2,WOB:6,MERC:5,CIR:4,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:4</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -1303,7 +1303,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,CS:3,LA:5,CGB.FRR:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:3,General:5,Periphery.Deep:6,Periphery:5</availability>
@@ -1351,7 +1351,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>CC:4,FRR:3,CLAN:4,IS:2,WOB:6,BAN:5,Periphery:1,CS:6,CGB.FRR:3,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -1709,7 +1709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:3-,Periphery.Deep:5,WOB:2-,FS:3-,Periphery:4,CS:4-,LA:6,CGB.FRR:4,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
+			<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:3-,Periphery.Deep:5,WOB:2-,Periphery:4,CS:4-,LA:6,CGB.FRR:4,FWL:6,NIOPS:4-,DC:5</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:6,MERC.WD:6,CWIE:1</availability>
 			</model>
@@ -1844,7 +1844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1904,7 +1904,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1969,7 +1969,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,CGB.FRR:1-,FS.CMM:1-</availability>
+			<availability>MOC:3-,CC:3-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,CGB.FRR:1-,FS.CMM:1-</availability>
 			<model name='ASN-21'>
 				<availability>General:1-</availability>
 			</model>
@@ -2058,7 +2058,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CC:2,FRR:6,IS:2,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:4,CGB.FRR:6,FWL:2,NIOPS:4-,DC:9</availability>
+			<availability>FRR:6,IS:2,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,CS:4-,LA:4,CGB.FRR:6,NIOPS:4-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -2232,7 +2232,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,FRR:2,IS:2,FS:4,CIR:2,TC:2,Periphery:1,OA:2,LA:4,CGB.FRR:2,FWL:3,DC:3</availability>
+			<availability>MOC:2,IS:2,FS:4,CIR:2,TC:2,Periphery:1,OA:2,LA:4,CGB.FRR:2,FWL:3,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:2-,General:4,FS:2-</availability>
@@ -2243,7 +2243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,ROS:5,FWL:9,NIOPS:7</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4,DC:4</availability>
 			</model>
@@ -2541,7 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>MOC:7-,CC:1-,PR:3-,HL:8-,FRR:2-,Periphery.Deep:9-,IS:1-,DGM:3-,FS:1-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,SC:3-,OA:7-,FVC:3-,LA:5-,MCM:3-,CGB.FRR:3-,PG:3-,FWL:3-,MH:7-,RFS:3-,DC:1-</availability>
+			<availability>MOC:7-,PR:3-,HL:8-,FRR:2-,Periphery.Deep:9-,IS:1-,DGM:3-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,SC:3-,OA:7-,FVC:3-,LA:5-,MCM:3-,CGB.FRR:3-,PG:3-,FWL:3-,MH:7-,RFS:3-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:1-,General:1-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 			</model>
@@ -2736,7 +2736,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,CGB.FRR:4,ROS:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
+			<availability>CC:4,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,Periphery:5,CS:6-,DC.GHO:5,LA:6,CGB.FRR:4,ROS:6,PIR:5,FWL:7,NIOPS:6-,DC:4</availability>
 			<model name='BLR-10S'>
 				<availability>LA:5,ROS:3,FS:3</availability>
 			</model>
@@ -2896,7 +2896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:4,Periphery:4,CS:4-,OA:4,CDS:5,LA:3,CGB.FRR:4,PIR:3,CNC:4,FWL:2,DC:5</availability>
+			<availability>HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:4,Periphery:4,CS:4-,CDS:5,CGB.FRR:4,PIR:3,CNC:4,FWL:2,DC:5</availability>
 			<model name=''>
 				<availability>FVC:3,CDS:3,General:8,DC:3</availability>
 			</model>
@@ -3052,7 +3052,7 @@
 				<availability>DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
-				<availability>:0,LA:2-,FRR:2-,FWL:1-,MERC:2-,FS:2-,CIR:6,DC:2-</availability>
+				<availability>LA:2-,FRR:2-,FWL:1-,MERC:2-,FS:2-,CIR:6,DC:2-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
 				<availability>FWL:1-,TC:1-</availability>
@@ -3209,14 +3209,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>DTA:6,SC:6,DoO:6,MCM:6,FWL:6,WOB:4,DO:6,DGM:6,TP:6,DA:6</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>General:4,RCM:0</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:2</availability>
+				<availability>IS:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Blue Flame' unitType='Mek'>
@@ -3290,7 +3290,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3395,7 +3395,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>MOC:2-,CC:3-,HL:3-,FRR:2-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,CGB.FRR:2-,ROS:3-,FWL:1-,DC:3-</availability>
+			<availability>MOC:2-,HL:3-,FRR:2-,IS:3-,Periphery.Deep:7,MERC:3-,TC:3-,Periphery:4-,LA:2-,CGB.FRR:2-,ROS:3-,FWL:1-</availability>
 			<model name=''>
 				<availability>LA:3,General:8,FS:3,MERC:3,DC:3</availability>
 			</model>
@@ -3642,7 +3642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cauldron-Born (Ebon Jaguar)' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CCC:5,CSR:3,CDS:5,CW:1,CLAN:1,CNC:5,CGS:6,CJF:1,CGB:1,DC:3+</availability>
+			<availability>CSA:5,CHH:5,CCC:5,CSR:3,CDS:5,CLAN:1,CNC:5,CGS:6,DC:3+</availability>
 			<model name='A'>
 				<availability>General:8</availability>
 			</model>
@@ -3917,7 +3917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CHH:2,PR:2,DoO:2,FRR:4,DO:2,FS:3,DC.GHO:5,SC:2,CGB.FRR:4,FWL:3,NIOPS:5,RFS:2,CGB:3,CC:4,IS:3,WOB:5,DGM:2,MERC:2,CS:5,DTA:2,FVC:2,LA:3,MCM:2,ROS:4,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
+			<availability>CHH:2,PR:2,DoO:2,FRR:4,DO:2,DC.GHO:5,SC:2,CGB.FRR:4,FWL:3,NIOPS:5,RFS:2,CGB:3,CC:4,IS:3,WOB:5,DGM:2,MERC:2,CS:5,DTA:2,FVC:2,MCM:2,ROS:4,PG:2,TP:2,DA:2,RCM:2</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -4068,16 +4068,16 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
+			<availability>FRR:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,HL:1-,LA:3-,IS:1-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
+				<availability>HL:1-,LA:3-,IS:1-,Periphery.Deep:8,MERC:3-,BAN:3,Periphery:4-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -4102,7 +4102,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,IS:1,WOB:4-,DGM:6,FS:1,MERC:3,CDP:3,Periphery:3,CS:4-,SC:6,LA:1,MCM:6,PG:6,FWL:6,RFS:6,DC:3</availability>
+			<availability>CC:4,IS:1,WOB:4-,DGM:6,MERC:3,CDP:3,Periphery:3,CS:4-,SC:6,MCM:6,PG:6,FWL:6,RFS:6,DC:3</availability>
 			<model name='CDA-3F'>
 				<roles>recon</roles>
 				<availability>FWL:5,IS:4,WOB:5</availability>
@@ -4330,7 +4330,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:3,MOC:2,PR:3,FRR:1,IS:1,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,CGB.FRR:1,PG:3,ROS:3,FWL:1,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3,DC:1</availability>
+			<availability>CC:3,PR:3,IS:1,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,CGB.FRR:1,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -4449,7 +4449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:2,HL:2,IS:3,WOB:3,FS:4,Periphery:3,TC:2,CS:3,FVC:4,LA:5,CGB.FRR:3,ROS:3,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:4-,FVC:4-,General:3-,FS:4-,Periphery:3-</availability>
 			</model>
@@ -4594,7 +4594,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
+			<availability>CC:1,FRR:2,CLAN:3,FS:8,MERC:4,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
 			<model name='CSR-12D'>
 				<availability>FS:4</availability>
 			</model>
@@ -4691,7 +4691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,CGB.FRR:4,ROS:5,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
+			<availability>FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,CGB.FRR:4,ROS:5,NIOPS:5,CJF:2,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4898,7 +4898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,CGB.FRR:5,ROS:3,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,Periphery:2,CS:3,LA:5,CGB.FRR:5,ROS:3,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -4953,7 +4953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>MERC.KH:4,HL:3,CEI:2,CLAN:1-,WOB:7,MERC:4,CDP:2:3081,TC:4,Periphery:4,CS:6,MERC.WD:4,ROS:6,NIOPS:6,CJF:3:3081</availability>
+			<availability>MERC.KH:4,HL:3,CEI:2,CLAN:1-,WOB:7,MERC:4,CDP:2:3081,Periphery:4,CS:6,MERC.WD:4,ROS:6,NIOPS:6,CJF:3:3081</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:3,CS:6,CEI:2-,ROS:4,WOB:6,TC:3</availability>
@@ -5055,7 +5055,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:4,IS:2+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,IS:2+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5150,7 +5150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CCC:3,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CDS:3,CJF:3,CGB:6</availability>
+			<availability>CHH:5,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -5250,7 +5250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,FS:9,CWIE:6,OA:9,CGB.FRR:7,FWL:8,NIOPS:6,MOC:10,CC:7,IS:7,WOB:6,CIR:9,Periphery:10,TC:9,CS:6,FVC:8,LA:5,ROS:8,CNC:5,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,Periphery.Deep:9,FS:9,CWIE:6,OA:9,CGB.FRR:7,FWL:8,NIOPS:6,MOC:10,IS:7,WOB:6,CIR:9,Periphery:10,TC:9,CS:6,FVC:8,LA:5,ROS:8,CNC:5,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
@@ -5320,7 +5320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:2,CC:2,HL:2,DoO:3,FRR:3,IS:2,Periphery.Deep:5,DO:3,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:1,FVC:5,LA:3,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:3</availability>
+			<availability>MOC:2,HL:2,DoO:3,FRR:3,IS:2,Periphery.Deep:5,DO:3,FS:5,MERC:3,Periphery.OS:4,Periphery:3,OA:1,FVC:5,LA:3,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:3</availability>
 			<model name='DV-1S'>
 				<availability>IS:3-</availability>
 			</model>
@@ -5376,7 +5376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:3-,CC:2-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:3-,OA:1-,LA:3-,CGB.FRR:1-,FWL:2-,MH:1-,DC:2-</availability>
+			<availability>MOC:3-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:3-,OA:1-,LA:3-,CGB.FRR:1-,MH:1-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5547,7 +5547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:3-,Periphery:3-,CS:3,FVC:4-,LA:7,ROS:3,FWL:3-,CC.MAC:3-,DC:3-</availability>
+			<availability>HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:3-,Periphery:3-,CS:3,FVC:4-,LA:7,ROS:3,CC.MAC:3-</availability>
 			<model name=''>
 				<availability>CC:3-,General:3-</availability>
 			</model>
@@ -5598,7 +5598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,HL:2,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,CS:3-,OA:2,CGB.FRR:3,FWL:4,NIOPS:3-</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:1-,FS:1-</availability>
@@ -5754,7 +5754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,CNC:5,NIOPS:7</availability>
 			<model name='EMP-6A'>
 				<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
@@ -5820,7 +5820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:1,LA:1,Periphery.HR:2,MH:2,DC:1</availability>
+			<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,Periphery:2,FVC:7,OA:1,LA:1,DC:1</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:2-,FS:3-,TC:3-</availability>
 			</model>
@@ -5898,7 +5898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,FRR:6,IS:5,WOB:5,FS:3,Periphery:2,TC:3,CS:5,CGB.FRR:6,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:5,FS:4,MERC:2</availability>
 			</model>
@@ -6490,7 +6490,7 @@
 		<chassis name='Flashman' unitType='Mek'>
 			<availability>CHH:2,FRR:4,CLAN:3,WOB:5,DGM:5,CGS:2,CS:5,DC.GHO:5,SC:5,Periphery.R:1,CDS:2,LA:4,CBS:2,MCM:5,CGB.FRR:4,ROS:4,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
 			<model name='FLS-7K'>
-				<availability>:0,MERC.KH:1-,LA:1-</availability>
+				<availability>MERC.KH:1-,LA:1-</availability>
 			</model>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,CS:4,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
@@ -6536,7 +6536,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,PR:3,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4,MERC.WD:4,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:2,DA:3,RCM:3,RFS:3</availability>
+			<availability>CC:6,PR:3,WOB:4,MERC:4,Periphery:4,MERC.WD:4,ROS:4,PG:3,FWL:2,DA:3,RCM:3,RFS:3</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:1</availability>
@@ -6725,7 +6725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:3-,General:8,FWL:1-,WOB:4-</availability>
@@ -6780,7 +6780,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,Periphery:6,CS:6,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -6863,7 +6863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,CEI:1:3079,CLAN:5,CNC:5,IS:1+,CJF:4,BAN:4,CWIE:1,CGB:9</availability>
+			<availability>CSA:6,MERC.WD:1,CSR:1,CEI:1:3079,CLAN:5,IS:1+,CJF:4,BAN:4,CWIE:1,CGB:9</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -7023,7 +7023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:4,MOC:3,HL:2,IS:1,WOB:2,FS:3,MERC:4,TC:3,Periphery:3,CS:1,DTA:2:3081,OA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,DA:2:3081,RCM:2:3081</availability>
+			<availability>CC:4,HL:2,IS:1,WOB:2,FS:3,MERC:4,Periphery:3,CS:1,DTA:2:3081,OA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,DA:2:3081,RCM:2:3081</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:3-,LA:3-,FWL:3-,Periphery.Deep:8,IS:1-,MERC:3-,Periphery:3-</availability>
@@ -7189,7 +7189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:5,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -7483,7 +7483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CC:5,CHH:3,CSR:2,FRR:1,IS:1,WOB:7,DGM:5,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:3,SC:5,MCM:5,CGB.FRR:1,ROS:6,FWL:5,NIOPS:7,DC:1</availability>
+			<availability>CC:5,CHH:3,CSR:2,IS:1,WOB:7,DGM:5,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:3,SC:5,MCM:5,CGB.FRR:1,ROS:6,FWL:5,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,ROS:6,FRR:8,CGB.FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
@@ -7711,7 +7711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>PR:5,HL:3-,DoO:5,FRR:5-,Periphery.Deep:4,DO:5,SC:5,FWL.pm:6-,CGB.FRR:5-,Periphery.CM:5-,Periphery.MW:5-,FWL:6-,MH:4-,RFS:5,MOC:4-,CC:4-,IS:4-,WOB:4-,DGM:5,MERC:4-,Periphery:3-,CS:4-,DTA:5,LA:4-,MCM:5,PG:5,Periphery.ME:5-,TP:5,DA:5,RCM:5,DC:4-</availability>
+			<availability>PR:5,HL:3-,DoO:5,FRR:5-,Periphery.Deep:4,DO:5,SC:5,FWL.pm:6-,CGB.FRR:5-,Periphery.CM:5-,Periphery.MW:5-,FWL:6-,MH:4-,RFS:5,MOC:4-,IS:4-,WOB:4-,DGM:5,MERC:4-,Periphery:3-,CS:4-,DTA:5,MCM:5,PG:5,Periphery.ME:5-,TP:5,DA:5,RCM:5</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -7919,7 +7919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>CC:3,MOC:5,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:5,Periphery:5,OA:6,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
+			<availability>CC:3,HL:4,MERC:3,Periphery.OS:4,FS:3,Periphery:5,OA:6,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7938,8 +7938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:2-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8203,7 +8202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>OA:4,HL:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,WOB:3,MERC:6,Periphery:4</availability>
+			<availability>HL:3,ROS:4,FWL:6,WOB:3,MERC:6,Periphery:4</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -8331,7 +8330,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>MOC:2,CC:3,CS:9,LA:6,CLAN:5,IS:2,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6,DC:2</availability>
+			<availability>MOC:2,CC:3,CS:9,LA:6,CLAN:5,IS:2,NIOPS:9,WOB:9,MERC:4,FS:5,CJF:6</availability>
 			<model name='HGN-641-X-2'>
 				<availability>CS:1</availability>
 			</model>
@@ -8441,7 +8440,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
+			<availability>FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,MERC.WD:3,FVC:8,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:3-</availability>
@@ -8497,7 +8496,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
+			<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:2,LA:5,CGB.FRR:6,ROS:3,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -8554,7 +8553,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:2,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,CGB.FRR:5,ROS:3,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:2,WOB:5-,MERC:6,CIR:5,Periphery:6,CS:5-,LA:8,CGB.FRR:5,ROS:3,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:4-</availability>
@@ -8841,7 +8840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,CS:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -8963,7 +8962,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>FS.DLC:4-,PR:1-,DC.LV:4-,HL:2-,DoO:2-,FRR:2-,Periphery.Deep:5,DO:2-,FS:3-,SC:2-,OA:2-,CGB.FRR:3-,FWL:2-,NIOPS:2-,RFS:1-,MOC:3-,CC:1-,DC.GR:3-,FS.AH:3-,IS:3-,WOB:3-,DGM:2-,CIR:4-,Periphery:3-,TC:4-,CS:2-,DTA:1-,LA:3-,MCM:2-,PG:1-,TP:2-,RCM:1-,DA:1-,DC:3-</availability>
+			<availability>FS.DLC:4-,PR:1-,DC.LV:4-,HL:2-,DoO:2-,FRR:2-,Periphery.Deep:5,DO:2-,SC:2-,OA:2-,CGB.FRR:3-,FWL:2-,NIOPS:2-,RFS:1-,CC:1-,DC.GR:3-,FS.AH:3-,IS:3-,WOB:3-,DGM:2-,CIR:4-,Periphery:3-,TC:4-,CS:2-,DTA:1-,MCM:2-,PG:1-,TP:2-,RCM:1-,DA:1-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -9024,7 +9023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jackal' unitType='Mek'>
-			<availability>MOC:5,CC:1,IS:1,WOB:6,DGM:6,FS:1,MERC:6,DTA:6,SC:6,FVC:1,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5</availability>
+			<availability>MOC:5,IS:1,WOB:6,DGM:6,MERC:6,DTA:6,SC:6,FVC:1,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5</availability>
 			<model name='JA-KL-1532'>
 				<availability>HL:6,General:1,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 			</model>
@@ -9079,7 +9078,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:3,CC:4-,FRR:3,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,CGB.FRR:3,Periphery.CM:2,Periphery.HR:3,ROS:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
+			<availability>MOC:3,CC:4-,FRR:3,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,CGB.FRR:3,Periphery.CM:2,Periphery.HR:3,ROS:3,PIR:3,Periphery.ME:2,NIOPS:3,MH:4,DC:3</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,CGB.FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
@@ -9120,7 +9119,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:4,HL:3,IS:1,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:1,LA:2,Periphery.HR:5,ROS:4</availability>
+			<availability>HL:3,IS:1,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,FVC:8,OA:1,LA:2,Periphery.HR:5,ROS:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -9190,7 +9189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
+			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:5,FS:5,DC:6</availability>
@@ -9519,7 +9518,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:3,FRR:4,CLAN:2,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:3,LA:3,CGB.FRR:4,ROS:6,FWL:3,NIOPS:6,CGB:3,DC:3</availability>
+			<availability>FRR:4,CLAN:2,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:3,CGB.FRR:4,ROS:6,NIOPS:6,CGB:3</availability>
 			<model name='KGC-000'>
 				<availability>CS:4,FRR:8,CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 			</model>
@@ -9592,7 +9591,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>CS:7,DC.GHO:6,CHH:1,CDS:1,FRR:4,CGB.FRR:4,ROS:6,NIOPS:7,WOB:7,FS:3,MERC:5,DC:4</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:3-,MERC:3-,DC:1-</availability>
+				<availability>FS:3-,MERC:3-,DC:1-</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:4,CS:4,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,WOB:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
@@ -9857,7 +9856,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
-			<availability>CSA:6,CHH:6,CSR:3,CDS:3,CW:4,CLAN:1,CNC:3,CGS:6,CJF:4,CGB:6,CWIE:1</availability>
+			<availability>CSA:6,CHH:6,CW:4,CLAN:1,CGS:6,CJF:4,CGB:6,CWIE:1</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
@@ -10024,7 +10023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,BAN:2,Periphery:8,CS:4,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FWL:2,WOB:6</availability>
 			</model>
@@ -10140,7 +10139,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,Periphery:4,TC:4,CS:3-,OA:6,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:5-</availability>
 			</model>
@@ -10418,7 +10417,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,CGB.FRR:4,ROS:6,NIOPS:3</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10510,7 +10509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
+			<availability>HL:4,FRR:3,FS:2,MERC:2,CIR:3,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
 			<model name='LCF-R15'>
 				<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 			</model>
@@ -10617,7 +10616,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:1,MERC.WD:7,CDS:5,CW:7,CBS:3,CLAN:3,WOB:1,CCO:5,CJF:5,BAN:2,CWIE:7</availability>
+			<availability>CSA:5,CHH:1,MERC.WD:7,CDS:5,CW:7,CLAN:3,WOB:1,CCO:5,CJF:5,BAN:2,CWIE:7</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -10761,7 +10760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,MERC.WD:7,CDS:7,CW:7,CBS:5,CLAN:1,CNC:3,IS:1+,CJF:7,BAN:5,CWIE:7,CGB:1</availability>
+			<availability>CHH:5,MERC.WD:7,CDS:7,CW:7,CBS:5,CLAN:1,CNC:3,IS:1+,CJF:7,BAN:5,CWIE:7</availability>
 			<model name='A'>
 				<availability>CDS:4,CW:8,CNC:8,General:7,CJF:9,CGB:9</availability>
 			</model>
@@ -10825,7 +10824,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,CGB.FRR:8,ROS:7,FWL:6,NIOPS:7,DC:9</availability>
+			<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,CS:7,CGB.FRR:8,ROS:7,FWL:6,NIOPS:7,DC:9</availability>
 			<model name=''>
 				<availability>HL:3,LA:2-,General:3-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 			</model>
@@ -10922,7 +10921,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
+			<availability>CC:4,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
 			<model name='C'>
 				<availability>CW:1,LA:1+,CNC:1,FS:1+,CJF:1,DC:1+,CGB:1,CWIE:1</availability>
 			</model>
@@ -11158,7 +11157,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:2,CC:2,FRR:2,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:1,LA:3,CGB.FRR:3,ROS:2,FWL:2,NIOPS:2-,DC:2</availability>
+			<availability>CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,CS:2-,OA:1,LA:3,CGB.FRR:3,ROS:2,NIOPS:2-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -11683,7 +11682,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,FS:2,DC.GHO:2,CS:5,CDS:1,CBS:1,CGB.FRR:3,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
+			<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,FS:2,DC.GHO:2,CS:5,CGB.FRR:3,NIOPS:1,DC:2</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:3,NIOPS:5,WOB:8,BAN:5</availability>
@@ -11884,7 +11883,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,OA:2,LA:5,WOB:4,FS:4,MERC:4,CIR:4,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:4,LA:5,WOB:4,FS:4,MERC:4,CIR:4,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -12095,7 +12094,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>PR:4,DoO:4,WOB:3,DO:4,FS:7,MERC:5,CIR:2,Periphery.R:2,LA:8,ROS:5,PG:4,TP:4,RFS:4</availability>
 			<model name='NGS-4S'>
-				<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
+				<availability>PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -12339,7 +12338,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,CGB.FRR:4,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
+			<availability>MOC:7,CC:6,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,CGB.FRR:4,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5</availability>
 			<model name=''>
 				<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -12386,7 +12385,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:2,CW:2,LA:2,CGB.FRR:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
+			<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:2,CW:2,CGB.FRR:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>HL:1-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -12458,7 +12457,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,CGB.FRR:5,ROS:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,CGB.FRR:5,ROS:4,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:1-,IS:1-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
@@ -12687,7 +12686,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,CGB.FRR:3-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
+			<availability>MOC:3-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,CGB.FRR:3-,FS.CMM:7-,FS.DMM:7-,NIOPS:6</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12698,7 +12697,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,FS:1,Periphery:3,CGB.FRR:2,PIR:2,General:2,FWL:1,DC:2</availability>
+				<availability>CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,Periphery:3,CGB.FRR:2,PIR:2,General:2,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -12818,7 +12817,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Air Defense Tank' unitType='Tank'>
-			<availability>CC:5,HL:3,FRR:4,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,CS:6,LA:7,CGB.FRR:4,CNC:5,DC:6</availability>
+			<availability>HL:3,FRR:4,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,CS:6,LA:7,CGB.FRR:4,CNC:5,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -12850,7 +12849,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:4-,CC:2-,HL:3-,FRR:1-,IS:3-,Periphery.Deep:9,WOB:4-,FS:4-,CIR:3-,Periphery:4-,TC:4-,CS:4-,OA:2-,CDS:2,LA:3-,CGB.FRR:1-,FWL:3-,DC:2-</availability>
+			<availability>CC:2-,HL:3-,FRR:1-,IS:3-,Periphery.Deep:9,WOB:4-,FS:4-,CIR:3-,Periphery:4-,CS:4-,OA:2-,CDS:2,CGB.FRR:1-,DC:2-</availability>
 			<model name=''>
 				<availability>General:5</availability>
 			</model>
@@ -12914,7 +12913,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:1,CC:1,FRR:1,IS:1,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:1,CS:5-,OA:1,LA:6,CGB.FRR:1,ROS:6,FWL:2,DC:6</availability>
+			<availability>IS:1,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,CWIE:1,CS:5-,LA:6,CGB.FRR:1,ROS:6,FWL:2,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:3</availability>
@@ -12993,7 +12992,7 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine Attack VTOL' unitType='VTOL'>
-			<availability>CC:1-,LA:1-,FRR:1-,CGB.FRR:1-,FWL:1-,IS:1-,FS:1-,MERC:1-,DC:1-</availability>
+			<availability>CGB.FRR:1-,IS:1-,MERC:1-</availability>
 			<model name=''>
 				<availability>General:8,DC:2</availability>
 			</model>
@@ -13216,7 +13215,7 @@
 			<availability>LA:2-,MERC:3-,TC:3-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:3,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:2-,MERC.WD:5,CDS:6,LA:2-,CGB.FRR:3-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
+			<availability>MOC:3,CC:1-,CHH:5,HL:2-,CLAN:5,IS:3-,WOB:4-,MERC:3-,CWIE:6,Periphery:3-,CS:4-,OA:2-,MERC.WD:5,CDS:6,LA:2-,CGB.FRR:3-,CNC:5,FWL:2-,MH:5-</availability>
 			<model name=''>
 				<availability>HL:3,IS:3,Periphery.Deep:2,Periphery:5</availability>
 			</model>
@@ -13658,7 +13657,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>PR:6,HL:3,DoO:6,FRR:7,Periphery.Deep:4,DO:6,FS:4,CDP:4,SC:6,OA:4,CGB.FRR:7,FWL:7,NIOPS:3-,RFS:6,MOC:4,CC:3,IS:4,WOB:3-,DGM:6,CIR:3,Periphery:4,TC:4,CS:3-,DTA:6,FVC:4,LA:4,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
+			<availability>PR:6,HL:3,DoO:6,FRR:7,Periphery.Deep:4,DO:6,CDP:4,SC:6,CGB.FRR:7,FWL:7,NIOPS:3-,RFS:6,CC:3,IS:4,WOB:3-,DGM:6,CIR:3,Periphery:4,CS:3-,DTA:6,FVC:4,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4-,OA:4-,HL:1-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
 			</model>
@@ -13906,7 +13905,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13953,7 +13952,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -14034,7 +14033,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:6,CCC:6,HL:3,FRR:7,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:4</availability>
+			<availability>CCC:6,HL:3,FRR:7,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:4</availability>
 			<model name='C'>
 				<availability>LA:1,CLAN:5,FS:1,BAN:1,DC:1</availability>
 			</model>
@@ -14459,7 +14458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:4,CS:5-,LA:6,CGB.FRR:7,FWL:6,CJF:4,DC:9</availability>
+			<availability>Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:4,CS:5-,CGB.FRR:7,FWL:6,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:5-,Periphery:5-</availability>
 			</model>
@@ -14526,7 +14525,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:3-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,CGB.FRR:6-,ROS:2-,FWL:6-,DC:7-</availability>
+			<availability>Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:3-,Periphery:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,CGB.FRR:6-,ROS:2-,FWL:6-,DC:7-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -14682,13 +14681,13 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek AC Carrier' unitType='Tank'>
-			<availability>MOC:1,CC:1,OA:1,LA:1,IS:1,FWL:1,FS:1,TC:1,Periphery:1,DC:1</availability>
+			<availability>IS:1,Periphery:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:2,HL:4,FRR:2,IS:3,Periphery.Deep:5,WOB:4,MERC:3,FS:3,CIR:5,Periphery:5,TC:3,CS:3,OA:3,LA:3,CGB.FRR:3,FWL:3,DC:2</availability>
+			<availability>MOC:3,CC:2,HL:4,FRR:2,IS:3,Periphery.Deep:5,WOB:4,MERC:3,Periphery:5,TC:3,CS:3,OA:3,CGB.FRR:3,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -14706,7 +14705,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,CGB.FRR:7-,FWL:3-,DC:6-</availability>
+			<availability>CC:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,FS:3-,Periphery:5-,CS:4-,OA:6-,CGB.FRR:7-,FWL:3-,DC:6-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -14860,7 +14859,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seeker' unitType='Dropship'>
-			<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,FS:5,CIR:3,Periphery:3,CS:3,LA:6,CGB.FRR:3,FWL:4,DC:4</availability>
+			<availability>CC:3,HL:2,FRR:3,IS:4,WOB:3,FS:5,Periphery:3,CS:3,LA:6,CGB.FRR:3</availability>
 			<model name='(2815)'>
 				<roles>vee_carrier</roles>
 				<availability>General:6</availability>
@@ -14871,7 +14870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
+			<availability>CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,LA:6,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -14926,7 +14925,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
+			<availability>MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
@@ -15310,7 +15309,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,CGB.FRR:5-,ROS:3-,FWL:3,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,CS:3-,OA:1,FVC:2,CGB.FRR:5-,ROS:3-,FWL:3,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:5-</availability>
@@ -15329,7 +15328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
+			<availability>Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 			</model>
@@ -15432,7 +15431,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,ROS:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
 			</model>
@@ -15492,7 +15491,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,CS:3,FVC:4,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:1-</availability>
@@ -15596,7 +15595,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,CGB.FRR:6,ROS:4,FWL:8,NIOPS:5,DC:5</availability>
+			<availability>MOC:6,CC:5,HL:9,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,CGB.FRR:6,ROS:4,FWL:8,NIOPS:5,DC:5</availability>
 			<model name='STK-3F'>
 				<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -15757,7 +15756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,CGB.FRR:4,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,CGB.FRR:4,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
@@ -15838,7 +15837,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -15850,7 +15849,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15917,7 +15916,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+			<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -15960,7 +15959,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,FRR:1,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:3,CGB.FRR:2,Periphery.HR:2,ROS:5,DC:1</availability>
+			<availability>FRR:1,CLAN:4,MERC:4,Periphery.OS:2,FS:7,Periphery:1,OA:2,FVC:7,LA:3,CGB.FRR:2,Periphery.HR:2,ROS:5,DC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,ROS:6,FS:6,MERC:6</availability>
 			</model>
@@ -16393,7 +16392,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:2,CLAN:3,IS:1+,CCO:3,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:3,CW:3,CNC:4,CJF:6,CGB:3</availability>
+			<availability>CHH:5,CSR:2,CLAN:3,IS:1+,BAN:4,CWIE:5,MERC.WD:4,CNC:4,CJF:6</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -16455,7 +16454,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,ROS:6,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+			<availability>CLAN:1,WOB:7,Periphery:1,CS:5,DC.GHO:1,ROS:6,NIOPS:5,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:5,CLAN:3,NIOPS:3,BAN:3</availability>
 			</model>
@@ -16582,7 +16581,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,CS:4-,OA:4,LA:6,CGB.FRR:4,NIOPS:4-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:4-</availability>
@@ -16603,7 +16602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:6,MERC.KH:4,HL:3,CEI:1+,MERC.ELH:8,CLAN:1,IS:5,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>CC:6,MERC.KH:4,HL:3,CEI:1+,MERC.ELH:8,CLAN:1,IS:5,Periphery.Deep:6,WOB:2-,MERC:6,Periphery:4,CS:3-,FVC:5,MERC.WD:2,LA:6,ROS:5,NIOPS:3-</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,CEI:1+,FS:2,CGS:1-,DC:1</availability>
 			</model>
@@ -16933,7 +16932,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>MOC:3,CC:3,PR:6,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:2,LA:3,CGB.FRR:4,Periphery.MW:5,ROS:4,PG:6,Periphery.ME:5,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+			<availability>MOC:3,PR:6,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:2,CGB.FRR:4,ROS:4,PG:6,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,SC:4,PR:4,MCM:4,ROS:5,PG:4,FWL:2,NIOPS:5,WOB:5,DGM:4,MERC:4,RFS:4</availability>
@@ -17129,7 +17128,7 @@
 			<availability>CS:4,WOB:4,DC:3</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:5</availability>
+				<availability>General:5</availability>
 			</model>
 			<model name='(C3)'>
 				<roles>apc,urban,spotter</roles>
@@ -17242,7 +17241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:8,CHH:3,CSR:3,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:1,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
+			<availability>CCC:8,CHH:3,CSR:3,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CW:3,CBS:5,CNC:1,CJF:6</availability>
 			<model name='A'>
 				<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -17370,7 +17369,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,Periphery:4-,TC:3-,CS:3-,OA:3-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -17586,7 +17585,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,CS:5,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:4</availability>
@@ -17630,7 +17629,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,CGB.FRR:6,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,Periphery:4,CS:3-,LA:5,CGB.FRR:6,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -17845,7 +17844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:3,MOC:5,FRR:4,IS:4,WOB:3,CIR:5,Periphery:5,TC:5,CS:3,LA:6,CGB.FRR:4,FWL:6,NIOPS:3</availability>
+			<availability>CC:3,IS:4,WOB:3,Periphery:5,CS:3,LA:6,CGB.FRR:4,FWL:6,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>FVC:3-,General:4-,FS:2-</availability>
@@ -17876,7 +17875,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,MERC.WD:6,CW:1,CLAN:6,CNC:1,CCO:6,CJF:6,BAN:6,CWIE:6,CGB:7,DC:2+</availability>
+			<availability>CHH:7,MERC.WD:6,CW:1,CLAN:6,CNC:1,BAN:6,CWIE:6,CGB:7,DC:2+</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 			</model>
@@ -18046,7 +18045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,CGB.FRR:5,ROS:6,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,CIR:5,CC.CHG:8,Periphery:6,CS:5-,LA:9,CGB.FRR:5,ROS:6,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -18202,7 +18201,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:1,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
+			<availability>MOC:1,MERC:2,Periphery:2,CS:1-,OA:1,FVC:3,FS.CMM:3,NIOPS:1-,DC:3</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
@@ -18307,7 +18306,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,HL:4,FRR:3,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CGB.FRR:3,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>HL:4,FRR:3,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,CS:3-,CGB.FRR:3,CNC:2,FWL:8,NIOPS:3-,MH:4</availability>
 			<model name='WVR-1R'>
 				<availability>CC:2-,FWL:2-,FS:2-,MERC:2,RCM:2,DC:2-</availability>
 			</model>
@@ -18386,7 +18385,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>PR:3,DoO:3,FRR:5,CLAN:2,DO:3,FS:7,DC.GHO:5,SC:3,CGB.FRR:5,NIOPS:5,RFS:3,CC:3,IS:3,WOB:4-,DGM:3,MERC:5,CS:5,DTA:3,FVC:3,MCM:3,PG:3,ROS:5,TP:3,RCM:3,DA:3,DC:6</availability>
+			<availability>PR:3,DoO:3,FRR:5,CLAN:2,DO:3,FS:7,DC.GHO:5,SC:3,CGB.FRR:5,NIOPS:5,RFS:3,IS:3,WOB:4-,DGM:3,MERC:5,CS:5,DTA:3,FVC:3,MCM:3,PG:3,ROS:5,TP:3,RCM:3,DA:3,DC:6</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:5,WOB:4</availability>
@@ -18598,7 +18597,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,HL:2,IS:3,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:5</availability>
+			<availability>CC:6,HL:2,IS:3,WOB:6,MERC:5,CIR:4,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:5</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -12,8 +12,7 @@
 			<pctClan>30</pctClan>
 			<pctSL>60</pctSL>
 			<techMargin>2</techMargin>
-			<salvage pct='10'>
-				CCC:2,CHH:2,CSR:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:1,CJF:2,CGB:2</salvage>
+			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,PIR:10,CNC:1,CJF:2,CGB:2</salvage>
 		</faction>
 		<faction key='CDP'>
 			<pctClan>0,0,0,1,5</pctClan>
@@ -849,8 +848,7 @@
 			<pctSL>73</pctSL>
 			<omniMargin>2</omniMargin>
 			<techMargin>2</techMargin>
-			<salvage pct='6'>
-				MOC:2,CC:8,FRR:0,WOB:15,CIR:0,FS:8,TC:2,DTA:1,OA:2,CDS:0,CW:5,LA:8,RIM:0,ROS:2,CNC:3,FWL:12,CJF:6,CGB:5,DC:9</salvage>
+			<salvage pct='6'>MOC:2,CC:8,FRR:0,WOB:15,CIR:0,FS:8,TC:2,DTA:1,OA:2,CDS:0,CW:5,LA:8,RIM:0,ROS:2,CNC:3,FWL:12,CJF:6,CGB:5,DC:9</salvage>
 		</faction>
 		<faction key='FWL.KIS'>
 			<pctOmni>35</pctOmni>
@@ -1305,8 +1303,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,FRR:4,IS:4,Periphery.Deep:4,FS:5,CIR:4,Periphery:4,TC:4,CS:3,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:3,General:5,Periphery.Deep:6,Periphery:5</availability>
@@ -1354,16 +1351,14 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:4</availability>
+			<availability>MOC:1,CC:4,FRR:3,CLAN:4,IS:2,WOB:6,FS:2,BAN:5,Periphery:1,TC:1,CS:6,OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
 			</model>
 			<model name='(3055)'>
 				<roles>assault</roles>
-				<availability>
-					CC:7,PR:7,DoO:7,IS:3,WOB:7,DO:7,DGM:7,DTA:7,SC:7,MCM:7,PG:7,FWL:7,TP:7,DA:7,RCM:7,RFS:7,DC:2</availability>
+				<availability>CC:7,PR:7,DoO:7,IS:3,WOB:7,DO:7,DGM:7,DTA:7,SC:7,MCM:7,PG:7,FWL:7,TP:7,DA:7,RCM:7,RFS:7,DC:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
@@ -1551,8 +1546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				MERC.KH:3,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
+			<availability>MERC.KH:3,CHH:2,CSR:2,CLAN:1,MERC:3,CCO:2,CWIE:4,BAN:2,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
 			<model name='ANH-1A'>
 				<availability>CLAN:1-,MERC:1-</availability>
 			</model>
@@ -1586,8 +1580,7 @@
 			</model>
 		</chassis>
 		<chassis name='Anvil' unitType='Mek'>
-			<availability>
-				CC:1,PR:6,DoO:6,WOB:2,DO:6,DGM:6,MERC:3,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,TP:6,DA:6,RFS:6</availability>
+			<availability>CC:1,PR:6,DoO:6,WOB:2,DO:6,DGM:6,MERC:3,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,TP:6,DA:6,RFS:6</availability>
 			<model name='ANV-3M'>
 				<availability>CC:5,ROS:6,FWL:4,WOB:4,MERC:5</availability>
 			</model>
@@ -1716,8 +1709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:4,HL:3,FRR:4,CLAN:1,IS:3-,Periphery.Deep:5,WOB:2-,FS:3-,Periphery:4,CS:4-,LA:6,CGB.FRR:4,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
+			<availability>CC:4,HL:3,FRR:4,CLAN:1,IS:3-,Periphery.Deep:5,WOB:2-,FS:3-,Periphery:4,CS:4-,LA:6,CGB.FRR:4,FWL:6,NIOPS:4-,DC:5,CGB:1</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:6,MERC.WD:6,CWIE:1</availability>
 			</model>
@@ -1782,8 +1774,7 @@
 			</model>
 			<model name='ARC-8M'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:1,MOC:3,DoO:5,FRR:3,WOB:3,DO:5,DGM:5,MERC:3,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,FWL:2,TP:5,DC:1</availability>
+				<availability>CC:1,MOC:3,DoO:5,FRR:3,WOB:3,DO:5,DGM:5,MERC:3,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,FWL:2,TP:5,DC:1</availability>
 			</model>
 			<model name='ARC-9K'>
 				<roles>fire_support</roles>
@@ -1913,8 +1904,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>
-				CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,CIR:10,DC:8,Periphery:10,TC:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1979,8 +1969,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,CGB.FRR:1-,FS.CMM:1-</availability>
+			<availability>MOC:3-,CC:3-,FRR:1-,IS:1-,WOB:2-,MERC:1-,FS:1,CDP:3-,Periphery:2-,TC:3-,CS:3-,OA:1-,FVC:1,LA:1,CGB.FRR:1-,FS.CMM:1-</availability>
 			<model name='ASN-21'>
 				<availability>General:1-</availability>
 			</model>
@@ -2069,8 +2058,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FRR:6,IS:2,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:4,CGB.FRR:6,FWL:2,NIOPS:4-,DC:9</availability>
+			<availability>MOC:1,CC:2,FRR:6,IS:2,WOB:4-,CLAN.IS:2,FS:4,MERC:2,CGS:2,CLAN.HW:2-,Periphery:1,TC:1,CS:4-,OA:1,LA:4,CGB.FRR:6,FWL:2,NIOPS:4-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -2255,8 +2243,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:6,Periphery.Deep:7,WOB:6,FS:6,CIR:7,Periphery:8,TC:7,CS:7,OA:7,LA:6,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,WOB:4,DO:4,DGM:4,TP:4,DC:4</availability>
 			</model>
@@ -2554,8 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:7-,CC:1-,PR:3-,HL:8-,FRR:2-,Periphery.Deep:9-,IS:1-,DGM:3-,FS:1-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,SC:3-,OA:7-,FVC:3-,LA:5-,MCM:3-,CGB.FRR:3-,PG:3-,FWL:3-,MH:7-,RFS:3-,DC:1-</availability>
+			<availability>MOC:7-,CC:1-,PR:3-,HL:8-,FRR:2-,Periphery.Deep:9-,IS:1-,DGM:3-,FS:1-,MERC:3-,CIR:7-,Periphery:9-,TC:7-,SC:3-,OA:7-,FVC:3-,LA:5-,MCM:3-,CGB.FRR:3-,PG:3-,FWL:3-,MH:7-,RFS:3-,DC:1-</availability>
 			<model name='BNC-3E'>
 				<availability>HL:1-,General:1-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
 			</model>
@@ -2750,8 +2736,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,CGB.FRR:4,ROS:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
+			<availability>CC:4,MOC:5,HL:4,FRR:4,CLAN:1,IS:5,WOB:6-,FS:5,Periphery:5,TC:5,CS:6-,DC.GHO:5,LA:6,CGB.FRR:4,ROS:6,PIR:5,FWL:7,NIOPS:6-,CJF:1,DC:4</availability>
 			<model name='BLR-10S'>
 				<availability>LA:5,ROS:3,FS:3</availability>
 			</model>
@@ -2911,8 +2896,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:4,Periphery:4,CS:4-,OA:4,CDS:5,LA:3,CGB.FRR:4,PIR:3,CNC:4,FWL:2,DC:5</availability>
+			<availability>CC:3,HL:3,FRR:4,IS:3,WOB:4-,MERC:3,FS:4,Periphery:4,CS:4-,OA:4,CDS:5,LA:3,CGB.FRR:4,PIR:3,CNC:4,FWL:2,DC:5</availability>
 			<model name=''>
 				<availability>FVC:3,CDS:3,General:8,DC:3</availability>
 			</model>
@@ -3057,18 +3041,15 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:4,PR:5,DoO:5,FRR:4,CLAN:5,DO:5,FS:5,CDP:3,CWIE:6,DC.GHO:3,SC:5,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,RFS:5,CGB:6,CSR:4,WOB:7,DGM:5,FWL.OH:3,MERC:4,CGS:6,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:6,LA:4,MCM:5,ROS:6,PG:5,CNC:6,TP:5,RCM:5,DA:5,CJF:4,DC:4</availability>
+			<availability>CHH:4,PR:5,DoO:5,FRR:4,CLAN:5,DO:5,FS:5,CDP:3,CWIE:6,DC.GHO:3,SC:5,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,RFS:5,CGB:6,CSR:4,WOB:7,DGM:5,FWL.OH:3,MERC:4,CGS:6,Periphery:3,TC:4,CS:7,DTA:5,FVC:3,CW:6,LA:4,MCM:5,ROS:6,PG:5,CNC:6,TP:5,RCM:5,DA:5,CJF:4,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:6,FS:6</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					FRR:6,CLAN:6,WOB:4,BAN:6,TC:5,Periphery:5,DC.GHO:4,CS:4,OA:5,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>FRR:6,CLAN:6,WOB:4,BAN:6,TC:5,Periphery:5,DC.GHO:4,CS:4,OA:5,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
-				<availability>
-					DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
+				<availability>DoO:6,CLAN:5,DO:6,MERC:4,FS:4,CGS:6,BAN:2,DTA:6,CS:6,LA:4,ROS:6,FWL:6,TP:6,DA:6,DC:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
 				<availability>:0,LA:2-,FRR:2-,FWL:1-,MERC:2-,FS:2-,CIR:6,DC:2-</availability>
@@ -3309,8 +3290,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3376,8 +3356,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
+			<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,WOB:5,FS:7,CIR:4,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3416,8 +3395,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:3-,HL:3-,FRR:2-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,CGB.FRR:2-,ROS:3-,FWL:1-,DC:3-</availability>
+			<availability>MOC:2-,CC:3-,HL:3-,FRR:2-,IS:3-,Periphery.Deep:7,FS:3-,CIR:4-,MERC:3-,TC:3-,Periphery:4-,LA:2-,CGB.FRR:2-,ROS:3-,FWL:1-,DC:3-</availability>
 			<model name=''>
 				<availability>LA:3,General:8,FS:3,MERC:3,DC:3</availability>
 			</model>
@@ -3576,8 +3554,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:1,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
+			<availability>CC:6,MOC:5,WOB:5,FS:5,MERC:5,CDP:5,TC:5,Periphery:1,FVC:5,LA:1,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2</availability>
 			<model name='CTF-1X'>
 				<availability>General:3-,Periphery:4-</availability>
 			</model>
@@ -3604,8 +3581,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,DoO:2,FRR:5,DO:2,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,CGB.FRR:5,FWL:1,NIOPS:4,MH:5,TP:2,DA:2,RCM:2,DC:6</availability>
+			<availability>MOC:3,CC:4,DoO:2,FRR:5,DO:2,MERC:3,CIR:4,Periphery:2,TC:3,CS:4,LA:1,CGB.FRR:5,FWL:1,NIOPS:4,MH:5,TP:2,DA:2,RCM:2,DC:6</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:1-</availability>
@@ -3809,8 +3785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				DoO:2,FRR:1,DO:2,Periphery.OS:4,FS:8,CDP:3,SC:2,CGB.FRR:1,FWL:2,NIOPS:2-,MH:4,CC:2,IS:1,WOB:2-,DGM:2,MERC:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,TP:2,DC:1</availability>
+			<availability>DoO:2,FRR:1,DO:2,Periphery.OS:4,FS:8,CDP:3,SC:2,CGB.FRR:1,FWL:2,NIOPS:2-,MH:4,CC:2,IS:1,WOB:2-,DGM:2,MERC:2,Periphery:2,CS:2-,DTA:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,TP:2,DC:1</availability>
 			<model name='CN10-B'>
 				<availability>LA:5,IS:4,FS:5,Periphery:2</availability>
 			</model>
@@ -3942,15 +3917,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CHH:2,PR:2,DoO:2,FRR:4,DO:2,FS:3,DC.GHO:5,SC:2,CGB.FRR:4,FWL:3,NIOPS:5,RFS:2,CGB:3,CC:4,IS:3,WOB:5,DGM:2,MERC:2,CS:5,DTA:2,FVC:2,LA:3,MCM:2,ROS:4,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
+			<availability>CHH:2,PR:2,DoO:2,FRR:4,DO:2,FS:3,DC.GHO:5,SC:2,CGB.FRR:4,FWL:3,NIOPS:5,RFS:2,CGB:3,CC:4,IS:3,WOB:5,DGM:2,MERC:2,CS:5,DTA:2,FVC:2,LA:3,MCM:2,ROS:4,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>
-					CC:1,CHH:2,WOB:4,FS:1,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:1,CGB:2</availability>
+				<availability>CC:1,CHH:2,WOB:4,FS:1,MERC:5,BAN:3,DC.GHO:3-,CS:4,LA:5,NIOPS:4,MERC.SI:4,DC:1,CGB:2</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CC:4,CS:4,LA:4,IS:1,MERC:4</availability>
@@ -3989,8 +3962,7 @@
 			</model>
 		</chassis>
 		<chassis name='Charger' unitType='Mek'>
-			<availability>
-				CC:3-,MOC:2-,FRR:4-,MERC:2-,TC:2-,Periphery:2,OA:2-,FVC:2,LA:3-,CGB.FRR:4-,ROS:2-,FWL:1-,DC:4-</availability>
+			<availability>CC:3-,MOC:2-,FRR:4-,MERC:2-,TC:2-,Periphery:2,OA:2-,FVC:2,LA:3-,CGB.FRR:4-,ROS:2-,FWL:1-,DC:4-</availability>
 			<model name='CGR-1A1'>
 				<roles>recon</roles>
 				<availability>CC:1-,MOC:1-,OA:1-,LA:1-,FRR:1-,CGB.FRR:1-,FWL:1-,DC:1-,Periphery:1-</availability>
@@ -4035,16 +4007,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:8,HL:2,DoO:10,FRR:3,DO:10,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,RFS:8,MOC:5,CC:3,WOB:6,DGM:10,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,FVC:2,LA:1-,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10,DC:1-</availability>
+			<availability>PR:8,HL:2,DoO:10,FRR:3,DO:10,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,RFS:8,MOC:5,CC:3,WOB:6,DGM:10,MERC:3,CIR:4,Periphery:3,TC:5,CS:3,DTA:9,FVC:2,LA:1-,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10,DC:1-</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
-				<availability>
-					CC:3-,PR:2-,HL:1-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,General:1-,FWL:3-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+				<availability>CC:3-,PR:2-,HL:1-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,General:1-,FWL:3-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:2,MOC:2,PR:8,DoO:8,FRR:6,WOB:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:2,PG:8,PIR:2,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:2,MOC:2,PR:8,DoO:8,FRR:6,WOB:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:2,PG:8,PIR:2,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -4052,8 +4021,7 @@
 			</model>
 			<model name='F-11-RR'>
 				<roles>recon</roles>
-				<availability>
-					CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,DTA:2,SC:2,MCM:2,PG:2,FWL:2,TP:2,DA:2,RCM:2,RFS:2</availability>
+				<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,DTA:2,SC:2,MCM:2,PG:2,FWL:2,TP:2,DA:2,RCM:2,RFS:2</availability>
 			</model>
 			<model name='F-12-S'>
 				<availability>FWL:2-,WOB:2-</availability>
@@ -4062,8 +4030,7 @@
 				<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,TP:4,MERC:4</availability>
 			</model>
 			<model name='F-14-S'>
-				<availability>
-					PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='OF-17A-R'>
 				<roles>recon</roles>
@@ -4096,8 +4063,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chimera' unitType='Mek'>
-			<availability>
-				PR:4,DoO:4,WOB:4,DO:4,FS:2,MERC:5,DTA:4,FVC:4,LA:6,ROS:4,PG:4,FWL:4,MH:3,TP:4,DA:4,RFS:4,DC:5</availability>
+			<availability>PR:4,DoO:4,WOB:4,DO:4,FS:2,MERC:5,DTA:4,FVC:4,LA:6,ROS:4,PG:4,FWL:4,MH:3,TP:4,DA:4,RFS:4,DC:5</availability>
 			<model name='CMA-1S'>
 				<availability>General:8,FWL:0</availability>
 			</model>
@@ -4106,8 +4072,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
+			<availability>MOC:2,FRR:2,MERC:5,FS:5,CIR:2,CDP:6,Periphery:2,TC:6,OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,FWL:2,DC:1,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:4,FS:1-,CDP:4,TC:4,Periphery:1-</availability>
 			</model>
@@ -4137,8 +4102,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>
-				CC:4,IS:1,WOB:4-,DGM:6,FS:1,MERC:3,CDP:3,Periphery:3,CS:4-,SC:6,LA:1,MCM:6,PG:6,FWL:6,RFS:6,DC:3</availability>
+			<availability>CC:4,IS:1,WOB:4-,DGM:6,FS:1,MERC:3,CDP:3,Periphery:3,CS:4-,SC:6,LA:1,MCM:6,PG:6,FWL:6,RFS:6,DC:3</availability>
 			<model name='CDA-3F'>
 				<roles>recon</roles>
 				<availability>FWL:5,IS:4,WOB:5</availability>
@@ -4366,8 +4330,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,PR:3,FRR:1,IS:1,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,CGB.FRR:1,PG:3,ROS:3,FWL:1,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3,DC:1</availability>
+			<availability>CC:3,MOC:2,PR:3,FRR:1,IS:1,WOB:1-,FS:3,MERC:2,CDP:2,TC:2,Periphery:2,CS:1-,FVC:2,LA:3,CGB.FRR:1,PG:3,ROS:3,FWL:1,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3,DC:1</availability>
 			<model name='CLNT-2-3T'>
 				<availability>IS:1-,Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -4446,8 +4409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,HL:4,FRR:4,WOB:5,MERC:5,FS:3,CIR:4,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:3-,LA:3-,Periphery:3-</availability>
@@ -4487,8 +4449,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:2,HL:2,FRR:3,IS:3,WOB:3,FS:4,CIR:3,Periphery:3,TC:2,CS:3,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:4-,FVC:4-,General:3-,FS:4-,Periphery:3-</availability>
 			</model>
@@ -4633,8 +4594,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
+			<availability>MOC:2,CC:1,FRR:2,CLAN:3,FS:8,MERC:4,CIR:2,TC:2,Periphery:2,OA:3,LA:4,CGB.FRR:2,ROS:4,DC:2</availability>
 			<model name='CSR-12D'>
 				<availability>FS:4</availability>
 			</model>
@@ -4731,8 +4691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,CGB.FRR:4,ROS:5,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
+			<availability>CHH:2,CSR:2,FRR:4,CLAN:2,WOB:5,CGS:3,CWIE:3,CS:5,DC.GHO:5,CDS:3,CW:3,CBS:3,CGB.FRR:4,ROS:5,NIOPS:5,CJF:2,CGB:2,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4790,8 +4749,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:6,CSR:4,FRR:6,CLAN:5,WOB:8,CIR:4,CGS:4,CWIE:6,DC.GHO:3,CS:9,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:5,NIOPS:9,CJF:4,CGB:6</availability>
+			<availability>CHH:6,CSR:4,FRR:6,CLAN:5,WOB:8,CIR:4,CGS:4,CWIE:6,DC.GHO:3,CS:9,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:5,NIOPS:9,CJF:4,CGB:6</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:3-,NIOPS:0</availability>
 			</model>
@@ -4940,8 +4898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,CGB.FRR:5,ROS:3,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>CC:5,MOC:4,FRR:5,IS:3,WOB:3,FS:5,CIR:2,Periphery:2,TC:2,CS:3,OA:2,LA:5,CGB.FRR:5,ROS:3,FWL:4,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:2</availability>
 			</model>
@@ -4996,8 +4953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>
-				MERC.KH:4,HL:3,CEI:2,CLAN:1-,WOB:7,MERC:4,CDP:2:3081,TC:4,Periphery:4,CS:6,MERC.WD:4,ROS:6,NIOPS:6,CJF:3:3081</availability>
+			<availability>MERC.KH:4,HL:3,CEI:2,CLAN:1-,WOB:7,MERC:4,CDP:2:3081,TC:4,Periphery:4,CS:6,MERC.WD:4,ROS:6,NIOPS:6,CJF:3:3081</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:3,CS:6,CEI:2-,ROS:4,WOB:6,TC:3</availability>
@@ -5099,8 +5055,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,IS:2+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,IS:2+,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,CBS:4,LA:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5195,8 +5150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CCC:3,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CDS:3,CJF:3,CGB:6</availability>
+			<availability>CHH:5,CCC:3,CLAN:3,IS:3+,CLAN.IS:3,MERC:3+,CCO:2,BAN:3,CSA:2,MERC.WD:3,CDS:3,CJF:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -5296,12 +5250,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,FS:9,CWIE:6,OA:9,CGB.FRR:7,FWL:8,NIOPS:6,MOC:10,CC:7,IS:7,WOB:6,CIR:9,Periphery:10,TC:9,CS:6,FVC:8,LA:5,ROS:8,CNC:5,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,FRR:7,CLAN:4,Periphery.Deep:9,FS:9,CWIE:6,OA:9,CGB.FRR:7,FWL:8,NIOPS:6,MOC:10,CC:7,IS:7,WOB:6,CIR:9,Periphery:10,TC:9,CS:6,FVC:8,LA:5,ROS:8,CNC:5,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>
-					CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
+				<availability>CC:5,MOC:4,FRR:4,IS:2,WOB:4,FS:4,CDP:4,TC:4,Periphery:3,CS:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
@@ -5310,8 +5262,7 @@
 				<availability>IS:1,Periphery:1</availability>
 			</model>
 			<model name='(Gauss)'>
-				<availability>
-					CC:8,MOC:7,FRR:6,IS:7,WOB:8,FS:8,TC:7,CWIE:4,CS:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,DC:8</availability>
+				<availability>CC:8,MOC:7,FRR:6,IS:7,WOB:8,FS:8,TC:7,CWIE:4,CS:8,LA:8,CGB.FRR:6,ROS:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='(MRM)'>
 				<availability>FVC:3,DC:7,Periphery:3</availability>
@@ -5369,8 +5320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:2,CC:2,HL:2,DoO:3,FRR:3,IS:2,Periphery.Deep:5,DO:3,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:1,FVC:5,LA:3,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:3</availability>
+			<availability>MOC:2,CC:2,HL:2,DoO:3,FRR:3,IS:2,Periphery.Deep:5,DO:3,FS:5,MERC:3,Periphery.OS:4,Periphery:3,TC:3,OA:1,FVC:5,LA:3,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:3</availability>
 			<model name='DV-1S'>
 				<availability>IS:3-</availability>
 			</model>
@@ -5426,8 +5376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:2-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:3-,OA:1-,LA:3-,CGB.FRR:1-,FWL:2-,MH:1-,DC:2-</availability>
+			<availability>MOC:3-,CC:2-,FRR:1-,IS:2-,MERC:3-,FS:3-,CIR:2,Periphery:4-,TC:3-,OA:1-,LA:3-,CGB.FRR:1-,FWL:2-,MH:1-,DC:2-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5598,8 +5547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:3-,Periphery:3-,CS:3,FVC:4-,LA:7,ROS:3,FWL:3-,CC.MAC:3-,DC:3-</availability>
+			<availability>CC:3-,HL:2,FRR:4,IS:3-,WOB:3,MERC:3-,FS:5,CC.CHG:3-,Periphery:3-,CS:3,FVC:4-,LA:7,ROS:3,FWL:3-,CC.MAC:3-,DC:3-</availability>
 			<model name=''>
 				<availability>CC:3-,General:3-</availability>
 			</model>
@@ -5650,8 +5598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,CC:3,HL:2,FRR:3,CLAN:3,IS:3,WOB:3-,FS:4,CIR:4,Periphery:3,TC:3,CS:3-,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 			<model name='EGL-R10'>
 				<roles>ground_support</roles>
 				<availability>LA:1-,FS:1-</availability>
@@ -5673,8 +5620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,PR:6,DGM:7,MERC:4,DTA:6,SC:7,FWL.MM:7,MCM:7,PG:6,FWL:6,MH:4,FWL.FO:7,DA:5,RFS:6</availability>
+			<availability>CC:4,MOC:4,PR:6,DGM:7,MERC:4,DTA:6,SC:7,FWL.MM:7,MCM:7,PG:6,FWL:6,MH:4,FWL.FO:7,DA:5,RFS:6</availability>
 			<model name='EGL-1M'>
 				<availability>CC:2,MOC:2,FWL:1,MH:2</availability>
 			</model>
@@ -5810,8 +5756,7 @@
 		<chassis name='Emperor' unitType='Mek'>
 			<availability>CC:5,MOC:4,CLAN:2,IS:4,WOB:7,FS:5,MERC:4,TC:4,CS:7,LA:4,CNC:5,FWL:4,NIOPS:7,DC:4</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
+				<availability>CC:5,CS:8,HL:6,LA:5,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
 			<model name='EMP-6D'>
 				<availability>FS:8</availability>
@@ -5875,8 +5820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>
-				CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:1,LA:1,Periphery.HR:2,MH:2,DC:1</availability>
+			<availability>CC:1,FS:7,MERC:4,Periphery.OS:2,CDP:2,TC:2,Periphery:2,FVC:7,OA:1,LA:1,Periphery.HR:2,MH:2,DC:1</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:2-,FS:3-,TC:3-</availability>
 			</model>
@@ -5954,8 +5898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,FRR:6,IS:5,WOB:5,FS:3,CIR:2,Periphery:2,TC:3,CS:5,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>WOB:5,FS:4,MERC:2</availability>
 			</model>
@@ -6232,8 +6175,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:4,HL:4,LA:5-,ROS:3-,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3-,FS:6-</availability>
+			<availability>Periphery.R:4,HL:4,LA:5-,ROS:3-,Periphery.HR:4,Periphery.MW:4,Periphery.CM:4,FWL:3-,FS:6-</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:5</availability>
@@ -6546,14 +6488,12 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:2,FRR:4,CLAN:3,WOB:5,DGM:5,CGS:2,CS:5,DC.GHO:5,SC:5,Periphery.R:1,CDS:2,LA:4,CBS:2,MCM:5,CGB.FRR:4,ROS:4,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
+			<availability>CHH:2,FRR:4,CLAN:3,WOB:5,DGM:5,CGS:2,CS:5,DC.GHO:5,SC:5,Periphery.R:1,CDS:2,LA:4,CBS:2,MCM:5,CGB.FRR:4,ROS:4,FWL:3,NIOPS:5,CJF:4,CGB:2,DC:4</availability>
 			<model name='FLS-7K'>
 				<availability>:0,MERC.KH:1-,LA:1-</availability>
 			</model>
 			<model name='FLS-8K'>
-				<availability>
-					DC.GHO:5,CS:4,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
+				<availability>DC.GHO:5,CS:4,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,WOB:4,MERC.SI:5,BAN:8</availability>
 			</model>
 			<model name='FLS-9B'>
 				<availability>WOB:6</availability>
@@ -6596,8 +6536,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,PR:3,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4,MERC.WD:4,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:2,DA:3,RCM:3,RFS:3</availability>
+			<availability>CC:6,MOC:4,PR:3,WOB:4,MERC:4,CIR:4,Periphery:4,TC:4,MERC.WD:4,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:2,DA:3,RCM:3,RFS:3</availability>
 			<model name='&apos;Fire Ant&apos;'>
 				<roles>urban</roles>
 				<availability>CC:1</availability>
@@ -6607,8 +6546,7 @@
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,PR:4-,HL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
+				<availability>MOC:4-,CC:4-,PR:4-,HL:4-,WOB:4-,MERC:5-,Periphery:6-,TC:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:3</availability>
@@ -6787,16 +6725,14 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,FRR:3,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:4,CS:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:3-,General:8,FWL:1-,WOB:4-</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>vee_carrier,infantry_carrier</roles>
-				<availability>
-					CC:7,PR:8,DoO:8,WOB:6,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:7,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:7,PR:8,DoO:8,WOB:6,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:7,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Gabriel Reconnaissance Hovercraft' unitType='Tank'>
@@ -6844,16 +6780,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,FRR:7,CLAN:5,IS:6,Periphery.Deep:4,WOB:6,FS:8,CIR:6,Periphery:6,TC:6,CS:6,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>
-					MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,CGB.FRR:5,FWL:7,DC:4</availability>
+				<availability>MOC:5,FRR:5,IS:3,WOB:3,FS:5,MERC:5,CIR:5,TC:5,Periphery:4,CS:5,OA:3,LA:5,CGB.FRR:5,FWL:7,DC:4</availability>
 			</model>
 			<model name='GAL-103'>
 				<roles>recon</roles>
@@ -6909,8 +6843,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gazelle' unitType='Dropship'>
-			<availability>
-				CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
+			<availability>CS:4,CHH:3,HL:5,CBS:3,CLAN:1,CNC:4,IS:6,NIOPS:4,Periphery.Deep:5,WOB:4,BAN:3,Periphery:6</availability>
 			<model name='(2531)'>
 				<roles>vee_carrier</roles>
 				<availability>General:5</availability>
@@ -6930,8 +6863,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSA:6,MERC.WD:1,CSR:1,CDS:5,CEI:1:3079,CLAN:5,CNC:5,IS:1+,CJF:4,BAN:4,CWIE:1,CGB:9</availability>
+			<availability>CSA:6,MERC.WD:1,CSR:1,CDS:5,CEI:1:3079,CLAN:5,CNC:5,IS:1+,CJF:4,BAN:4,CWIE:1,CGB:9</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -7091,8 +7023,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,HL:2,IS:1,WOB:2,FS:3,MERC:4,TC:3,Periphery:3,CS:1,DTA:2:3081,OA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,DA:2:3081,RCM:2:3081</availability>
+			<availability>CC:4,MOC:3,HL:2,IS:1,WOB:2,FS:3,MERC:4,TC:3,Periphery:3,CS:1,DTA:2:3081,OA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,DA:2:3081,RCM:2:3081</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:3-,LA:3-,FWL:3-,Periphery.Deep:8,IS:1-,MERC:3-,Periphery:3-</availability>
@@ -7110,8 +7041,7 @@
 				<availability>CC:8,FWL:8,WOB:8,MERC:6</availability>
 			</model>
 			<model name='GOL-3M2'>
-				<availability>
-					CC:3,MOC:2:3081,DTA:2:3081,RIM:2:3081,FWL:2,WOB:2,MH:2:3081,MERC:3,DA:2:3081,TC:2:3081</availability>
+				<availability>CC:3,MOC:2:3081,DTA:2:3081,RIM:2:3081,FWL:2,WOB:2,MH:2:3081,MERC:3,DA:2:3081,TC:2:3081</availability>
 			</model>
 			<model name='GOL-3S'>
 				<roles>fire_support</roles>
@@ -7185,14 +7115,12 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				DoO:7,CLAN:4,WOB:9,DO:7,DGM:7,MERC:4-,CS:8,DTA:7,SC:7,CDS:5,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,TP:7</availability>
+			<availability>DoO:7,CLAN:4,WOB:9,DO:7,DGM:7,MERC:4-,CS:8,DTA:7,SC:7,CDS:5,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:5,FWL:7,NIOPS:8,TP:7</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:4-,FWL:4-,MH:4-,MERC:4-</availability>
 			</model>
 			<model name='GTHA-500'>
-				<availability>
-					CS:6,CDS:4,HL:4,ROS:6,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
+				<availability>CS:6,CDS:4,HL:4,ROS:6,CNC:4,FWL:6,NIOPS:6,Periphery.Deep:5,WOB:6,MERC:6,BAN:2,Periphery:6</availability>
 			</model>
 			<model name='GTHA-500b'>
 				<availability>ROS:6,CLAN:4,FWL:5,MERC:4,BAN:2</availability>
@@ -7252,8 +7180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				PR:7,DoO:7,DO:7,FWL.KIS:8,FS:5,SC:7,Periphery.MW:4,FWL:7,MH:4,RFS:7,CC:5,MOC:5,IS:1,WOB:5,DGM:7,MERC:5,CS:3,DTA:7,FVC:5,MCM:7,ROS:6,PG:7,Periphery.ME:2,TP:7,DA:7,RCM:7,DC:5</availability>
+			<availability>PR:7,DoO:7,DO:7,FWL.KIS:8,FS:5,SC:7,Periphery.MW:4,FWL:7,MH:4,RFS:7,CC:5,MOC:5,IS:1,WOB:5,DGM:7,MERC:5,CS:3,DTA:7,FVC:5,MCM:7,ROS:6,PG:7,Periphery.ME:2,TP:7,DA:7,RCM:7,DC:5</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:4,ROS:5,General:1,FWL:6,Periphery.Deep:2,MERC:6,Periphery:6</availability>
 			</model>
@@ -7262,8 +7189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
-			<availability>
-				CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:5,TC:6</availability>
+			<availability>CS:4-,MOC:6,OA:6,HL:5,IS:5,NIOPS:4-,Periphery.Deep:5,WOB:4-,MERC:7,Periphery:6,DC:5,TC:6</availability>
 			<model name='GHR-5H'>
 				<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -7402,8 +7328,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:2,CC:5,HL:3,CLAN:1,IS:6,Periphery.Deep:6,WOB:2,MERC:7,TC:5,Periphery:4,CS:2,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1A'>
 				<availability>LA:3-,MERC:3-,TC:3-</availability>
 			</model>
@@ -7417,12 +7342,10 @@
 				<availability>LA:3-,MERC:3-</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>
-					CC:3,DoO:4,CLAN:6,WOB:5,DO:4,DGM:4,FS:3,MERC:3,BAN:4,SC:4,MCM:4,FWL:2,TP:4,RCM:4,DC:3</availability>
+				<availability>CC:3,DoO:4,CLAN:6,WOB:5,DO:4,DGM:4,FS:3,MERC:3,BAN:4,SC:4,MCM:4,FWL:2,TP:4,RCM:4,DC:3</availability>
 			</model>
 			<model name='GRF-3M'>
-				<availability>
-					PR:6,DoO:5,IS:6,DO:5,DGM:5,FS:5,DTA:5,SC:5,LA:6,MCM:5,PG:6,FWL:6,TP:5,RCM:6,DA:6,RFS:6,DC:3</availability>
+				<availability>PR:6,DoO:5,IS:6,DO:5,DGM:5,FS:5,DTA:5,SC:5,LA:6,MCM:5,PG:6,FWL:6,TP:5,RCM:6,DA:6,RFS:6,DC:3</availability>
 			</model>
 			<model name='GRF-4N'>
 				<availability>TC:3</availability>
@@ -7535,8 +7458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:8,MOC:1,DTA:2,MERC.KH:2,MERC.WD:2,CEI:2,IS:4-,FR:2,MERC:6,DA:2,RCM:2,Periphery:3</availability>
+			<availability>CC:8,MOC:1,DTA:2,MERC.KH:2,MERC.WD:2,CEI:2,IS:4-,FR:2,MERC:6,DA:2,RCM:2,Periphery:3</availability>
 			<model name=''>
 				<roles>ground_support</roles>
 				<availability>CC:8-,DTA:2,MERC.KH:2,MERC.WD:2-,CEI:2-,IS:4-,DA:2,RCM:2,Periphery:3</availability>
@@ -7561,8 +7483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:3,CSR:2,FRR:1,IS:1,WOB:7,DGM:5,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:3,SC:5,MCM:5,CGB.FRR:1,ROS:6,FWL:5,NIOPS:7,DC:1</availability>
+			<availability>CC:5,CHH:3,CSR:2,FRR:1,IS:1,WOB:7,DGM:5,FS:5,MERC:3,Periphery:2,CS:7,DC.GHO:3,SC:5,MCM:5,CGB.FRR:1,ROS:6,FWL:5,NIOPS:7,DC:1</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>CS:8,ROS:6,FRR:8,CGB.FRR:8,CLAN:8,NIOPS:8,WOB:5,MERC.SI:8,BAN:8,DC:8</availability>
@@ -7790,8 +7711,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				PR:5,HL:3-,DoO:5,FRR:5-,Periphery.Deep:4,DO:5,SC:5,FWL.pm:6-,CGB.FRR:5-,Periphery.CM:5-,Periphery.MW:5-,FWL:6-,MH:4-,RFS:5,MOC:4-,CC:4-,IS:4-,WOB:4-,DGM:5,MERC:4-,Periphery:3-,CS:4-,DTA:5,LA:4-,MCM:5,PG:5,Periphery.ME:5-,TP:5,DA:5,RCM:5,DC:4-</availability>
+			<availability>PR:5,HL:3-,DoO:5,FRR:5-,Periphery.Deep:4,DO:5,SC:5,FWL.pm:6-,CGB.FRR:5-,Periphery.CM:5-,Periphery.MW:5-,FWL:6-,MH:4-,RFS:5,MOC:4-,CC:4-,IS:4-,WOB:4-,DGM:5,MERC:4-,Periphery:3-,CS:4-,DTA:5,LA:4-,MCM:5,PG:5,Periphery.ME:5-,TP:5,DA:5,RCM:5,DC:4-</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -7875,8 +7795,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FRR:3,WOB:4,FS:5,MERC:3,Periphery:2,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FRR:3,WOB:4,FS:5,MERC:3,Periphery:2,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:2-,LA:2-,TC.PL:3-,MERC:2-,FS:1-,Periphery:2-</availability>
@@ -8000,8 +7919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				CC:3,MOC:5,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:5,Periphery:5,OA:6,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
+			<availability>CC:3,MOC:5,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:5,Periphery:5,OA:6,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8143,8 +8061,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2-,OA:5,FVC:3,CSR:2,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
+			<availability>MOC:2-,OA:5,FVC:3,CSR:2,HL:2-,LA:3-,Periphery.Deep:1-,MERC:3-,FS:1-,CDP:3,TC:2-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:4</availability>
 			</model>
@@ -8295,8 +8212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
-			<availability>
-				MOC:2-,CC:4,DoO:4,FRR:2-,WOB:4,DO:4,DGM:4,MERC:4,FS:5,SC:4,LA:4,MCM:4,ROS:2,PIR:4,FWL:8,MH:4,TP:4,DC:2-</availability>
+			<availability>MOC:2-,CC:4,DoO:4,FRR:2-,WOB:4,DO:4,DGM:4,MERC:4,FS:5,SC:4,LA:4,MCM:4,ROS:2,PIR:4,FWL:8,MH:4,TP:4,DC:2-</availability>
 			<model name='HER-2S'>
 				<roles>recon</roles>
 				<availability>HL:1-,IS:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
@@ -8331,8 +8247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>
-				CHH:1,DoO:8,FRR:3,WOB:3,DO:8,DGM:8,CS:3,DC.GHO:5,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,TP:8,CGB:1,DC:6</availability>
+			<availability>CHH:1,DoO:8,FRR:3,WOB:3,DO:8,DGM:8,CS:3,DC.GHO:5,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,TP:8,CGB:1,DC:6</availability>
 			<model name='HER-1S'>
 				<roles>recon</roles>
 				<availability>DC.GHO:3-,CS:4,CLAN:6,NIOPS:4,BAN:8</availability>
@@ -8367,8 +8282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:8,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CS:2-,CDS:3,Periphery.CM:7,CGB.FRR:2,CNC:3,CGB:2</availability>
+			<availability>CC:8,IS:4-,Periphery.Deep:6,WOB:2-,MERC:1,Periphery:1,CWIE:3,CS:2-,CDS:3,Periphery.CM:7,CGB.FRR:2,CNC:3,CGB:2</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -8425,8 +8339,7 @@
 				<availability>LA:1</availability>
 			</model>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:4,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6</availability>
+				<availability>MOC:6,CC:4,CLAN:6,IS:6,WOB:3,MERC:6,FS:6,BAN:8,DC.GHO:8,CS:3,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>CS:5,LA:3,CLAN:4,WOB:5,FS:3,BAN:2</availability>
@@ -8528,8 +8441,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
+			<availability>MOC:2,FS:6,MERC:4,Periphery.OS:4,FS.CrMM:8,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,Periphery.HR:4,FS.CMM:8,FS.DMM:8</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:3-</availability>
@@ -8585,8 +8497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
+			<availability>MOC:3,CC:3,HL:4,FRR:6,IS:3-,Periphery.Deep:5,WOB:3-,FS:4,CIR:4,Periphery:5,TC:3,CS:4-,OA:2,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:3,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -8643,8 +8554,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:2,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,CGB.FRR:5,ROS:3,FWL:5,DC:4</availability>
+			<availability>MOC:5,CC:7,HL:5,FRR:5,IS:6,Periphery.Deep:2,WOB:5-,MERC:6,FS:6,CIR:5,Periphery:6,TC:6,CS:5-,OA:6,LA:8,CGB.FRR:5,ROS:3,FWL:5,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:4-</availability>
@@ -8931,8 +8841,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,CC:4,HL:2,FRR:4,CLAN:1,IS:4,WOB:4,FS:3,CIR:4,BAN:4,Periphery:3,TC:3,CS:4,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:5</availability>
@@ -8943,11 +8852,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:8,MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>CS:8,MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					CS:6,MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>CS:6,MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CEI:6,CLAN:8</availability>
@@ -9032,8 +8939,7 @@
 			<model name='(Armor)'>
 				<roles>support</roles>
 				<deployedWith>req:J-27 Ordnance Transport (Trailer)</deployedWith>
-				<availability>
-					MOC:3,CC:4,WOB:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
+				<availability>MOC:3,CC:4,WOB:4,MERC:3,FS:4,CIR:2,TC:3,CS:4,OA:3,LA:4,General:2,FWL:4,MH:3,DC:4</availability>
 			</model>
 			<model name='(Fusion)'>
 				<roles>support</roles>
@@ -9057,8 +8963,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				FS.DLC:4-,PR:1-,DC.LV:4-,HL:2-,DoO:2-,FRR:2-,Periphery.Deep:5,DO:2-,FS:3-,SC:2-,OA:2-,CGB.FRR:3-,FWL:2-,NIOPS:2-,RFS:1-,MOC:3-,CC:1-,DC.GR:3-,FS.AH:3-,IS:3-,WOB:3-,DGM:2-,CIR:4-,Periphery:3-,TC:4-,CS:2-,DTA:1-,LA:3-,MCM:2-,PG:1-,TP:2-,RCM:1-,DA:1-,DC:3-</availability>
+			<availability>FS.DLC:4-,PR:1-,DC.LV:4-,HL:2-,DoO:2-,FRR:2-,Periphery.Deep:5,DO:2-,FS:3-,SC:2-,OA:2-,CGB.FRR:3-,FWL:2-,NIOPS:2-,RFS:1-,MOC:3-,CC:1-,DC.GR:3-,FS.AH:3-,IS:3-,WOB:3-,DGM:2-,CIR:4-,Periphery:3-,TC:4-,CS:2-,DTA:1-,LA:3-,MCM:2-,PG:1-,TP:2-,RCM:1-,DA:1-,DC:3-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -9119,8 +9024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jackal' unitType='Mek'>
-			<availability>
-				MOC:5,CC:1,IS:1,WOB:6,DGM:6,FS:1,MERC:6,DTA:6,SC:6,FVC:1,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5</availability>
+			<availability>MOC:5,CC:1,IS:1,WOB:6,DGM:6,FS:1,MERC:6,DTA:6,SC:6,FVC:1,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5</availability>
 			<model name='JA-KL-1532'>
 				<availability>HL:6,General:1,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 			</model>
@@ -9175,8 +9079,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4-,FRR:3,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,CGB.FRR:3,Periphery.CM:2,Periphery.HR:3,ROS:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
+			<availability>MOC:3,CC:4-,FRR:3,IS:1,WOB:3,MERC:3,Periphery.OS:2,FS:7,CIR:3,TC:3,CS:3,FVC:7,OA:2,LA:3,CGB.FRR:3,Periphery.CM:2,Periphery.HR:3,ROS:3,PIR:3,Periphery.ME:2,FWL:1,NIOPS:3,MH:4,DC:3</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:2,FVC:6,OA:6,LA:6,FRR:6,CGB.FRR:6,FS:6,MERC:6,CDP:2,DC:6,TC:2</availability>
@@ -9217,8 +9120,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:4,HL:3,IS:1,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:1,LA:2,Periphery.HR:5,ROS:4</availability>
+			<availability>MOC:4,HL:3,IS:1,Periphery.Deep:4,FS:8,MERC:5,Periphery.OS:6,Periphery:4,TC:4,FVC:8,OA:1,LA:2,Periphery.HR:5,ROS:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -9288,8 +9190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
+			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,FRR:8,IS:3,MERC:4,Periphery.OS:5,FS:4,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:5,FS:5,DC:6</availability>
@@ -9535,8 +9436,7 @@
 			</model>
 		</chassis>
 		<chassis name='Karnov UR Transport' unitType='VTOL'>
-			<availability>
-				CC:3:3081,MERC.KH:3,HL:3,IS:5,MERC:5,Periphery:4,MERC.WD:3,LA:4,ROS:5,PIR:2,MH:3,SL3.CSJ:5,DA:3:3081,DC:4</availability>
+			<availability>CC:3:3081,MERC.KH:3,HL:3,IS:5,MERC:5,Periphery:4,MERC.WD:3,LA:4,ROS:5,PIR:2,MH:3,SL3.CSJ:5,DA:3:3081,DC:4</availability>
 			<model name=''>
 				<roles>apc,cargo</roles>
 				<availability>General:4</availability>
@@ -9619,8 +9519,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:3,FRR:4,CLAN:2,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:3,LA:3,CGB.FRR:4,ROS:6,FWL:3,NIOPS:6,CGB:3,DC:3</availability>
+			<availability>CC:3,FRR:4,CLAN:2,IS:3,WOB:6,FS:6,MERC:4,CIR:2,CGS:4,DC.GHO:6,CS:6,FVC:3,LA:3,CGB.FRR:4,ROS:6,FWL:3,NIOPS:6,CGB:3,DC:3</availability>
 			<model name='KGC-000'>
 				<availability>CS:4,FRR:8,CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,WOB:4,BAN:8,DC:8</availability>
 			</model>
@@ -9883,8 +9782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CSR:6,CLAN:1,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5,DC:3+</availability>
+			<availability>CHH:6,CSR:6,CLAN:1,IS:3+,CCO:2,CGS:5,BAN:6,CSA:6,MERC.WD:6,CDS:6,CW:6,CBS:6,CJF:5,DC:3+</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CDS:7,CW:4,General:5,CWIE:4,CGB:4</availability>
@@ -9999,8 +9897,7 @@
 			</model>
 			<model name='(3055 Upgrade)'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:8,MOC:8,FRR:8,IS:8,FS:8,CIR:6,TC:7,Periphery:5,CS:8,LA:8,CGB.FRR:8,FWL:8,DC:8</availability>
+				<availability>CC:8,MOC:8,FRR:8,IS:8,FS:8,CIR:6,TC:7,Periphery:5,CS:8,LA:8,CGB.FRR:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='(WoB)'>
 				<roles>fire_support</roles>
@@ -10123,13 +10020,11 @@
 			</model>
 			<model name='(3054)'>
 				<roles>asf_carrier</roles>
-				<availability>
-					CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,FRR:7,IS:8,Periphery.Deep:7,WOB:4,FS:7,CIR:8,BAN:2,Periphery:8,TC:8,CS:4,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FWL:2,WOB:6</availability>
 			</model>
@@ -10139,8 +10034,7 @@
 			</model>
 			<model name='(3056)'>
 				<roles>mek_carrier</roles>
-				<availability>
-					PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+				<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -10184,22 +10078,19 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:2,HL:3,CIR:5,Periphery.OS:5,TC:8,Periphery:4,OA:5,FVC:2,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
+			<availability>MOC:7,CC:2,HL:3,CIR:5,Periphery.OS:5,TC:8,Periphery:4,OA:5,FVC:2,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,MOC:5:3081,DTA:7,FVC:7,LA:8-,CEI:3-,FWL:7-,FR:5:3081,DA:7,RCM:7,BAN:2,DC:7-</availability>
+			<availability>CC:7-,MOC:5:3081,DTA:7,FVC:7,LA:8-,CEI:3-,FWL:7-,FR:5:3081,DA:7,RCM:7,BAN:2,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>DTA:5,FWL:5,RCM:5,DA:7</availability>
 			</model>
 			<model name='Angel'>
 				<roles>recon</roles>
-				<availability>
-					CC:2-,LA:2-,CEI:3-,Periphery.MW:3,Periphery.ME:3,FWL:4-,Periphery:4,DC:2-,BAN:2</availability>
+				<availability>CC:2-,LA:2-,CEI:3-,Periphery.MW:3,Periphery.ME:3,FWL:4-,Periphery:4,DC:2-,BAN:2</availability>
 			</model>
 			<model name='Angel (Upgrade)'>
 				<availability>MOC:5:3081,FWL:7-,IS:7-,FR:5:3081,MERC:2-</availability>
@@ -10249,8 +10140,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,FRR:4,CLAN:2,IS:3,WOB:3-,FS:3,Periphery:4,TC:4,CS:3-,OA:6,LA:3,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:5-</availability>
 			</model>
@@ -10429,8 +10319,7 @@
 			</model>
 			<model name='LCT-3M'>
 				<roles>recon</roles>
-				<availability>
-					MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:6,DTA:5,SC:5,MCM:5,PG:5,FWL:6,TP:5,RCM:5,DA:5,RFS:5</availability>
+				<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:6,DTA:5,SC:5,MCM:5,PG:5,FWL:6,TP:5,RCM:5,DA:5,RFS:5</availability>
 			</model>
 			<model name='LCT-3S'>
 				<roles>recon</roles>
@@ -10529,8 +10418,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6</availability>
+			<availability>MOC:6,CC:4,HL:6,FRR:4,IS:6,Periphery.Deep:6,WOB:6,FS:5,Periphery:7,TC:6,CS:3,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10554,8 +10442,7 @@
 			</model>
 			<model name='LGB-13C'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:5,MOC:3,DoO:4,DO:4,DGM:4,FS:5,MERC:5,SC:4,MCM:4,ROS:5,FWL:2,TP:4,DA:5,RCM:5,DC:5</availability>
+				<availability>CC:5,MOC:3,DoO:4,DO:4,DGM:4,FS:5,MERC:5,SC:4,MCM:4,ROS:5,FWL:2,TP:4,DA:5,RCM:5,DC:5</availability>
 			</model>
 			<model name='LGB-13NAIS'>
 				<availability>WOB:3,FS:4</availability>
@@ -10581,8 +10468,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
-			<availability>
-				PR:8,DoO:8,WOB:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:5,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>PR:8,DoO:8,WOB:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:5,TP:8,RCM:8,DA:8,RFS:8</availability>
 			<model name='(Magnetic)(Sqd4)' mechanized='true'>
 				<availability>FWL:5</availability>
 			</model>
@@ -10624,8 +10510,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
+			<availability>MOC:2,HL:4,FRR:3,FS:2,MERC:2,CIR:3,TC:2,Periphery:2,Periphery.R:4,OA:1,FVC:2,LA:7,Periphery.MW:3</availability>
 			<model name='LCF-R15'>
 				<availability>FVC:2-,LA:2-,General:1-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 			</model>
@@ -10940,8 +10825,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,CGB.FRR:8,ROS:7,FWL:6,NIOPS:7,DC:9</availability>
+			<availability>MOC:6,CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,WOB:7,MERC:7,FS:7,CIR:6,Periphery:7,TC:7,CS:7,OA:7,LA:7,CGB.FRR:8,ROS:7,FWL:6,NIOPS:7,DC:9</availability>
 			<model name=''>
 				<availability>HL:3,LA:2-,General:3-,Periphery.Deep:6,FS:2-,DC:2-,Periphery:5</availability>
 			</model>
@@ -11005,8 +10889,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder II' unitType='Mek'>
-			<availability>
-				CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,CGB.FRR:5,ROS:6,PIR:4,CNC:1,FWL:5,MH:4,DC:5</availability>
+			<availability>CC:4,FRR:5,WOB:2,FS:6,MERC:6,TC:4,CS:3,MERC.WD:6,LA:4,CGB.FRR:5,ROS:6,PIR:4,CNC:1,FWL:5,MH:4,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:4</availability>
 			</model>
@@ -11039,8 +10922,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
+			<availability>CC:4,MOC:2,FRR:4,CLAN:1,IS:3-,WOB:7,FS:6,TC:3,Periphery:2,CS:6,LA:5,CGB.FRR:4,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
 			<model name='C'>
 				<availability>CW:1,LA:1+,CNC:1,FS:1+,CJF:1,DC:1+,CGB:1,CWIE:1</availability>
 			</model>
@@ -11144,8 +11026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,TC:4</availability>
 			</model>
@@ -11167,8 +11048,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:2,CSR:2,CEI:7,CLAN:1,IS:1+,MERC:2+,CGS:7,BAN:1,CWIE:1,CSA:2,MERC.WD:3,CDS:6,CW:2,CBS:4,CNC:3,CJF:4,CGB:5</availability>
+			<availability>MERC.KH:2,CSR:2,CEI:7,CLAN:1,IS:1+,MERC:2+,CGS:7,BAN:1,CWIE:1,CSA:2,MERC.WD:3,CDS:6,CW:2,CBS:4,CNC:3,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<availability>CDS:8,General:5,CGB:5</availability>
 			</model>
@@ -11278,8 +11158,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,FRR:2,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:1,LA:3,CGB.FRR:3,ROS:2,FWL:2,NIOPS:2-,DC:2</availability>
+			<availability>MOC:2,CC:2,FRR:2,CLAN:2,IS:2,Periphery.Deep:5,WOB:2-,MERC:2,FS:1,CIR:3,Periphery:2,TC:2,CS:2-,OA:1,LA:3,CGB.FRR:3,ROS:2,FWL:2,NIOPS:2-,DC:2</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
@@ -11461,8 +11340,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,CGB.FRR:4,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,FRR:4,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,CIR:5,BAN:4,Periphery:6,TC:6,OA:5,LA:6,CGB.FRR:4,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -11531,8 +11409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				CS:5,MERC.KH:4,MERC.WD:4,HL:5,CEI:5,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,WOB:5,MERC:5,Periphery:5</availability>
+			<availability>CS:5,MERC.KH:4,MERC.WD:4,HL:5,CEI:5,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,WOB:5,MERC:5,Periphery:5</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -11806,8 +11683,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>
-				CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,FS:2,DC.GHO:2,CS:5,CDS:1,CBS:1,CGB.FRR:3,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
+			<availability>CHH:1,FRR:3,CLAN:1,WOB:3,MERC:2,FS:2,DC.GHO:2,CS:5,CDS:1,CBS:1,CGB.FRR:3,NIOPS:1,CJF:1,CGB:1,DC:2</availability>
 			<model name='MON-66'>
 				<roles>recon</roles>
 				<availability>CS:8,CLAN:3,NIOPS:5,WOB:8,BAN:5</availability>
@@ -12219,8 +12095,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>PR:4,DoO:4,WOB:3,DO:4,FS:7,MERC:5,CIR:2,Periphery.R:2,LA:8,ROS:5,PG:4,TP:4,RFS:4</availability>
 			<model name='NGS-4S'>
-				<availability>
-					:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
+				<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -12464,8 +12339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,CGB.FRR:4,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
+			<availability>MOC:7,CC:6,FRR:4,IS:4,MERC:4,FS:7,CIR:4,Periphery:2,TC:5,FVC:7,CDS:5,LA:7,CGB.FRR:4,Periphery.MW:4,PIR:4,CNC:4,Periphery.ME:4,FWL:8,MH:5,DC:4</availability>
 			<model name=''>
 				<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -12512,8 +12386,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:2,CW:2,LA:2,CGB.FRR:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
+			<availability>MOC:3,CC:3,HL:3,FRR:4,CLAN:1,IS:2,Periphery.Deep:4,WOB:3-,FS:3,CIR:5,Periphery:4,TC:3,CWIE:2,CS:4-,OA:2,CW:2,LA:2,CGB.FRR:4,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>HL:1-,General:3-,CLAN:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -12528,8 +12401,7 @@
 				<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
 			</model>
 			<model name='ON1-MB'>
-				<availability>
-					CC:2,MOC:2,DoO:4,WOB:4,DO:4,DGM:4,FS:1,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,TP:4,DA:4,RCM:4,DC:2</availability>
+				<availability>CC:2,MOC:2,DoO:4,WOB:4,DO:4,DGM:4,FS:1,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,TP:4,DA:4,RCM:4,DC:2</availability>
 			</model>
 			<model name='ON1-MC'>
 				<availability>FRR:4,CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
@@ -12586,8 +12458,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,CGB.FRR:5,ROS:4,NIOPS:3-,DC:5</availability>
+			<availability>MOC:4,CC:3,FRR:5,CLAN:1-,IS:4,Periphery.Deep:4,WOB:3,MERC:4,TC:4,Periphery:2,CS:3-,LA:4,CGB.FRR:5,ROS:4,NIOPS:3-,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>HL:1-,IS:1-,Periphery.Deep:8,MERC:4-,BAN:1,Periphery:4-</availability>
@@ -12644,8 +12515,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:2,PR:4,DoO:4,FRR:3,CLAN:1-,IS:1,WOB:3,DO:4,FS:2,MERC:3,CS:3,FVC:2,LA:2,CGB.FRR:3,ROS:4,PG:4,FWL:2,NIOPS:3,TP:4,RFS:4,DC:5</availability>
+			<availability>CC:2,PR:4,DoO:4,FRR:3,CLAN:1-,IS:1,WOB:3,DO:4,FS:2,MERC:3,CS:3,FVC:2,LA:2,CGB.FRR:3,ROS:4,PG:4,FWL:2,NIOPS:3,TP:4,RFS:4,DC:5</availability>
 			<model name='OTT-10CS'>
 				<roles>recon</roles>
 				<availability>CS:6,WOB:4</availability>
@@ -12676,8 +12546,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>
-				PR:5,DoO:5,IS:1,WOB:6,DO:5,DGM:5,FS:5,MERC:4,Periphery:2,CS:6,DTA:5,SC:5,MCM:5,ROS:4,PG:5,FWL:5,NIOPS:6,TP:5,RFS:5</availability>
+			<availability>PR:5,DoO:5,IS:1,WOB:6,DO:5,DGM:5,FS:5,MERC:4,Periphery:2,CS:6,DTA:5,SC:5,MCM:5,ROS:4,PG:5,FWL:5,NIOPS:6,TP:5,RFS:5</availability>
 			<model name='OTL-4D'>
 				<availability>IS:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 			</model>
@@ -12741,8 +12610,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,FRR:6,CLAN:8,IS:5,Periphery.Deep:4,WOB:7,FS:6,CIR:5,BAN:5,Periphery:4,TC:5,CS:7,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:4,BAN:1</availability>
@@ -12819,8 +12687,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,CGB.FRR:3-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
+			<availability>MOC:3-,CC:4-,HL:3-,FRR:3-,IS:4-,Periphery.Deep:4,WOB:6,FS:6-,CIR:4-,FS.CrMM:7-,Periphery:4-,TC:3-,CS:6,OA:3-,FVC:7-,LA:6-,CGB.FRR:3-,FS.CMM:7-,FS.DMM:7-,FWL:4-,NIOPS:6,DC:4-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12831,8 +12698,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,FS:1,Periphery:3,CGB.FRR:2,PIR:2,General:2,FWL:1,DC:2</availability>
+				<availability>CC:2,MERC.KH:1,FRR:2,IS:1,Periphery.Deep:6,MERC:2,FS:1,Periphery:3,CGB.FRR:2,PIR:2,General:2,FWL:1,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -12891,8 +12757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:7,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,CGB.FRR:7,ROS:4,FS.DMM:5,CNC:2,FWL:1,NIOPS:2,DC:9</availability>
+			<availability>CC:1,Periphery.DD:5,FS.RR:5,HL:2,FRR:7,WOB:4,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CS:2,LA:1,CGB.FRR:7,ROS:4,FS.DMM:5,CNC:2,FWL:1,NIOPS:2,DC:9</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:4,FVC:2,FRR:5,CGB.FRR:5,PIR:2,CNC:4,FS.DMM:4,WOB:6,MERC:4,DC:5,TC:2</availability>
@@ -12953,8 +12818,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Air Defense Tank' unitType='Tank'>
-			<availability>
-				CC:5,HL:3,FRR:4,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,CS:6,LA:7,CGB.FRR:4,CNC:5,DC:6</availability>
+			<availability>CC:5,HL:3,FRR:4,IS:5,WOB:6,FS:8,Periphery:4,CWIE:5,CS:6,LA:7,CGB.FRR:4,CNC:5,DC:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -12986,8 +12850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4-,CC:2-,HL:3-,FRR:1-,IS:3-,Periphery.Deep:9,WOB:4-,FS:4-,CIR:3-,Periphery:4-,TC:4-,CS:4-,OA:2-,CDS:2,LA:3-,CGB.FRR:1-,FWL:3-,DC:2-</availability>
+			<availability>MOC:4-,CC:2-,HL:3-,FRR:1-,IS:3-,Periphery.Deep:9,WOB:4-,FS:4-,CIR:3-,Periphery:4-,TC:4-,CS:4-,OA:2-,CDS:2,LA:3-,CGB.FRR:1-,FWL:3-,DC:2-</availability>
 			<model name=''>
 				<availability>General:5</availability>
 			</model>
@@ -13036,8 +12899,7 @@
 			</model>
 		</chassis>
 		<chassis name='Patron MilitiaMech' unitType='Mek'>
-			<availability>
-				PR:4-,DoO:4-,DO:4-,DGM:4-,RCM.pm:4,SC:4-,FWL.pm:4,DA.pm:4,MCM:4-,PG:4-,TP:4-,DTA.pm:5,RFS:4-</availability>
+			<availability>PR:4-,DoO:4-,DO:4-,DGM:4-,RCM.pm:4,SC:4-,FWL.pm:4,DA.pm:4,MCM:4-,PG:4-,TP:4-,DTA.pm:5,RFS:4-</availability>
 			<model name='PTN-2'>
 				<availability>PR:6,DoO:6,DO:6,DGM:6,DTA:6,SC:6,MCM:6,PG:6,FWL:6,TP:6,RCM:6,DA:6,RFS:6</availability>
 			</model>
@@ -13052,8 +12914,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:1,CC:1,FRR:1,IS:1,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:1,CS:5-,OA:1,LA:6,CGB.FRR:1,ROS:6,FWL:2,DC:6</availability>
+			<availability>MOC:1,CC:1,FRR:1,IS:1,Periphery.Deep:8,WOB:5-,FS:6,CIR:2,Periphery:1,TC:1,CWIE:1,CS:5-,OA:1,LA:6,CGB.FRR:1,ROS:6,FWL:2,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:3</availability>
@@ -13355,8 +13216,7 @@
 			<availability>LA:2-,MERC:3-,TC:3-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:3,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:2-,MERC.WD:5,CDS:6,LA:2-,CGB.FRR:3-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
+			<availability>MOC:3,CC:1-,CHH:5,HL:2-,FRR:3-,CLAN:5,IS:3-,WOB:4-,FS:3-,MERC:3-,CIR:3-,CWIE:6,Periphery:3-,TC:3-,CS:4-,OA:2-,MERC.WD:5,CDS:6,LA:2-,CGB.FRR:3-,CNC:5,FWL:2-,MH:5-,DC:3-</availability>
 			<model name=''>
 				<availability>HL:3,IS:3,Periphery.Deep:2,Periphery:5</availability>
 			</model>
@@ -13682,8 +13542,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:4,CLAN:7,IS:1+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
+			<availability>CSR:4,CLAN:7,IS:1+,MERC:2+,CCO:6,BAN:6,CWIE:8,CSA:8,MERC.WD:6,CDS:8,CW:8,CBS:6,CNC:8,CJF:5,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -13799,8 +13658,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				PR:6,HL:3,DoO:6,FRR:7,Periphery.Deep:4,DO:6,FS:4,CDP:4,SC:6,OA:4,CGB.FRR:7,FWL:7,NIOPS:3-,RFS:6,MOC:4,CC:3,IS:4,WOB:3-,DGM:6,CIR:3,Periphery:4,TC:4,CS:3-,DTA:6,FVC:4,LA:4,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
+			<availability>PR:6,HL:3,DoO:6,FRR:7,Periphery.Deep:4,DO:6,FS:4,CDP:4,SC:6,OA:4,CGB.FRR:7,FWL:7,NIOPS:3-,RFS:6,MOC:4,CC:3,IS:4,WOB:3-,DGM:6,CIR:3,Periphery:4,TC:4,CS:3-,DTA:6,FVC:4,LA:4,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:4-,OA:4-,HL:1-,Periphery.Deep:8,FWL:3-,IS:3-,Periphery:4-,DC:3-,TC:4-</availability>
 			</model>
@@ -14095,8 +13953,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,FRR:5,CLAN:5,Periphery.Deep:9,IS:5,WOB:7,FS:6,CIR:7,MERC:7,Periphery:10,TC:7,CS:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:2,CW:2,General:8,CNC:2</availability>
 			</model>
@@ -14122,11 +13979,9 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:7,DoO:8,FRR:5,DO:8,FS:3,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,RFS:7,MOC:3,CC:3,WOB:6,DGM:8,MERC:2,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:1,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:4</availability>
+			<availability>PR:7,DoO:8,FRR:5,DO:8,FS:3,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,RFS:7,MOC:3,CC:3,WOB:6,DGM:8,MERC:2,CIR:3,Periphery:2,TC:3,DTA:8,FVC:3,LA:1,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:4</availability>
 			<model name='F-100'>
-				<availability>
-					CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
+				<availability>CC:1-,FVC:4-,HL:1-,LA:1,FRR:1,CGB.FRR:1,FWL:3-,Periphery.Deep:8,MERC:3-,DC:1,Periphery:4-</availability>
 			</model>
 			<model name='F-100a'>
 				<availability>CC:1-,FWL:3-,MERC:3-</availability>
@@ -14135,12 +13990,10 @@
 				<availability>FRR:2-,CGB.FRR:2-,DC:2-</availability>
 			</model>
 			<model name='F-700'>
-				<availability>
-					CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,PR:8,DoO:8,WOB:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='F-700a'>
-				<availability>
-					CC:7,PR:6,DoO:6,WOB:7,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,TP:6,DA:6,RCM:6,RFS:6</availability>
+				<availability>CC:7,PR:6,DoO:6,WOB:7,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,TP:6,DA:6,RCM:6,RFS:6</availability>
 			</model>
 			<model name='F-700b'>
 				<availability>DTA:8,SC:8,DoO:8,MCM:8,ROS:6,FWL:5,WOB:5,DO:8,DGM:8,TP:8,MERC:5,DC:5</availability>
@@ -14181,8 +14034,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:6,CCC:6,HL:3,FRR:7,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:4</availability>
+			<availability>CC:6,CCC:6,HL:3,FRR:7,IS:6,Periphery.Deep:5,WOB:5,FS:8,CGS:6,Periphery:4,CS:5,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:4</availability>
 			<model name='C'>
 				<availability>LA:1,CLAN:5,FS:1,BAN:1,DC:1</availability>
 			</model>
@@ -14224,8 +14076,7 @@
 				<availability>FVC:2,FS:3,MERC:2</availability>
 			</model>
 			<model name='RFL-7M'>
-				<availability>
-					PR:6,DoO:6,FRR:4,WOB:5,DO:6,DGM:6,DTA:6,SC:6,MCM:6,CGB.FRR:4,PG:6,FWL:6,TP:6,DA:6,RCM:6,RFS:6,DC:4</availability>
+				<availability>PR:6,DoO:6,FRR:4,WOB:5,DO:6,DGM:6,DTA:6,SC:6,MCM:6,CGB.FRR:4,PG:6,FWL:6,TP:6,DA:6,RCM:6,RFS:6,DC:4</availability>
 			</model>
 			<model name='RFL-7X'>
 				<roles>fire_support</roles>
@@ -14249,8 +14100,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>
-			<availability>
-				CC:5,CHH:4,CSR:1,FRR:5,CLAN:2,WOB:6,FS:5,CS:6,FVC:4,LA:5,CGB.FRR:5,ROS:6,NIOPS:6,DC:5</availability>
+			<availability>CC:5,CHH:4,CSR:1,FRR:5,CLAN:2,WOB:6,FS:5,CS:6,FVC:4,LA:5,CGB.FRR:5,ROS:6,NIOPS:6,DC:5</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8,BAN:2</availability>
@@ -14415,8 +14265,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:6,CSR:4,CLAN:5,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:6,CW:6,CBS:7,CNC:2,CJF:6,DC:3+</availability>
+			<availability>CHH:6,CSR:4,CLAN:5,WOB:3+,MERC:2+,BAN:7,CWIE:7,MERC.WD:7,CDS:6,CW:6,CBS:7,CNC:2,CJF:6,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -14532,8 +14381,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
+			<availability>CC:3,MOC:3,HL:2-,CLAN:3,IS:3-,Periphery.Deep:4-,FS:3,MERC:3,Periphery:3-,OA:2-,LA:3,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:5-</availability>
 			</model>
@@ -14611,8 +14459,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:4,CS:5-,LA:6,CGB.FRR:7,FWL:6,CJF:4,DC:9</availability>
+			<availability>CC:6,Periphery.DD:7,FRR:7,DC.AL:10,IS:6,WOB:5-,MERC:6,Periphery.OS:7,FS:5,CIR:5,Periphery:4,CS:5-,LA:6,CGB.FRR:7,FWL:6,CJF:4,DC:9</availability>
 			<model name=''>
 				<availability>IS:5-,Periphery:5-</availability>
 			</model>
@@ -14679,8 +14526,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:3-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,CGB.FRR:6-,ROS:2-,FWL:6-,DC:7-</availability>
+			<availability>MOC:5,CC:5-,Periphery.DD:7,HL:4,FRR:6-,IS:5-,WOB:4,Periphery.OS:7,FS:3-,CIR:5,Periphery:5,TC:5,CS:4,OA:7,CDS:4,FWL.MM:6,CW:3,LA:4-,CGB.FRR:6-,ROS:2-,FWL:6-,DC:7-</availability>
 			<model name=''>
 				<availability>General:6-</availability>
 			</model>
@@ -14842,8 +14688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:2,HL:4,FRR:2,IS:3,Periphery.Deep:5,WOB:4,MERC:3,FS:3,CIR:5,Periphery:5,TC:3,CS:3,OA:3,LA:3,CGB.FRR:3,FWL:3,DC:2</availability>
+			<availability>MOC:3,CC:2,HL:4,FRR:2,IS:3,Periphery.Deep:5,WOB:4,MERC:3,FS:3,CIR:5,Periphery:5,TC:3,CS:3,OA:3,LA:3,CGB.FRR:3,FWL:3,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -14861,8 +14706,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,CGB.FRR:7-,FWL:3-,DC:6-</availability>
+			<availability>MOC:5-,CC:5-,Periphery.DD:5-,HL:4-,FRR:7-,IS:4-,WOB:4-,MERC:4-,Periphery.OS:5-,FS:3-,CIR:5-,Periphery:5-,TC:5-,CS:4-,OA:6-,LA:4-,CGB.FRR:7-,FWL:3-,DC:6-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -14878,8 +14722,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,FS:6,Periphery:7,FVC:6,LA:6,CGB.FRR:8,FWL:6,CJF:4,DC:6</availability>
+			<availability>CC:6,HL:6,FRR:8,IS:7,Periphery.Deep:7,FS:6,Periphery:7,FVC:6,LA:6,CGB.FRR:8,FWL:6,CJF:4,DC:6</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -14900,8 +14743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,MERC:2-,Periphery:3-,CS:2-,LA:3,CGB.FRR:2-,FWL:2-,NIOPS:2-,RCM:2-,DC:2-</availability>
+			<availability>CC:2-,HL:2-,FRR:2-,Periphery.Deep:4-,WOB:2-,MERC:2-,Periphery:3-,CS:2-,LA:3,CGB.FRR:2-,FWL:2-,NIOPS:2-,RCM:2-,DC:2-</availability>
 			<model name='SCP-10M'>
 				<availability>CS:3,CC:3,FRR:2,CGB.FRR:3,FWL:5,MERC:3,DC:3</availability>
 			</model>
@@ -15029,8 +14871,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
+			<availability>CLAN:2,WOB:4,FS:5,MERC:5,CGS:3,CWIE:2,CS:4,DC.GHO:4,FVC:5,CDS:2,CW:2,CBS:2,LA:6,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>CS:8,FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,WOB:4,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -15085,8 +14926,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
+			<availability>MOC:4,CC:3,MERC.KH:5,HL:5,FRR:2,Periphery.Deep:4,MERC:4,FS:3,CIR:3,TC:7,Periphery:6,Periphery.R:6,OA:7,FVC:3,LA:8,CGB.FRR:2,ROS:4,FWL:3-,MH:2,DC:3-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,FS:1-,MERC:2-,Periphery:2-</availability>
@@ -15096,8 +14936,7 @@
 			</model>
 			<model name='SYD-Z1'>
 				<roles>interceptor</roles>
-				<availability>
-					OA:2-,HL:4,FRR:2-,ROS:2-,Periphery.Deep:2,FWL:2-,WOB:2-,Periphery:6,TC:3-,DC:2-</availability>
+				<availability>OA:2-,HL:4,FRR:2-,ROS:2-,Periphery.Deep:2,FWL:2-,WOB:2-,Periphery:6,TC:3-,DC:2-</availability>
 			</model>
 			<model name='SYD-Z2'>
 				<roles>interceptor</roles>
@@ -15198,8 +15037,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				PR:3,CHH:6,DoO:3,FRR:3,CLAN:2,DO:3,FS:3,CWIE:6,SC:3,OA:3,CDS:6,CGB.FRR:3,FWL:3,RFS:3,CGB:6,IS:1,DGM:3,MERC:3,DTA:3,CS:3,CW:4,LA:3,MCM:3,ROS:3,PG:3,CNC:6,TP:3,RCM:3,DA:2,CJF:1,DC:3</availability>
+			<availability>PR:3,CHH:6,DoO:3,FRR:3,CLAN:2,DO:3,FS:3,CWIE:6,SC:3,OA:3,CDS:6,CGB.FRR:3,FWL:3,RFS:3,CGB:6,IS:1,DGM:3,MERC:3,DTA:3,CS:3,CW:4,LA:3,MCM:3,ROS:3,PG:3,CNC:6,TP:3,RCM:3,DA:2,CJF:1,DC:3</availability>
 			<model name=''>
 				<availability>CLAN:1</availability>
 			</model>
@@ -15277,8 +15115,7 @@
 				<availability>CS:5,WOB:4</availability>
 			</model>
 			<model name='SHD-7M'>
-				<availability>
-					CC:4,MOC:3,DoO:5,DO:5,DGM:5,MERC:3,CDP:2,TC:3,DTA:5,SC:5,FVC:2,MCM:5,ROS:4,FWL:3,TP:5,RCM:5</availability>
+				<availability>CC:4,MOC:3,DoO:5,DO:5,DGM:5,MERC:3,CDP:2,TC:3,DTA:5,SC:5,FVC:2,MCM:5,ROS:4,FWL:3,TP:5,RCM:5</availability>
 			</model>
 			<model name='SHD-8L'>
 				<availability>CC:5</availability>
@@ -15318,8 +15155,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
+			<availability>Periphery.DD:4,OA:4,FVC:2,FRR:7,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
@@ -15377,8 +15213,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
-			<availability>
-				Periphery.DD:3,OA:3,LA:2,FRR:6,CGB.FRR:6,ROS:3,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
+			<availability>Periphery.DD:3,OA:3,LA:2,FRR:6,CGB.FRR:6,ROS:3,MERC:3,Periphery.OS:3,FS:3-,DC:7,Periphery:2</availability>
 			<model name='SL-21'>
 				<availability>HL:4,LA:2,Periphery.Deep:7,MERC:4,DC:4,Periphery:6</availability>
 			</model>
@@ -15475,8 +15310,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,CGB.FRR:5-,ROS:3-,FWL:3,NIOPS:3-,DC:6</availability>
+			<availability>CC:3,Periphery.DD:3,FRR:5-,IS:2,WOB:3-,MERC:2,Periphery.OS:3,FS:2,CS:3-,OA:1,FVC:2,LA:2,CGB.FRR:5-,ROS:3-,FWL:3,NIOPS:3-,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:5-</availability>
@@ -15495,8 +15329,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,FRR:7,MERC:3,Periphery.OS:3,FS:3,CIR:2,Periphery:2,TC:5,OA:5,FVC:4,LA:1,CGB.FRR:7,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>HL:1-,ROS:0,IS:3-,Periphery.Deep:8,FS:0,Periphery:4-</availability>
 			</model>
@@ -15599,8 +15432,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+			<availability>MOC:2,CC:1,HL:3,FRR:5,Periphery.Deep:4,WOB:3,MERC:5,Periphery.OS:4,FS:9,CIR:2,Periphery:4,TC:2,CS:3,OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:3,FRR:5,CGB.FRR:5,ROS:3,PIR:1,FS:8,MERC:5,CDP:1,TC:1</availability>
 			</model>
@@ -15660,8 +15492,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:4,FRR:5,IS:1,WOB:2,MERC:3,FS:4,Periphery:2,TC:2,CS:3,FVC:4,LA:1,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:1-</availability>
@@ -15765,14 +15596,12 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,CGB.FRR:6,ROS:4,FWL:8,NIOPS:5,DC:5</availability>
+			<availability>MOC:6,CC:5,HL:9,FRR:6,CLAN:3,IS:6,Periphery.Deep:9,WOB:4,FS:6,CIR:8,Periphery:10,TC:8,CS:5,OA:8,LA:7,CGB.FRR:6,ROS:4,FWL:8,NIOPS:5,DC:5</availability>
 			<model name='STK-3F'>
 				<availability>HL:1-,IS:3-,Periphery.Deep:8,Periphery:4-</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>
-					CC:2,MOC:2,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
+				<availability>CC:2,MOC:2,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 			</model>
 			<model name='STK-3H'>
 				<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
@@ -15928,8 +15757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,CGB.FRR:4,NIOPS:2-,DC:5,CGB:2-</availability>
+			<availability>MOC:6,HL:5,FRR:4,CLAN:1-,IS:8,Periphery.Deep:5,WOB:2-,MERC:8,Periphery:6,CS:2-,CGB.FRR:4,NIOPS:2-,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
@@ -15980,8 +15808,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:5,DoO:6,DO:6,FS:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:2,RFS:5,MOC:2,CC:5,IS:3,WOB:3,DGM:6,MERC:5,CIR:2,Periphery:1,TC:2,CS:3,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+			<availability>PR:5,DoO:6,DO:6,FS:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:2,RFS:5,MOC:2,CC:5,IS:3,WOB:3,DGM:6,MERC:5,CIR:2,Periphery:1,TC:2,CS:3,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>CS:2-,LA:2-,IS:4-,FS:2-,Periphery:4-</availability>
 			</model>
@@ -15996,8 +15823,7 @@
 				<availability>IS:5</availability>
 			</model>
 			<model name='F-95'>
-				<availability>
-					CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:3,PG:6,FWL:5,TP:6,RCM:6,DA:6,RFS:6</availability>
+				<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:3,PG:6,FWL:5,TP:6,RCM:6,DA:6,RFS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
@@ -16091,8 +15917,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>
-				CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
+			<availability>CC:2,FRR:3,IS:4,WOB:3-,FS:7,MERC:3,CWIE:4,CS:3-,FVC:7,CDS:3,LA:4,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:3,DC:2</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -16135,8 +15960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FRR:1,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:3,CGB.FRR:2,Periphery.HR:2,ROS:5,DC:1</availability>
+			<availability>MOC:1,FRR:1,CLAN:4,MERC:4,Periphery.OS:2,FS:7,CIR:1,Periphery:1,TC:1,OA:2,FVC:7,LA:3,CGB.FRR:2,Periphery.HR:2,ROS:5,DC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,ROS:6,FS:6,MERC:6</availability>
 			</model>
@@ -16154,8 +15978,7 @@
 			</model>
 		</chassis>
 		<chassis name='SturmFeur Heavy Tank' unitType='Tank'>
-			<availability>
-				PR:4,HL:2,WOB:3,MERC:2,FS:4,CWIE:4,Periphery.R:3,CDS:3,LA:6,ROS:4,PG:4,CNC:4,RFS:4</availability>
+			<availability>PR:4,HL:2,WOB:3,MERC:2,FS:4,CWIE:4,Periphery.R:3,CDS:3,LA:6,ROS:4,PG:4,CNC:4,RFS:4</availability>
 			<model name=''>
 				<availability>General:5,WOB:0</availability>
 			</model>
@@ -16389,8 +16212,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tarantula' unitType='Mek'>
-			<availability>
-				MOC:3,CC:5,DoO:6,IS:1,WOB:4,DO:6,DGM:6,MERC:4,CS:3,DTA:6,SC:6,FVC:1,MCM:6,ROS:4,FWL:6,TP:6,DC:6</availability>
+			<availability>MOC:3,CC:5,DoO:6,IS:1,WOB:4,DO:6,DGM:6,MERC:4,CS:3,DTA:6,SC:6,FVC:1,MCM:6,ROS:4,FWL:6,TP:6,DC:6</availability>
 			<model name='ZPH-1'>
 				<roles>recon</roles>
 				<availability>CC:5,MOC:5,ROS:5,General:1,FWL:5,MERC:5,DC:5</availability>
@@ -16436,8 +16258,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tempest' unitType='Mek'>
-			<availability>
-				PR:8,DoO:8,WOB:6,DO:8,DGM:8,MERC:4,DTA:8,SC:8,FWL.MM:8,MCM:8,ROS:5,PG:8,FWL:8,TP:8,RFS:8</availability>
+			<availability>PR:8,DoO:8,WOB:6,DO:8,DGM:8,MERC:4,DTA:8,SC:8,FWL.MM:8,MCM:8,ROS:5,PG:8,FWL:8,TP:8,RFS:8</availability>
 			<model name='TMP-3G'>
 				<availability>ROS:2,FWL:2,WOB:2,MERC:2</availability>
 			</model>
@@ -16572,8 +16393,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:2,CLAN:3,IS:1+,CCO:3,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:3,CW:3,CNC:4,CJF:6,CGB:3</availability>
+			<availability>CHH:5,CSR:2,CLAN:3,IS:1+,CCO:3,BAN:4,CWIE:5,CSA:3,MERC.WD:4,CDS:3,CW:3,CNC:4,CJF:6,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -16635,8 +16455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>
-				MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,ROS:6,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
+			<availability>MOC:1,CLAN:1,WOB:7,CCO:1,Periphery:1,TC:1,CS:5,DC.GHO:1,CSA:1,OA:1,CDS:1,ROS:6,NIOPS:5,CJF:1,CGB:1,DC:1</availability>
 			<model name='THE-N'>
 				<availability>CS:5,CLAN:3,NIOPS:3,BAN:3</availability>
 			</model>
@@ -16664,8 +16483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:3-,FVC:4-,HL:3-,General:1-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:5-</availability>
@@ -16678,14 +16496,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:3,PR:5,DoO:2,CLAN:4,DO:2,FS:3,CWIE:5,DC.GHO:5,SC:5,OA:4,CDS:3,CBS:3,FWL:5,NIOPS:8,MH:2,RFS:5,CGB:5,MOC:2,IS:3,WOB:7,DGM:5,CS:8,DTA:1,FVC:1,CW:5,LA:1,MCM:5,ROS:6,PG:5,CNC:3,TP:2,DA:5,RCM:1,CJF:5</availability>
+			<availability>CHH:3,PR:5,DoO:2,CLAN:4,DO:2,FS:3,CWIE:5,DC.GHO:5,SC:5,OA:4,CDS:3,CBS:3,FWL:5,NIOPS:8,MH:2,RFS:5,CGB:5,MOC:2,IS:3,WOB:7,DGM:5,CS:8,DTA:1,FVC:1,CW:5,LA:1,MCM:5,ROS:6,PG:5,CNC:3,TP:2,DA:5,RCM:1,CJF:5</availability>
 			<model name='THG-10E'>
 				<availability>SC:3-,MOC:3-,PR:3-,MCM:3-,PG:3-,PIR:3-,FWL:3-,MH:3-,MERC:3-,DA:3-</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					FRR:6,CLAN:6,IS:8,WOB:4,FS:8,BAN:8,DC.GHO:8,CS:4,OA:6,CGB.FRR:6,ROS:8,PG:8,FWL:8,NIOPS:4,DC:8</availability>
+				<availability>FRR:6,CLAN:6,IS:8,WOB:4,FS:8,BAN:8,DC.GHO:8,CS:4,OA:6,CGB.FRR:6,ROS:8,PG:8,FWL:8,NIOPS:4,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>SC:5,MCM:5,ROS:5,CLAN:4,FWL:5,WOB:5,DGM:5,MERC:5,BAN:2</availability>
@@ -16766,8 +16582,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:4,FRR:4,CLAN:1,IS:4,Periphery.Deep:5,WOB:4-,FS:5,CIR:4,Periphery:5,TC:5,CS:4-,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:4-</availability>
@@ -16788,8 +16603,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:6,MERC.KH:4,HL:3,CEI:1+,MERC.ELH:8,CLAN:1,IS:5,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>CC:6,MERC.KH:4,HL:3,CEI:1+,MERC.ELH:8,CLAN:1,IS:5,Periphery.Deep:6,WOB:2-,FS:5,MERC:6,Periphery:4,TC:4,CS:3-,FVC:5,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,CEI:1+,FS:2,CGS:1-,DC:1</availability>
 			</model>
@@ -17119,8 +16933,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,PR:6,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:2,LA:3,CGB.FRR:4,Periphery.MW:5,ROS:4,PG:6,Periphery.ME:5,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+			<availability>MOC:3,CC:3,PR:6,FRR:4,IS:3,WOB:3-,FS:2,MERC:3,Periphery:5,TC:4,CS:3-,OA:2,LA:3,CGB.FRR:4,Periphery.MW:5,ROS:4,PG:6,Periphery.ME:5,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>CS:5,SC:4,PR:4,MCM:4,ROS:5,PG:4,FWL:2,NIOPS:5,WOB:5,DGM:4,MERC:4,RFS:4</availability>
@@ -17130,8 +16943,7 @@
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:2-,CS:2-,MOC:5-,LA:2-,FWL:2-,IS:3-,NIOPS:2-,WOB:2-,FS:2-,MERC:3-,DC:2-,Periphery:5-</availability>
+				<availability>CC:2-,CS:2-,MOC:5-,LA:2-,FWL:2-,IS:3-,NIOPS:2-,WOB:2-,FS:2-,MERC:3-,DC:2-,Periphery:5-</availability>
 			</model>
 			<model name='TBT-5S'>
 				<availability>MOC:1-,IS:1-,Periphery.Deep:4,FWL:1-,MERC:1-,CDP:2,Periphery:1-,TC:2-</availability>
@@ -17430,8 +17242,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>
-				CCC:8,CHH:3,CSR:3,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:1,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
+			<availability>CCC:8,CHH:3,CSR:3,CLAN:1,CCO:2,CWIE:3,MERC.WD:3,CDS:1,CW:3,CBS:5,CNC:1,CJF:6,CGB:1</availability>
 			<model name='A'>
 				<availability>CHH:6,CDS:6,CW:6,General:5,CCO:4,CJF:6,CWIE:6,CGB:4</availability>
 			</model>
@@ -17559,8 +17370,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,FRR:5-,CLAN:1-,IS:4-,WOB:2-,WOB.PM:4,FS:4-,CIR:4-,Periphery:4-,TC:3-,CS:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -17776,8 +17586,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,FRR:4,IS:1,WOB:5,FS:4,Periphery:1,TC:1,CS:5,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:4</availability>
@@ -17821,8 +17630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,CGB.FRR:6,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
+			<availability>MOC:4,CC:7,HL:3,FRR:6,IS:4-,Periphery.Deep:4,WOB:3,FS:9,CIR:4,Periphery.OS:4,Periphery:4,TC:4,CS:3-,OA:4,LA:5,CGB.FRR:6,Periphery.HR:4,FWL:4,NIOPS:3-,DC:6</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -18037,8 +17845,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>
-				CC:3,MOC:5,FRR:4,IS:4,WOB:3,CIR:5,Periphery:5,TC:5,CS:3,LA:6,CGB.FRR:4,FWL:6,NIOPS:3</availability>
+			<availability>CC:3,MOC:5,FRR:4,IS:4,WOB:3,CIR:5,Periphery:5,TC:5,CS:3,LA:6,CGB.FRR:4,FWL:6,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>FVC:3-,General:4-,FS:2-</availability>
@@ -18159,8 +17966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>
-				CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
+			<availability>CS:4-,HL:5,LA:9,CLAN:1,IS:8,FWL:9,NIOPS:4-,Periphery.Deep:5,WOB:3-,TC:7,Periphery:6</availability>
 			<model name='C'>
 				<availability>LA:1+,FS:1+,DC:1+</availability>
 			</model>
@@ -18240,8 +18046,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,CGB.FRR:5,ROS:6,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,FRR:5,IS:6,Periphery.Deep:4,WOB:5-,FWL.FWG:7,FS:6,CIR:5,CC.CHG:8,Periphery:6,TC:6,CS:5-,OA:6,LA:9,CGB.FRR:5,ROS:6,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -18256,8 +18061,7 @@
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
 			<model name='H-8'>
-				<availability>
-					HL:4,LA:5,FS.CH:8,FRR:6,CGB.FRR:6,ROS:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
+				<availability>HL:4,LA:5,FS.CH:8,FRR:6,CGB.FRR:6,ROS:6,Periphery.Deep:4,FS:6,MERC:6,Periphery:6</availability>
 			</model>
 			<model name='H-9'>
 				<availability>LA:4</availability>
@@ -18398,8 +18202,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:1,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
+			<availability>MOC:1,Periphery.DD:2,MERC:2,Periphery.OS:2,TC:2,Periphery:2,CS:1-,OA:1,FVC:3,FS.CMM:3,NIOPS:1-,MH:2,DC:3</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>Periphery.Deep:8,MERC:2,Periphery:2</availability>
@@ -18470,8 +18273,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolfhound' unitType='Mek'>
-			<availability>
-				MOC:4,MERC.KH:7,DoO:3,FRR:5,DO:3,DGM:3,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:3,LA:7,MCM:3,CGB.FRR:5,ROS:5,FWL:2,MH:4,TP:3</availability>
+			<availability>MOC:4,MERC.KH:7,DoO:3,FRR:5,DO:3,DGM:3,FS:3,MERC:4,CIR:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:3,LA:7,MCM:3,CGB.FRR:5,ROS:5,FWL:2,MH:4,TP:3</availability>
 			<model name='WLF-1'>
 				<availability>MERC.KH:3,MERC.WD:1,HL:6,LA:3,ROS:3,Periphery.Deep:6,FS:2,MERC:3,Periphery:8</availability>
 			</model>
@@ -18505,8 +18307,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:5,HL:4,FRR:3,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CGB.FRR:3,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>CC:5,HL:4,FRR:3,IS:5,Periphery.Deep:5,WOB:3-,FS:6,Periphery:5,TC:5,CS:3-,LA:5,CGB.FRR:3,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5</availability>
 			<model name='WVR-1R'>
 				<availability>CC:2-,FWL:2-,FS:2-,MERC:2,RCM:2,DC:2-</availability>
 			</model>
@@ -18534,8 +18335,7 @@
 				<availability>CC:4,FWL:6,WOB:5,MERC:6,DC:4</availability>
 			</model>
 			<model name='WVR-7M2'>
-				<availability>
-					CC:6,MOC:2:3081,MERC.KH:5,WOB:6,DO:6,MERC:6,DTA:5,MERC.WD:4,FWL:6,MH:2:3081,DA:6,RCM:2,DC:4</availability>
+				<availability>CC:6,MOC:2:3081,MERC.KH:5,WOB:6,DO:6,MERC:6,DTA:5,MERC.WD:4,FWL:6,MH:2:3081,DA:6,RCM:2,DC:4</availability>
 			</model>
 			<model name='WVR-8C'>
 				<availability>ROS:4,DC:5</availability>
@@ -18586,8 +18386,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				PR:3,DoO:3,FRR:5,CLAN:2,DO:3,FS:7,DC.GHO:5,SC:3,CGB.FRR:5,NIOPS:5,RFS:3,CC:3,IS:3,WOB:4-,DGM:3,MERC:5,CS:5,DTA:3,FVC:3,MCM:3,PG:3,ROS:5,TP:3,RCM:3,DA:3,DC:6</availability>
+			<availability>PR:3,DoO:3,FRR:5,CLAN:2,DO:3,FS:7,DC.GHO:5,SC:3,CGB.FRR:5,NIOPS:5,RFS:3,CC:3,IS:3,WOB:4-,DGM:3,MERC:5,CS:5,DTA:3,FVC:3,MCM:3,PG:3,ROS:5,TP:3,RCM:3,DA:3,DC:6</availability>
 			<model name='WVE-10N'>
 				<roles>urban</roles>
 				<availability>CS:5,WOB:4</availability>
@@ -18774,8 +18573,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zeus' unitType='Mek'>
-			<availability>
-				HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:1,TC:4,Periphery.R:5,LA:10,CGB.FRR:4,ROS:5,PIR:4,MH:4</availability>
+			<availability>HL:5,FRR:4,IS:1,WOB:3,FS:5-,MERC:5,CDP:4,Periphery:1,TC:4,Periphery.R:5,LA:10,CGB.FRR:4,ROS:5,PIR:4,MH:4</availability>
 			<model name='ZEU-10WB'>
 				<availability>LA:4,ROS:4,WOB:8</availability>
 			</model>
@@ -18800,8 +18598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:6,HL:2,IS:3,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:5</availability>
+			<availability>MOC:3,CC:6,HL:2,IS:3,WOB:6,MERC:5,CIR:4,TC:3,Periphery:3,CS:5-,MERC.WD:7,FWL:5,DC:5</availability>
 			<model name=''>
 				<availability>General:6</availability>
 			</model>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -1129,7 +1129,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,RA.OA:4,LA:5,CGB.FRR:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:2,General:4,Periphery.Deep:6,Periphery:4</availability>
@@ -1158,7 +1158,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:2,BAN:5,Periphery:1,RA.OA:1,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:3</availability>
@@ -1628,7 +1628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,OA:8,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1688,7 +1688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1831,7 +1831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:2,CC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,CLAN.HW:1-,Periphery:2,TC:2,RA.OA:1,OA:1,LA:4,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
+			<availability>CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,CLAN.HW:1-,Periphery:2,RA.OA:1,OA:1,LA:4,CGB.FRR:6,NIOPS:4-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -2011,7 +2011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:1-,General:4,FS:1-</availability>
@@ -2022,7 +2022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:5,Periphery.Deep:7,Periphery:8,TC:6,RA.OA:7,OA:7,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4,DC:5</availability>
 			</model>
@@ -2484,7 +2484,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
+			<availability>HL:4,IS:5,Periphery:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2624,7 +2624,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:2,HL:3,IS:2,MERC:2,FS:4,Periphery:4,RA.OA:3,OA:3,CDS:5,LA:3,CGB.FRR:3,PIR:2,CNC:4,FWL:2,DC:5</availability>
+			<availability>HL:3,IS:2,MERC:2,FS:4,Periphery:4,RA.OA:3,OA:3,CDS:5,LA:3,CGB.FRR:3,PIR:2,CNC:4,DC:5</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,DC:3</availability>
 			</model>
@@ -2934,14 +2934,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,MCM:6,ROS:3,FWL:6,MH:3,MSC:4,TP:6,DA:6</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>General:4,RCM:0</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:3</availability>
+				<availability>IS:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3009,7 +3009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3607,7 +3607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
-			<availability>MOC:5,CC:5,RA.OA:5,OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4,DC:4</availability>
+			<availability>MOC:5,CC:5,RA.OA:5,OA:5,HL:3,LA:6,IS:4,FWL:5,FS:5,TC:5,Periphery:4</availability>
 			<model name='CLN-7V'>
 				<roles>training</roles>
 				<availability>HL:4,IS:8,Periphery.Deep:4,Periphery:6</availability>
@@ -3626,7 +3626,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,SC:2,CGB.FRR:4,FWL:2,NIOPS:5,MSC:1,RFS:2,CGB:3,CC:4,IS:2,DGM:2,MERC:1,DTA:2,FVC:2,LA:3,MCM:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
+			<availability>CHH:1,PR:2,DoO:2,DO:2,DC.GHO:4,SC:2,CGB.FRR:4,NIOPS:5,MSC:1,RFS:2,CGB:3,CC:4,IS:2,DGM:2,MERC:1,DTA:2,FVC:2,LA:3,MCM:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -3767,16 +3767,16 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
+			<availability>MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:3,CDP:3,TC:3</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
+				<availability>LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2</availability>
@@ -4138,7 +4138,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:4,LA:5,CGB.FRR:3,ROS:3,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:4-,FVC:3-,General:2-,FS:4-,Periphery:3-</availability>
 			</model>
@@ -4283,7 +4283,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:3,OA:3,LA:4,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
+			<availability>RA.OA:3,OA:3,LA:4,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,Periphery:2,DC:1</availability>
 			<model name='CSR-12D'>
 				<availability>FS:5</availability>
 			</model>
@@ -4377,7 +4377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:1,CSR:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CBS:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
+			<availability>CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CBS:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4568,7 +4568,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:1</availability>
 			</model>
@@ -4722,7 +4722,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,CBS:4,ROS:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,ROS:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -4826,7 +4826,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CJF:3,CGB:6</availability>
+			<availability>CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -4935,7 +4935,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,OA:9,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,OA:9,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,HL:1,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
@@ -5003,7 +5003,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:1,CC:1,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,OA:1,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
+			<availability>MOC:1,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,RA.OA:1,FVC:5,OA:1,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
 			<model name='DV-1S'>
 				<availability>IS:2-</availability>
 			</model>
@@ -5024,7 +5024,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,OA:1-,LA:2-,FWL:2-,IS:2-,MERC:2-,FS:2-,Periphery:3-,TC:3-,DC:2-</availability>
+			<availability>MOC:2-,OA:1-,IS:2-,MERC:2-,Periphery:3-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5192,7 +5192,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:3-,Periphery:2-,FVC:4-,LA:6,ROS:3,FWL:2-,CC.MAC:3-,DC:2-</availability>
+			<availability>HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:3-,Periphery:2-,FVC:4-,LA:6,ROS:3,CC.MAC:3-</availability>
 			<model name=''>
 				<availability>CC:2-,General:3-</availability>
 			</model>
@@ -5234,7 +5234,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,RA.OA:2,OA:2,CGB.FRR:3,FWL:4,NIOPS:3-</availability>
 			<model name='EGL-R11'>
 				<availability>PR:6,LA:5,ROS:6,PG:6,MERC:5,FS:3,RFS:6</availability>
 			</model>
@@ -5377,7 +5377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:2,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:2,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:2,TC:4,CNC:5,NIOPS:7,MH:2</availability>
 			<model name='EMP-6A'>
 				<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
@@ -5518,7 +5518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,IS:5,FS:2,Periphery:2,TC:3,RA.OA:2,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,IS:5,FS:2,Periphery:2,TC:3,RA.OA:2,CGB.FRR:6,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -6062,7 +6062,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
+			<availability>CC:6,PR:3,MERC:4,Periphery:4,MERC.WD:4,FVC:3,ROS:4,PG:3,FWL:1,DA:3,RCM:3,RFS:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:7,PR:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
 			</model>
@@ -6274,7 +6274,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,OA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -6337,7 +6337,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -6580,7 +6580,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>CC:4,MOC:4,HL:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:2,DTA:2,FVC:2,OA:3,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
+			<availability>CC:4,MOC:4,HL:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:2,DTA:2,FVC:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:2-,LA:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
@@ -7182,7 +7182,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,SC:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:4-,Periphery.MW:4-,FWL:5,MH:4,MSC:4,RFS:5,MOC:4,CC:4,IS:3-,DGM:5,MERC:4,Periphery:2-,DTA:5,LA:3,MCM:5,PG:5,Periphery.ME:4-,TP:5,DA:5,RCM:5,DC:3-</availability>
+			<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,SC:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:4-,Periphery.MW:4-,FWL:5,MH:4,MSC:4,RFS:5,MOC:4,CC:4,IS:3-,DGM:5,MERC:4,Periphery:2-,DTA:5,LA:3,MCM:5,PG:5,Periphery.ME:4-,TP:5,DA:5,RCM:5</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -7383,7 +7383,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>CC:2,MOC:5,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:5,Periphery:5,RA.OA:5,OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:5</availability>
+			<availability>CC:2,HL:4,MERC:3,Periphery.OS:4,FS:3,Periphery:5,RA.OA:5,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7409,7 +7409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:1-,ROS:3-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:1-,ROS:3-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7650,7 +7650,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,OA:4,HL:3,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,Periphery:4</availability>
+			<availability>RA.OA:4,HL:3,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,Periphery:4</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -7763,9 +7763,9 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>MOC:2,CC:3,LA:6,CLAN:4,IS:2,FWL:2,NIOPS:9,MH:2,MERC:4,FS:5,CJF:5,DC:2</availability>
+			<availability>MOC:2,CC:3,LA:6,CLAN:4,IS:2,NIOPS:9,MH:2,MERC:4,FS:5,CJF:5</availability>
 			<model name='HGN-732'>
-				<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
+				<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,BAN:8,DC.GHO:8,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:2,FWL:2,MH:4,FS:4,BAN:2</availability>
@@ -7853,7 +7853,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,FS.PMM:4,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
+			<availability>FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:3,FVC:8,FS.PMM:4,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:2-</availability>
@@ -7960,7 +7960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
+			<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,Periphery:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:3-</availability>
@@ -8206,7 +8206,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -8317,7 +8317,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>MOC:3-,DC.LV:4-,DC.GR:3-,FS.AH:3-,IS:3-,Periphery.Deep:5,FS:2-,Periphery:3-,TC:4-,RA.OA:3-,OA:2-,LA:3-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:3-</availability>
+			<availability>DC.LV:4-,DC.GR:3-,FS.AH:3-,IS:3-,Periphery.Deep:5,FS:2-,Periphery:3-,TC:4-,RA.OA:3-,OA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8428,7 +8428,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:3,CC:3-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,OA:2,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
+			<availability>CC:3-,MERC:3,Periphery.OS:2,FS:6,Periphery:3,RA.OA:2,FVC:7,OA:2,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:3,RA.OA:5,FVC:5,OA:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
@@ -8469,7 +8469,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,OA:1,LA:1,Periphery.HR:4,ROS:4</availability>
+			<availability>HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,RA.OA:1,FVC:7,OA:1,LA:1,Periphery.HR:4,ROS:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -8539,7 +8539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:3,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
+			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:3,Periphery:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:6,FS:6,DC:5</availability>
@@ -8866,7 +8866,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,FVC:2,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:2,CGB:3,DC:4</availability>
+			<availability>CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,FVC:2,CGB.FRR:4,ROS:6,NIOPS:6,MH:2,CGB:3</availability>
 			<model name='KGC-000'>
 				<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
 			</model>
@@ -8939,7 +8939,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>DC.GHO:5,CGB.FRR:4,ROS:6,NIOPS:7,FS:2,MERC:4,DC:4</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:3-,MERC:3-</availability>
+				<availability>FS:3-,MERC:3-</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:3,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
@@ -9311,7 +9311,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,RA.OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:3-</availability>
@@ -9415,7 +9415,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,Periphery:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:4-</availability>
 			</model>
@@ -9662,7 +9662,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:2</availability>
+			<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,OA:6,LA:5,CGB.FRR:4,ROS:6,NIOPS:3,CGB:2</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -9850,7 +9850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>MERC.KH:2+,CLAN:3,MERC:1+,CCO:4,BAN:2,CWIE:7,CSA:4,MERC.WD:7,CDS:4,CW:6,CBS:3,ROS:1+,CJF:4</availability>
+			<availability>MERC.KH:2+,CLAN:3,MERC:1+,CCO:4,BAN:2,CWIE:7,CSA:4,MERC.WD:7,CDS:4,CW:6,ROS:1+,CJF:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -10039,7 +10039,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:4,RA.OA:6,OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
+			<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,Periphery:6,CWIE:4,RA.OA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
 			<model name=''>
 				<availability>HL:2,LA:1-,General:3-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 			</model>
@@ -10133,7 +10133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2,IS:2-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
+			<availability>CC:4,IS:2-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
 			<model name='MAD-2R'>
 				<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
 			</model>
@@ -10354,7 +10354,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,OA:1,LA:3,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
+			<availability>CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,RA.OA:1,LA:3,CGB.FRR:2,ROS:1,NIOPS:2-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
@@ -11056,7 +11056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:5,RA.OA:2,OA:2,LA:5,ROS:4,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:5,RA.OA:2,LA:5,ROS:4,FS:5,MERC:5,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11239,7 +11239,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,PR:5,LA:8,DoO:5,ROS:6,PG:5,DO:5,TP:5,FS:7,MERC:6,RFS:5</availability>
 			<model name='NGS-4S'>
-				<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
+				<availability>PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -11497,7 +11497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:7,CC:5,HL:1,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
+			<availability>MOC:7,CC:5,HL:1,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4</availability>
 			<model name=''>
 				<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -11547,7 +11547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
+			<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,OA:2,CW:2,CGB.FRR:4,FWL:6,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -11630,7 +11630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
+			<availability>MOC:4,CC:3,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
@@ -11841,7 +11841,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,OA:3-,LA:5-,FS.PMM:4-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
+			<availability>MOC:2-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,RA.OA:3-,FVC:6-,LA:5-,FS.PMM:4-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,NIOPS:6</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -11979,7 +11979,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Air Defense Tank' unitType='Tank'>
-			<availability>CC:5,HL:4,LA:7,CGB.FRR:4,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
+			<availability>HL:4,LA:7,CGB.FRR:4,CNC:5,IS:5,FS:8,DC:6,Periphery:5,CWIE:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -12011,7 +12011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:4-,CC:1-,HL:3-,IS:3-,Periphery.Deep:9,FS:4-,Periphery:4-,TC:4-,RA.OA:2-,OA:2-,CDS:1,LA:3-,FWL:3-,DC:1-</availability>
+			<availability>CC:1-,HL:3-,IS:3-,Periphery.Deep:9,FS:4-,Periphery:4-,RA.OA:2-,OA:2-,CDS:1,DC:1-</availability>
 			<model name=''>
 				<availability>General:5</availability>
 			</model>
@@ -12087,7 +12087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:1,RA.OA:1,OA:1,LA:6,ROS:6,FWL:1,Periphery.Deep:8,FS:6,Periphery:1,TC:1,DC:6</availability>
+			<availability>RA.OA:1,LA:6,ROS:6,FWL:1,Periphery.Deep:8,FS:6,Periphery:1,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:3-</availability>
@@ -12249,7 +12249,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CC:2,CCC:5,CSR:3,CLAN:3,MERC:2,FS:2,CCO:5,RA:4,CSA:3,DTA:2,CDS:5,CBS:3,LA:2,ROS:3,MSC:2,DC:2</availability>
+			<availability>CC:2,CCC:5,CLAN:3,MERC:2,FS:2,CCO:5,RA:4,DTA:2,CDS:5,LA:2,ROS:3,MSC:2,DC:2</availability>
 			<model name=''>
 				<availability>CDS:3,CSR:2,CNC:3,IS:2,CCO:3,DC:3</availability>
 			</model>
@@ -12355,7 +12355,7 @@
 			<availability>LA:1-,MERC:2-,TC:2-,Periphery:1-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:3,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:3-,OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
+			<availability>MOC:3,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:3-,OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-</availability>
 			<model name=''>
 				<availability>HL:3,IS:3,Periphery:5</availability>
 			</model>
@@ -12760,7 +12760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,SC:6,OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:4,RFS:6,MOC:3,CC:4,IS:3,DGM:6,Periphery:4,TC:3,DTA:6,FVC:3,LA:3,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
+			<availability>PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,SC:6,OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:4,RFS:6,MOC:3,CC:4,IS:3,DGM:6,Periphery:4,TC:3,DTA:6,FVC:3,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:3-,OA:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
 			</model>
@@ -12989,7 +12989,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13051,7 +13051,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
+			<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,CC:3,DGM:8,MERC:2,Periphery:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 			<model name='F-100'>
 				<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 			</model>
@@ -13099,7 +13099,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+			<availability>CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
 			<model name='C 2'>
 				<availability>CJF:4</availability>
 			</model>
@@ -13268,7 +13268,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:4,CLAN:4,MERC:3+,RA:4,BAN:6,CWIE:6,MERC.WD:6,CDS:6,CW:5,CBS:7,CJF:6,DC:3+</availability>
+			<availability>CHH:5,CLAN:4,MERC:3+,RA:4,BAN:6,CWIE:6,MERC.WD:6,CDS:6,CW:5,CBS:7,CJF:6,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -13455,7 +13455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:5,Periphery.DD:5,DC.AL:9,IS:5,MERC:5,Periphery.OS:5,FS:4,Periphery:4,RA.OA:4,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
+			<availability>Periphery.DD:5,DC.AL:9,IS:5,MERC:5,Periphery.OS:5,FS:4,Periphery:4,RA.OA:4,CGB.FRR:6,CJF:4,DC:8</availability>
 			<model name=''>
 				<availability>IS:5-,Periphery:5-</availability>
 			</model>
@@ -13518,7 +13518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:3-,Periphery:4,TC:4,RA.OA:6,OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:7-</availability>
+			<availability>Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:3-,Periphery:4,RA.OA:6,OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:7-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -13670,7 +13670,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:1,HL:3,IS:3,Periphery.Deep:5,MERC:3,FS:3,Periphery:4,TC:3,RA:3,RA.OA:4,OA:3,LA:3,CGB.FRR:2,CNC:3,FWL:2,DC:1</availability>
+			<availability>MOC:3,CC:1,HL:3,IS:3,Periphery.Deep:5,MERC:3,Periphery:4,TC:3,RA:3,RA.OA:4,OA:3,LA:3,CGB.FRR:2,CNC:3,FWL:2,DC:1</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -13688,7 +13688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
+			<availability>CC:4-,HL:3-,IS:3-,MERC:3-,FS:2-,Periphery:4-,RA.OA:5-,OA:5-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -13848,7 +13848,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:2,FS:5,MERC:4,CWIE:2,DC.GHO:3,FVC:5,CDS:2,CW:2,LA:5,CBS:2,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
+			<availability>CLAN:2,FS:5,MERC:4,CWIE:2,DC.GHO:3,FVC:5,LA:5,CBS:2,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -13869,7 +13869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
+			<availability>MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
@@ -14203,7 +14203,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,RA.OA:1,OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:4-</availability>
@@ -14222,7 +14222,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
+			<availability>Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 			</model>
@@ -14333,7 +14333,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+			<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 			</model>
@@ -14388,7 +14388,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:3,MERC:3,FS:3,Periphery:2,TC:2,FVC:3,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>CC:3,MERC:3,FS:3,Periphery:2,FVC:3,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5K'>
 				<roles>anti_infantry</roles>
 				<availability>CGB.FRR:2-,DC:2-</availability>
@@ -14637,7 +14637,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
+			<availability>HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
@@ -14714,7 +14714,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -14726,7 +14726,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -14772,7 +14772,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -14815,7 +14815,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,OA:2,LA:3,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
+			<availability>CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,RA.OA:2,FVC:7,OA:2,LA:3,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
 			</model>
@@ -15229,7 +15229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CSR:2,CLAN:3,CCO:3,RA:1,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:3,CW:3,ROS:1+,CNC:3,CJF:5,CGB:3</availability>
+			<availability>CHH:5,CSR:2,CLAN:3,RA:1,BAN:4,CWIE:4,CSA:2,MERC.WD:3,ROS:1+,CJF:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -15303,7 +15303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:3-,FVC:3-,HL:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
@@ -15403,7 +15403,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,NIOPS:4-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:3-</availability>
@@ -15720,7 +15720,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,OA:2,LA:2,CGB.FRR:4,ROS:4,Periphery.MW:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+			<availability>CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,RA.OA:2,OA:2,LA:2,CGB.FRR:4,ROS:4,PG:6,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>SC:4,PR:4,MCM:4,ROS:5,PG:4,NIOPS:5,DGM:4,MSC:4,MERC:4,RFS:4</availability>
@@ -15920,7 +15920,7 @@
 			<availability>ROS:3,DC:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:5</availability>
+				<availability>General:5</availability>
 			</model>
 			<model name='(C3)'>
 				<roles>apc,urban,spotter</roles>
@@ -16153,7 +16153,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,IS:4-,Periphery:4-,TC:3-,RA.OA:3-,OA:3-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -16354,7 +16354,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:2,CC:4,IS:1,FS:4,Periphery:1,TC:1,RA.OA:1,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,IS:1,FS:4,Periphery:1,RA.OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:3</availability>
@@ -16616,7 +16616,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,MERC.WD:5,ROS:2,CLAN:5,MERC:1+,CCO:5,CJF:5,BAN:6,CWIE:5,CGB:6,DC:3</availability>
+			<availability>CHH:6,MERC.WD:5,ROS:2,CLAN:5,MERC:1+,BAN:6,CWIE:5,CGB:6,DC:3</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 			</model>
@@ -16779,7 +16779,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:3,RA:4,RA.OA:6,OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:3,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,IS:6,Periphery.Deep:4,CC.CHG:8,Periphery:6,CWIE:3,RA:4,RA.OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:3,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -17002,7 +17002,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
+			<availability>HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,CNC:2,FWL:8,NIOPS:3-,CGB:1</availability>
 			<model name='WVR-1R'>
 				<availability>CC:2-,FWL:2-,FS:2-,MERC:2,RCM:2,DC:2-</availability>
 			</model>
@@ -17087,7 +17087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:2,PR:2,DoO:2,IS:2,DO:2,DGM:2,FS:7,MERC:5,DC.GHO:4,SC:2,DTA:2,FVC:2,MCM:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
+			<availability>PR:2,DoO:2,IS:2,DO:2,DGM:2,FS:7,MERC:5,DC.GHO:4,SC:2,DTA:2,FVC:2,MCM:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
@@ -17270,7 +17270,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,HL:2,IS:3,FWL:5,MERC:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,HL:2,IS:3,FWL:5,MERC:4,Periphery:3,DC:5</availability>
 			<model name=''>
 				<availability>General:5</availability>
 			</model>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -774,8 +774,7 @@
 			<pctSL>71</pctSL>
 			<omniMargin>3</omniMargin>
 			<techMargin>3</techMargin>
-			<salvage pct='6'>
-				MOC:2,CC:8,FS:8,TC:2,DTA:4,OA:2,CDS:1,CW:5,LA:8,RIM:1,ROS:5,CNC:3,FWL:10,CJF:5,CGB:5,DC:8</salvage>
+			<salvage pct='6'>MOC:2,CC:8,FS:8,TC:2,DTA:4,OA:2,CDS:1,CW:5,LA:8,RIM:1,ROS:5,CNC:3,FWL:10,CJF:5,CGB:5,DC:8</salvage>
 		</faction>
 		<faction key='CGB.FRR'>
 			<pctOmni>12</pctOmni>
@@ -1130,8 +1129,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:2,General:4,Periphery.Deep:6,Periphery:4</availability>
@@ -1160,16 +1158,14 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:3</availability>
 			</model>
 			<model name='(3055)'>
 				<roles>assault</roles>
-				<availability>
-					CC:8,PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8,DC:3</availability>
+				<availability>CC:8,PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8,DC:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Aegis Heavy Cruiser' unitType='Warship'>
@@ -1363,8 +1359,7 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>
-				MERC.KH:3,CHH:3,CSR:3,MERC:3,CCO:2,CWIE:4,BAN:2,RA:3,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
+			<availability>MERC.KH:3,CHH:3,CSR:3,MERC:3,CCO:2,CWIE:4,BAN:2,RA:3,CSA:2,MERC.WD:8,LA:4,ROS:5,CGB:2</availability>
 			<model name='ANH-2A'>
 				<availability>MERC.KH:6,MERC.WD:8,General:8</availability>
 			</model>
@@ -1398,8 +1393,7 @@
 			</model>
 		</chassis>
 		<chassis name='Anvil' unitType='Mek'>
-			<availability>
-				PR:6,DoO:6,DO:6,DGM:6,MERC:4,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,MSC:4,TP:6,DA:6,RFS:6</availability>
+			<availability>PR:6,DoO:6,DO:6,DGM:6,MERC:4,DTA:6,SC:6,MCM:6,ROS:4,PG:6,FWL:5,MSC:4,TP:6,DA:6,RFS:6</availability>
 			<model name='ANV-3M'>
 				<availability>ROS:6,FWL:4,MERC:4</availability>
 			</model>
@@ -1422,8 +1416,7 @@
 			</model>
 		</chassis>
 		<chassis name='Apollo' unitType='Mek'>
-			<availability>
-				CC:5,SC:8,MCM:8,Periphery.MW:1,ROS:4,Periphery.ME:1,FWL:8,MH:3,DGM:8,MSC:6,MERC:4,DC:6</availability>
+			<availability>CC:5,SC:8,MCM:8,Periphery.MW:1,ROS:4,Periphery.ME:1,FWL:8,MH:3,DGM:8,MSC:6,MERC:4,DC:6</availability>
 			<model name='APL-1M'>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -1504,8 +1497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:2-,Periphery:4,DC:5,CGB:2</availability>
+			<availability>CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:2-,Periphery:4,DC:5,CGB:2</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:6,MERC.WD:6</availability>
 			</model>
@@ -1562,8 +1554,7 @@
 			</model>
 			<model name='ARC-8M'>
 				<roles>fire_support</roles>
-				<availability>
-					MOC:3,DoO:5,DO:5,DGM:5,MERC:4,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,MSC:5,TP:5</availability>
+				<availability>MOC:3,DoO:5,DO:5,DGM:5,MERC:4,DTA:5,SC:5,MCM:5,CGB.FRR:3,ROS:4,PIR:3,MH:3,MSC:5,TP:5</availability>
 			</model>
 			<model name='ARC-9K'>
 				<roles>fire_support</roles>
@@ -1769,8 +1760,7 @@
 			<availability>MOC:2-,CC:2-,FVC:1,LA:1,FS.CMM:1-,MERC:1-,RCM:1-,DA:1-,CDP:2-,TC:2-,Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:2,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
+				<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:2,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1841,8 +1831,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,CLAN.HW:1-,Periphery:2,TC:2,RA.OA:1,OA:1,LA:4,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
+			<availability>MOC:2,CC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,CLAN.HW:1-,Periphery:2,TC:2,RA.OA:1,OA:1,LA:4,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
 			<model name='AS7-A'>
 				<availability>CC:1,FWL:1,MERC:1</availability>
 			</model>
@@ -2033,8 +2022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:7,CLAN:2-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:2-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,SC:4,DoO:4,MCM:4,ROS:4,FWL:4,DO:4,DGM:4,MSC:4,TP:4,DC:5</availability>
 			</model>
@@ -2330,8 +2318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,DGM:2-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,SC:2-,FVC:3-,OA:6-,LA:4-,MCM:2-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:1-,RFS:3-</availability>
+			<availability>MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,DGM:2-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,SC:2-,FVC:3-,OA:6-,LA:4-,MCM:2-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:1-,RFS:3-</availability>
 			<model name='BNC-3E'>
 				<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 			</model>
@@ -2497,8 +2484,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2528,8 +2514,7 @@
 				<availability>LA:1-</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
+				<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -2639,8 +2624,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:2,HL:3,IS:2,MERC:2,FS:4,Periphery:4,RA.OA:3,OA:3,CDS:5,LA:3,CGB.FRR:3,PIR:2,CNC:4,FWL:2,DC:5</availability>
+			<availability>CC:2,HL:3,IS:2,MERC:2,FS:4,Periphery:4,RA.OA:3,OA:3,CDS:5,LA:3,CGB.FRR:3,PIR:2,CNC:4,FWL:2,DC:5</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,DC:3</availability>
 			</model>
@@ -2788,14 +2772,12 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:5,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,SC:6,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,MSC:4,RFS:6,CGB:6,CSR:4,IS:4,DGM:6,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,LA:4,MCM:6,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
+			<availability>CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:5,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,SC:6,OA:3,CDS:4,CBS:6,CGB.FRR:4,FWL:4,NIOPS:7,MSC:4,RFS:6,CGB:6,CSR:4,IS:4,DGM:6,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,LA:4,MCM:6,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:6,FS:6</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:5,Periphery:5,DC.GHO:4,RA.OA:6,OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:5,Periphery:5,DC.GHO:4,RA.OA:6,OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
@@ -3027,8 +3009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3098,8 +3079,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3130,8 +3110,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:3-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
+			<availability>MOC:2-,CC:3-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
 			<model name=''>
 				<availability>LA:3-,General:8,FS:3-,MERC:3-,DC:3-</availability>
 			</model>
@@ -3302,8 +3281,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
 			<model name='CTF-1X'>
 				<availability>General:3-,Periphery:4-</availability>
 			</model>
@@ -3330,8 +3308,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,DoO:2,DO:2,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:2,DA:3,RCM:3,DC:6</availability>
+			<availability>MOC:3,CC:4,DoO:2,DO:2,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:2,DA:3,RCM:3,DC:6</availability>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
 				<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
@@ -3517,8 +3494,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,DoO:2,DO:2,DGM:2,Periphery.OS:4,FS:8,MERC:2,CDP:3,Periphery:2,DTA:2,SC:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:1,TP:2</availability>
+			<availability>CC:2,DoO:2,DO:2,DGM:2,Periphery.OS:4,FS:8,MERC:2,CDP:3,Periphery:2,DTA:2,SC:2,FVC:8,LA:4,MCM:2,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:1,TP:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
 			</model>
@@ -3556,8 +3532,7 @@
 				<availability>FS:2</availability>
 			</model>
 			<model name='CN9-Da'>
-				<availability>
-					DoO:3,DO:3,DGM:3,FS:2,MERC:2,Periphery:2,SC:3,FVC:2,MCM:3,ROS:2,FWL:2,MSC:3,TP:3</availability>
+				<availability>DoO:3,DO:3,DGM:3,FS:2,MERC:2,Periphery:2,SC:3,FVC:2,MCM:3,ROS:2,FWL:2,MSC:3,TP:3</availability>
 			</model>
 			<model name='CN9-H'>
 				<availability>MH:6</availability>
@@ -3651,8 +3626,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,SC:2,CGB.FRR:4,FWL:2,NIOPS:5,MSC:1,RFS:2,CGB:3,CC:4,IS:2,DGM:2,MERC:1,DTA:2,FVC:2,LA:3,MCM:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
+			<availability>CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,SC:2,CGB.FRR:4,FWL:2,NIOPS:5,MSC:1,RFS:2,CGB:3,CC:4,IS:2,DGM:2,MERC:1,DTA:2,FVC:2,LA:3,MCM:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:3</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -3691,8 +3665,7 @@
 			</model>
 		</chassis>
 		<chassis name='Charger' unitType='Mek'>
-			<availability>
-				CC:2-,MOC:2-,RA.OA:2-,FVC:2,OA:2-,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-</availability>
+			<availability>CC:2-,MOC:2-,RA.OA:2-,FVC:2,OA:2-,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-</availability>
 			<model name='CGR-1A5'>
 				<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 			</model>
@@ -3733,16 +3706,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:8,HL:2,DoO:10,DO:10,FS:2,RA.OA:4,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:7,RFS:8,MOC:5,CC:2,DGM:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
+			<availability>PR:8,HL:2,DoO:10,DO:10,FS:2,RA.OA:4,SC:10,OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:7,RFS:8,MOC:5,CC:2,DGM:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,MCM:10,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
-				<availability>
-					CC:3-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,FWL:3-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+				<availability>CC:3-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,DGM:2-,MERC:3-,Periphery:3-,DTA:2-,SC:2-,MCM:2-,PG:2-,FWL:3-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:3,MOC:3,PR:8,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:1,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:3,MOC:3,PR:8,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:1,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -3750,8 +3720,7 @@
 			</model>
 			<model name='F-11-RR'>
 				<roles>recon</roles>
-				<availability>
-					CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,Periphery:1,DTA:2,SC:2,FVC:1,MCM:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
+				<availability>CC:2,PR:2,DoO:2,DO:2,DGM:2,MERC:2,Periphery:1,DTA:2,SC:2,FVC:1,MCM:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
 			</model>
 			<model name='F-12-S'>
 				<availability>FWL:1-</availability>
@@ -3760,8 +3729,7 @@
 				<availability>CC:2,DoO:4,DO:4,DGM:4,FS:3,MERC:4,DTA:4,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4</availability>
 			</model>
 			<model name='F-14-S'>
-				<availability>
-					PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:3,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='OF-17A-R'>
 				<roles>recon</roles>
@@ -3794,8 +3762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chimera' unitType='Mek'>
-			<availability>
-				PR:4,DoO:4,DO:4,FS:2,MERC:5,DTA:4,FVC:4,LA:6,ROS:4,PG:4,FWL:4,MH:4,TP:4,DA:4,RFS:4,DC:5</availability>
+			<availability>PR:4,DoO:4,DO:4,FS:2,MERC:5,DTA:4,FVC:4,LA:6,ROS:4,PG:4,FWL:4,MH:4,TP:4,DA:4,RFS:4,DC:5</availability>
 			<model name='CMA-1S'>
 				<availability>General:8,FWL:0</availability>
 			</model>
@@ -3804,8 +3771,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
+			<availability>MOC:2,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,RA.OA:2,FVC:5,OA:2,LA:8,CGB.FRR:2,ROS:5,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:3,CDP:3,TC:3</availability>
 			</model>
@@ -4067,8 +4033,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,PR:3,HL:1,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
+			<availability>CC:3,MOC:2,PR:3,HL:1,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
 			<model name='CLNT-2-3T'>
 				<availability>Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -4137,8 +4102,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:2-,LA:2-,Periphery:2-</availability>
@@ -4174,8 +4138,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:4,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:4-,FVC:3-,General:2-,FS:4-,Periphery:3-</availability>
 			</model>
@@ -4414,8 +4377,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:1,CSR:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CBS:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
+			<availability>CHH:1,CSR:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CBS:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4433,8 +4395,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crimson Hawk' unitType='Mek'>
-			<availability>
-				CC:2,DGM:3,FS:2,MERC:3,CWIE:5,SC:3,CDS:5,LA:3,CBS:5,MCM:3,ROS:3,CNC:4,MSC:2,CJF:5,DC:3</availability>
+			<availability>CC:2,DGM:3,FS:2,MERC:3,CWIE:5,SC:3,CDS:5,LA:3,CBS:5,MCM:3,ROS:3,CNC:4,MSC:2,CJF:5,DC:3</availability>
 			<model name=''>
 				<availability>SC:8,MCM:8,ROS:8,CLAN.IS:8,DGM:8,MSC:8,FS:8</availability>
 			</model>
@@ -4468,8 +4429,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>
-				CHH:6,CSR:4,CLAN:5,RA:4,CWIE:6,DC.GHO:2,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:4,NIOPS:9,CJF:4,CGB:6</availability>
+			<availability>CHH:6,CSR:4,CLAN:5,RA:4,CWIE:6,DC.GHO:2,CDS:4,CW:6,CBS:6,CGB.FRR:6,ROS:4,NIOPS:9,CJF:4,CGB:6</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:3-,NIOPS:0</availability>
 			</model>
@@ -4532,8 +4492,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crow Scout Helicopter' unitType='VTOL'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:3,IS:1,FR:2,MERC:3,DTA:2,MERC.WD:3,ROS:3,CNC:2,FWL:2,MSC:2,DA:2,RCM:2,DC:5</availability>
+			<availability>CC:2,MOC:2,MERC.KH:3,IS:1,FR:2,MERC:3,DTA:2,MERC.WD:3,ROS:3,CNC:2,FWL:2,MSC:2,DA:2,RCM:2,DC:5</availability>
 			<model name=''>
 				<roles>recon,spotter</roles>
 				<availability>MOC:5,MERC.KH:5,MERC.WD:5,IS:2+,FR:5,MERC:5,DC:8</availability>
@@ -4548,8 +4507,7 @@
 			</model>
 			<model name='(Export)'>
 				<roles>recon</roles>
-				<availability>
-					CC:6,MOC:6,MERC.KH:6,FR:6,MERC:6,DTA:6,MERC.WD:6,ROS:6,CNC:2,FWL:6,MSC:6,DA:6,RCM:6</availability>
+				<availability>CC:6,MOC:6,MERC.KH:6,FR:6,MERC:6,DTA:6,MERC.WD:6,ROS:6,CNC:2,FWL:6,MSC:6,DA:6,RCM:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Crucible Station' unitType='Space Station'>
@@ -4600,8 +4558,7 @@
 				<availability>CC:7</availability>
 			</model>
 			<model name='CRD-7W'>
-				<availability>
-					DTA:5,SC:5,MCM:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,DGM:5,MSC:5,MERC:3,RCM:5</availability>
+				<availability>DTA:5,SC:5,MCM:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,DGM:5,MSC:5,MERC:3,RCM:5</availability>
 			</model>
 			<model name='CRD-8L'>
 				<availability>CC:4</availability>
@@ -4611,8 +4568,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:1</availability>
 			</model>
@@ -4664,8 +4620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>
-				CC:2,MOC:2,CHH:2-,MERC.KH:3,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4,MERC.WD:3,ROS:6,NIOPS:6,CJF:2-</availability>
+			<availability>CC:2,MOC:2,CHH:2-,MERC.KH:3,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4,MERC.WD:3,ROS:6,NIOPS:6,CJF:2-</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:3-,ROS:5,TC:3</availability>
@@ -4767,8 +4722,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,CBS:4,ROS:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,CBS:4,ROS:3+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -4872,8 +4826,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CJF:3,CGB:6</availability>
+			<availability>CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CJF:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -4982,12 +4935,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,OA:9,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,OA:9,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>
-					CC:5,MOC:4,HL:1,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
+				<availability>CC:5,MOC:4,HL:1,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
@@ -5052,8 +5003,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,OA:1,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
+			<availability>MOC:1,CC:1,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,OA:1,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
 			<model name='DV-1S'>
 				<availability>IS:2-</availability>
 			</model>
@@ -5242,8 +5192,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:3-,Periphery:2-,FVC:4-,LA:6,ROS:3,FWL:2-,CC.MAC:3-,DC:2-</availability>
+			<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:3-,Periphery:2-,FVC:4-,LA:6,ROS:3,FWL:2-,CC.MAC:3-,DC:2-</availability>
 			<model name=''>
 				<availability>CC:2-,General:3-</availability>
 			</model>
@@ -5285,8 +5234,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 			<model name='EGL-R11'>
 				<availability>PR:6,LA:5,ROS:6,PG:6,MERC:5,FS:3,RFS:6</availability>
 			</model>
@@ -5431,8 +5379,7 @@
 		<chassis name='Emperor' unitType='Mek'>
 			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:2,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:2,DC:4</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
+				<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
 			<model name='EMP-6D'>
 				<availability>ROS:8,FS:8</availability>
@@ -5571,8 +5518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>
-				MOC:3,CC:5,IS:5,FS:2,Periphery:2,TC:3,RA.OA:2,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
+			<availability>MOC:3,CC:5,IS:5,FS:2,Periphery:2,TC:3,RA.OA:2,OA:2,LA:5,CGB.FRR:6,FWL:5,NIOPS:5,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -5803,8 +5749,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:3,HL:4,LA:4-,ROS:3-,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3-,FS:5-</availability>
+			<availability>Periphery.R:3,HL:4,LA:4-,ROS:3-,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3-,FS:5-</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:4</availability>
@@ -5983,8 +5928,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,Periphery.CM:2-,PIR:2-,Periphery.ME:2-,FWL:1-,FS:1-,DA:1-,Periphery:1-</availability>
+			<availability>CC:3,MOC:3,Periphery.CM:2-,PIR:2-,Periphery.ME:2-,FWL:1-,FS:1-,DA:1-,Periphery:1-</availability>
 			<model name='FRB-1E (WAM-B)'>
 				<availability>General:3-</availability>
 			</model>
@@ -6082,8 +6026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:2,DGM:5,DC.GHO:5,SC:5,CDS:1,LA:4,CBS:1,MCM:5,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:4,CJF:3,CGB:1,DC:4</availability>
+			<availability>CHH:1,CLAN:2,DGM:5,DC.GHO:5,SC:5,CDS:1,LA:4,CBS:1,MCM:5,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:4,CJF:3,CGB:1,DC:4</availability>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,SC:6,LA:8,MCM:6,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
 			</model>
@@ -6119,15 +6062,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
+			<availability>CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:7,PR:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
+				<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,OA:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:1</availability>
@@ -6333,16 +6274,14 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,OA:4,LA:4,CBS:2,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>vee_carrier,infantry_carrier</roles>
-				<availability>
-					CC:7,PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:7,PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Fwltur' unitType='Mek'>
@@ -6398,8 +6337,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -6470,8 +6408,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>
-				CC:2,MOC:1,DoO:3,IS:1,DO:3,DGM:3,MERC:2,FS:2,TC:1,DTA:2,SC:3,FVC:2,LA:3,MCM:3,PIR:1,FWL:2,MH:1,MSC:2,TP:3,DC:2</availability>
+			<availability>CC:2,MOC:1,DoO:3,IS:1,DO:3,DGM:3,MERC:2,FS:2,TC:1,DTA:2,SC:3,FVC:2,LA:3,MCM:3,PIR:1,FWL:2,MH:1,MSC:2,TP:3,DC:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -6643,16 +6580,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,HL:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:2,DTA:2,FVC:2,OA:3,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
+			<availability>CC:4,MOC:4,HL:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:2,DTA:2,FVC:2,OA:3,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:2-,LA:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 			</model>
 			<model name='GOL-2H'>
 				<roles>fire_support</roles>
-				<availability>
-					HL:1,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
+				<availability>HL:1,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 			</model>
 			<model name='GOL-3L'>
 				<roles>fire_support</roles>
@@ -6679,8 +6614,7 @@
 			</model>
 			<model name='GOL-6H'>
 				<roles>fire_support</roles>
-				<availability>
-					HL:1,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:5,Periphery:4</availability>
+				<availability>HL:1,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:5,Periphery:4</availability>
 			</model>
 			<model name='GOL-6M'>
 				<roles>fire_support</roles>
@@ -6734,8 +6668,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				DoO:7,CLAN:3,DO:7,DGM:7,MERC:3,DTA:7,SC:7,CDS:4,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:5,TP:7</availability>
+			<availability>DoO:7,CLAN:3,DO:7,DGM:7,MERC:3,DTA:7,SC:7,CDS:4,MCM:7,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:5,TP:7</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
 			</model>
@@ -6776,8 +6709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,PR:7,DoO:7,DO:7,DGM:7,FS:5,MERC:5,SC:7,DTA:7,FVC:5,MCM:7,ROS:6,Periphery.MW:4,PG:7,Periphery.ME:3,FWL:7,MH:4,MSC:5,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
+			<availability>CC:5,MOC:5,PR:7,DoO:7,DO:7,DGM:7,FS:5,MERC:5,SC:7,DTA:7,FVC:5,MCM:7,ROS:6,Periphery.MW:4,PG:7,Periphery.ME:3,FWL:7,MH:4,MSC:5,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:3,ROS:5,FWL:5,MERC:5,Periphery:5</availability>
 			</model>
@@ -6785,8 +6717,7 @@
 				<availability>DTA:5,CC:5,MOC:5,SC:6,MCM:6,ROS:6,DGM:6,MSC:6,MERC:4,FS:5,DC:5</availability>
 			</model>
 			<model name='T-IT-N13M'>
-				<availability>
-					PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:4,SC:4,MCM:4,ROS:2,PG:2,MSC:4,TP:4,DA:2,RCM:2,RFS:2</availability>
+				<availability>PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:4,SC:4,MCM:4,ROS:2,PG:2,MSC:4,TP:4,DA:2,RCM:2,RFS:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Grasshopper' unitType='Mek'>
@@ -6938,8 +6869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1A'>
 				<availability>LA:2-,MERC:2-,TC:3-</availability>
 			</model>
@@ -6953,12 +6883,10 @@
 				<availability>LA:2-,MERC:2-</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>
-					CC:3,MOC:2,DoO:4,CLAN:6,DO:4,DGM:4,FS:3,MERC:4,BAN:4,SC:4,MCM:4,MH:3,MSC:4,TP:4,RCM:4,DC:3</availability>
+				<availability>CC:3,MOC:2,DoO:4,CLAN:6,DO:4,DGM:4,FS:3,MERC:4,BAN:4,SC:4,MCM:4,MH:3,MSC:4,TP:4,RCM:4,DC:3</availability>
 			</model>
 			<model name='GRF-3M'>
-				<availability>
-					MOC:2,PR:6,DoO:5,IS:5,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:5,MCM:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
+				<availability>MOC:2,PR:6,DoO:5,IS:5,DO:5,DGM:5,FS:4,DTA:5,SC:5,LA:5,MCM:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
 			</model>
 			<model name='GRF-4N'>
 				<availability>TC:4</availability>
@@ -7027,12 +6955,10 @@
 			</model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:8,MOC:2,MERC.KH:2,CEI:2,IS:3-,FR:4,MERC:7,Periphery:5,DTA:4,MERC.WD:2,ROS:2-,MSC:4,DA:4,RCM:4</availability>
+			<availability>CC:8,MOC:2,MERC.KH:2,CEI:2,IS:3-,FR:4,MERC:7,Periphery:5,DTA:4,MERC.WD:2,ROS:2-,MSC:4,DA:4,RCM:4</availability>
 			<model name=''>
 				<roles>ground_support</roles>
-				<availability>
-					CC:8-,DTA:4,MERC.KH:2,MERC.WD:2-,CEI:2-,ROS:2-,IS:3-,MSC:4,DA:4,RCM:4,Periphery:5</availability>
+				<availability>CC:8-,DTA:4,MERC.KH:2,MERC.WD:2-,CEI:2-,ROS:2-,IS:3-,MSC:4,DA:4,RCM:4,Periphery:5</availability>
 			</model>
 			<model name='B'>
 				<availability>DTA:4,CC:6-,ROS:2-,IS:3-,MSC:4,DA:2,RCM:4,MERC:7-,Periphery:5</availability>
@@ -7054,8 +6980,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,CHH:2,CSR:2,DGM:5,FS:5,MERC:3,RA:1,Periphery:2,DC.GHO:3,SC:5,DTA:3,MCM:5,ROS:6,FWL:5,NIOPS:7,MSC:5,DA:3,RCM:3</availability>
+			<availability>CC:5,CHH:2,CSR:2,DGM:5,FS:5,MERC:3,RA:1,Periphery:2,DC.GHO:3,SC:5,DTA:3,MCM:5,ROS:6,FWL:5,NIOPS:7,MSC:5,DA:3,RCM:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>ROS:6,CGB.FRR:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8,DC:8</availability>
@@ -7257,8 +7182,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,SC:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:4-,Periphery.MW:4-,FWL:5,MH:4,MSC:4,RFS:5,MOC:4,CC:4,IS:3-,DGM:5,MERC:4,Periphery:2-,DTA:5,LA:3,MCM:5,PG:5,Periphery.ME:4-,TP:5,DA:5,RCM:5,DC:3-</availability>
+			<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,SC:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:4-,Periphery.MW:4-,FWL:5,MH:4,MSC:4,RFS:5,MOC:4,CC:4,IS:3-,DGM:5,MERC:4,Periphery:2-,DTA:5,LA:3,MCM:5,PG:5,Periphery.ME:4-,TP:5,DA:5,RCM:5,DC:3-</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -7267,8 +7191,7 @@
 				<availability>FWL:3</availability>
 			</model>
 			<model name='(MML)'>
-				<availability>
-					MOC:2,CC:2,PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:2,SC:4,LA:2,MCM:4,PG:2,MSC:4,TP:4,RCM:2,DA:2,RFS:2</availability>
+				<availability>MOC:2,CC:2,PR:2,DoO:4,DO:4,DGM:4,MERC:2,DTA:2,SC:4,LA:2,MCM:4,PG:2,MSC:4,TP:4,RCM:2,DA:2,RFS:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Harpy' unitType='ProtoMek'>
@@ -7336,8 +7259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:4,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:3,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:4,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:3,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:2-,LA:2-,TC.PL:3-,MERC:2-,Periphery:2-</availability>
@@ -7461,8 +7383,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				CC:2,MOC:5,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:5,Periphery:5,RA.OA:5,OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:5</availability>
+			<availability>CC:2,MOC:5,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:5,Periphery:5,RA.OA:5,OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7488,8 +7409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:1-,ROS:3-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,MERC.WD:1-,ROS:3-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7598,8 +7518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2-,CSR:2,HL:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:3,TC:2-,Periphery:3-,RA.OA:5,FVC:4,OA:5,LA:2-</availability>
+			<availability>MOC:2-,CSR:2,HL:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:3,TC:2-,Periphery:3-,RA.OA:5,FVC:4,OA:5,LA:2-</availability>
 			<model name='HCT-213'>
 				<availability>General:3</availability>
 			</model>
@@ -7740,8 +7659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
-			<availability>
-				MOC:2,CC:4,DoO:4,DO:4,DGM:4,MERC:3,FS:4,SC:4,LA:3,MCM:4,ROS:2,PIR:3,FWL:7,MH:4,MSC:3,TP:4,DC:2-</availability>
+			<availability>MOC:2,CC:4,DoO:4,DO:4,DGM:4,MERC:3,FS:4,SC:4,LA:3,MCM:4,ROS:2,PIR:3,FWL:7,MH:4,MSC:3,TP:4,DC:2-</availability>
 			<model name='HER-2S'>
 				<roles>recon</roles>
 				<availability>FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
@@ -7772,8 +7690,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>
-				DoO:8,DO:8,DGM:8,MERC:3,DC.GHO:6,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,MSC:6,TP:8,DC:6</availability>
+			<availability>DoO:8,DO:8,DGM:8,MERC:3,DC.GHO:6,SC:8,MCM:8,CGB.FRR:3,FWL:7,NIOPS:3,MSC:6,TP:8,DC:6</availability>
 			<model name='HER-1S'>
 				<roles>recon</roles>
 				<availability>DC.GHO:3-,CLAN:6,NIOPS:4,BAN:8</availability>
@@ -7800,8 +7717,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:1,Periphery:1,CWIE:3</availability>
+			<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:1,Periphery:1,CWIE:3</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -7849,8 +7765,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>MOC:2,CC:3,LA:6,CLAN:4,IS:2,FWL:2,NIOPS:9,MH:2,MERC:4,FS:5,CJF:5,DC:2</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
+				<availability>MOC:6,CC:4,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:4,NIOPS:3,MERC.SI:8,MH:6,DC:3</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:2,FWL:2,MH:4,FS:4,BAN:2</availability>
@@ -7938,8 +7853,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,FS.PMM:4,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
+			<availability>MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:3,FVC:8,OA:2,FS.PMM:4,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:2-</availability>
@@ -7992,8 +7906,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,OA:2,CW:1-:3080,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2,CGB:2-</availability>
+			<availability>MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,OA:2,CW:1-:3080,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2,CGB:2-</availability>
 			<model name='C'>
 				<availability>CW:3,CGB:5</availability>
 			</model>
@@ -8047,8 +7960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
+			<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:3-</availability>
@@ -8294,24 +8206,20 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>assault</roles>
-				<availability>
-					PR:8,DoO:8,IS:1,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+				<availability>PR:8,DoO:8,IS:1,DO:8,DGM:8,DTA:8,SC:8,MCM:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CEI:6,CLAN:8</availability>
@@ -8409,8 +8317,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:3-,DC.LV:4-,DC.GR:3-,FS.AH:3-,IS:3-,Periphery.Deep:5,FS:2-,Periphery:3-,TC:4-,RA.OA:3-,OA:2-,LA:3-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:3-</availability>
+			<availability>MOC:3-,DC.LV:4-,DC.GR:3-,FS.AH:3-,IS:3-,Periphery.Deep:5,FS:2-,Periphery:3-,TC:4-,RA.OA:3-,OA:2-,LA:3-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:3-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8478,8 +8385,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jackal' unitType='Mek'>
-			<availability>
-				MOC:5,DTA:6,SC:6,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,DGM:6,MSC:4,MERC:6</availability>
+			<availability>MOC:5,DTA:6,SC:6,MCM:6,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:6,MH:5,DGM:6,MSC:4,MERC:6</availability>
 			<model name='JA-KL-1532'>
 				<availability>HL:6,FWL:4,Periphery.Deep:6,MERC:4,Periphery:8</availability>
 			</model>
@@ -8522,8 +8428,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,OA:2,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
+			<availability>MOC:3,CC:3-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,OA:2,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:3,RA.OA:5,FVC:5,OA:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
@@ -8564,8 +8469,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,OA:1,LA:1,Periphery.HR:4,ROS:4</availability>
+			<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,OA:1,LA:1,Periphery.HR:4,ROS:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -8635,8 +8539,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:2-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:3,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
+			<availability>CC:2-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:3,Periphery:3,OA:3,CGB.FRR:8,FS.DMM:5,FWL:2-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:6,FS:6,DC:5</availability>
@@ -8963,8 +8866,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,FVC:2,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:2,CGB:3,DC:4</availability>
+			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,FVC:2,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:2,CGB:3,DC:4</availability>
 			<model name='KGC-000'>
 				<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
 			</model>
@@ -9342,14 +9244,12 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:6,DoO:6,DO:6,FS:2,SC:6,Periphery.MW:2,Periphery.CM:2,FWL:6,MH:2,MSC:4,RFS:6,CC:2,MOC:2,DGM:6,MERC:2,DTA:6,FVC:2,LA:2,MCM:6,ROS:2,PG:6,Periphery.ME:2,TP:6,DA:6,RCM:6</availability>
+			<availability>PR:6,DoO:6,DO:6,FS:2,SC:6,Periphery.MW:2,Periphery.CM:2,FWL:6,MH:2,MSC:4,RFS:6,CC:2,MOC:2,DGM:6,MERC:2,DTA:6,FVC:2,LA:2,MCM:6,ROS:2,PG:6,Periphery.ME:2,TP:6,DA:6,RCM:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
 			<model name='LX-2A'>
-				<availability>
-					PR:5,DoO:5,DO:5,DGM:5,MERC:5,DTA:5,SC:5,LA:5,MCM:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+				<availability>PR:5,DoO:5,DO:5,DGM:5,MERC:5,DTA:5,SC:5,LA:5,MCM:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 			</model>
 			<model name='LX-3'>
 				<availability>IS:4,MERC:0</availability>
@@ -9407,21 +9307,18 @@
 			</model>
 			<model name='(3054)'>
 				<roles>asf_carrier</roles>
-				<availability>
-					CC:8,PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:3-</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>mek_carrier</roles>
-				<availability>
-					PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+				<availability>PR:8,DoO:8,DO:8,DGM:8,FS:8,DTA:8,SC:8,LA:8,MCM:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9465,15 +9362,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:3,HL:3,Periphery.OS:5,TC:8,Periphery:4,RA.OA:5,FVC:3,OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
+			<availability>MOC:7,CC:3,HL:3,Periphery.OS:5,TC:8,Periphery:4,RA.OA:5,FVC:3,OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,MOC:4,CEI:3-,FR:4,BAN:2,Periphery:6-,DTA:7,FVC:7,LA:8-,ROS:5-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
+			<availability>CC:7-,MOC:4,CEI:3-,FR:4,BAN:2,Periphery:6-,DTA:7,FVC:7,LA:8-,ROS:5-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>DTA:5,FWL:5,MSC:5,DA:7,RCM:5</availability>
 			</model>
@@ -9520,8 +9415,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:4-</availability>
 			</model>
@@ -9670,8 +9564,7 @@
 			</model>
 			<model name='LCT-3M'>
 				<roles>recon</roles>
-				<availability>
-					MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+				<availability>MOC:3,PR:5,DoO:5,IS:3,DO:5,DGM:5,MERC:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 			</model>
 			<model name='LCT-3S'>
 				<roles>recon</roles>
@@ -9741,8 +9634,7 @@
 				<availability>General:4</availability>
 			</model>
 			<model name='M'>
-				<availability>
-					MERC.KH:2,MERC.WD:2,CHH:2,CW:1:3081,CEI:1,IS:1,CLAN.IS:3,MERC:1,CLAN.HW:3,CWIE:1:3081</availability>
+				<availability>MERC.KH:2,MERC.WD:2,CHH:2,CW:1:3081,CEI:1,IS:1,CLAN.IS:3,MERC:1,CLAN.HW:3,CWIE:1:3081</availability>
 			</model>
 			<model name='Prime'>
 				<availability>General:8,CJF:9,CGB:8</availability>
@@ -9770,8 +9662,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:2</availability>
+			<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:2</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -9795,8 +9686,7 @@
 			</model>
 			<model name='LGB-13C'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:5,MOC:3,DoO:6,DO:6,DGM:6,FS:5,MERC:5,SC:6,MCM:6,ROS:6,MSC:6,TP:6,DA:6,RCM:5,DC:5</availability>
+				<availability>CC:5,MOC:3,DoO:6,DO:6,DGM:6,FS:5,MERC:5,SC:6,MCM:6,ROS:6,MSC:6,TP:6,DA:6,RCM:5,DC:5</availability>
 			</model>
 			<model name='LGB-13NAIS'>
 				<availability>FS:4</availability>
@@ -9826,8 +9716,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longinus Battle Armor' unitType='BattleArmor'>
-			<availability>
-				PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:6,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MH:6,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
 			<model name='(Magnetic)(Sqd4)' mechanized='true'>
 				<availability>FWL:6</availability>
 			</model>
@@ -9854,8 +9743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,RA.OA:1,Periphery.R:4,FVC:2,OA:1,HL:4,LA:7,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
+			<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,OA:1,HL:4,LA:7,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:5-,Periphery:2-</availability>
 			</model>
@@ -9962,8 +9850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:2+,CLAN:3,MERC:1+,CCO:4,BAN:2,CWIE:7,CSA:4,MERC.WD:7,CDS:4,CW:6,CBS:3,ROS:1+,CJF:4</availability>
+			<availability>MERC.KH:2+,CLAN:3,MERC:1+,CCO:4,BAN:2,CWIE:7,CSA:4,MERC.WD:7,CDS:4,CW:6,CBS:3,ROS:1+,CJF:4</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -10000,8 +9887,7 @@
 				<availability>CHH:2,CW:2,CNC:2,CLAN:1,General:2,CJF:3,CWIE:2,CGB:2</availability>
 			</model>
 			<model name='TC'>
-				<availability>
-					MERC.WD:2,MERC.KH:2,CDS:2,CW:2,CNC:2,CLAN.IS:1,MERC:2,CLAN.HW:1,CJF:2,CWIE:2,RA:1</availability>
+				<availability>MERC.WD:2,MERC.KH:2,CDS:2,CW:2,CNC:2,CLAN.IS:1,MERC:2,CLAN.HW:1,CJF:2,CWIE:2,RA:1</availability>
 			</model>
 			<model name='U'>
 				<availability>General:2</availability>
@@ -10047,8 +9933,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:2,Periphery.MM:2,PR:8,DoO:8,DO:8,DGM:8,MERC:2,DTA:8,SC:8,LA:2,MCM:8,ROS:2,Periphery.CM:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>CC:2,MOC:2,Periphery.MM:2,PR:8,DoO:8,DO:8,DGM:8,MERC:2,DTA:8,SC:8,LA:2,MCM:8,ROS:2,Periphery.CM:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RCM:8,DA:8,RFS:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10154,8 +10039,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:4,RA.OA:6,OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
+			<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:4,RA.OA:6,OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
 			<model name=''>
 				<availability>HL:2,LA:1-,General:3-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 			</model>
@@ -10249,8 +10133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2,IS:2-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
+			<availability>CC:4,MOC:2,IS:2-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
 			<model name='MAD-2R'>
 				<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
 			</model>
@@ -10336,15 +10219,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				DoO:4,DO:4,FS:4,Periphery.R:3,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,TP:4,DA:4,RCM:4</availability>
+			<availability>DoO:4,DO:4,FS:4,Periphery.R:3,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,TP:4,DA:4,RCM:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:3,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:3,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,HL:2,PIR:4,MERC:4,TC:4,Periphery:2</availability>
 			</model>
@@ -10366,8 +10247,7 @@
 			</model>
 		</chassis>
 		<chassis name='Masakari (Warhawk)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:1,CEI:7,MERC:2+,RA:2,BAN:1,CSA:1,MERC.WD:3,CDS:3,CW:1+,CBS:4,CNC:1,CJF:3,CGB:3</availability>
+			<availability>CSR:1,CEI:7,MERC:2+,RA:2,BAN:1,CSA:1,MERC.WD:3,CDS:3,CW:1+,CBS:4,CNC:1,CJF:3,CGB:3</availability>
 			<model name='A'>
 				<availability>CDS:8,General:5,CGB:5</availability>
 			</model>
@@ -10474,8 +10354,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,OA:1,LA:3,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
+			<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,OA:1,LA:3,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:3-,Periphery.Deep:8,Periphery:3-</availability>
@@ -10656,8 +10535,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,BAN:4,Periphery:6,TC:6,RA.OA:5,OA:5,LA:6,CGB.FRR:4,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,BAN:4,Periphery:6,TC:6,RA.OA:5,OA:5,LA:6,CGB.FRR:4,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -10726,8 +10604,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:4,MERC.WD:4,HL:5,CEI:5,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,MERC:5,Periphery:6</availability>
+			<availability>MERC.KH:4,MERC.WD:4,HL:5,CEI:5,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,MERC:5,Periphery:6</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -11362,8 +11239,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,PR:5,LA:8,DoO:5,ROS:6,PG:5,DO:5,TP:5,FS:7,MERC:6,RFS:5</availability>
 			<model name='NGS-4S'>
-				<availability>
-					:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
+				<availability>:0,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -11621,8 +11497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:5,HL:1,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
+			<availability>MOC:7,CC:5,HL:1,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
 			<model name=''>
 				<availability>HL:3,General:3,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -11672,8 +11547,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
+			<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -11688,8 +11562,7 @@
 				<availability>MOC:4,FWL:6,IS:4,MH:4</availability>
 			</model>
 			<model name='ON1-MB'>
-				<availability>
-					CC:2,MOC:2,DoO:4,DO:4,DGM:4,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
+				<availability>CC:2,MOC:2,DoO:4,DO:4,DGM:4,MERC:2,SC:4,MCM:4,ROS:4,FWL:4,MSC:4,TP:4,DA:4,RCM:4,DC:2</availability>
 			</model>
 			<model name='ON1-MC'>
 				<availability>CGB.FRR:4,FS:2,MERC:2,DC:4</availability>
@@ -11757,8 +11630,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
+			<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
@@ -11802,8 +11674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:2,PR:4,DoO:4,DO:4,FS:2,MERC:3,FVC:2,LA:2,CGB.FRR:3,ROS:4,PG:4,NIOPS:3,FWL:2,TP:4,RFS:4,DC:5</availability>
+			<availability>CC:2,PR:4,DoO:4,DO:4,FS:2,MERC:3,FVC:2,LA:2,CGB.FRR:3,ROS:4,PG:4,NIOPS:3,FWL:2,TP:4,RFS:4,DC:5</availability>
 			<model name='OTT-11J'>
 				<roles>recon,spotter</roles>
 				<availability>LA:2,ROS:3,FS:1</availability>
@@ -11826,8 +11697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>
-				PR:5,DoO:5,DO:5,DGM:5,FS:5,MERC:3,Periphery:2,DTA:5,SC:5,MCM:5,ROS:4,PG:5,FWL:5,NIOPS:6,MSC:4,TP:5,RFS:5</availability>
+			<availability>PR:5,DoO:5,DO:5,DGM:5,FS:5,MERC:3,Periphery:2,DTA:5,SC:5,MCM:5,ROS:4,PG:5,FWL:5,NIOPS:6,MSC:4,TP:5,RFS:5</availability>
 			<model name='OTL-4D'>
 				<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 			</model>
@@ -11888,8 +11758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,OA:5,LA:6,CBS:7,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:3,BAN:1</availability>
@@ -11972,8 +11841,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,OA:3-,LA:5-,FS.PMM:4-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
+			<availability>MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,OA:3-,LA:5-,FS.PMM:4-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -11984,8 +11852,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
+				<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -12040,8 +11907,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:2,NIOPS:2,DC:8</availability>
+			<availability>Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:2,NIOPS:2,DC:8</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
@@ -12145,8 +12011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4-,CC:1-,HL:3-,IS:3-,Periphery.Deep:9,FS:4-,Periphery:4-,TC:4-,RA.OA:2-,OA:2-,CDS:1,LA:3-,FWL:3-,DC:1-</availability>
+			<availability>MOC:4-,CC:1-,HL:3-,IS:3-,Periphery.Deep:9,FS:4-,Periphery:4-,TC:4-,RA.OA:2-,OA:2-,CDS:1,LA:3-,FWL:3-,DC:1-</availability>
 			<model name=''>
 				<availability>General:5</availability>
 			</model>
@@ -12195,8 +12060,7 @@
 			</model>
 		</chassis>
 		<chassis name='Patron MilitiaMech' unitType='Mek'>
-			<availability>
-				PR:4-,DoO:4-,IS.pm:2,DO:4-,DGM:4-,RCM.pm:4,SC:4-,FWL.pm:4,DA.pm:4,MCM:4-,PG:4-,MSC.pm:4,TP:4-,DTA.pm:5,RFS:4-</availability>
+			<availability>PR:4-,DoO:4-,IS.pm:2,DO:4-,DGM:4-,RCM.pm:4,SC:4-,FWL.pm:4,DA.pm:4,MCM:4-,PG:4-,MSC.pm:4,TP:4-,DTA.pm:5,RFS:4-</availability>
 			<model name='PTN-2'>
 				<availability>PR:5,DoO:5,DO:5,DGM:5,DTA:5,SC:5,MCM:5,PG:5,FWL:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 			</model>
@@ -12385,8 +12249,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>
-				CC:2,CCC:5,CSR:3,CLAN:3,MERC:2,FS:2,CCO:5,RA:4,CSA:3,DTA:2,CDS:5,CBS:3,LA:2,ROS:3,MSC:2,DC:2</availability>
+			<availability>CC:2,CCC:5,CSR:3,CLAN:3,MERC:2,FS:2,CCO:5,RA:4,CSA:3,DTA:2,CDS:5,CBS:3,LA:2,ROS:3,MSC:2,DC:2</availability>
 			<model name=''>
 				<availability>CDS:3,CSR:2,CNC:3,IS:2,CCO:3,DC:3</availability>
 			</model>
@@ -12457,8 +12320,7 @@
 			</model>
 			<model name='PXH-3M'>
 				<roles>recon</roles>
-				<availability>
-					PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>PR:8,DoO:8,IS:4,DO:8,DGM:8,DTA:8,SC:8,MCM:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='PXH-3PL'>
 				<availability>ROS:4,FS:6,MERC:4</availability>
@@ -12493,8 +12355,7 @@
 			<availability>LA:1-,MERC:2-,TC:2-,Periphery:1-</availability>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:3,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:3-,OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
+			<availability>MOC:3,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:3-,OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
 			<model name=''>
 				<availability>HL:3,IS:3,Periphery:5</availability>
 			</model>
@@ -12820,8 +12681,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSR:4,CLAN:6,MERC:2+,CCO:6,RA:5,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:7,CW:8,CBS:6,ROS:2+,CNC:8,CJF:5,CGB:6</availability>
+			<availability>CSR:4,CLAN:6,MERC:2+,CCO:6,RA:5,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:7,CW:8,CBS:6,ROS:2+,CNC:8,CJF:5,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -12900,8 +12760,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,SC:6,OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:4,RFS:6,MOC:3,CC:4,IS:3,DGM:6,Periphery:4,TC:3,DTA:6,FVC:3,LA:3,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
+			<availability>PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,SC:6,OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:4,RFS:6,MOC:3,CC:4,IS:3,DGM:6,Periphery:4,TC:3,DTA:6,FVC:3,LA:3,MCM:6,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:3-,OA:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
 			</model>
@@ -13166,8 +13025,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:1,CW:1,General:8,CNC:1</availability>
 			</model>
@@ -13193,8 +13051,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
+			<availability>PR:7,DoO:8,DO:8,FS:2,SC:8,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:6,RFS:7,MOC:2,CC:3,DGM:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,MCM:8,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 			<model name='F-100'>
 				<availability>FVC:3-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:3-</availability>
 			</model>
@@ -13205,16 +13062,13 @@
 				<availability>CGB.FRR:1-,DC:2-</availability>
 			</model>
 			<model name='F-700'>
-				<availability>
-					CC:8,MOC:2,PR:8,DoO:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,MOC:2,PR:8,DoO:8,DO:8,DGM:8,MERC:8,DTA:8,SC:8,MCM:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='F-700a'>
-				<availability>
-					CC:7,MOC:2,PR:6,DoO:6,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+				<availability>CC:7,MOC:2,PR:6,DoO:6,DO:6,DGM:6,FS:5,MERC:7,DTA:6,SC:6,MCM:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 			</model>
 			<model name='F-700b'>
-				<availability>
-					MOC:2,CC:2,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,ROS:6,FWL:6,MSC:8,TP:8,DC:6</availability>
+				<availability>MOC:2,CC:2,DoO:8,DO:8,DGM:8,MERC:6,DTA:8,SC:8,MCM:8,ROS:6,FWL:6,MSC:8,TP:8,DC:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
@@ -13241,13 +13095,11 @@
 				<availability>ROS:4,CNC:6,DC:5</availability>
 			</model>
 			<model name='8'>
-				<availability>
-					CC:3,DoO:3,IS:2,DO:3,DGM:3,FS:3,MERC:3,SC:3,CDS:4,LA:3,MCM:3,MSC:3,TP:3,DC:3,CGB:6</availability>
+				<availability>CC:3,DoO:3,IS:2,DO:3,DGM:3,FS:3,MERC:3,SC:3,CDS:4,LA:3,MCM:3,MSC:3,TP:3,DC:3,CGB:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+			<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
 			<model name='C 2'>
 				<availability>CJF:4</availability>
 			</model>
@@ -13279,8 +13131,7 @@
 				<availability>ROS:4</availability>
 			</model>
 			<model name='RFL-7M'>
-				<availability>
-					MOC:3,PR:7,DoO:7,IS:2,DO:7,DGM:7,CDP:3,TC:3,DTA:7,SC:7,MCM:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
+				<availability>MOC:3,PR:7,DoO:7,IS:2,DO:7,DGM:7,CDP:3,TC:3,DTA:7,SC:7,MCM:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
 			</model>
 			<model name='RFL-7X'>
 				<roles>fire_support</roles>
@@ -13417,8 +13268,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:4,CLAN:4,MERC:3+,RA:4,BAN:6,CWIE:6,MERC.WD:6,CDS:6,CW:5,CBS:7,CJF:6,DC:3+</availability>
+			<availability>CHH:5,CSR:4,CLAN:4,MERC:3+,RA:4,BAN:6,CWIE:6,MERC.WD:6,CDS:6,CW:5,CBS:7,CJF:6,DC:3+</availability>
 			<model name='A'>
 				<availability>CDS:9,CW:6,General:6,CJF:5,CGB:3</availability>
 			</model>
@@ -13453,8 +13303,7 @@
 				<availability>CDS:5,CW:8,CNC:8,General:7,CJF:9,CGB:8</availability>
 			</model>
 			<model name='TC'>
-				<availability>
-					CHH:2,MERC.WD:1,CDS:2,CW:2,CEI:1:3080,CLAN.IS:2,MERC:2,CLAN.HW:2,CJF:2,CWIE:2,DC:2</availability>
+				<availability>CHH:2,MERC.WD:1,CDS:2,CW:2,CEI:1:3080,CLAN.IS:2,MERC:2,CLAN.HW:2,CJF:2,CWIE:2,DC:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Ryoken II' unitType='Mek'>
@@ -13522,8 +13371,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,OA:2-,LA:4,ROS:3,FWL:2-,DC:5</availability>
+			<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,OA:2-,LA:4,ROS:3,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:4-</availability>
 			</model>
@@ -13607,8 +13455,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:5,Periphery.DD:5,DC.AL:9,IS:5,MERC:5,Periphery.OS:5,FS:4,Periphery:4,RA.OA:4,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
+			<availability>CC:5,Periphery.DD:5,DC.AL:9,IS:5,MERC:5,Periphery.OS:5,FS:4,Periphery:4,RA.OA:4,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
 			<model name=''>
 				<availability>IS:5-,Periphery:5-</availability>
 			</model>
@@ -13671,8 +13518,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:3-,Periphery:4,TC:4,RA.OA:6,OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:7-</availability>
+			<availability>MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:3-,Periphery:4,TC:4,RA.OA:6,OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:7-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -13824,8 +13670,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:1,HL:3,IS:3,Periphery.Deep:5,MERC:3,FS:3,Periphery:4,TC:3,RA:3,RA.OA:4,OA:3,LA:3,CGB.FRR:2,CNC:3,FWL:2,DC:1</availability>
+			<availability>MOC:3,CC:1,HL:3,IS:3,Periphery.Deep:5,MERC:3,FS:3,Periphery:4,TC:3,RA:3,RA.OA:4,OA:3,LA:3,CGB.FRR:2,CNC:3,FWL:2,DC:1</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -13843,8 +13688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
+			<availability>MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -13860,8 +13704,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
+			<availability>CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -13886,8 +13729,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,HL:2,Periphery.Deep:4-,MERC:2,Periphery:3-,FVC:1,LA:4,CGB.FRR:2-,ROS:1,FWL:2,NIOPS:2-,RCM:2-,DC:3</availability>
+			<availability>CC:2,HL:2,Periphery.Deep:4-,MERC:2,Periphery:3-,FVC:1,LA:4,CGB.FRR:2-,ROS:1,FWL:2,NIOPS:2-,RCM:2-,DC:3</availability>
 			<model name='SCP-10M'>
 				<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
 			</model>
@@ -14006,8 +13848,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:2,FS:5,MERC:4,CWIE:2,DC.GHO:3,FVC:5,CDS:2,CW:2,LA:5,CBS:2,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
+			<availability>CLAN:2,FS:5,MERC:4,CWIE:2,DC.GHO:3,FVC:5,CDS:2,CW:2,LA:5,CBS:2,ROS:4,NIOPS:4,CJF:3,CGB:3,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -14028,8 +13869,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
+			<availability>MOC:4,CC:3,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,OA:7,LA:7,CGB.FRR:2,ROS:6,FWL:2-,MH:2,DC:2-</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
@@ -14126,8 +13966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,SC:3,OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:2,RFS:3,CGB:5,IS:2,DGM:3,MERC:4,RA:5,DTA:3,CW:4,LA:3,MCM:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
+			<availability>PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,SC:3,OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:2,RFS:3,CGB:5,IS:2,DGM:3,MERC:4,RA:5,DTA:3,CW:4,LA:3,MCM:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
 			<model name='10'>
 				<availability>CHH:6-,CW:5-</availability>
 			</model>
@@ -14190,8 +14029,7 @@
 				<availability>MERC:4</availability>
 			</model>
 			<model name='SHD-7M'>
-				<availability>
-					CC:4,MOC:3,DoO:6,DO:6,DGM:6,MERC:4,CDP:3,TC:3,DTA:6,SC:6,FVC:3,MCM:6,ROS:4,MSC:6,TP:6,RCM:6</availability>
+				<availability>CC:4,MOC:3,DoO:6,DO:6,DGM:6,MERC:4,CDP:3,TC:3,DTA:6,SC:6,FVC:3,MCM:6,ROS:4,MSC:6,TP:6,RCM:6</availability>
 			</model>
 			<model name='SHD-8L'>
 				<availability>CC:6</availability>
@@ -14213,8 +14051,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>
+			<availability>RA.OA:4,Periphery.DD:4,FVC:2,OA:4,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:3,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -14232,8 +14069,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shiva' unitType='AeroSpaceFighter' omni='IS'>
-			<availability>
-				PR:4,DoO:6,DO:6,DGM:6,DTA:4,SC:6,MCM:6,ROS:3,PG:4,FWL:5,MSC:4,TP:6,RCM:4,DA:4,RFS:4</availability>
+			<availability>PR:4,DoO:6,DO:6,DGM:6,DTA:4,SC:6,MCM:6,ROS:3,PG:4,FWL:5,MSC:4,TP:6,RCM:4,DA:4,RFS:4</availability>
 			<model name='SHV-O'>
 				<availability>General:8</availability>
 			</model>
@@ -14273,8 +14109,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:3,Periphery.DD:3,FVC:1,OA:3,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
+			<availability>RA.OA:3,Periphery.DD:3,FVC:1,OA:3,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
 			<model name='SL-21'>
 				<availability>FVC:4,HL:3,Periphery.Deep:7,MERC:4,DC:4,Periphery:5</availability>
 			</model>
@@ -14368,8 +14203,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:4-</availability>
@@ -14388,8 +14222,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
+			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,OA:5,CGB.FRR:7,ROS:4,DC:7,CGB:4</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 			</model>
@@ -14500,8 +14333,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+			<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,OA:2,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:3,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 			</model>
@@ -14556,8 +14388,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,MERC:3,FS:3,Periphery:2,TC:2,FVC:3,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
+			<availability>MOC:2,CC:3,MERC:3,FS:3,Periphery:2,TC:2,FVC:3,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,DC:6</availability>
 			<model name='SDR-5K'>
 				<roles>anti_infantry</roles>
 				<availability>CGB.FRR:2-,DC:2-</availability>
@@ -14659,14 +14490,12 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
+			<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
 			<model name='STK-3F'>
 				<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>
-					CC:3,MOC:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
+				<availability>CC:3,MOC:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 			</model>
 			<model name='STK-3H'>
 				<availability>MOC:2-,OA:2-,IS:2-,TC:2-,Periphery:2-</availability>
@@ -14808,16 +14637,14 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
+			<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>
-					CC:3,DoO:6,CLAN:8,DGM:6,DO:6,MERC:2,BAN:2,SC:6,MCM:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6</availability>
+				<availability>CC:3,DoO:6,CLAN:8,DGM:6,DO:6,MERC:2,BAN:2,SC:6,MCM:6,FWL:5,MSC:6,TP:6,RCM:6,DA:6</availability>
 			</model>
 			<model name='STG-3P'>
 				<roles>recon</roles>
@@ -14861,8 +14688,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:5,DoO:6,DO:6,FS:1,RA.OA:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:4,RFS:5,MOC:3,CC:5,IS:3,DGM:6,MERC:5,TC:2,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+			<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,SC:6,OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:4,RFS:5,MOC:3,CC:5,IS:3,DGM:6,MERC:5,TC:2,DTA:6,LA:5,MCM:6,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:3-,Periphery:3-</availability>
 			</model>
@@ -14873,8 +14699,7 @@
 				<availability>MOC:2,Periphery.MW:2,Periphery.ME:2,IS:4,MH:2</availability>
 			</model>
 			<model name='F-95'>
-				<availability>
-					CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
+				<availability>CC:3,PR:6,DoO:6,DO:6,DGM:6,MERC:3,DTA:6,SC:6,LA:3,MCM:6,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
@@ -14947,8 +14772,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>
-				CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2</availability>
+			<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -14991,8 +14815,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,OA:2,LA:3,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
+			<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,OA:2,LA:3,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
 			</model>
@@ -15223,8 +15046,7 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>
-				PR:3,DoO:4,CLAN:4,DO:4,FS:4,MERC:4,LA:4,CGB.FRR:3,ROS:3,PG:3,TP:4,DA:2,RFS:3,DC:2</availability>
+			<availability>PR:3,DoO:4,CLAN:4,DO:4,FS:4,MERC:4,LA:4,CGB.FRR:3,ROS:3,PG:3,TP:4,DA:2,RFS:3,DC:2</availability>
 			<model name='TLN-5W'>
 				<availability>LA:8,CLAN:8</availability>
 			</model>
@@ -15308,8 +15130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tempest' unitType='Mek'>
-			<availability>
-				PR:8,DoO:8,DO:8,DGM:8,MERC:4,DTA:8,SC:8,MCM:8,ROS:5,Periphery.MW:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RFS:8</availability>
+			<availability>PR:8,DoO:8,DO:8,DGM:8,MERC:4,DTA:8,SC:8,MCM:8,ROS:5,Periphery.MW:2,PG:8,Periphery.ME:2,FWL:8,MH:2,MSC:6,TP:8,RFS:8</availability>
 			<model name='TMP-3G'>
 				<availability>ROS:2,FWL:2,MERC:2</availability>
 			</model>
@@ -15408,8 +15229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CSR:2,CLAN:3,CCO:3,RA:1,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:3,CW:3,ROS:1+,CNC:3,CJF:5,CGB:3</availability>
+			<availability>CHH:5,CSR:2,CLAN:3,CCO:3,RA:1,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:3,CW:3,ROS:1+,CNC:3,CJF:5,CGB:3</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -15483,8 +15303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,OA:3,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:3-,FVC:3-,HL:2-,FWL:3-,Periphery.Deep:8,MERC:3-,Periphery:4-</availability>
@@ -15497,14 +15316,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:3,PR:5,CLAN:4,FS:2,CWIE:5,DC.GHO:4,SC:5,RA.OA:4,OA:4,CDS:3,CBS:3,Periphery.MW:1,FWL:5,NIOPS:8,MH:3,MSC:4,RFS:5,CGB:5,MOC:3,IS:4,DGM:5,CW:5,MCM:5,ROS:5,PG:5,PIR:1,CNC:3,Periphery.ME:1,DA:5,CJF:5</availability>
+			<availability>CHH:3,PR:5,CLAN:4,FS:2,CWIE:5,DC.GHO:4,SC:5,RA.OA:4,OA:4,CDS:3,CBS:3,Periphery.MW:1,FWL:5,NIOPS:8,MH:3,MSC:4,RFS:5,CGB:5,MOC:3,IS:4,DGM:5,CW:5,MCM:5,ROS:5,PG:5,PIR:1,CNC:3,Periphery.ME:1,DA:5,CJF:5</availability>
 			<model name='THG-10E'>
 				<availability>MOC:3-,PIR:3-,FWL:3-,MH:3-,MSC:3-,MERC:3-,DA:3-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,OA:8,CGB.FRR:6,ROS:8,PG:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,NIOPS:4,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,OA:8,CGB.FRR:6,ROS:8,PG:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,NIOPS:4,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>SC:6,MCM:6,ROS:6,CLAN:4,FWL:6,DGM:6,MSC:6,MERC:6,BAN:2</availability>
@@ -15586,8 +15403,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:3-</availability>
@@ -15608,8 +15424,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:5,MERC.KH:4,HL:2,CEI:1+,IS:4,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,FVC:4,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
+			<availability>CC:5,MERC.KH:4,HL:2,CEI:1+,IS:4,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,FVC:4,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:5</availability>
 			<model name='C'>
 				<availability>CSA:1-,CCC:1-,LA:2,CEI:1+,FS:2,DC:1</availability>
 			</model>
@@ -15659,8 +15474,7 @@
 				<availability>CC:8,MOC:6,DTA:3,FWL.pm:3,PIR:2,FWL:6,MH:2,MSC:3,DA:3,MERC:4</availability>
 			</model>
 			<model name='TDR-9M'>
-				<availability>
-					MOC:3,CC:3,DoO:5,DO:5,DGM:5,MERC:2,DTA:5,SC:5,MCM:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
+				<availability>MOC:3,CC:3,DoO:5,DO:5,DGM:5,MERC:2,DTA:5,SC:5,MCM:5,PIR:3,FWL:3,MH:3,MSC:5,TP:5,DA:5</availability>
 			</model>
 			<model name='TDR-9NAIS'>
 				<availability>FS:2</availability>
@@ -15906,8 +15720,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,OA:2,LA:2,CGB.FRR:4,ROS:4,Periphery.MW:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+			<availability>CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,OA:2,LA:2,CGB.FRR:4,ROS:4,Periphery.MW:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>SC:4,PR:4,MCM:4,ROS:5,PG:4,NIOPS:5,DGM:4,MSC:4,MERC:4,RFS:4</availability>
@@ -16340,8 +16153,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -16532,8 +16344,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
+				<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:3</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:2</availability>
@@ -16543,8 +16354,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>
-				MOC:2,CC:4,IS:1,FS:4,Periphery:1,TC:1,RA.OA:1,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
+			<availability>MOC:2,CC:4,IS:1,FS:4,Periphery:1,TC:1,RA.OA:1,OA:1,LA:4,CGB.FRR:4,FWL:4,NIOPS:5,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:3</availability>
@@ -16588,8 +16398,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:3,CC:6,HL:3,IS:3-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
+			<availability>MOC:3,CC:6,HL:3,IS:3-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -16840,8 +16649,7 @@
 				<availability>CNC:7,General:8,CJF:7,CGB:8</availability>
 			</model>
 			<model name='S'>
-				<availability>
-					MERC.WD:1,CHH:2:3081,CDS:2:3081,CEI:2:3080,ROS:1:3081,CLAN.IS:4,MERC:1:3081,CLAN.HW:4,CJF:2:3081,DC:2,CWIE:1:3081</availability>
+				<availability>MERC.WD:1,CHH:2:3081,CDS:2:3081,CEI:2:3080,ROS:1:3081,CLAN.IS:4,MERC:1:3081,CLAN.HW:4,CJF:2:3081,DC:2,CWIE:1:3081</availability>
 			</model>
 			<model name='U'>
 				<availability>General:2</availability>
@@ -16866,8 +16674,7 @@
 				<availability>CC:3,CDS:5,LA:3,ROS:3,FWL:3,DC:3</availability>
 			</model>
 			<model name='4'>
-				<availability>
-					CC:3,CHH:3,CSR:1,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
+				<availability>CC:3,CHH:3,CSR:1,FS:3,CCO:5,RA:4,CWIE:5,CSA:5,CDS:6,LA:3,ROS:3,CNC:5,CGB:5,DC:3</availability>
 			</model>
 			<model name='5'>
 				<availability>CDS:5,IS:4</availability>
@@ -16972,8 +16779,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:3,RA:4,RA.OA:6,OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:3,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:3,RA:4,RA.OA:6,OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:3,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -16988,8 +16794,7 @@
 				<availability>IS:1-,Periphery:1-</availability>
 			</model>
 			<model name='H-8'>
-				<availability>
-					HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:2,Periphery.Deep:4,FWL:2,FS:6,MERC:6,Periphery:6,RA:8</availability>
+				<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:2,Periphery.Deep:4,FWL:2,FS:6,MERC:6,Periphery:6,RA:8</availability>
 			</model>
 			<model name='H-9'>
 				<availability>LA:5</availability>
@@ -17098,8 +16903,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,Periphery.DD:1,MERC:2,Periphery.OS:1,Periphery:2,TC:1,RA.OA:1,FVC:2,OA:1,FS.CMM:2,NIOPS:1-,MH:1,DC:2</availability>
+			<availability>MOC:1,Periphery.DD:1,MERC:2,Periphery.OS:1,Periphery:2,TC:1,RA.OA:1,FVC:2,OA:1,FS.CMM:2,NIOPS:1-,MH:1,DC:2</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>Periphery.Deep:8,MERC:1,Periphery:1</availability>
@@ -17170,8 +16974,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolfhound' unitType='Mek'>
-			<availability>
-				MOC:4,MERC.KH:7,DoO:3,DO:3,DGM:3,FS:2,MERC:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:2,LA:7,MCM:3,CGB.FRR:5,ROS:5,MH:4,MSC:2,TP:3</availability>
+			<availability>MOC:4,MERC.KH:7,DoO:3,DO:3,DGM:3,FS:2,MERC:4,CWIE:5,DTA:3,SC:3,MERC.WD:5,FVC:2,LA:7,MCM:3,CGB.FRR:5,ROS:5,MH:4,MSC:2,TP:3</availability>
 			<model name='WLF-1'>
 				<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
 			</model>
@@ -17199,8 +17002,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
+			<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
 			<model name='WVR-1R'>
 				<availability>CC:2-,FWL:2-,FS:2-,MERC:2,RCM:2,DC:2-</availability>
 			</model>
@@ -17225,8 +17027,7 @@
 				<availability>CC:4,MOC:4,FWL:5,MH:2,MERC:6,DC:4</availability>
 			</model>
 			<model name='WVR-7M2'>
-				<availability>
-					CC:6,MOC:3,MERC.KH:4,DO:6,MERC:6,DTA:5,MERC.WD:2,FWL:6,MH:3,MSC:4,DA:6,RCM:2,DC:4</availability>
+				<availability>CC:6,MOC:3,MERC.KH:4,DO:6,MERC:6,DTA:5,MERC.WD:2,FWL:6,MH:3,MSC:4,DA:6,RCM:2,DC:4</availability>
 			</model>
 			<model name='WVR-8C'>
 				<availability>ROS:4,MERC:3,DC:6</availability>
@@ -17286,8 +17087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:2,PR:2,DoO:2,IS:2,DO:2,DGM:2,FS:7,MERC:5,DC.GHO:4,SC:2,DTA:2,FVC:2,MCM:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
+			<availability>CC:2,PR:2,DoO:2,IS:2,DO:2,DGM:2,FS:7,MERC:5,DC.GHO:4,SC:2,DTA:2,FVC:2,MCM:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -750,8 +750,7 @@
 			<pctSL>70</pctSL>
 			<omniMargin>3</omniMargin>
 			<techMargin>3</techMargin>
-			<salvage pct='6'>
-				MOC:2,CC:8,RT:0,FS:8,Periphery:0,TC:2,DTA:3,CDS:1,CW:5,LA:8,RIM:1,ROS:6,CNC:3,FWL:10,CJF:5,CGB:5,DC:8</salvage>
+			<salvage pct='6'>MOC:2,CC:8,RT:0,FS:8,Periphery:0,TC:2,DTA:3,CDS:1,CW:5,LA:8,RIM:1,ROS:6,CNC:3,FWL:10,CJF:5,CGB:5,DC:8</salvage>
 		</faction>
 		<faction key='CGB.FRR'>
 			<pctOmni>16</pctOmni>
@@ -1121,8 +1120,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>
-				MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:2,General:4,Periphery.Deep:6,Periphery:3</availability>
@@ -1151,16 +1149,14 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>
-				MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:3</availability>
 			</model>
 			<model name='(3055)'>
 				<roles>assault</roles>
-				<availability>
-					CC:8,OP:8,PR:8,DoO:8,IS:5,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8,DC:3</availability>
+				<availability>CC:8,OP:8,PR:8,DoO:8,IS:5,DO:8,DTA:8,RF:8,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8,DC:3</availability>
 			</model>
 			<model name='(3088)'>
 				<availability>DC:3</availability>
@@ -1510,8 +1506,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>
-				CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:1-,Periphery:4,DC:5,CGB:2</availability>
+			<availability>CC:4,HL:3,LA:6,CGB.FRR:4,IS:2-,Periphery.Deep:5,FWL:6,NIOPS:4-,FS:1-,Periphery:4,DC:5,CGB:2</availability>
 			<model name='(Wolf)'>
 				<availability>MERC.KH:6,MERC.WD:6</availability>
 			</model>
@@ -1798,8 +1793,7 @@
 			<availability>MOC:2-,CC:2-,FVC:1,LA:1,FS.CMM:1-,MERC:1-,RCM:2-,DA:2-,CDP:2-,TC:2-,Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:3,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
+				<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:3,FVC:4,Periphery.HR:4,PIR:3,MH:4,RCM:4,DA:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1870,8 +1864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:2,TC:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
+			<availability>MOC:2,CC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:2,TC:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
 			<model name='AS7-C'>
 				<availability>CGB.FRR:2,MERC:2,DC:2</availability>
 			</model>
@@ -2059,8 +2052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>
-				MOC:7,CC:6,HL:7,CLAN:1-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:1-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,DC:5</availability>
 			</model>
@@ -2362,8 +2354,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,FVC:3-,RF:3-,LA:4-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:2-,RFS:3-</availability>
+			<availability>MOC:6-,PR:3-,HL:7-,Periphery.Deep:8-,MERC:3-,Periphery:8-,TC:6-,RA.OA:6-,FVC:3-,RF:3-,LA:4-,CGB.FRR:2-,PG:3-,FWL:2-,MH:6-,MSC:2-,RFS:3-</availability>
 			<model name='BNC-3E'>
 				<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 			</model>
@@ -2514,8 +2505,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2545,8 +2535,7 @@
 				<availability>LA:1-</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
+				<availability>CC:5,FVC:4,Periphery.MW:3,Periphery.CM:3,Periphery.HR:3,ROS:5,PIR:5,Periphery.ME:3,FWL:4,MH:5,MERC:5,Periphery:2</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -2665,8 +2654,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:2,HL:3,IS:2,MERC:2,FS:3,Periphery:4,RA.OA:3,CDS:5,LA:2,CGB.FRR:3,PIR:2,CNC:5,FWL:2,DC:5</availability>
+			<availability>CC:2,HL:3,IS:2,MERC:2,FS:3,Periphery:4,RA.OA:3,CDS:5,LA:2,CGB.FRR:3,PIR:2,CNC:5,FWL:2,DC:5</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,DC:2</availability>
 			</model>
@@ -2830,14 +2818,12 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:4,CGB.FRR:4,FWL:5,NIOPS:7,MSC:6,RFS:6,CGB:6,MOC:2,CC:2,OP:6,IS:4,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,RF:6,LA:5,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
+			<availability>CHH:4,PR:6,DoO:6,CLAN:5,DO:6,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:4,CGB.FRR:4,FWL:5,NIOPS:7,MSC:6,RFS:6,CGB:6,MOC:2,CC:2,OP:6,IS:4,MERC:4,RA:4,Periphery:2,TC:4,DTA:6,FVC:4,CW:6,RF:6,LA:5,ROS:6,PG:6,CNC:6,TP:6,RCM:6,DA:6,CJF:4,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:6,FS:6</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,PG:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>OP:6,DoO:6,CLAN:5,DO:6,MERC:5,FS:5,BAN:2,DTA:6,LA:5,ROS:6,FWL:6,TP:6,DA:6,DC:5</availability>
@@ -3014,8 +3000,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bloodhound' unitType='Mek'>
-			<availability>
-				OP:6,PR:1,DoO:6,DO:6,MERC:4,DTA:6,RF:1,ROS:4,PG:1,FWL:6,MH:4,MSC:6,TP:6,DA:6,RCM:1,RFS:1</availability>
+			<availability>OP:6,PR:1,DoO:6,DO:6,MERC:4,DTA:6,RF:1,ROS:4,PG:1,FWL:6,MH:4,MSC:6,TP:6,DA:6,RCM:1,RFS:1</availability>
 			<model name='B1-HND'>
 				<availability>:0,General:8</availability>
 			</model>
@@ -3082,8 +3067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,OP:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MOC:3,OP:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3153,8 +3137,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3185,8 +3168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>
-				MOC:1-,CC:2-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
+			<availability>MOC:1-,CC:2-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
 			<model name=''>
 				<availability>LA:2-,General:8,FS:2-,MERC:2-,DC:2-</availability>
 			</model>
@@ -3382,8 +3364,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
+			<availability>CC:5,MOC:4,FVC:4,Periphery.CM:3,Periphery.HR:2,Periphery.ME:2,MH:2,FS:4,MERC:4,CDP:4,TC:4</availability>
 			<model name='CTF-1X'>
 				<availability>General:2-,Periphery:3-</availability>
 			</model>
@@ -3410,8 +3391,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,OP:3,DoO:3,DO:3,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:3,DA:4,RCM:3,DC:6</availability>
+			<availability>MOC:3,CC:4,OP:3,DoO:3,DO:3,MERC:2,Periphery:2,TC:3,CGB.FRR:5,FWL:2,NIOPS:4,MH:4,TP:3,DA:4,RCM:3,DC:6</availability>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
 				<availability>CC:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:2-</availability>
@@ -3599,8 +3579,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,OP:2,DoO:2,DO:2,Periphery.OS:4,FS:8,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:2,TP:2</availability>
+			<availability>CC:2,OP:2,DoO:2,DO:2,Periphery.OS:4,FS:8,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:3,FWL:2,NIOPS:2-,MH:5,MSC:2,TP:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:4,IS:4,FS:4,Periphery:3</availability>
 			</model>
@@ -3735,8 +3714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,CGB.FRR:4,FWL:2,NIOPS:5,MSC:2,RFS:2,CGB:4,CC:3,OP:2,IS:2,MERC:1,DTA:2,FVC:2,RF:2,LA:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:2</availability>
+			<availability>CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,CGB.FRR:4,FWL:2,NIOPS:5,MSC:2,RFS:2,CGB:4,CC:3,OP:2,IS:2,MERC:1,DTA:2,FVC:2,RF:2,LA:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:2</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -3775,8 +3753,7 @@
 			</model>
 		</chassis>
 		<chassis name='Charger' unitType='Mek'>
-			<availability>
-				CC:2-,MOC:2-,RA.OA:2-,FVC:2,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-,CGB:1-</availability>
+			<availability>CC:2-,MOC:2-,RA.OA:2-,FVC:2,LA:2-,CGB.FRR:4-,ROS:2-,MERC:1-,TC:2-,Periphery:2,DC:4-,CGB:1-</availability>
 			<model name='CGR-1A5'>
 				<availability>CC:2,MOC:2,FVC:2,MERC:2,Periphery:2</availability>
 			</model>
@@ -3817,16 +3794,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:8,HL:2,DoO:10,DO:10,FS:3,RA.OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:10,RFS:8,MOC:5,CC:2,OP:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,RF:8,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
+			<availability>PR:8,HL:2,DoO:10,DO:10,FS:3,RA.OA:4,CGB.FRR:3,Periphery.MW:4,FWL:10,NIOPS:3,MSC:10,RFS:8,MOC:5,CC:2,OP:10,MERC:3,Periphery:3,TC:5,DTA:9,FVC:3,RF:8,PG:8,ROS:5,Periphery.ME:4,TP:10,DA:8,RCM:10</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
-				<availability>
-					CC:2-,OP:2-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,MERC:2-,Periphery:2-,DTA:2-,RF:2-,PG:2-,FWL:2-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
+				<availability>CC:2-,OP:2-,PR:2-,DoO:2-,Periphery.Deep:8,DO:2-,MERC:2-,Periphery:2-,DTA:2-,RF:2-,PG:2-,FWL:2-,MSC:2-,TP:2-,DA:2-,RCM:2-,RFS:2-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:3,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:6,DTA:8,RF:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:2,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:3,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:6,DTA:8,RF:8,CGB.FRR:6,ROS:8,Periphery.MW:3,PG:8,PIR:3,Periphery.ME:2,FWL:8,MH:2,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -3834,8 +3808,7 @@
 			</model>
 			<model name='F-11-RR'>
 				<roles>recon</roles>
-				<availability>
-					CC:2,OP:2,PR:2,DoO:2,DO:2,MERC:2,Periphery:2,DTA:2,FVC:2,RF:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
+				<availability>CC:2,OP:2,PR:2,DoO:2,DO:2,MERC:2,Periphery:2,DTA:2,FVC:2,RF:2,PG:2,FWL:2,MSC:2,TP:2,DA:2,RCM:2,RFS:2</availability>
 			</model>
 			<model name='F-12-S'>
 				<availability>FWL:1-</availability>
@@ -3844,8 +3817,7 @@
 				<availability>DTA:4,CC:3,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,FS:3,MERC:4</availability>
 			</model>
 			<model name='F-14-S'>
-				<availability>
-					OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,PG:8,FWL:8,MH:4,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,PG:8,FWL:8,MH:4,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='OF-17A-R'>
 				<roles>recon</roles>
@@ -3878,8 +3850,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chimera' unitType='Mek'>
-			<availability>
-				OP:4,PR:4,DoO:4,DO:4,FS:1,MERC:5,DTA:4,FVC:4,RF:4,LA:6,ROS:4,PG:4,FWL:4,MH:4,TP:4,DA:4,RFS:4,DC:5</availability>
+			<availability>OP:4,PR:4,DoO:4,DO:4,FS:1,MERC:5,DTA:4,FVC:4,RF:4,LA:6,ROS:4,PG:4,FWL:4,MH:4,TP:4,DA:4,RFS:4,DC:5</availability>
 			<model name='CMA-1S'>
 				<availability>General:8,FWL:0</availability>
 			</model>
@@ -3888,8 +3859,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
+			<availability>MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:3,CDP:3,TC:3</availability>
 			</model>
@@ -4161,8 +4131,7 @@
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,PR:3,HL:2,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,RF:3,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
+			<availability>CC:3,MOC:2,PR:3,HL:2,FS:3,MERC:2,CDP:2,TC:2,Periphery:3,FVC:2,RF:3,LA:3,PG:3,ROS:3,NIOPS:1-,MH:2,DA:3,RCM:2,RFS:3</availability>
 			<model name='CLNT-2-3T'>
 				<availability>Periphery.Deep:8,NIOPS:8</availability>
 			</model>
@@ -4231,8 +4200,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,HL:4,MERC:5,FS:2,TC:6,Periphery:3,Periphery.R:4,FVC:4,LA:9,CGB.FRR:4,Periphery.CM:5,Periphery.HR:5,ROS:4,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:2-,LA:2-,Periphery:2-</availability>
@@ -4268,8 +4236,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:3,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:3,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
 			<model name=''>
 				<availability>CC:3-,FVC:3-,General:2-,FS:3-,Periphery:3-</availability>
 			</model>
@@ -4540,8 +4507,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
+			<availability>CHH:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4617,8 +4583,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>
-				OP:1,PR:1,HL:3,DoO:1,DO:1,MERC:4,Periphery:4,DTA:1,RF:1,Periphery.MW:4,ROS:3,PG:1,Periphery.ME:4,FWL:4,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
+			<availability>OP:1,PR:1,HL:3,DoO:1,DO:1,MERC:4,Periphery:4,DTA:1,RF:1,Periphery.MW:4,ROS:3,PG:1,Periphery.ME:4,FWL:4,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -4660,8 +4625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crow Scout Helicopter' unitType='VTOL'>
-			<availability>
-				CC:3,MOC:3,OP:3,MERC.KH:3,IS:2,FR:2,MERC:3,DTA:3,MERC.WD:3,RF:3,ROS:4,CNC:3,FWL:3,MSC:3,DA:3,RCM:3,DC:5</availability>
+			<availability>CC:3,MOC:3,OP:3,MERC.KH:3,IS:2,FR:2,MERC:3,DTA:3,MERC.WD:3,RF:3,ROS:4,CNC:3,FWL:3,MSC:3,DA:3,RCM:3,DC:5</availability>
 			<model name=''>
 				<roles>recon,spotter</roles>
 				<availability>MOC:5,MERC.KH:5,MERC.WD:5,IS:4,FR:5,MERC:5,DC:8</availability>
@@ -4676,8 +4640,7 @@
 			</model>
 			<model name='(Export)'>
 				<roles>recon</roles>
-				<availability>
-					CC:6,MOC:6,OP:6,MERC.KH:6,FR:6,MERC:6,DTA:6,MERC.WD:6,RF:6,ROS:6,CNC:3,FWL:6,MSC:6,DA:6,RCM:6</availability>
+				<availability>CC:6,MOC:6,OP:6,MERC.KH:6,FR:6,MERC:6,DTA:6,MERC.WD:6,RF:6,ROS:6,CNC:3,FWL:6,MSC:6,DA:6,RCM:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Crucible Station' unitType='Space Station'>
@@ -4725,12 +4688,10 @@
 				<availability>CC:7</availability>
 			</model>
 			<model name='CRD-7M'>
-				<availability>
-					DTA:4:3087,FWL.pm:4:3087,OP:4:3087,RF:4:3087,ROS:2:3087,MSC:4:3087,DA:4:3087,RCM:2:3087</availability>
+				<availability>DTA:4:3087,FWL.pm:4:3087,OP:4:3087,RF:4:3087,ROS:2:3087,MSC:4:3087,DA:4:3087,RCM:2:3087</availability>
 			</model>
 			<model name='CRD-7M2'>
-				<availability>
-					DTA:4:3088,FWL.pm:2:3088,OP:4:3088,RF:4:3088,ROS:4:3088,MSC:4:3088,DA:4:3088,RCM:2:3088</availability>
+				<availability>DTA:4:3088,FWL.pm:2:3088,OP:4:3088,RF:4:3088,ROS:4:3088,MSC:4:3088,DA:4:3088,RCM:2:3088</availability>
 			</model>
 			<model name='CRD-7W'>
 				<availability>DTA:5,ROS:4,Periphery.MW:3,Periphery.ME:3,MH:3,MSC:5,MERC:3,RCM:5</availability>
@@ -4752,8 +4713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:1</availability>
 			</model>
@@ -4808,8 +4768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>
-				CC:3,MOC:3,CHH:2-,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:2,TC:4,Periphery:4,ROS:6,NIOPS:6,CJF:2-</availability>
+			<availability>CC:3,MOC:3,CHH:2-,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:2,TC:4,Periphery:4,ROS:6,NIOPS:6,CJF:2-</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:4,ROS:5</availability>
@@ -4921,8 +4880,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
+			<availability>CLAN:4,FS:3+,MERC:3+,BAN:3,CWIE:6,MERC.WD:6,CDS:5,CW:6,LA:3+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:3+</availability>
 			<model name='A'>
 				<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5026,8 +4984,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CJF:3,CGB:6</availability>
+			<availability>CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CJF:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -5161,12 +5118,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>
-					CC:5,MOC:4,HL:2,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
+				<availability>CC:5,MOC:4,HL:2,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
@@ -5231,8 +5186,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,OP:3,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
+			<availability>MOC:1,CC:1,OP:3,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
 			<model name='DV-1S'>
 				<availability>IS:2-</availability>
 			</model>
@@ -5447,8 +5401,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>
-				CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:2-,Periphery:2-,FVC:2-,LA:6,ROS:3,FWL:2-,CC.MAC:2-,DC:2-</availability>
+			<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:2-,Periphery:2-,FVC:2-,LA:6,ROS:3,FWL:2-,CC.MAC:2-,DC:2-</availability>
 			<model name=''>
 				<availability>CC:2-,General:2-</availability>
 			</model>
@@ -5490,8 +5443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
 			<model name='EGL-R11'>
 				<availability>PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:5,FS:6,RFS:6</availability>
 			</model>
@@ -5648,8 +5600,7 @@
 		<chassis name='Emperor' unitType='Mek'>
 			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:3,DC:4</availability>
 			<model name='EMP-6A'>
-				<availability>
-					CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
+				<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
 			<model name='EMP-6D'>
 				<availability>ROS:8,FS:8</availability>
@@ -6038,8 +5989,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:3,HL:4,LA:4-,ROS:3-,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3-,FS:5-</availability>
+			<availability>Periphery.R:3,HL:4,LA:4-,ROS:3-,Periphery.HR:3,Periphery.MW:3,Periphery.CM:3,FWL:3-,FS:5-</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:4</availability>
@@ -6218,8 +6168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,Periphery.CM:2-,PIR:2-,Periphery.ME:2-,FWL:1-,FS:1-,DA:2-,Periphery:1-</availability>
+			<availability>CC:3,MOC:3,Periphery.CM:2-,PIR:2-,Periphery.ME:2-,FWL:1-,FS:1-,DA:2-,Periphery:1-</availability>
 			<model name='FRB-1E (WAM-B)'>
 				<availability>General:2-</availability>
 			</model>
@@ -6326,8 +6275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:1,DC.GHO:5,CDS:1,LA:4,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:5,CJF:2,CGB:1,DC:4</availability>
+			<availability>CHH:1,CLAN:1,DC.GHO:5,CDS:1,LA:4,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:5,CJF:2,CGB:1,DC:4</availability>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,LA:8,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
 			</model>
@@ -6363,15 +6311,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
+			<availability>CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:6,PR:7,RF:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
+				<availability>MOC:4-,CC:4-,PR:4-,HL:4-,MERC:5-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,PG:4-,FWL:4-,RCM:4-,DA:4-,RFS:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:2</availability>
@@ -6577,16 +6523,14 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,CGB.FRR:3,FWL:5,NIOPS:4,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>vee_carrier,infantry_carrier</roles>
-				<availability>
-					CC:8,OP:8,PR:8,DoO:8,DO:8,DTA:8,RF:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,DTA:8,RF:8,ROS:5,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Fwltur' unitType='Mek'>
@@ -6642,16 +6586,14 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
 			</model>
 			<model name='GAL-102'>
 				<roles>recon</roles>
-				<availability>
-					MOC:5,RA.OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:1,Periphery:4</availability>
+				<availability>MOC:5,RA.OA:3,LA:5,CGB.FRR:5,IS:3,FWL:7,FS:5,MERC:5,TC:5,DC:4,CGB:1,Periphery:4</availability>
 			</model>
 			<model name='GAL-200'>
 				<availability>MOC:1,LA:1,CGB.FRR:1,IS:1,DC:1,Periphery:1</availability>
@@ -6715,8 +6657,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2,OP:3,DoO:3,IS:2,DO:3,MERC:2,FS:2,TC:2,DTA:3,FVC:2,LA:3,PIR:2,FWL:2,MH:2,MSC:3,TP:3,DC:2</availability>
+			<availability>CC:2,MOC:2,OP:3,DoO:3,IS:2,DO:3,MERC:2,FS:2,TC:2,DTA:3,FVC:2,LA:3,PIR:2,FWL:2,MH:2,MSC:3,TP:3,DC:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -6906,16 +6847,14 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,OP:2,HL:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,DTA:2,FVC:2,RF:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
+			<availability>CC:4,MOC:4,OP:2,HL:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,DTA:2,FVC:2,RF:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>CC:2-,LA:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 			</model>
 			<model name='GOL-2H'>
 				<roles>fire_support</roles>
-				<availability>
-					HL:2,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:6,Periphery:4</availability>
+				<availability>HL:2,Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:6,Periphery:4</availability>
 			</model>
 			<model name='GOL-3L'>
 				<roles>fire_support</roles>
@@ -6942,8 +6881,7 @@
 			</model>
 			<model name='GOL-6H'>
 				<roles>fire_support</roles>
-				<availability>
-					HL:2,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:6,Periphery:4</availability>
+				<availability>HL:2,Periphery.HR:5,Periphery.CM:5,Periphery.MW:5,Periphery.ME:5,MH:6,Periphery:4</availability>
 			</model>
 			<model name='GOL-6M'>
 				<roles>fire_support</roles>
@@ -7010,8 +6948,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				OP:7,DoO:7,CLAN:3,DO:7,MERC:4,DTA:7,CDS:4,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:7,TP:7</availability>
+			<availability>OP:7,DoO:7,CLAN:3,DO:7,MERC:4,DTA:7,CDS:4,ROS:8,Periphery.MW:5,PIR:5,Periphery.ME:5,CNC:4,FWL:7,NIOPS:8,MSC:7,TP:7</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:3-,FWL:3-,MH:3-,MERC:3-</availability>
 			</model>
@@ -7052,8 +6989,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,OP:7,PR:7,DoO:7,DO:7,FS:5,MERC:5,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,PG:7,Periphery.ME:3,FWL:7,MH:4,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
+			<availability>CC:5,MOC:5,OP:7,PR:7,DoO:7,DO:7,FS:5,MERC:5,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,PG:7,Periphery.ME:3,FWL:7,MH:4,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
 			<model name='T-IT-N10M'>
 				<availability>HL:3,ROS:5,FWL:5,MERC:5,Periphery:5</availability>
 			</model>
@@ -7223,8 +7159,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
+			<availability>MOC:2,CC:5,HL:3,IS:6,Periphery.Deep:6,MERC:7,TC:5,Periphery:4,RA.OA:1,LA:7,ROS:5,CNC:2,NIOPS:2,DC:7</availability>
 			<model name='GRF-1A'>
 				<availability>LA:2-,MERC:2-,TC:3-</availability>
 			</model>
@@ -7241,8 +7176,7 @@
 				<availability>CC:4,MOC:3,OP:4,DoO:4,CLAN:6,DO:4,FS:4,MERC:4,BAN:4,MH:3,MSC:4,TP:4,RCM:4,DC:4</availability>
 			</model>
 			<model name='GRF-3M'>
-				<availability>
-					MOC:3,OP:5,PR:6,DoO:5,IS:5,DO:5,FS:4,DTA:5,RF:6,LA:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
+				<availability>MOC:3,OP:5,PR:6,DoO:5,IS:5,DO:5,FS:4,DTA:5,RF:6,LA:5,PG:6,FWL:5,MH:3,MSC:5,TP:5,RCM:6,DA:6,RFS:6,DC:2</availability>
 			</model>
 			<model name='GRF-3N'>
 				<availability>RF:4</availability>
@@ -7314,12 +7248,10 @@
 			</model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:8,MOC:2,OP:4,MERC.KH:2,CEI:2,FR:4,MERC:7,Periphery:5,DTA:4,MERC.WD:2,RF:4,ROS:3-,MSC:4,DA:4,RCM:4</availability>
+			<availability>CC:8,MOC:2,OP:4,MERC.KH:2,CEI:2,FR:4,MERC:7,Periphery:5,DTA:4,MERC.WD:2,RF:4,ROS:3-,MSC:4,DA:4,RCM:4</availability>
 			<model name=''>
 				<roles>ground_support</roles>
-				<availability>
-					CC:8-,DTA:4,OP:4,MERC.KH:2,MERC.WD:2-,RF:4,CEI:2-,ROS:3-,MSC:4,DA:4,RCM:4,Periphery:5</availability>
+				<availability>CC:8-,DTA:4,OP:4,MERC.KH:2,MERC.WD:2-,RF:4,CEI:2-,ROS:3-,MSC:4,DA:4,RCM:4,Periphery:5</availability>
 			</model>
 			<model name='B'>
 				<availability>DTA:4,CC:6-,OP:4,RF:4,ROS:3-,MSC:4,DA:2,RCM:4,MERC:7-,Periphery:5</availability>
@@ -7341,8 +7273,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:5,OP:3,CHH:2,FS:5,MERC:3,RA:2,Periphery:2,DC.GHO:2,DTA:3,RF:3,ROS:6,FWL:5,NIOPS:7,MSC:5,DA:3,RCM:3</availability>
+			<availability>CC:5,OP:3,CHH:2,FS:5,MERC:3,RA:2,Periphery:2,DC.GHO:2,DTA:3,RF:3,ROS:6,FWL:5,NIOPS:7,MSC:5,DA:3,RCM:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>ROS:6,CGB.FRR:8,CLAN:8,NIOPS:8,MERC.SI:8,BAN:8,DC:8</availability>
@@ -7551,8 +7482,7 @@
 			</model>
 		</chassis>
 		<chassis name='Harasser Missile Platform' unitType='Tank'>
-			<availability>
-				PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:2-,Periphery.MW:2-,FWL:5,MH:3,MSC:5,RFS:5,MOC:3,CC:3,OP:5,IS:2-,MERC:3,Periphery:1-,DTA:5,RF:5,LA:3,PG:5,Periphery.ME:2-,TP:5,DA:5,RCM:5,DC:2-</availability>
+			<availability>PR:5,HL:2-,DoO:5,Periphery.Deep:4,DO:5,FWL.pm:5,CGB.FRR:4-,Periphery.CM:2-,Periphery.MW:2-,FWL:5,MH:3,MSC:5,RFS:5,MOC:3,CC:3,OP:5,IS:2-,MERC:3,Periphery:1-,DTA:5,RF:5,LA:3,PG:5,Periphery.ME:2-,TP:5,DA:5,RCM:5,DC:2-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -7561,12 +7491,10 @@
 				<availability>FWL:3</availability>
 			</model>
 			<model name='(MML)'>
-				<availability>
-					MOC:3,CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:3,DTA:4,RF:4,LA:3,PG:4,MSC:4,TP:4,RCM:4,DA:4,RFS:4</availability>
+				<availability>MOC:3,CC:3,OP:4,PR:4,DoO:4,DO:4,MERC:3,DTA:4,RF:4,LA:3,PG:4,MSC:4,TP:4,RCM:4,DA:4,RFS:4</availability>
 			</model>
 			<model name='(Thunderbolt)'>
-				<availability>
-					CC:2,MOC:2,OP:3,PR:3,DoO:3,DO:3,MERC:2,DTA:3,RF:3,PG:3,MH:2,MSC:3,TP:3,DA:3,RCM:3,RFS:3</availability>
+				<availability>CC:2,MOC:2,OP:3,PR:3,DoO:3,DO:3,MERC:2,DTA:3,RF:3,PG:3,MH:2,MSC:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Harpy' unitType='ProtoMek'>
@@ -7631,8 +7559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:4,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:4,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:4,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:4,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:2-,LA:2-,TC.PL:2-,MERC:2-,Periphery:2-</availability>
@@ -7760,8 +7687,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				CC:2,MOC:4,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:4,Periphery:5,RA.OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:5</availability>
+			<availability>CC:2,MOC:4,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:4,Periphery:5,RA.OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:5</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7787,8 +7713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7900,8 +7825,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hellcat' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2-,RA.OA:5,FVC:4,HL:2-,LA:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
+			<availability>MOC:2-,RA.OA:5,FVC:4,HL:2-,LA:2-,Periphery.Deep:1-,MERC:2-,CDP:4,RA:4,TC:2-,Periphery:3-</availability>
 			<model name='HCT-213'>
 				<availability>General:3</availability>
 			</model>
@@ -8053,8 +7977,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
-			<availability>
-				MOC:3,CC:4,OP:4,DoO:4,DO:4,MERC:3,FS:4,LA:3,ROS:2,PIR:3,FWL:7,MH:4,MSC:4,TP:4,DC:2-</availability>
+			<availability>MOC:3,CC:4,OP:4,DoO:4,DO:4,MERC:3,FS:4,LA:3,ROS:2,PIR:3,FWL:7,MH:4,MSC:4,TP:4,DC:2-</availability>
 			<model name='HER-2S'>
 				<roles>recon</roles>
 				<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
@@ -8112,8 +8035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:6,Periphery:6,CWIE:3</availability>
+			<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:6,Periphery:6,CWIE:3</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -8161,8 +8083,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>MOC:3,CC:4,LA:6,CLAN:4,IS:3,FWL:3,NIOPS:9,MH:3,MERC:4,FS:5,CJF:5,DC:3</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
+				<availability>MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:3,FWL:3,MH:4,FS:4,BAN:2</availability>
@@ -8246,8 +8167,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
+			<availability>MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:2-</availability>
@@ -8307,8 +8227,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,CW:1-,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2</availability>
+			<availability>MOC:2,CC:2,HL:3,IS:2-,Periphery.Deep:5,FS:3,Periphery:4,TC:2,RA.OA:2,CW:1-,LA:5,CGB.FRR:6,ROS:3,Periphery.MW:5,Periphery.ME:5,FWL:7,NIOPS:4-,DC:2</availability>
 			<model name='HBK-4G'>
 				<availability>General:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -8363,8 +8282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
+			<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:3-</availability>
@@ -8611,24 +8529,20 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>assault</roles>
-				<availability>
-					OP:8,PR:8,DoO:8,IS:2,DO:8,DTA:8,RF:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+				<availability>OP:8,PR:8,DoO:8,IS:2,DO:8,DTA:8,RF:8,ROS:4,PG:8,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CEI:6,CLAN:8</availability>
@@ -8726,8 +8640,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:2-,DC.LV:3-,DC.GR:2-,FS.AH:2-,IS:2-,Periphery.Deep:5,FS:2-,Periphery:2-,TC:3-,RA.OA:2-,LA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:2-</availability>
+			<availability>MOC:2-,DC.LV:3-,DC.GR:2-,FS.AH:2-,IS:2-,Periphery.Deep:5,FS:2-,Periphery:2-,TC:3-,RA.OA:2-,LA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:2-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8849,8 +8762,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:3,CC:2-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
+			<availability>MOC:3,CC:2-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:3,RA.OA:5,FVC:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
@@ -8891,8 +8803,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>
-				MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,LA:1,Periphery.HR:4,ROS:4</availability>
+			<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,LA:1,Periphery.HR:4,ROS:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -8962,8 +8873,7 @@
 			</model>
 		</chassis>
 		<chassis name='Jenner' unitType='Mek'>
-			<availability>
-				CC:1-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:4,Periphery:3,CGB.FRR:8,FS.DMM:5,FWL:1-,DC:8</availability>
+			<availability>CC:1-,Periphery.DD:5,FS.RR:5,HL:2,IS:3,MERC:4,Periphery.OS:5,FS:4,RA:4,Periphery:3,CGB.FRR:8,FS.DMM:5,FWL:1-,DC:8</availability>
 			<model name='JR7-C'>
 				<roles>raider</roles>
 				<availability>MERC:6,FS:6,DC:5</availability>
@@ -9289,8 +9199,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>
-				CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:3,CGB:3,DC:4</availability>
+			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:3,CGB:3,DC:4</availability>
 			<model name='KGC-000'>
 				<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
 			</model>
@@ -9710,14 +9619,12 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:3,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:3,MERC:3,DTA:6,FVC:3,RF:6,LA:3,ROS:3,Periphery.MW:3,Periphery.CM:3,PG:6,Periphery.ME:3,FWL:6,MH:3,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+			<availability>CC:3,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:3,MERC:3,DTA:6,FVC:3,RF:6,LA:3,ROS:3,Periphery.MW:3,Periphery.CM:3,PG:6,Periphery.ME:3,FWL:6,MH:3,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
 			<model name='LX-2A'>
-				<availability>
-					OP:5,PR:5,DoO:5,DO:5,MERC:5,DTA:5,RF:5,LA:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+				<availability>OP:5,PR:5,DoO:5,DO:5,MERC:5,DTA:5,RF:5,LA:5,ROS:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 			</model>
 			<model name='LX-3'>
 				<availability>IS:4,MERC:0</availability>
@@ -9781,21 +9688,18 @@
 			</model>
 			<model name='(3054)'>
 				<roles>asf_carrier</roles>
-				<availability>
-					CC:8,OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
+			<availability>MOC:8,CC:7,HL:7,IS:8,Periphery.Deep:7,FS:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,CGB.FRR:7,FWL:7,NIOPS:4,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2-</availability>
 			</model>
 			<model name='(3056)'>
 				<roles>mek_carrier</roles>
-				<availability>
-					OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
+				<availability>OP:8,PR:8,DoO:8,DO:8,FS:8,DTA:8,RF:8,LA:8,ROS:8,PG:8,General:2,FWL:8,MSC:8,TP:8,DA:8,RCM:8,RFS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Leviathan Heavy Transport' unitType='Warship'>
@@ -9839,15 +9743,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:3,HL:3,Periphery.OS:5,TC:8,Periphery:4,RA.OA:5,FVC:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
+			<availability>MOC:7,CC:3,HL:3,Periphery.OS:5,TC:8,Periphery:4,RA.OA:5,FVC:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,MOC:4,OP:7,CEI:3-,FR:4,BAN:2,Periphery:8-,DTA:7,FVC:7,RF:7,LA:8-,ROS:9-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
+			<availability>CC:7-,MOC:4,OP:7,CEI:3-,FR:4,BAN:2,Periphery:8-,DTA:7,FVC:7,RF:7,LA:8-,ROS:9-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>DTA:5,OP:5,RF:5,FWL:5,MSC:5,DA:7,RCM:5</availability>
 			</model>
@@ -9894,8 +9796,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:4-</availability>
 			</model>
@@ -10044,8 +9945,7 @@
 			</model>
 			<model name='LCT-3M'>
 				<roles>recon</roles>
-				<availability>
-					MOC:3,OP:5,PR:5,DoO:5,IS:3,DO:5,MERC:5,DTA:5,RF:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
+				<availability>MOC:3,OP:5,PR:5,DoO:5,IS:3,DO:5,MERC:5,DTA:5,RF:5,PG:5,FWL:5,MSC:5,TP:5,RCM:5,DA:5,RFS:5</availability>
 			</model>
 			<model name='LCT-3S'>
 				<roles>recon</roles>
@@ -10143,8 +10043,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>
-				MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:3</availability>
+			<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:3</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10231,8 +10130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lucifer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,RA.OA:1,Periphery.R:4,FVC:2,HL:4,LA:6,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
+			<availability>MOC:1,RA.OA:1,Periphery.R:4,FVC:2,HL:4,LA:6,Periphery.MW:3,MERC:1,TC:1,Periphery:2</availability>
 			<model name='LCF-R15'>
 				<availability>FVC:2-,LA:2-,Periphery.Deep:4,MERC:4-,Periphery:2-</availability>
 			</model>
@@ -10346,8 +10244,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CSA:4,MERC.KH:3+,MERC.WD:6,CDS:4,CW:6,ROS:2+,CLAN:2,MERC:1+,CCO:4,CJF:4,BAN:2,CWIE:6</availability>
+			<availability>CSA:4,MERC.KH:3+,MERC.WD:6,CDS:4,CW:6,ROS:2+,CLAN:2,MERC:1+,CCO:4,CJF:4,BAN:2,CWIE:6</availability>
 			<model name='A'>
 				<availability>CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -10452,8 +10349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:3,MOC:3,OP:8,Periphery.MM:3,PR:8,DoO:8,DO:8,MERC:3,DTA:8,RF:8,LA:3,ROS:3,Periphery.CM:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+			<availability>CC:3,MOC:3,OP:8,Periphery.MM:3,PR:8,DoO:8,DO:8,MERC:3,DTA:8,RF:8,LA:3,ROS:3,Periphery.CM:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -10565,8 +10461,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:6,RA.OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
+			<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:6,RA.OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
 			<model name=''>
 				<availability>HL:2,LA:1-,General:2-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 			</model>
@@ -10657,8 +10552,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>
-				CC:4,MOC:2,IS:1-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
+			<availability>CC:4,MOC:2,IS:1-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
 			<model name='MAD-2R'>
 				<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
 			</model>
@@ -10756,15 +10650,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				OP:4,DoO:4,DO:4,FS:4,Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,TP:4,DA:4,RCM:4</availability>
+			<availability>OP:4,DoO:4,DO:4,FS:4,Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,TP:4,DA:4,RCM:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,HL:2,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 			</model>
@@ -10893,8 +10785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>
-				MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
+			<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -11072,8 +10963,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,HL:5,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,CGB.FRR:4,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,HL:5,CLAN:4,IS:5,Periphery.Deep:5,MERC:6,FS:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,CGB.FRR:4,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -11142,8 +11032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Merchant Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:4,MERC.WD:4,HL:5,CEI:5,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,MERC:5,Periphery:6</availability>
+			<availability>MERC.KH:4,MERC.WD:4,HL:5,CEI:5,CLAN:5,IS:5,Periphery.Deep:3,NIOPS:5,MERC:5,Periphery:6</availability>
 			<model name='(2503)'>
 				<availability>General:6</availability>
 			</model>
@@ -11372,8 +11261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Moltke MBT' unitType='Tank'>
-			<availability>
-				CC:4,MOC:4,OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,PG:4,FWL:4,TP:4,DA:6,RCM:4,RFS:4</availability>
+			<availability>CC:4,MOC:4,OP:4,PR:4,DoO:4,DO:4,MERC:4,DTA:4,RF:4,PG:4,FWL:4,TP:4,DA:6,RCM:4,RFS:4</availability>
 			<model name='M1'>
 				<availability>General:8</availability>
 			</model>
@@ -11830,8 +11718,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>OP:5,PR:5,DoO:5,DO:5,FS:7,MERC:6,Periphery.R:2,RF:5,LA:8,ROS:6,PG:5,TP:5,RFS:5</availability>
 			<model name='NGS-4S'>
-				<availability>
-					:0,OP:4,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,RF:4,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
+				<availability>:0,OP:4,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,RF:4,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -12110,8 +11997,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CC:5,HL:2,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
+			<availability>MOC:7,CC:5,HL:2,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
 			<model name=''>
 				<availability>HL:3,General:2,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -12161,8 +12047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
+			<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -12245,8 +12130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>
-				MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
+			<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
@@ -12293,8 +12177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>
-				CC:2,OP:4,PR:4,DoO:4,DO:4,FS:2,MERC:3,FVC:2,RF:4,LA:2,CGB.FRR:3,ROS:4,PG:4,NIOPS:3,FWL:2,TP:4,RFS:4,DC:5</availability>
+			<availability>CC:2,OP:4,PR:4,DoO:4,DO:4,FS:2,MERC:3,FVC:2,RF:4,LA:2,CGB.FRR:3,ROS:4,PG:4,NIOPS:3,FWL:2,TP:4,RFS:4,DC:5</availability>
 			<model name='OTT-11J'>
 				<roles>recon,spotter</roles>
 				<availability>LA:3,ROS:3,FS:1</availability>
@@ -12317,8 +12200,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>
-				OP:5,PR:5,DoO:5,DO:5,FS:5,MERC:3,Periphery:1,DTA:5,RF:5,ROS:4,PG:5,FWL:5,NIOPS:6,MSC:5,TP:5,RFS:5</availability>
+			<availability>OP:5,PR:5,DoO:5,DO:5,FS:5,MERC:3,Periphery:1,DTA:5,RF:5,ROS:4,PG:5,FWL:5,NIOPS:6,MSC:5,TP:5,RFS:5</availability>
 			<model name='OTL-4D'>
 				<availability>FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:2-</availability>
 			</model>
@@ -12379,8 +12261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,HL:3,CLAN:8,IS:5,Periphery.Deep:4,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,CGB.FRR:6,FWL:6,NIOPS:7,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:3,BAN:1</availability>
@@ -12469,8 +12350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,LA:5-,FS.PMM:6-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
+			<availability>MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,LA:5-,FS.PMM:6-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12481,8 +12361,7 @@
 			</model>
 			<model name='PKR-T5 (ICE)'>
 				<roles>recon,raider</roles>
-				<availability>
-					CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
+				<availability>CC:2,CGB.FRR:2,PIR:2,General:2,FWL:2,Periphery.Deep:6,MERC:2,FS:2,Periphery:3,DC:2</availability>
 			</model>
 			<model name='PKR-T5 (ML)'>
 				<roles>recon,raider</roles>
@@ -12537,8 +12416,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,RA:1,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:1,NIOPS:2,DC:8,CGB:1</availability>
+			<availability>Periphery.DD:5,FS.RR:4,HL:2,MERC:4,FS:1,Periphery.OS:5,Periphery:3,RA:1,CGB.FRR:6,ROS:4,FS.DMM:4,CNC:1,NIOPS:2,DC:8,CGB:1</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:3,FVC:3,CGB.FRR:5,PIR:3,CNC:4,FS.DMM:3,MERC:3,DC:4,TC:3</availability>
@@ -12642,8 +12520,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3-,CC:1-,HL:2-,IS:2-,Periphery.Deep:9,FS:3-,Periphery:3-,TC:3-,RA.OA:2-,CDS:1,LA:2-,FWL:2-,DC:1-</availability>
+			<availability>MOC:3-,CC:1-,HL:2-,IS:2-,Periphery.Deep:9,FS:3-,Periphery:3-,TC:3-,RA.OA:2-,CDS:1,LA:2-,FWL:2-,DC:1-</availability>
 			<model name=''>
 				<availability>General:4</availability>
 			</model>
@@ -12692,8 +12569,7 @@
 			</model>
 		</chassis>
 		<chassis name='Patron MilitiaMech' unitType='Mek'>
-			<availability>
-				PR:4-,DoO:4-,IS.pm:2,DO:4-,RCM.pm:4,FWL.pm:4,DA.pm:4,RF.pm:4,OP.pm:4,PG:4-,MSC.pm:4,TP:4-,DTA.pm:5,RFS:4-</availability>
+			<availability>PR:4-,DoO:4-,IS.pm:2,DO:4-,RCM.pm:4,FWL.pm:4,DA.pm:4,RF.pm:4,OP.pm:4,PG:4-,MSC.pm:4,TP:4-,DTA.pm:5,RFS:4-</availability>
 			<model name='PTN-2'>
 				<availability>DTA:4,PR:4,DoO:4,PG:4,FWL:4,DO:4,TP:4,RCM:4,DA:4,RFS:4</availability>
 			</model>
@@ -12882,8 +12758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>
-				CC:3,CCC:5,CLAN:3,MERC:3,FS:3,CCO:5,RA:5,CSA:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
+			<availability>CC:3,CCC:5,CLAN:3,MERC:3,FS:3,CCO:5,RA:5,CSA:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
 			<model name=''>
 				<availability>CDS:3,CNC:3,IS:2,CCO:2,DC:3</availability>
 			</model>
@@ -12995,8 +12870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>
-				MOC:2,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
+			<availability>MOC:2,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
 			<model name=''>
 				<availability>HL:2,IS:2,Periphery:4</availability>
 			</model>
@@ -13340,8 +13214,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:6,MERC:2+,CCO:6,RA:7,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:7,CW:8,ROS:3+,CNC:8,CJF:5,CGB:6</availability>
+			<availability>CLAN:6,MERC:2+,CCO:6,RA:7,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:7,CW:8,ROS:3+,CNC:8,CJF:5,CGB:6</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -13427,8 +13300,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:6,RFS:6,CGB:1,MOC:3,CC:4,OP:6,IS:3,Periphery:4,TC:3,DTA:6,FVC:3,RF:6,LA:3,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
+			<availability>PR:6,HL:3,DoO:6,Periphery.Deep:4,DO:6,FS:4,CDP:3,RA.OA:3,CGB.FRR:7,FWL:6,NIOPS:3-,MSC:6,RFS:6,CGB:1,MOC:3,CC:4,OP:6,IS:3,Periphery:4,TC:3,DTA:6,FVC:3,RF:6,LA:3,PG:6,ROS:4,TP:6,DA:5,RCM:5,DC:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:3-,Periphery.Deep:8,FWL:2-,IS:2-,Periphery:3-,DC:2-,TC:3-</availability>
 			</model>
@@ -13680,8 +13552,7 @@
 			</model>
 		</chassis>
 		<chassis name='Razorback' unitType='Mek'>
-			<availability>
-				OP:4,PR:4,DoO:4,DO:4,MERC:4,FS:4,RF:4,LA:6,ROS:4,CGB.FRR:5,PG:4,MH:4,TP:4,DA:4,RFS:4</availability>
+			<availability>OP:4,PR:4,DoO:4,DO:4,MERC:4,FS:4,RF:4,LA:6,ROS:4,CGB.FRR:5,PG:4,MH:4,TP:4,DA:4,RFS:4</availability>
 			<model name='RZK-10S'>
 				<availability>LA:4</availability>
 			</model>
@@ -13728,8 +13599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,HL:9,CLAN:4,Periphery.Deep:9,IS:5,FS:6,MERC:7,Periphery:10,TC:7,RA.OA:7,LA:7,CGB.FRR:5,ROS:7,NIOPS:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:1,CW:1,General:8,CNC:1</availability>
 			</model>
@@ -13755,8 +13625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:7,DoO:8,DO:8,FS:2,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:8,RFS:7,MOC:2,CC:2,OP:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,RF:7,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
+			<availability>PR:7,DoO:8,DO:8,FS:2,CGB.FRR:5,Periphery.MW:3,FWL:8,MSC:8,RFS:7,MOC:2,CC:2,OP:8,MERC:2,Periphery:2,TC:2,DTA:8,FVC:3,RF:7,ROS:5,PG:7,Periphery.ME:3,TP:8,DA:6,RCM:8,DC:3</availability>
 			<model name='F-100'>
 				<availability>FVC:3-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 			</model>
@@ -13767,12 +13636,10 @@
 				<availability>CGB.FRR:1-,DC:1-</availability>
 			</model>
 			<model name='F-700'>
-				<availability>
-					CC:8,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:8,DTA:8,RF:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
+				<availability>CC:8,MOC:3,OP:8,PR:8,DoO:8,DO:8,MERC:8,DTA:8,RF:8,ROS:8,PG:8,FWL:8,MSC:8,TP:8,RCM:8,DA:8,RFS:8</availability>
 			</model>
 			<model name='F-700a'>
-				<availability>
-					CC:7,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:5,MERC:7,DTA:6,RF:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
+				<availability>CC:7,MOC:3,OP:6,PR:6,DoO:6,DO:6,FS:5,MERC:7,DTA:6,RF:6,ROS:8,PG:6,FWL:7,MSC:6,TP:6,DA:6,RCM:6,RFS:6</availability>
 			</model>
 			<model name='F-700b'>
 				<availability>MOC:3,CC:3,DTA:8,OP:8,DoO:8,ROS:6,FWL:6,DO:8,MSC:8,TP:8,MERC:6,DC:6</availability>
@@ -13806,8 +13673,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>
-				CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+			<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
 			<model name='C 2'>
 				<availability>CJF:4</availability>
 			</model>
@@ -13839,8 +13705,7 @@
 				<availability>ROS:6</availability>
 			</model>
 			<model name='RFL-7M'>
-				<availability>
-					MOC:3,OP:7,PR:7,DoO:7,IS:3,DO:7,CDP:3,TC:3,DTA:7,RF:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
+				<availability>MOC:3,OP:7,PR:7,DoO:7,IS:3,DO:7,CDP:3,TC:3,DTA:7,RF:7,CGB.FRR:5,PG:7,FWL:7,MSC:7,TP:7,DA:7,RCM:7,RFS:7,DC:5</availability>
 			</model>
 			<model name='RFL-7X'>
 				<roles>fire_support</roles>
@@ -14095,8 +13960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
+			<availability>CC:4,MOC:4,HL:2-,CLAN:2,IS:3-,Periphery.Deep:4-,FS:3,MERC:4,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:4-</availability>
 			</model>
@@ -14180,8 +14044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:5,Periphery.DD:3,DC.AL:9,IS:5,MERC:5,Periphery.OS:3,FS:4,Periphery:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
+			<availability>CC:5,Periphery.DD:3,DC.AL:9,IS:5,MERC:5,Periphery.OS:3,FS:4,Periphery:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
 			<model name=''>
 				<availability>IS:4-,Periphery:4-</availability>
 			</model>
@@ -14244,8 +14107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:2-,Periphery:4,TC:4,RA.OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:6-</availability>
+			<availability>MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:2-,Periphery:4,TC:4,RA.OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:6-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -14428,8 +14290,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>
-				MOC:2,CC:1,HL:3,IS:2,Periphery.Deep:5,MERC:2,FS:2,Periphery:4,TC:2,RA:4,RA.OA:3,LA:2,CGB.FRR:2,CNC:4,FWL:2,DC:1</availability>
+			<availability>MOC:2,CC:1,HL:3,IS:2,Periphery.Deep:5,MERC:2,FS:2,Periphery:4,TC:2,RA:4,RA.OA:3,LA:2,CGB.FRR:2,CNC:4,FWL:2,DC:1</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -14447,8 +14308,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
+			<availability>MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -14464,8 +14324,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
+			<availability>CC:6,FVC:6,HL:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:7,FS:6,CJF:4,DC:6,Periphery:7</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -14490,8 +14349,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,HL:2,Periphery.Deep:4-,MERC:2,Periphery:3-,FVC:2,RF:2-,LA:4,CGB.FRR:2-,ROS:2,FWL:2,NIOPS:2-,RCM:2-,DC:3</availability>
+			<availability>CC:2,HL:2,Periphery.Deep:4-,MERC:2,Periphery:3-,FVC:2,RF:2-,LA:4,CGB.FRR:2-,ROS:2,FWL:2,NIOPS:2-,RCM:2-,DC:3</availability>
 			<model name='SCP-10M'>
 				<availability>CC:4,MOC:3,CGB.FRR:4,ROS:4,FWL:6,MERC:4,DC:4</availability>
 			</model>
@@ -14506,8 +14364,7 @@
 				<availability>FRR:2-,Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
 			</model>
 			<model name='SCP-1O'>
-				<availability>
-					CC:2-,HL:2,RF:2-,FRR:2-,Periphery.Deep:1,FWL:2-,RCM:2-,MERC:1-,Periphery:4,DC:1-</availability>
+				<availability>CC:2-,HL:2,RF:2-,FRR:2-,Periphery.Deep:1,FWL:2-,RCM:2-,MERC:1-,Periphery:4,DC:1-</availability>
 			</model>
 			<model name='SCP-1TB'>
 				<availability>ROS:4,MERC:4</availability>
@@ -14611,8 +14468,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:1,FS:5,MERC:4,CWIE:1,DC.GHO:3,FVC:5,CDS:1,CW:1,LA:5,ROS:4,NIOPS:4,CJF:2,CGB:2,DC:3</availability>
+			<availability>CLAN:1,FS:5,MERC:4,CWIE:1,DC.GHO:3,FVC:5,CDS:1,CW:1,LA:5,ROS:4,NIOPS:4,CJF:2,CGB:2,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -14633,8 +14489,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
@@ -14731,8 +14586,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:3,RFS:3,CGB:5,OP:3,IS:2,MERC:4,RA:5,DTA:3,RF:3,CW:4,LA:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
+			<availability>PR:3,CHH:5,DoO:3,DO:3,FS:3,CWIE:5,RA.OA:3,CDS:5,CGB.FRR:4,FWL:3,MSC:3,RFS:3,CGB:5,OP:3,IS:2,MERC:4,RA:5,DTA:3,RF:3,CW:4,LA:3,ROS:4,PG:3,CNC:5,TP:3,RCM:3,DA:3,DC:3</availability>
 			<model name='10'>
 				<availability>CHH:6-,CW:5-</availability>
 			</model>
@@ -14875,8 +14729,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:4,Periphery.DD:4,FVC:2,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
+			<availability>RA.OA:4,Periphery.DD:4,FVC:2,CGB.FRR:7,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>ROS:0,IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -14934,8 +14787,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:3,Periphery.DD:3,FVC:2,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
+			<availability>RA.OA:3,Periphery.DD:3,FVC:2,LA:1,CGB.FRR:5,ROS:3,MERC:3,Periphery.OS:3,FS:2-,DC:7,Periphery:2</availability>
 			<model name='SL-21'>
 				<availability>FVC:4,HL:3,Periphery.Deep:8,MERC:3,DC:3,Periphery:5</availability>
 			</model>
@@ -15033,8 +14885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:4-</availability>
@@ -15053,8 +14904,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
+			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 			</model>
@@ -15178,8 +15028,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+			<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 			</model>
@@ -15239,8 +15088,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:2,CC:3,OP:4,MERC:3,FS:3,Periphery:2,TC:2,DTA:4,FVC:3,RF:5,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,MSC:3,DA:3,RCM:6,DC:6</availability>
+			<availability>MOC:2,CC:3,OP:4,MERC:3,FS:3,Periphery:2,TC:2,DTA:4,FVC:3,RF:5,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,MSC:3,DA:3,RCM:6,DC:6</availability>
 			<model name='SDR-5K'>
 				<roles>anti_infantry</roles>
 				<availability>CGB.FRR:2-,DC:2-</availability>
@@ -15330,14 +15178,12 @@
 			<availability>CHH:4,CSL:4,CCO:5</availability>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
+			<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
 			<model name='STK-3F'>
 				<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>
-					CC:3,MOC:3,OP:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,RF:3,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
+				<availability>CC:3,MOC:3,OP:3,PR:3,DoO:3,CLAN:8,DO:3,MERC:3,BAN:2,RF:3,PG:3,FWL:3,TP:3,DA:3,RCM:3,RFS:3</availability>
 			</model>
 			<model name='STK-3H'>
 				<availability>MOC:2-,IS:2-,TC:2-,Periphery:2-</availability>
@@ -15355,8 +15201,7 @@
 				<availability>CDS:3,LA:5,MERC:4,FS:5,CJF:3,TC:4</availability>
 			</model>
 			<model name='STK-6M'>
-				<availability>
-					CC:5,MOC:5,OP:6,PR:6,DoO:6,DO:6,MERC:6,RF:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
+				<availability>CC:5,MOC:5,OP:6,PR:6,DoO:6,DO:6,MERC:6,RF:6,ROS:6,PG:6,FWL:6,TP:6,DA:5,RCM:6,RFS:6</availability>
 			</model>
 			<model name='STK-7C3BS'>
 				<availability>IS:2</availability>
@@ -15428,8 +15273,7 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>
-				MOC:4,CC:4,OP:4,PR:4,DoO:4,DO:4,FS:4,MERC:4,RF:4,LA:6,CGB.FRR:4,ROS:4,PG:4,TP:4,DA:4,RFS:4</availability>
+			<availability>MOC:4,CC:4,OP:4,PR:4,DoO:4,DO:4,FS:4,MERC:4,RF:4,LA:6,CGB.FRR:4,ROS:4,PG:4,TP:4,DA:4,RFS:4</availability>
 			<model name='STY-3C'>
 				<roles>raider</roles>
 				<availability>General:8</availability>
@@ -15503,8 +15347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>
-				MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
+			<availability>MOC:6,HL:5,CGB.FRR:4,IS:8,NIOPS:2-,Periphery.Deep:5,MERC:8,Periphery:6,DC:5,CGB:2-</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery.Deep:4,Periphery:1-</availability>
@@ -15523,8 +15366,7 @@
 			</model>
 			<model name='STG-5G'>
 				<roles>recon</roles>
-				<availability>
-					CC:4,OP:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
+				<availability>CC:4,OP:4,DoO:4,DO:4,MERC:1,FS:4,CDP:4,TC:4,FVC:4,ROS:4,FWL:1,MH:4,TP:4,RCM:4,DA:4</availability>
 			</model>
 			<model name='STG-5M'>
 				<roles>recon</roles>
@@ -15552,8 +15394,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				PR:5,DoO:6,DO:6,FS:1,RA.OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:6,RFS:5,MOC:3,CC:5,OP:6,IS:3,MERC:5,TC:3,DTA:6,RF:5,LA:5,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
+			<availability>PR:5,DoO:6,DO:6,FS:1,RA.OA:1,Periphery.MW:2,FWL:6,NIOPS:3,MH:3,MSC:6,RFS:5,MOC:3,CC:5,OP:6,IS:3,MERC:5,TC:3,DTA:6,RF:5,LA:5,PG:5,Periphery.ME:2,TP:6,RCM:6,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:3-,Periphery:3-</availability>
 			</model>
@@ -15564,8 +15405,7 @@
 				<availability>MOC:4,Periphery.MW:4,Periphery.ME:4,IS:4,MH:4</availability>
 			</model>
 			<model name='F-95'>
-				<availability>
-					CC:4,OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,LA:4,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
+				<availability>CC:4,OP:6,PR:6,DoO:6,DO:6,MERC:4,DTA:6,RF:6,LA:4,ROS:4,PG:6,FWL:6,MSC:6,TP:6,RCM:6,DA:6,RFS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Stooping Hawk' unitType='Mek' omni='Clan'>
@@ -15653,8 +15493,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>
-				CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2,CGB:1</availability>
+			<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2,CGB:1</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -15697,8 +15536,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,LA:2,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
+			<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,LA:2,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
 			</model>
@@ -15710,8 +15548,7 @@
 			</model>
 		</chassis>
 		<chassis name='SturmFeur Heavy Tank' unitType='Tank'>
-			<availability>
-				PR:4,HL:2,MERC:1,FS:3,CWIE:3,Periphery.R:3,CDS:2,RF:4,LA:5,ROS:4,PG:4,CNC:3,RFS:4</availability>
+			<availability>PR:4,HL:2,MERC:1,FS:3,CWIE:3,Periphery.R:3,CDS:2,RF:4,LA:5,ROS:4,PG:4,CNC:3,RFS:4</availability>
 			<model name=''>
 				<availability>General:4</availability>
 			</model>
@@ -15936,8 +15773,7 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>
-				OP:4,PR:4,DoO:4,CLAN:3,DO:4,FS:4,MERC:4,RF:4,LA:4,CGB.FRR:3,ROS:4,PG:4,TP:4,DA:3,RFS:4,DC:2</availability>
+			<availability>OP:4,PR:4,DoO:4,CLAN:3,DO:4,FS:4,MERC:4,RF:4,LA:4,CGB.FRR:3,ROS:4,PG:4,TP:4,DA:3,RFS:4,DC:2</availability>
 			<model name='TLN-5W'>
 				<availability>LA:8,CLAN:8</availability>
 			</model>
@@ -16021,8 +15857,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tempest' unitType='Mek'>
-			<availability>
-				OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,ROS:5,Periphery.MW:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RFS:8</availability>
+			<availability>OP:8,PR:8,DoO:8,DO:8,MERC:4,DTA:8,RF:8,ROS:5,Periphery.MW:3,PG:8,Periphery.ME:3,FWL:8,MH:3,MSC:8,TP:8,RFS:8</availability>
 			<model name='TMP-3G'>
 				<availability>ROS:2,FWL:2,MERC:2</availability>
 			</model>
@@ -16135,8 +15970,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CLAN:2,CCO:2,RA:2,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:2,CW:2,ROS:2+,CNC:2,CJF:5,CGB:2</availability>
+			<availability>CHH:5,CLAN:2,CCO:2,RA:2,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:2,CW:2,ROS:2+,CNC:2,CJF:5,CGB:2</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -16232,8 +16066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:2-,FVC:3-,HL:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:4-</availability>
@@ -16246,14 +16079,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				CHH:2,PR:5,CLAN:3,FS:2,CWIE:4,DC.GHO:4,RA.OA:4,CDS:2,Periphery.MW:2,FWL:5,NIOPS:8,MH:3,MSC:5,RFS:5,CGB:4,MOC:3,IS:4,CW:4,RF:5,ROS:5,PG:5,PIR:2,CNC:2,Periphery.ME:2,DA:5,CJF:4</availability>
+			<availability>CHH:2,PR:5,CLAN:3,FS:2,CWIE:4,DC.GHO:4,RA.OA:4,CDS:2,Periphery.MW:2,FWL:5,NIOPS:8,MH:3,MSC:5,RFS:5,CGB:4,MOC:3,IS:4,CW:4,RF:5,ROS:5,PG:5,PIR:2,CNC:2,Periphery.ME:2,DA:5,CJF:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:2-,RF:2-,PIR:2-,FWL:2-,MH:2-,MSC:2-,MERC:2-,DA:2-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,RA.OA:8,CGB.FRR:6,ROS:8,PG:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,NIOPS:4,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,RA.OA:8,CGB.FRR:6,ROS:8,PG:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,NIOPS:4,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,BAN:2</availability>
@@ -16347,8 +16178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:3-</availability>
@@ -16375,8 +16205,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:5,MERC.KH:4,HL:2,CEI:1+,IS:3,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,FVC:4,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:4</availability>
+			<availability>CC:5,MERC.KH:4,HL:2,CEI:1+,IS:3,Periphery.Deep:6,FS:5,MERC:6,Periphery:3,TC:4,FVC:4,MERC.WD:2,LA:6,ROS:5,NIOPS:3-,MH:4,DC:4</availability>
 			<model name='C'>
 				<availability>CEI:1+</availability>
 			</model>
@@ -16714,8 +16543,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,RF:6,LA:2,CGB.FRR:4,Periphery.MW:4,ROS:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+			<availability>CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,RF:6,LA:2,CGB.FRR:4,Periphery.MW:4,ROS:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>PR:4,RF:4,ROS:5,PG:4,NIOPS:5,MSC:4,MERC:4,RFS:4</availability>
@@ -17165,8 +16993,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -17229,8 +17056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Uziel' unitType='Mek'>
-			<availability>
-				OP:1,PR:1,DoO:1,DO:1,FS:4,MERC:4,DTA:1,RF:1,LA:6,ROS:4,PG:1,FWL:2,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
+			<availability>OP:1,PR:1,DoO:1,DO:1,FS:4,MERC:4,DTA:1,RF:1,LA:6,ROS:4,PG:1,FWL:2,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
 			<model name='UZL-2S'>
 				<availability>LA:5,ROS:4,FS:5,MERC:5</availability>
 			</model>
@@ -17361,8 +17187,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
+				<availability>CC:8,MOC:8,FVC:5,Periphery.CM:5,Periphery.HR:5,PIR:5,MH:5,CDP:5,TC:8,Periphery:4</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:2</availability>
@@ -17416,8 +17241,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:3,CC:6,HL:3,IS:2-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
+			<availability>MOC:3,CC:6,HL:3,IS:2-,Periphery.Deep:4,FS:8,Periphery.OS:3,Periphery:4,TC:3,RA.OA:3,LA:4,CGB.FRR:6,Periphery.HR:3,FWL:3,NIOPS:3-,DC:5</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -17835,8 +17659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -17851,8 +17674,7 @@
 				<availability>IS:1-,Periphery:1-</availability>
 			</model>
 			<model name='H-8'>
-				<availability>
-					HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:3,Periphery.Deep:4,FWL:4,FS:6,MERC:6,Periphery:6,RA:8</availability>
+				<availability>HL:4,LA:4,FS.CH:8,CGB.FRR:6,ROS:6,IS:3,Periphery.Deep:4,FWL:4,FS:6,MERC:6,Periphery:6,RA:8</availability>
 			</model>
 			<model name='H-9'>
 				<availability>LA:5</availability>
@@ -17961,8 +17783,7 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>
-				MOC:1,RA.OA:1,Periphery.DD:1,FVC:2,FS.CMM:2,NIOPS:1-,MH:1,MERC:2,Periphery.OS:1,Periphery:2,TC:1,DC:2</availability>
+			<availability>MOC:1,RA.OA:1,Periphery.DD:1,FVC:2,FS.CMM:2,NIOPS:1-,MH:1,MERC:2,Periphery.OS:1,Periphery:2,TC:1,DC:2</availability>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
 				<availability>Periphery.Deep:8,MERC:1,Periphery:1</availability>
@@ -18051,8 +17872,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolfhound' unitType='Mek'>
-			<availability>
-				MOC:4,OP:3,MERC.KH:7,DoO:3,DO:3,FS:2,MERC:4,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,CGB.FRR:5,ROS:5,MH:4,MSC:3,TP:3</availability>
+			<availability>MOC:4,OP:3,MERC.KH:7,DoO:3,DO:3,FS:2,MERC:4,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,CGB.FRR:5,ROS:5,MH:4,MSC:3,TP:3</availability>
 			<model name='WLF-1'>
 				<availability>MERC.KH:2,HL:6,LA:2,ROS:2,Periphery.Deep:6,FS:1,MERC:2,Periphery:8</availability>
 			</model>
@@ -18080,8 +17900,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>
-				CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
+			<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
 			<model name='WVR-1R'>
 				<availability>CC:1-,RF:2,FWL:1-,FS:1-,MERC:1,RCM:2,DC:1-</availability>
 			</model>
@@ -18176,8 +17995,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:2,OP:2,PR:2,DoO:2,IS:2,DO:2,FS:7,MERC:5,DC.GHO:3,DTA:2,FVC:2,RF:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
+			<availability>CC:2,OP:2,PR:2,DoO:2,IS:2,DO:2,FS:7,MERC:5,DC.GHO:3,DTA:2,FVC:2,RF:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -1120,7 +1120,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,TC:4,RA.OA:4,LA:5,CGB.FRR:4,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>MOC:3,HL:3,IS:4,Periphery.Deep:4,FS:5,Periphery:4,RA.OA:4,LA:5,CGB.FRR:4,NIOPS:3,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>HL:2,General:4,Periphery.Deep:6,Periphery:3</availability>
@@ -1149,7 +1149,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
+			<availability>CC:4,CLAN:4,IS:2,BAN:5,Periphery:1,RA.OA:1,CGB.FRR:3,FWL:4,NIOPS:6,DC:5</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:3</availability>
@@ -1654,7 +1654,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1714,7 +1714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,HL:9,CLAN:6,IS:9,Periphery.Deep:9,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery.Deep:3-,Periphery:3-</availability>
@@ -1864,7 +1864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:2,CC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:2,TC:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:3,NIOPS:4-,DC:9</availability>
+			<availability>CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:2,RA.OA:2,LA:5,CGB.FRR:6,NIOPS:4-,DC:9</availability>
 			<model name='AS7-C'>
 				<availability>CGB.FRR:2,MERC:2,DC:2</availability>
 			</model>
@@ -2041,7 +2041,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>LA:1-,General:4,FS:1-</availability>
@@ -2052,7 +2052,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CC:6,HL:7,CLAN:1-,IS:5,Periphery.Deep:7,FS:5,Periphery:8,TC:6,RA.OA:7,LA:5,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
+			<availability>MOC:7,CC:6,HL:7,CLAN:1-,IS:5,Periphery.Deep:7,Periphery:8,TC:6,RA.OA:7,ROS:5,FWL:9,NIOPS:7,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,OP:4,DoO:4,ROS:4,FWL:4,DO:4,MSC:4,TP:4,DC:5</availability>
 			</model>
@@ -2505,7 +2505,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,HL:4,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
+			<availability>HL:4,IS:5,Periphery:5,DC.GHO:4,LA:7,CGB.FRR:4,ROS:6,PIR:5,FWL:8,NIOPS:6-,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2654,7 +2654,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:2,HL:3,IS:2,MERC:2,FS:3,Periphery:4,RA.OA:3,CDS:5,LA:2,CGB.FRR:3,PIR:2,CNC:5,FWL:2,DC:5</availability>
+			<availability>HL:3,IS:2,MERC:2,FS:3,Periphery:4,RA.OA:3,CDS:5,CGB.FRR:3,PIR:2,CNC:5,DC:5</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,DC:2</availability>
 			</model>
@@ -3002,14 +3002,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>OP:6,PR:1,DoO:6,DO:6,MERC:4,DTA:6,RF:1,ROS:4,PG:1,FWL:6,MH:4,MSC:6,TP:6,DA:6,RCM:1,RFS:1</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>RF:0,General:4,RCM:0</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:3</availability>
+				<availability>IS:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3067,7 +3067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,OP:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,OP:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3137,7 +3137,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>HL:3,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3168,7 +3168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bulldog Medium Tank' unitType='Tank'>
-			<availability>MOC:1-,CC:2-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
+			<availability>MOC:1-,HL:2-,IS:2-,Periphery.Deep:7,FS:3,MERC:2,TC:2-,Periphery:3-,LA:2,CGB.FRR:1-,ROS:3,DC:3</availability>
 			<model name=''>
 				<availability>LA:2-,General:8,FS:2-,MERC:2-,DC:2-</availability>
 			</model>
@@ -3714,7 +3714,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CHH:1,PR:2,DoO:2,DO:2,FS:2,DC.GHO:4,CGB.FRR:4,FWL:2,NIOPS:5,MSC:2,RFS:2,CGB:4,CC:3,OP:2,IS:2,MERC:1,DTA:2,FVC:2,RF:2,LA:2,ROS:3,PG:2,TP:2,DA:2,RCM:2,DC:2</availability>
+			<availability>CHH:1,PR:2,DoO:2,DO:2,DC.GHO:4,CGB.FRR:4,NIOPS:5,MSC:2,RFS:2,CGB:4,CC:3,OP:2,IS:2,MERC:1,DTA:2,FVC:2,RF:2,ROS:3,PG:2,TP:2,DA:2,RCM:2</availability>
 			<model name='C'>
 				<availability>CHH:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -3855,16 +3855,16 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
+			<availability>RA.OA:2,FVC:5,LA:8,CGB.FRR:2,ROS:5,MERC:5,FS:5,CDP:6,Periphery:2,TC:6,CGB:3</availability>
 			<model name='CHP-W10'>
 				<availability>FVC:3,CDP:3,TC:3</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
+				<availability>LA:2-,Periphery.Deep:8,MERC:2-,BAN:3,Periphery:3-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2,BAN:0</availability>
@@ -4236,7 +4236,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:3,LA:5,CGB.FRR:3,ROS:3,FWL:3,NIOPS:3,DC:3</availability>
+			<availability>CC:2,MOC:1,HL:2,IS:3,FS:4,Periphery:3,TC:2,FVC:3,LA:5,CGB.FRR:3,ROS:3,NIOPS:3</availability>
 			<model name=''>
 				<availability>CC:3-,FVC:3-,General:2-,FS:3-,Periphery:3-</availability>
 			</model>
@@ -4404,7 +4404,7 @@
 			</model>
 		</chassis>
 		<chassis name='Corsair' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:3,LA:3,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,TC:2,Periphery:2,DC:1</availability>
+			<availability>RA.OA:3,LA:3,CGB.FRR:2,ROS:4,CLAN:2,FS:8,MERC:3,Periphery:2,DC:1</availability>
 			<model name='CSR-12D'>
 				<availability>FS:6</availability>
 			</model>
@@ -4507,7 +4507,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,CGB:1,DC:5</availability>
+			<availability>CLAN:1,MERC:3,RA:1,CWIE:2,DC.GHO:5,CDS:2,CW:2,CGB.FRR:4,ROS:5,NIOPS:5,FWL:3,CJF:1,DC:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
 				<availability>Periphery.Deep:8,NIOPS:0</availability>
@@ -4583,7 +4583,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>OP:1,PR:1,HL:3,DoO:1,DO:1,MERC:4,Periphery:4,DTA:1,RF:1,Periphery.MW:4,ROS:3,PG:1,Periphery.ME:4,FWL:4,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
+			<availability>OP:1,PR:1,HL:3,DoO:1,DO:1,MERC:4,Periphery:4,DTA:1,RF:1,ROS:3,PG:1,FWL:4,MSC:1,TP:1,DA:1,RCM:1,RFS:1</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -4713,7 +4713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,TC:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,FWL:3,NIOPS:3,DC:5</availability>
+			<availability>CC:4,MOC:4,IS:3,FS:4,Periphery:2,RA.OA:2,LA:4,CGB.FRR:5,ROS:3,NIOPS:3,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:1</availability>
 			</model>
@@ -4768,7 +4768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:3,MOC:3,CHH:2-,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:2,TC:4,Periphery:4,ROS:6,NIOPS:6,CJF:2-</availability>
+			<availability>CC:3,MOC:3,CHH:2-,HL:3,CEI:2,FR:2,MERC:4,CDP:4,RA:2Periphery:4,ROS:6,NIOPS:6,CJF:2-</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:4,ROS:5</availability>
@@ -4984,7 +4984,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CCC:2,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CDS:2,CJF:3,CGB:6</availability>
+			<availability>CHH:4,CLAN:2,IS:3,CLAN.IS:2,MERC:3+,CCO:1,BAN:3,CSA:1,MERC.WD:3,CJF:3,CGB:6</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CSA:3,CDS:5,General:3,CCO:2,CJF:4,CGB:2</availability>
@@ -5118,7 +5118,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2,DC:7</availability>
+			<availability>CHH:5,HL:9,CLAN:4,IS:7,Periphery.Deep:9,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CGB.FRR:7,ROS:8,CNC:5,FWL:8,NIOPS:6,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,HL:2,IS:2,FS:4,CDP:4,TC:4,Periphery:4,LA:4,CGB.FRR:4,ROS:4,FWL:4,DC:4</availability>
@@ -5186,7 +5186,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>MOC:1,CC:1,OP:3,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,TC:3,RA.OA:1,FVC:5,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
+			<availability>MOC:1,OP:3,HL:2,DoO:3,IS:1,Periphery.Deep:5,DO:3,FS:5,MERC:2,Periphery.OS:4,Periphery:3,RA.OA:1,FVC:5,LA:2,CGB.FRR:3,ROS:3,Periphery.HR:4,TP:3,DC:2</availability>
 			<model name='DV-1S'>
 				<availability>IS:2-</availability>
 			</model>
@@ -5401,7 +5401,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drillson Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2-,HL:2,IS:2-,MERC:2-,FS:5,CC.CHG:2-,Periphery:2-,FVC:2-,LA:6,ROS:3,FWL:2-,CC.MAC:2-,DC:2-</availability>
+			<availability>HL:2,IS:2-,MERC:2-,FS:5,Periphery:2-,FVC:2-,LA:6,ROS:3</availability>
 			<model name=''>
 				<availability>CC:2-,General:2-</availability>
 			</model>
@@ -5443,7 +5443,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,TC:3,RA.OA:2,LA:3,CGB.FRR:3,FWL:4,NIOPS:3-,DC:3</availability>
+			<availability>MOC:4,HL:2,CLAN:3,IS:3,FS:4,Periphery:3,RA.OA:2,CGB.FRR:3,FWL:4,NIOPS:3-</availability>
 			<model name='EGL-R11'>
 				<availability>PR:6,RF:6,LA:5,ROS:6,PG:6,MERC:5,FS:6,RFS:6</availability>
 			</model>
@@ -5598,7 +5598,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,NIOPS:7,MH:3,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,CNC:5,NIOPS:7,MH:3</availability>
 			<model name='EMP-6A'>
 				<availability>CC:5,HL:6,LA:5,ROS:4,CLAN:8,IS:8,NIOPS:8,Periphery.Deep:6,FWL:5,FS:5,BAN:4,Periphery:8</availability>
 			</model>
@@ -5752,7 +5752,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,RA.OA:2,LA:5,CGB.FRR:6,IS:5,FWL:5,NIOPS:5,FS:2,Periphery:2,TC:3,DC:6</availability>
+			<availability>MOC:3,RA.OA:2,CGB.FRR:6,IS:5,NIOPS:5,FS:2,Periphery:2,TC:3,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -6275,7 +6275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,DC.GHO:5,CDS:1,LA:4,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:5,CJF:2,CGB:1,DC:4</availability>
+			<availability>CLAN:1,DC.GHO:5,LA:4,CGB.FRR:4,ROS:3,FWL:4,NIOPS:5,MSC:5,CJF:2,DC:4</availability>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,LA:8,CGB.FRR:6,ROS:6,CLAN:8,NIOPS:4,MERC.SI:5,MSC:6,BAN:8</availability>
 			</model>
@@ -6311,7 +6311,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,PR:3,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,PG:3,Periphery.ME:4,FWL:1,DA:3,RCM:3,RFS:3</availability>
+			<availability>CC:6,PR:3,MERC:4,Periphery:4,MERC.WD:4,FVC:4,RF:3,ROS:4,PG:3,FWL:1,DA:3,RCM:3,RFS:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:6,PR:7,RF:7,ROS:8,PG:7,FWL:6,MERC:6,RCM:7,DA:7,RFS:7,Periphery:6</availability>
 			</model>
@@ -6586,7 +6586,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
+			<availability>HL:5,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,RA.OA:8,LA:7,CGB.FRR:7,FWL:8,NIOPS:6,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -6657,7 +6657,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>CC:2,MOC:2,OP:3,DoO:3,IS:2,DO:3,MERC:2,FS:2,TC:2,DTA:3,FVC:2,LA:3,PIR:2,FWL:2,MH:2,MSC:3,TP:3,DC:2</availability>
+			<availability>MOC:2,OP:3,DoO:3,IS:2,DO:3,MERC:2,TC:2,DTA:3,FVC:2,LA:3,PIR:2,MH:2,MSC:3,TP:3</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -6680,7 +6680,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CSA:6,CDS:5,CW:2,CEI:1,ROS:3+,CNC:5,CLAN:5,CJF:4,BAN:4,CGB:9</availability>
+			<availability>CSA:6,CW:2,CEI:1,ROS:3+,CLAN:5,CJF:4,BAN:4,CGB:9</availability>
 			<model name='A'>
 				<availability>CDS:5,CW:8,CNC:5,General:6,CJF:5,CWIE:8,CGB:7</availability>
 			</model>
@@ -7687,7 +7687,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>CC:2,MOC:4,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:4,Periphery:5,RA.OA:5,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:5</availability>
+			<availability>CC:2,MOC:4,HL:4,MERC:3,Periphery.OS:4,FS:3,TC:4,Periphery:5,RA.OA:5,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -7713,7 +7713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -7968,7 +7968,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,HL:4,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,Periphery:5</availability>
+			<availability>RA.OA:4,HL:4,ROS:4,FWL:6,MERC:6,Periphery:5</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -8035,7 +8035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>CC:7,CDS:3,Periphery.CM:6,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:6,Periphery:6,CWIE:3</availability>
+			<availability>CC:7,CDS:3,CGB.FRR:2,CNC:3,IS:3-,Periphery.Deep:6,MERC:6,Periphery:6,CWIE:3</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -8081,7 +8081,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>MOC:3,CC:4,LA:6,CLAN:4,IS:3,FWL:3,NIOPS:9,MH:3,MERC:4,FS:5,CJF:5,DC:3</availability>
+			<availability>MOC:3,CC:4,LA:6,CLAN:4,IS:3,NIOPS:9,MH:3,MERC:4,FS:5,CJF:5</availability>
 			<model name='HGN-732'>
 				<availability>MOC:6,CC:5,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:5,NIOPS:3,MERC.SI:8,MH:6,DC:5</availability>
 			</model>
@@ -8167,7 +8167,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,TC:2,MERC.WD:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
+			<availability>FS:5,MERC:3,Periphery.OS:4,FS.CrMM:7,Periphery:2,MERC.WD:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:7,FS.DMM:7</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:2-</availability>
@@ -8282,7 +8282,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
+			<availability>MOC:4,CC:6,HL:4,IS:5,MERC:5,Periphery:5,RA.OA:5,LA:7,CGB.FRR:5,ROS:3,FWL:4,DC:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:3-</availability>
@@ -8529,7 +8529,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:3,LA:4,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
+			<availability>MOC:4,HL:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,CGB.FRR:4,FWL:6,NIOPS:4,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -8640,7 +8640,7 @@
 			</model>
 		</chassis>
 		<chassis name='J. Edgar Light Hover Tank' unitType='Tank'>
-			<availability>MOC:2-,DC.LV:3-,DC.GR:2-,FS.AH:2-,IS:2-,Periphery.Deep:5,FS:2-,Periphery:2-,TC:3-,RA.OA:2-,LA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-,DC:2-</availability>
+			<availability>DC.LV:3-,DC.GR:2-,FS.AH:2-,IS:2-,Periphery.Deep:5,Periphery:2-,TC:3-,RA.OA:2-,CGB.FRR:2-,FWL:1-,NIOPS:2-</availability>
 			<model name=''>
 				<availability>HL:2,General:7,Periphery.Deep:6,Periphery:4</availability>
 			</model>
@@ -8675,7 +8675,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>CC:4,LA:4,ROS:4,CGB.FRR:4,IS:4,FWL:4,FS:5,MERC:4,CJF:4,CGB:5,Periphery:3,DC:4</availability>
+			<availability>ROS:4,CGB.FRR:4,IS:4,FS:5,MERC:4,CJF:4,CGB:5,Periphery:3,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -8762,7 +8762,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:3,CC:2-,MERC:3,Periphery.OS:2,FS:6,TC:3,Periphery:3,RA.OA:2,FVC:7,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,MH:3,DC:2</availability>
+			<availability>CC:2-,MERC:3,Periphery.OS:2,FS:6,Periphery:3,RA.OA:2,FVC:7,LA:2,Periphery.CM:2,ROS:4,PIR:3,Periphery.ME:2,NIOPS:3,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:3,RA.OA:5,FVC:5,LA:5,CGB.FRR:5,FS:5,MERC:5,CDP:3,DC:5,TC:3</availability>
@@ -8803,7 +8803,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,TC:3,RA.OA:1,FVC:7,LA:1,Periphery.HR:4,ROS:4</availability>
+			<availability>HL:2,Periphery.Deep:4,FS:8,MERC:4,Periphery.OS:6,Periphery:3,RA.OA:1,FVC:7,LA:1,Periphery.HR:4,ROS:4</availability>
 			<model name='JVN-10F &apos;Fire Javelin&apos;'>
 				<roles>recon</roles>
 				<availability>MOC:1,IS:1,MERC:1,TC:1,Periphery:1</availability>
@@ -9199,7 +9199,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,LA:4,CGB.FRR:4,ROS:6,FWL:4,NIOPS:6,MH:3,CGB:3,DC:4</availability>
+			<availability>CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,CGB.FRR:4,ROS:6,NIOPS:6,MH:3,CGB:3</availability>
 			<model name='KGC-000'>
 				<availability>CGB.FRR:8,ROS:6,CLAN:6,NIOPS:4,BAN:8,DC:8</availability>
 			</model>
@@ -9275,7 +9275,7 @@
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>DC.GHO:5,CGB.FRR:4,ROS:6,NIOPS:7,FS:2,MERC:4,DC:4</availability>
 			<model name='KTO-18'>
-				<availability>:0,FS:2-,MERC:2-</availability>
+				<availability>FS:2-,MERC:2-</availability>
 			</model>
 			<model name='KTO-19'>
 				<availability>DC.GHO:3,DC.SL:4,ROS:4,CLAN:6,NIOPS:4,MERC.SI:5,FS:8,MERC:8,BAN:7</availability>
@@ -9796,7 +9796,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,FS:3,Periphery:4,TC:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>MOC:5,CC:4,HL:3,CLAN:2,IS:3,Periphery:4,RA.OA:6,LA:2,CGB.FRR:4,FWL:2,NIOPS:3-,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:4-</availability>
 			</model>
@@ -10043,7 +10043,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,DC:6,CGB:3</availability>
+			<availability>MOC:6,CC:4,HL:6,IS:6,Periphery.Deep:6,FS:5,Periphery:7,TC:6,RA.OA:6,LA:5,CGB.FRR:4,ROS:6,FWL:7,NIOPS:3,CGB:3</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10461,7 +10461,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,FS:6,Periphery:6,TC:6,CWIE:6,RA.OA:6,LA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
+			<availability>MOC:5,CC:5,HL:5,IS:6,Periphery.Deep:7,MERC:6,Periphery:6,CWIE:6,RA.OA:6,CGB.FRR:7,ROS:6,FWL:5,NIOPS:7,DC:8</availability>
 			<model name=''>
 				<availability>HL:2,LA:1-,General:2-,Periphery.Deep:6,FS:1-,DC:1-,Periphery:4</availability>
 			</model>
@@ -10552,7 +10552,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,MOC:2,IS:1-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
+			<availability>CC:4,IS:1-,FS:6,TC:3,Periphery:2,RA.OA:2,LA:5,CGB.FRR:4,ROS:2,FWL:3,NIOPS:6,DC:3,CGB:3</availability>
 			<model name='MAD-2R'>
 				<availability>MOC:3,RA.OA:3,MH:3,MERC:3,BAN:1,TC:4</availability>
 			</model>
@@ -10785,7 +10785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Maxim Heavy Hover Transport' unitType='Tank'>
-			<availability>MOC:1,CC:1,CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,TC:1,RA.OA:1,LA:2,CGB.FRR:2,ROS:1,FWL:1,NIOPS:2-,DC:1</availability>
+			<availability>CLAN:1,IS:1,Periphery.Deep:5,MERC:1,Periphery:1,RA.OA:1,LA:2,CGB.FRR:2,ROS:1,NIOPS:2-</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
@@ -11513,7 +11513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:5,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
+			<availability>MOC:2CC:5,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11718,7 +11718,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>OP:5,PR:5,DoO:5,DO:5,FS:7,MERC:6,Periphery.R:2,RF:5,LA:8,ROS:6,PG:5,TP:5,RFS:5</availability>
 			<model name='NGS-4S'>
-				<availability>:0,OP:4,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,RF:4,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
+				<availability>OP:4,PR:4,HL:6,DoO:4,Periphery.Deep:6,DO:4,FS:5,MERC:5,Periphery:8,RF:4,LA:5,ROS:4,PG:4,General:8,TP:4,RFS:4</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -11997,7 +11997,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:7,CC:5,HL:2,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4,DC:3</availability>
+			<availability>MOC:7,CC:5,HL:2,IS:3,MERC:3,FS:6,Periphery:3,TC:4,FVC:6,CDS:5,LA:6,CGB.FRR:3,Periphery.MW:5,PIR:5,CNC:5,Periphery.ME:5,FWL:7,MH:4</availability>
 			<model name=''>
 				<availability>HL:3,General:2,Periphery.Deep:8,Periphery:5</availability>
 			</model>
@@ -12047,7 +12047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,CW:2,LA:1,CGB.FRR:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:4-,DC:4</availability>
+			<availability>MOC:2,CC:3,HL:3,CLAN:1,IS:1,Periphery.Deep:4,FS:2,Periphery:4,TC:2,CWIE:2,RA.OA:2,CW:2,CGB.FRR:4,FWL:6,NIOPS:4-,DC:4</availability>
 			<model name='ON1-K'>
 				<availability>General:2-,CLAN:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -12130,7 +12130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>MOC:4,CC:3,LA:4,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
+			<availability>MOC:4,CC:3,CGB.FRR:5,ROS:4,IS:4,NIOPS:3-,Periphery.Deep:4,MERC:4,TC:4,Periphery:2,DC:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>Periphery.Deep:8,MERC:2-,Periphery:3-</availability>
@@ -12350,7 +12350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:3-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,TC:3-,RA.OA:3-,FVC:6-,LA:5-,FS.PMM:6-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,FWL:3-,NIOPS:6,DC:3-</availability>
+			<availability>MOC:2-,HL:2-,IS:3-,Periphery.Deep:4,FS:5-,FS.CrMM:6-,Periphery:3-,RA.OA:3-,FVC:6-,LA:5-,FS.PMM:6-,CGB.FRR:3-,FS.CMM:6-,FS.DMM:6-,NIOPS:6</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12520,7 +12520,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:3-,CC:1-,HL:2-,IS:2-,Periphery.Deep:9,FS:3-,Periphery:3-,TC:3-,RA.OA:2-,CDS:1,LA:2-,FWL:2-,DC:1-</availability>
+			<availability>CC:1-,HL:2-,IS:2-,Periphery.Deep:9,FS:3-,Periphery:3-,RA.OA:2-,CDS:1,DC:1-</availability>
 			<model name=''>
 				<availability>General:4</availability>
 			</model>
@@ -12596,7 +12596,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pegasus Scout Hover Tank' unitType='Tank'>
-			<availability>MOC:1,RA.OA:1,LA:6,ROS:6,FWL:1,Periphery.Deep:8,FS:6,Periphery:1,TC:1,DC:6</availability>
+			<availability>RA.OA:1,LA:6,ROS:6,FWL:1,Periphery.Deep:8,FS:6,Periphery:1,DC:6</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:2-</availability>
@@ -12758,7 +12758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CC:3,CCC:5,CLAN:3,MERC:3,FS:3,CCO:5,RA:5,CSA:3,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
+			<availability>CC:3,CCC:5,CLAN:3,MERC:3,FS:3,CCO:5,RA:5,DTA:3,CDS:5,RF:3,LA:3,ROS:4,MSC:3,DC:3</availability>
 			<model name=''>
 				<availability>CDS:3,CNC:3,IS:2,CCO:2,DC:3</availability>
 			</model>
@@ -12870,7 +12870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>MOC:2,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,FS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-,DC:2-</availability>
+			<availability>MOC:2,CC:2,CHH:4,HL:2-,CLAN:4,IS:2-,MERC:2-,CWIE:5,Periphery:3-,TC:2-,RA.OA:2-,MERC.WD:4,CDS:5,LA:1-,CGB.FRR:3-,CNC:4,FWL:1-,MH:4-</availability>
 			<model name=''>
 				<availability>HL:2,IS:2,Periphery:4</availability>
 			</model>
@@ -13214,7 +13214,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CLAN:6,MERC:2+,CCO:6,RA:7,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:7,CW:8,ROS:3+,CNC:8,CJF:5,CGB:6</availability>
+			<availability>CLAN:6,MERC:2+,CCO:6,RA:7,BAN:6,CWIE:8,CSA:8,MERC.WD:5,CDS:7,CW:8,ROS:3+,CNC:8,CJF:5</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CSA:8,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -13563,7 +13563,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -13673,7 +13673,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:5,CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
+			<availability>CCC:6,HL:2,IS:5,Periphery.Deep:5,FS:8,Periphery:3,CSA:6,CGB.FRR:7,ROS:6,FWL:7,NIOPS:5,CJF:5</availability>
 			<model name='C 2'>
 				<availability>CJF:4</availability>
 			</model>
@@ -14044,7 +14044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:5,Periphery.DD:3,DC.AL:9,IS:5,MERC:5,Periphery.OS:3,FS:4,Periphery:2,RA.OA:2,LA:5,CGB.FRR:6,FWL:5,CJF:4,DC:8</availability>
+			<availability>Periphery.DD:3,DC.AL:9,IS:5,MERC:5,Periphery.OS:3,FS:4,Periphery:2,RA.OA:2,CGB.FRR:6,CJF:4,DC:8</availability>
 			<model name=''>
 				<availability>IS:4-,Periphery:4-</availability>
 			</model>
@@ -14107,7 +14107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:4,CC:4-,Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:2-,Periphery:4,TC:4,RA.OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:6-</availability>
+			<availability>Periphery.DD:6,HL:3,IS:4-,Periphery.OS:6,FS:2-,Periphery:4,RA.OA:6,CDS:3,CW:2,LA:3-,CGB.FRR:5-,ROS:2-,FWL:5-,DC:6-</availability>
 			<model name=''>
 				<availability>General:5-</availability>
 			</model>
@@ -14290,7 +14290,7 @@
 			</model>
 		</chassis>
 		<chassis name='Schrek PPC Carrier' unitType='Tank'>
-			<availability>MOC:2,CC:1,HL:3,IS:2,Periphery.Deep:5,MERC:2,FS:2,Periphery:4,TC:2,RA:4,RA.OA:3,LA:2,CGB.FRR:2,CNC:4,FWL:2,DC:1</availability>
+			<availability>MOC:2,CC:1,HL:3,IS:2,Periphery.Deep:5,MERC:2,Periphery:4,TC:2,RA:4,RA.OA:3,CGB.FRR:2,CNC:4,DC:1</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:8</availability>
@@ -14308,7 +14308,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:4-,CC:4-,Periphery.DD:4-,HL:3-,IS:3-,MERC:3-,Periphery.OS:4-,FS:2-,Periphery:4-,TC:4-,RA.OA:5-,LA:3-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
+			<availability>CC:4-,HL:3-,IS:3-,MERC:3-,FS:2-,Periphery:4-,RA.OA:5-,CGB.FRR:7-,FWL:2-,DC:5-</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -14468,7 +14468,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:1,FS:5,MERC:4,CWIE:1,DC.GHO:3,FVC:5,CDS:1,CW:1,LA:5,ROS:4,NIOPS:4,CJF:2,CGB:2,DC:3</availability>
+			<availability>CLAN:1,FS:5,MERC:4,CWIE:1,DC.GHO:3,FVC:5,LA:5,ROS:4,NIOPS:4,CJF:2,CGB:2,DC:3</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,NIOPS:8,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -14489,7 +14489,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:6,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,HL:5,Periphery.Deep:4,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,FVC:3,LA:7,CGB.FRR:2,ROS:7,MH:2,CGB:0</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:2-,MERC.KH:2-,LA:2-,Periphery.Deep:4,MERC:2-,Periphery:2-</availability>
@@ -14885,7 +14885,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:2,Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,FS:2,RA.OA:1,FVC:2,LA:2,CGB.FRR:4-,ROS:3-,FWL:2,NIOPS:3-,DC:5</availability>
+			<availability>Periphery.DD:3,IS:2,MERC:2,Periphery.OS:3,RA.OA:1,FVC:2,CGB.FRR:4-,ROS:3-,NIOPS:3-,DC:5</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:4-</availability>
@@ -14904,7 +14904,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
+			<availability>Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,CGB.FRR:7,ROS:4,DC:7,CGB:5</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,IS:2-,Periphery.Deep:8,FS:0,Periphery:3-</availability>
 			</model>
@@ -15028,7 +15028,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,Periphery.OS:4,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,Periphery.HR:4,ROS:4,NIOPS:3</availability>
+			<availability>MOC:2,HL:3,Periphery.Deep:4,MERC:5,FS:9,Periphery:4,TC:2,RA.OA:2,FVC:8,LA:3,CGB.FRR:5,ROS:4,NIOPS:3</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:4,CGB.FRR:5,ROS:4,FS:8,MERC:5</availability>
 			</model>
@@ -15088,7 +15088,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>MOC:2,CC:3,OP:4,MERC:3,FS:3,Periphery:2,TC:2,DTA:4,FVC:3,RF:5,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,MSC:3,DA:3,RCM:6,DC:6</availability>
+			<availability>CC:3,OP:4,MERC:3,FS:3,Periphery:2,DTA:4,FVC:3,RF:5,CGB.FRR:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,NIOPS:3,MSC:3,DA:3,RCM:6,DC:6</availability>
 			<model name='SDR-5K'>
 				<roles>anti_infantry</roles>
 				<availability>CGB.FRR:2-,DC:2-</availability>
@@ -15178,7 +15178,7 @@
 			<availability>CHH:4,CSL:4,CCO:5</availability>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,FS:5,Periphery:10,TC:7,RA.OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
+			<availability>MOC:5,CC:4,HL:9,CLAN:2,IS:5,Periphery.Deep:9,Periphery:10,TC:7,RA.OA:7,LA:6,CGB.FRR:5,ROS:4,FWL:7,NIOPS:5,DC:4</availability>
 			<model name='STK-3F'>
 				<availability>IS:2-,Periphery.Deep:8,Periphery:3-</availability>
 			</model>
@@ -15420,7 +15420,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -15432,7 +15432,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -15493,7 +15493,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,LA:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2,CGB:1</availability>
+			<availability>CC:2,IS:3,FS:6,MERC:3,CWIE:4,FVC:6,CDS:3,CGB.FRR:3,ROS:4,PIR:3,CNC:4,FWL:2,DC:2,CGB:1</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -15536,7 +15536,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>MOC:1,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1,RA.OA:2,FVC:7,LA:2,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
+			<availability>CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,RA.OA:2,FVC:7,LA:2,CGB.FRR:1,Periphery.HR:2,ROS:5</availability>
 			<model name='STU-D6'>
 				<availability>FVC:5,LA:6,ROS:6,FS:5,MERC:6,CDP:3</availability>
 			</model>
@@ -15970,7 +15970,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CLAN:2,CCO:2,RA:2,BAN:4,CWIE:4,CSA:2,MERC.WD:3,CDS:2,CW:2,ROS:2+,CNC:2,CJF:5,CGB:2</availability>
+			<availability>CHH:5,CLAN:2,RA:2,BAN:4,CWIE:4,MERC.WD:3,ROS:2+,CJF:5</availability>
 			<model name='A'>
 				<availability>CHH:8,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -16066,7 +16066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,HL:2,FS:4,MERC:3,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>CC:2-,FVC:3-,HL:2-,FWL:2-,Periphery.Deep:8,MERC:2-,Periphery:4-</availability>
@@ -16178,7 +16178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,TC:5,RA.OA:4,LA:6,CGB.FRR:4,FWL:4,NIOPS:4-,DC:4</availability>
+			<availability>MOC:4,HL:4,IS:4,Periphery.Deep:5,FS:5,Periphery:5,RA.OA:4,LA:6,CGB.FRR:4,NIOPS:4-</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:3-</availability>
@@ -16543,7 +16543,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,RF:6,LA:2,CGB.FRR:4,Periphery.MW:4,ROS:4,PG:6,Periphery.ME:4,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
+			<availability>CC:3,MOC:2,PR:6,IS:2,FS:1,MERC:3,Periphery:4,TC:4,RA.OA:2,RF:6,CGB.FRR:4,ROS:4,PG:6,FWL:6,NIOPS:3-,RFS:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>PR:4,RF:4,ROS:5,PG:4,NIOPS:5,MSC:4,MERC:4,RFS:4</availability>
@@ -16756,7 +16756,7 @@
 			<availability>ROS:4,DC:4</availability>
 			<model name=''>
 				<roles>apc,urban</roles>
-				<availability>:0,General:4</availability>
+				<availability>General:4</availability>
 			</model>
 			<model name='(C3)'>
 				<roles>apc,urban,spotter</roles>
@@ -16993,7 +16993,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,HL:3-,IS:4-,FS:4-,Periphery:4-,TC:3-,RA.OA:3-,LA:4-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,HL:3-,IS:4-,Periphery:4-,TC:3-,RA.OA:3-,CGB.FRR:5-,FS.CMM:5-,FWL:5-,NIOPS:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -17453,7 +17453,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:2,MOC:4,LA:5,CGB.FRR:4,FWL:5,IS:3,NIOPS:3,Periphery:4,CGB:1,TC:4</availability>
+			<availability>CC:2,LA:5,CGB.FRR:4,FWL:5,IS:3,NIOPS:3,Periphery:4,CGB:1</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
 				<availability>FVC:2-,General:3-,FS:2-</availability>
@@ -17480,7 +17480,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,MERC.WD:5,ROS:3,CLAN:5,MERC:1+,CCO:5,CJF:5,BAN:6,CWIE:5,CGB:6,DC:3</availability>
+			<availability>CHH:6,MERC.WD:5,ROS:3,CLAN:5,MERC:1+,CCO:5,BAN:6,CWIE:5,CGB:6,DC:3</availability>
 			<model name='A'>
 				<availability>CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 			</model>
@@ -17659,7 +17659,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,HL:5,FS.CH:8,IS:6,Periphery.Deep:4,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+			<availability>HL:5,FS.CH:8,IS:6,Periphery.Deep:4,CC.CHG:8,Periphery:6,CWIE:4,RA:4,RA.OA:6,LA:9,CGB.FRR:5,ROS:6,CNC:4,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -17900,7 +17900,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,TC:4,LA:5,CNC:2,FWL:8,NIOPS:3-,MH:4,DC:5,CGB:1</availability>
+			<availability>HL:3,IS:5,Periphery.Deep:5,FS:6,Periphery:4,CNC:2,FWL:8,NIOPS:3-,CGB:1</availability>
 			<model name='WVR-1R'>
 				<availability>CC:1-,RF:2,FWL:1-,FS:1-,MERC:1,RCM:2,DC:1-</availability>
 			</model>
@@ -17995,7 +17995,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:2,OP:2,PR:2,DoO:2,IS:2,DO:2,FS:7,MERC:5,DC.GHO:3,DTA:2,FVC:2,RF:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
+			<availability>OP:2,PR:2,DoO:2,IS:2,DO:2,FS:7,MERC:5,DC.GHO:3,DTA:2,FVC:2,RF:2,CGB.FRR:5,PG:2,ROS:5,NIOPS:5,MSC:1,TP:2,RCM:2,DA:2,RFS:2,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,CGB.FRR:8,ROS:6,NIOPS:4,FS:8,MERC:8,BAN:2,DC:3</availability>
@@ -18220,7 +18220,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,HL:2,IS:4,FWL:5,MERC:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,HL:2,IS:4,FWL:5,MERC:4,Periphery:3,DC:5</availability>
 			<model name=''>
 				<availability>General:5</availability>
 			</model>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -749,8 +749,7 @@
 			<omniMargin>6</omniMargin>
 			<techMargin>6</techMargin>
 			<upgradeMargin>3</upgradeMargin>
-			<salvage pct='6'>
-				MOC:2,CC:8,RT:1,FS:8,Periphery:1,TC:2,DTA:2,CDS:1,CW:6,LA:8,RIM:1,ROS:15,CNC:3,FWL:14,CJF:10,CGB:8,DC:10</salvage>
+			<salvage pct='6'>MOC:2,CC:8,RT:1,FS:8,Periphery:1,TC:2,DTA:2,CDS:1,CW:6,LA:8,RIM:1,ROS:15,CNC:3,FWL:14,CJF:10,CGB:8,DC:10</salvage>
 		</faction>
 		<faction key='CGB.FRR'>
 			<pctOmni>16</pctOmni>
@@ -1901,8 +1900,7 @@
 			<availability>CC:1-,MOC:1-,FVC:1,LA:1,MERC:1-,RCM:2-,DA:2-,CDP:1-,TC:1-,Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
+				<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1972,8 +1970,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:3,TC:3,RA.OA:3,LA:6,FWL:3,DC:8</availability>
+			<availability>CC:3,MOC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:3,TC:3,RA.OA:3,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2466,8 +2463,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:5-,RA.OA:5-,FVC:2-,RF:2-,LA:3-,FWL:1-,MH:5-,MSC:1-,MERC:2-,Periphery:7-,TC:5-</availability>
+			<availability>MOC:5-,RA.OA:5-,FVC:2-,RF:2-,LA:3-,FWL:1-,MH:5-,MSC:1-,MERC:2-,Periphery:7-,TC:5-</availability>
 			<model name='BNC-3E'>
 				<availability>MERC:1-,Periphery:2-</availability>
 			</model>
@@ -2628,8 +2624,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:5,FWL:8,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:5,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:5,FWL:8,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2652,8 +2647,7 @@
 				<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:4,FVC:4,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:3,MH:5,MERC:4,Periphery:2</availability>
+				<availability>CC:4,FVC:4,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:3,MH:5,MERC:4,Periphery:2</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -2775,8 +2769,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>
-				CC:2,IS:2,MERC:2,FS:2,Periphery:2,RA.OA:2,CDS:3,LA:2,CGB.FRR:2,PIR:2,CNC:3,FWL:2,DC:3</availability>
+			<availability>CC:2,IS:2,MERC:2,FS:2,Periphery:2,RA.OA:2,CDS:3,LA:2,CGB.FRR:2,PIR:2,CNC:3,FWL:2,DC:3</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8</availability>
 			</model>
@@ -2953,14 +2946,12 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:3,FWL:6,MSC:6,CGB:5,MOC:3,CC:3,OP:6,IS:4,MERC:4,RA:3,Periphery:3,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:3,FWL:6,MSC:6,CGB:5,MOC:3,CC:3,OP:6,IS:4,MERC:4,RA:3,Periphery:3,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:5,FS:5</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,CGB.FRR:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,BAN:2,DC:6</availability>
@@ -3214,8 +3205,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,OP:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MOC:3,OP:4,MERC.KH:3,FRR:4,FR:2,FS:6,MERC:6,Periphery:3,DTA:4,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3285,8 +3275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3543,8 +3532,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,FVC:4,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:3,MERC:4,CDP:4,TC:4</availability>
+			<availability>CC:5,MOC:4,FVC:4,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:3,MERC:4,CDP:4,TC:4</availability>
 			<model name='CTF-1X'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -3767,8 +3755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:2,OP:2,Periphery.OS:4,FS:7,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:4,FWL:2,MH:6,MSC:2</availability>
+			<availability>CC:2,OP:2,Periphery.OS:4,FS:7,MERC:2,CDP:4,Periphery:2,DTA:2,FVC:8,LA:4,Periphery.HR:4,ROS:4,FWL:2,MH:6,MSC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 			</model>
@@ -3922,8 +3909,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>
-				CC:2,OP:1,CHH:1,DC.GHO:2,DTA:1,FVC:1,RD:4,RF:1,LA:1,ROS:2,MSC:1,DA:1,RCM:1,CGB:4,DC:1</availability>
+			<availability>CC:2,OP:1,CHH:1,DC.GHO:2,DTA:1,FVC:1,RD:4,RF:1,LA:1,ROS:2,MSC:1,DA:1,RCM:1,CGB:4,DC:1</availability>
 			<model name='C'>
 				<availability>CHH:6,RD:6,CLAN:8,CGB:6</availability>
 			</model>
@@ -4003,15 +3989,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:2,OP:10,MERC:3,FS:3,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
+			<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,Periphery:1-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:4,MOC:4,OP:8,MERC:6,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
+				<availability>CC:4,MOC:4,OP:8,MERC:6,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -4409,8 +4393,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:2-,LA:1-,Periphery:2-</availability>
@@ -4711,8 +4694,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:1,MERC:4,RA:1,CWIE:2,DC.GHO:5,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,CGB:1,DC:5</availability>
+			<availability>CHH:1,CLAN:1,MERC:4,RA:1,CWIE:2,DC.GHO:5,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,CGB:1,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -4781,8 +4763,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>
-				DTA:4,OP:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,MERC:4,DA:4,RCM:4,Periphery:4</availability>
+			<availability>DTA:4,OP:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,MERC:4,DA:4,RCM:4,Periphery:4</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -4830,8 +4811,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crow Scout Helicopter' unitType='VTOL'>
-			<availability>
-				CC:3,MOC:3,OP:3,MERC.KH:3,IS:2,FR:2,MERC:3,DTA:3,MERC.WD:3,RF:3,ROS:4,CNC:3,FWL:3,MSC:3,DA:3,RCM:3,DC:5</availability>
+			<availability>CC:3,MOC:3,OP:3,MERC.KH:3,IS:2,FR:2,MERC:3,DTA:3,MERC.WD:3,RF:3,ROS:4,CNC:3,FWL:3,MSC:3,DA:3,RCM:3,DC:5</availability>
 			<model name=''>
 				<roles>recon,spotter</roles>
 				<availability>MOC:5,MERC.KH:5,MERC.WD:5,IS:5,FR:5,MERC:5,DC:8</availability>
@@ -4846,8 +4826,7 @@
 			</model>
 			<model name='(Export)'>
 				<roles>recon</roles>
-				<availability>
-					CC:6,MOC:6,OP:6,MERC.KH:6,FR:6,MERC:6,DTA:6,MERC.WD:6,RF:6,ROS:6,CNC:3,FWL:6,MSC:6,DA:6,RCM:6</availability>
+				<availability>CC:6,MOC:6,OP:6,MERC.KH:6,FR:6,MERC:6,DTA:6,MERC.WD:6,RF:6,ROS:6,CNC:3,FWL:6,MSC:6,DA:6,RCM:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Crucible Station' unitType='Space Station'>
@@ -5115,8 +5094,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,FS:4+,MERC:4+,BAN:3,CWIE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:4+</availability>
+			<availability>CLAN:4,FS:4+,MERC:4+,BAN:3,CWIE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,CGB:5,DC:4+</availability>
 			<model name='A'>
 				<availability>CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5360,8 +5338,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,ROS:8,CNC:5,FWL:8,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,ROS:8,CNC:5,FWL:8,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,LA:4,CGB.FRR:4,ROS:4,IS:2,FWL:4,FS:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -5430,8 +5407,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
+			<availability>OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
 			<model name='DV-1S'>
 				<availability>IS:1-</availability>
 			</model>
@@ -6291,8 +6267,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:2,LA:3-,ROS:2-,Periphery.HR:2,Periphery.MW:2,Periphery.CM:2,FWL:2-,FS:3-</availability>
+			<availability>Periphery.R:2,LA:3-,ROS:2-,Periphery.HR:2,Periphery.MW:2,Periphery.CM:2,FWL:2-,FS:3-</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:3</availability>
@@ -6633,15 +6608,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,DA:3,RCM:3</availability>
+			<availability>CC:6,MOC:4,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,DA:3,RCM:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:5,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,RCM:4-,DA:4-,Periphery:6-,TC:4-</availability>
+				<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,RCM:4-,DA:4-,Periphery:6-,TC:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:4</availability>
@@ -6919,8 +6892,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7013,8 +6985,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
+			<availability>CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -7198,8 +7169,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,OP:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,DTA:2,FVC:2,RF:2,CW:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
+			<availability>CC:4,MOC:4,OP:2,FR:2,FS:3,MERC:4,TC:4,Periphery:3,RA.OA:3,DTA:2,FVC:2,RF:2,CW:2,LA:5,ROS:4,Periphery.MW:2,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
 			<model name='GOL-1H'>
 				<roles>fire_support</roles>
 				<availability>MERC:1-</availability>
@@ -7309,8 +7279,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
-			<availability>
-				DTA:7,OP:7,CDS:4,ROS:7,Periphery.MW:5,PIR:5,Periphery.ME:5,CLAN:3,CNC:4,FWL:7,MSC:7,MERC:4</availability>
+			<availability>DTA:7,OP:7,CDS:4,ROS:7,Periphery.MW:5,PIR:5,Periphery.ME:5,CLAN:3,CNC:4,FWL:7,MSC:7,MERC:4</availability>
 			<model name='GTHA-400'>
 				<availability>PIR:2-,FWL:2-,MH:2-,MERC:2-</availability>
 			</model>
@@ -7348,8 +7317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,OP:7,FS:5,MERC:5,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,MSC:7,DA:7,RCM:7,DC:5</availability>
+			<availability>CC:5,MOC:5,OP:7,FS:5,MERC:5,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,MSC:7,DA:7,RCM:7,DC:5</availability>
 			<model name='T-IT-N10M'>
 				<availability>ROS:4,FWL:4,MERC:4,Periphery:4</availability>
 			</model>
@@ -7614,12 +7582,10 @@
 			</model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:8,MOC:2,OP:4,MERC.KH:2,CEI:2,FR:6,MERC:7,Periphery:5,DTA:4,MERC.WD:2,RF:6,ROS:4-,FWL:6:3131,MSC:4,DA:6,RCM:6</availability>
+			<availability>CC:8,MOC:2,OP:4,MERC.KH:2,CEI:2,FR:6,MERC:7,Periphery:5,DTA:4,MERC.WD:2,RF:6,ROS:4-,FWL:6:3131,MSC:4,DA:6,RCM:6</availability>
 			<model name=''>
 				<roles>ground_support</roles>
-				<availability>
-					CC:8-,OP:4,MERC.KH:2,CEI:2-,Periphery:5,DTA:4,MERC.WD:2-,RF:6,ROS:4-,FWL:6-:3131,MSC:4,DA:6,RCM:6</availability>
+				<availability>CC:8-,OP:4,MERC.KH:2,CEI:2-,Periphery:5,DTA:4,MERC.WD:2-,RF:6,ROS:4-,FWL:6-:3131,MSC:4,DA:6,RCM:6</availability>
 			</model>
 			<model name='B'>
 				<availability>DTA:4,CC:6-,OP:4,RF:6,ROS:4-,FWL:4-:3131,MSC:4,DA:2,RCM:6,MERC:7-,Periphery:5</availability>
@@ -7641,8 +7607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:4,OP:3,CHH:1,FS:4,MERC:2,RA:1,Periphery:1,DTA:3,RF:3,ROS:5,FWL:4,MSC:5,DA:3,RCM:3</availability>
+			<availability>CC:4,OP:3,CHH:1,FS:4,MERC:2,RA:1,Periphery:1,DTA:3,RF:3,ROS:5,FWL:4,MSC:5,DA:3,RCM:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
@@ -7957,8 +7922,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:5,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:5,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,Periphery:2,DTA:5,Periphery.R:3,FVC:5,LA:6,CGB.FRR:3,ROS:5,Periphery.MW:3,MSC:5,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:2-,LA:1-,TC.PL:2-,MERC:1-,Periphery:2-</availability>
@@ -8113,8 +8077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:2,Periphery.OS:4,MERC:3,FS:3,TC:2,Periphery:5,RA.OA:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:3</availability>
+			<availability>MOC:2,Periphery.OS:4,MERC:3,FS:3,TC:2,Periphery:5,RA.OA:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8140,8 +8103,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2:3131,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8476,8 +8438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:6,RD:2-,CDS:2,Periphery.CM:6,CGB.FRR:1,CNC:2,IS:2-,Periphery.Deep:4,MERC:5,Periphery:6,CWIE:2</availability>
+			<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CGB.FRR:1,CNC:2,IS:2-,Periphery.Deep:4,MERC:5,Periphery:6,CWIE:2</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -8525,8 +8486,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:4,MH:4,MERC:4,FS:4,CJF:5,DC:4</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -8628,8 +8588,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -8685,8 +8644,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,FS:2,Periphery:3,TC:1,RA.OA:1,CW:1-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
+			<availability>MOC:1,CC:1,FS:2,Periphery:3,TC:1,RA.OA:1,CW:1-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
 			<model name='C'>
 				<availability>RD:3</availability>
 			</model>
@@ -8965,11 +8923,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CEI:6,CLAN:8</availability>
@@ -9098,8 +9054,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>
-				CC:4,IS:4,FS:6,MERC:4,Periphery:4,RD:6,LA:4,ROS:5,CGB.FRR:5,FWL:4,CJF:4,CGB:6,DC:4</availability>
+			<availability>CC:4,IS:4,FS:6,MERC:4,Periphery:4,RD:6,LA:4,ROS:5,CGB.FRR:5,FWL:4,CJF:4,CGB:6,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>RD:4,IS:8,Periphery:8</availability>
@@ -9186,8 +9141,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:4,RA.OA:4,FVC:4,LA:4,MERC:4,FS:4,CDP:4,DC:4,TC:4</availability>
@@ -9615,8 +9569,7 @@
 			</model>
 		</chassis>
 		<chassis name='Katya Ground Assault Craft' unitType='Conventional Fighter'>
-			<availability>
-				CC:6-,DTA:3-,OP:3-,RF:3-,ROS:4-,FWL:3:3131,MSC:3-,DA:3-,RCM:3-,MERC:2,CC.CHG:7,Periphery:3</availability>
+			<availability>CC:6-,DTA:3-,OP:3-,RF:3-,ROS:4-,FWL:3:3131,MSC:3-,DA:3-,RCM:3-,MERC:2,CC.CHG:7,Periphery:3</availability>
 			<model name='C-904(RL15)'>
 				<roles>ground_support</roles>
 				<availability>General:6</availability>
@@ -10125,8 +10078,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,OP:6,FS:3,MERC:4,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
+			<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
@@ -10216,8 +10168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,RA.OA:8,LA:7,IS:8,Periphery.Deep:6,FWL:7,FS:7,BAN:2,Periphery:8,TC:8,DC:7</availability>
+			<availability>MOC:8,CC:7,RA.OA:8,LA:7,IS:8,Periphery.Deep:6,FWL:7,FS:7,BAN:2,Periphery:8,TC:8,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2-</availability>
@@ -10268,15 +10219,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
+			<availability>MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,MOC:3,OP:7,CEI:3-,FR:3,MERC:8-,BAN:2,Periphery:8-,DTA:7,FVC:7,RF:7,LA:8-,ROS:9-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
+			<availability>CC:7-,MOC:3,OP:7,CEI:3-,FR:3,MERC:8-,BAN:2,Periphery:8-,DTA:7,FVC:7,RF:7,LA:8-,ROS:9-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>DTA:5,OP:5,RF:5,FWL:5,MSC:5,DA:7,RCM:5</availability>
 			</model>
@@ -10783,8 +10732,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:3+,CLAN:1,MERC:2+,BAN:1,CWIE:4,RA:2,MERC.WD:4,RD:2+,CDS:2,CW:4,ROS:3+,CJF:2,CGB:2+</availability>
+			<availability>MERC.KH:3+,CLAN:1,MERC:2+,BAN:1,CWIE:4,RA:2,MERC.WD:4,RD:2+,CDS:2,CW:4,ROS:3+,CJF:2,CGB:2+</availability>
 			<model name='A'>
 				<availability>RD:8,CDS:8,CW:7,General:7,CJF:8,CGB:8</availability>
 			</model>
@@ -10896,8 +10844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:4,MOC:4,OP:8,Periphery.MM:4,MERC:4,DTA:8,RF:8,LA:4,ROS:4,Periphery.CM:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,RCM:8,DA:8</availability>
+			<availability>CC:4,MOC:4,OP:8,Periphery.MM:4,MERC:4,DTA:8,RF:8,LA:4,ROS:4,Periphery.CM:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,RCM:8,DA:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11003,8 +10950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:4,CC:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,CWIE:5,RA.OA:5,LA:5,ROS:5,FWL:4,DC:6</availability>
+			<availability>MOC:4,CC:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,CWIE:5,RA.OA:5,LA:5,ROS:5,FWL:4,DC:6</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -11225,15 +11171,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,OP:4,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4,RCM:4</availability>
+			<availability>Periphery.R:3,OP:4,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4,RCM:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 			</model>
@@ -11495,8 +11439,7 @@
 			<availability>MOC:2,CC:5,Periphery.CM:2,Periphery.ME:2</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -12559,8 +12502,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,IS:2,MERC:2,FS:5,Periphery:3,TC:3,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:5,Periphery.ME:6,FWL:6,MH:3,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,Periphery:3,TC:3,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:5,Periphery.ME:6,FWL:6,MH:3,DC:2</availability>
 			<model name=''>
 				<availability>General:2-,Periphery:4</availability>
 			</model>
@@ -12617,8 +12559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,CW:2,Periphery.MW:3,CLAN:1,Periphery.ME:3,FWL:5,FS:2,Periphery:3,TC:1,DC:3,CWIE:2</availability>
+			<availability>MOC:1,CC:2,CW:2,Periphery.MW:3,CLAN:1,Periphery.ME:3,FWL:5,FS:2,Periphery:3,TC:1,DC:3,CWIE:2</availability>
 			<model name='ON1-K'>
 				<availability>CLAN:2-,Periphery:2-</availability>
 			</model>
@@ -12817,8 +12758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2,BAN:1</availability>
@@ -12907,8 +12847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:2-,IS:3-,FS:4-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,CGB.FRR:2-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>MOC:2-,CC:2-,IS:3-,FS:4-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,CGB.FRR:2-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -12981,8 +12920,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:7,CGB:5</availability>
+			<availability>Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:7,CGB:5</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
@@ -13771,8 +13709,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:5,MERC:3+,RA:6,BAN:5,CWIE:7,MERC.WD:5,RD:5,CDS:6,CW:7,ROS:4+,CNC:7,CJF:4,CGB:5</availability>
+			<availability>CLAN:5,MERC:3+,RA:6,BAN:5,CWIE:7,MERC.WD:5,RD:5,CDS:6,CW:7,ROS:4+,CNC:7,CJF:4,CGB:5</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>RD:5,CDS:8,CW:5,CNC:8,General:7,CWIE:6,CGB:5</availability>
@@ -13861,8 +13798,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,OP:6,IS:3,FS:5,CDP:3,Periphery:3,TC:2,DTA:6,RA.OA:3,FVC:3,RD:5,RF:6,LA:3,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4,CGB:5</availability>
+			<availability>MOC:4,CC:5,OP:6,IS:3,FS:5,CDP:3,Periphery:3,TC:2,DTA:6,RA.OA:3,FVC:3,RD:5,RF:6,LA:3,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4,CGB:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -13909,16 +13845,14 @@
 			</model>
 		</chassis>
 		<chassis name='R10 Mechanized ICV' unitType='Tank'>
-			<availability>
-				CC:2,OP:3,CLAN.IS:2,MERC:2,CWIE:2,DTA:3,RF:3,ROS:2,CNC:2,FWL:3,MSC:4,DA:3,RCM:3,CGB:2</availability>
+			<availability>CC:2,OP:3,CLAN.IS:2,MERC:2,CWIE:2,DTA:3,RF:3,ROS:2,CNC:2,FWL:3,MSC:4,DA:3,RCM:3,CGB:2</availability>
 			<model name='(Coolant Truck)'>
 				<roles>apc,support</roles>
 				<availability>General:4</availability>
 			</model>
 		</chassis>
 		<chassis name='R10 Mechanized ICV' unitType='Tank' omni='IS'>
-			<availability>
-				CC:4,OP:5,CLAN.IS:4,MERC:4,CWIE:4,DTA:5,RF:5,CW:4,ROS:4,CNC:4,FWL:5,MSC:6,DA:5,RCM:5</availability>
+			<availability>CC:4,OP:5,CLAN.IS:4,MERC:4,CWIE:4,DTA:5,RF:5,CW:4,ROS:4,CNC:4,FWL:5,MSC:6,DA:5,RCM:5</availability>
 			<model name='(A)'>
 				<roles>apc</roles>
 				<availability>General:7</availability>
@@ -14193,8 +14127,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,RA.OA:7,LA:7,ROS:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,Periphery:10,TC:7,DC:6</availability>
+			<availability>MOC:7,RA.OA:7,LA:7,ROS:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,Periphery:10,TC:7,DC:6</availability>
 			<model name=''>
 				<availability>CHH:1,CW:1,General:8,CNC:1</availability>
 			</model>
@@ -14220,8 +14153,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,OP:8,FS:2,MERC:1,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8,DC:2</availability>
+			<availability>MOC:1,OP:8,FS:2,MERC:1,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8,DC:2</availability>
 			<model name='F-100'>
 				<availability>FVC:2-,Periphery:2-</availability>
 			</model>
@@ -14239,8 +14171,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>
-				CC:1:3131,CHH:5,CEI:3,CLAN:1,IS:3,FS:1:3131,RA:5,RD:5,CDS:5,CNC:5,FWL:1:3131,MH:1:3131,CGB:5</availability>
+			<availability>CC:1:3131,CHH:5,CEI:3,CLAN:1,IS:3,FS:1:3131,RA:5,RD:5,CDS:5,CNC:5,FWL:1:3131,MH:1:3131,CGB:5</availability>
 			<model name=''>
 				<availability>CC:2:3131,CDS:2,CEI:2,CNC:2,FWL:2:3131,MH:2:3131,FS:2:3131,RA:2</availability>
 			</model>
@@ -14647,8 +14578,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>
-				CC:4,Periphery.DD:2,LA:4,DC.AL:8,IS:4,FWL:4,MERC:4,Periphery.OS:2,FS:3,CJF:4,DC:7</availability>
+			<availability>CC:4,Periphery.DD:2,LA:4,DC.AL:8,IS:4,FWL:4,MERC:4,Periphery.OS:2,FS:3,CJF:4,DC:7</availability>
 			<model name=''>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -14712,8 +14642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:2-,Periphery.DD:5,IS:2-,Periphery.OS:5,Periphery:3,TC:3,RA.OA:5,CDS:2,LA:2-,ROS:2-,FWL:3-,DC:4-</availability>
+			<availability>MOC:3,CC:2-,Periphery.DD:5,IS:2-,Periphery.OS:5,Periphery:3,TC:3,RA.OA:5,CDS:2,LA:2-,ROS:2-,FWL:3-,DC:4-</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -14962,8 +14891,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:2-,RA.OA:4-,Periphery.DD:3-,LA:1-,IS:1-,MERC:1-,Periphery.OS:3-,Periphery:2-,TC:2-,DC:4-</availability>
+			<availability>MOC:2-,CC:2-,RA.OA:4-,Periphery.DD:3-,LA:1-,IS:1-,MERC:1-,Periphery.OS:3-,Periphery:2-,TC:2-,DC:4-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -14982,8 +14910,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>
-				CC:6,FVC:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:5,FS:6,CJF:4,DC:6,Periphery:7</availability>
+			<availability>CC:6,FVC:6,LA:6,CGB.FRR:8,FWL:6,IS:7,Periphery.Deep:5,FS:6,CJF:4,DC:6,Periphery:7</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -15008,8 +14935,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,OP:2,MERC:2,Periphery:3-,DTA:2,FVC:2,RF:2-,LA:4,ROS:2,PIR:2,FWL:2,MSC:2,RCM:2-,DA:2,DC:4</availability>
+			<availability>CC:2,OP:2,MERC:2,Periphery:3-,DTA:2,FVC:2,RF:2-,LA:4,ROS:2,PIR:2,FWL:2,MSC:2,RCM:2-,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,DC:6</availability>
 			</model>
@@ -15145,8 +15071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:1,FS:4,MERC:4,CWIE:1,DC.GHO:3,FVC:4,RD:2,CDS:1,CW:1,LA:4,ROS:3,CJF:2,CGB:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CWIE:1,DC.GHO:3,FVC:4,RD:2,CDS:1,CW:1,LA:4,ROS:3,CJF:2,CGB:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -15167,8 +15092,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2,CGB:2</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2,CGB:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>FVC:1-,MERC.KH:1-,LA:1-,MERC:1-,Periphery:1-</availability>
@@ -15273,8 +15197,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				OP:3,CHH:4,IS:3,FS:3,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,CW:4,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3,CGB:4</availability>
+			<availability>OP:3,CHH:4,IS:3,FS:3,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,CW:4,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3,CGB:4</availability>
 			<model name='10'>
 				<availability>CHH:7-,RD:4-,CW:5-</availability>
 			</model>
@@ -15425,8 +15348,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,CGB.FRR:7,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
+			<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,CGB.FRR:7,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>ROS:0,Periphery:2-</availability>
 			</model>
@@ -15487,8 +15409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:3,Periphery.DD:3,FVC:2,RD:3,ROS:3,CGB.FRR:4,MERC:3,Periphery.OS:3,FS:1-,DC:6,Periphery:2</availability>
+			<availability>RA.OA:3,Periphery.DD:3,FVC:2,RD:3,ROS:3,CGB.FRR:4,MERC:3,Periphery.OS:3,FS:1-,DC:6,Periphery:2</availability>
 			<model name='SL-21'>
 				<availability>FVC:4,MERC:1,Periphery:4</availability>
 			</model>
@@ -15609,8 +15530,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:2,Periphery.DD:3,IS:1,MERC:1,Periphery.OS:3,FS:1,RA.OA:1,FVC:1,LA:1,CGB.FRR:3-,ROS:2-,FWL:2,DC:4</availability>
+			<availability>CC:2,Periphery.DD:3,IS:1,MERC:1,Periphery.OS:3,FS:1,RA.OA:1,FVC:1,LA:1,CGB.FRR:3-,ROS:2-,FWL:2,DC:4</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:3-</availability>
@@ -15629,8 +15549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
+			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -15758,8 +15677,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -15819,8 +15737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,OP:4,FR:1:3131,MERC:2,FS:2,Periphery:2,TC:1,DTA:4,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1:3131,MSC:3,DA:3,RCM:6,DC:6</availability>
+			<availability>MOC:1,CC:2,OP:4,FR:1:3131,MERC:2,FS:2,Periphery:2,TC:1,DTA:4,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1:3131,MSC:3,DA:3,RCM:6,DC:6</availability>
 			<model name='SDR-10K'>
 				<availability>ROS:3</availability>
 			</model>
@@ -15858,8 +15775,7 @@
 				<availability>ROS:4,MERC:4,DC:4</availability>
 			</model>
 			<model name='SDR-9M'>
-				<availability>
-					DTA:4,MOC:1:3131,OP:4,RF:5,FWL:4,MH:1:3131,MSC:3,FR:1:3131,MERC:2,RCM:6,DA:3,DC:4</availability>
+				<availability>DTA:4,MOC:1:3131,OP:4,RF:5,FWL:4,MH:1:3131,MSC:3,FR:1:3131,MERC:2,RCM:6,DA:3,DC:4</availability>
 			</model>
 			<model name='SDR-C'>
 				<availability>CC:4,FWL:4,FS:4,MERC:4,DC:4</availability>
@@ -15913,8 +15829,7 @@
 			<availability>CHH:4</availability>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:4,CC:2,CLAN:2,IS:5,Periphery.Deep:8,FS:4,Periphery:10,TC:6,RA.OA:6,LA:5,ROS:3,FWL:6,DC:2</availability>
+			<availability>MOC:4,CC:2,CLAN:2,IS:5,Periphery.Deep:8,FS:4,Periphery:10,TC:6,RA.OA:6,LA:5,ROS:3,FWL:6,DC:2</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -16132,8 +16047,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,OP:6,IS:2,MERC:4,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
+			<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -16232,8 +16146,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>
-				CC:2,IS:2,FS:5,MERC:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,FWL:1,DC:1,CGB:4</availability>
+			<availability>CC:2,IS:2,FS:5,MERC:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,FWL:1,DC:1,CGB:4</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -16283,8 +16196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -16858,8 +16770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
+			<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -16872,14 +16783,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				MOC:4,CHH:2,CLAN:3,IS:4,CWIE:4,DC.GHO:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:3,ROS:5,PIR:3,CNC:2,Periphery.ME:3,FWL:4,MH:4,MSC:5,DA:5,CJF:4,CGB:4</availability>
+			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CWIE:4,DC.GHO:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:3,ROS:5,PIR:3,CNC:2,Periphery.ME:3,FWL:4,MH:4,MSC:5,DA:5,CJF:4,CGB:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:2-,RF:2-,PIR:2-,MH:2-,MSC:2-,MERC:2-,DA:2-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,BAN:2</availability>
@@ -17000,8 +16909,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:5,MERC.KH:4,CEI:1+,FS:5,MERC:6,Periphery:3,TC:4,FVC:4,MERC.WD:2,CW:1,LA:6,ROS:5,MH:4,DC:4</availability>
+			<availability>CC:5,MERC.KH:4,CEI:1+,FS:5,MERC:6,Periphery:3,TC:4,FVC:4,MERC.WD:2,CW:1,LA:6,ROS:5,MH:4,DC:4</availability>
 			<model name='C'>
 				<availability>CEI:1+</availability>
 			</model>
@@ -17346,8 +17254,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:3,MOC:3,RF:6,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MERC:3,Periphery:3,TC:4,DC:4</availability>
+			<availability>CC:3,MOC:3,RF:6,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MERC:3,Periphery:3,TC:4,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,MSC:4,MERC:4</availability>
@@ -17797,8 +17704,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -18004,8 +17910,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+				<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:1</availability>
@@ -18062,8 +17967,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FS:7,Periphery.OS:2,MERC:1,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:1,FWL:2,DC:4</availability>
+			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,MERC:1,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:1,FWL:2,DC:4</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -18495,8 +18399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,FS.CH:8,IS:6,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -18707,8 +18610,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolfhound' unitType='Mek'>
-			<availability>
-				MOC:4,OP:3,MERC.KH:7,MERC:4,FS:2,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,ROS:5,MH:4,MSC:3</availability>
+			<availability>MOC:4,OP:3,MERC.KH:7,MERC:4,FS:2,CWIE:5,DTA:3,MERC.WD:5,FVC:2,LA:7,ROS:5,MH:4,MSC:3</availability>
 			<model name='WLF-1'>
 				<availability>LA:1,ROS:1,Periphery.Deep:6,MERC:1,Periphery:8</availability>
 			</model>
@@ -18853,8 +18755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>
-				CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,CGB.FRR:5,ROS:5,MSC:1,RCM:1,DA:2,DC:6</availability>
+			<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,CGB.FRR:5,ROS:5,MSC:1,RCM:1,DA:2,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -1175,7 +1175,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,RA.OA:4,LA:5,CGB.FRR:4,IS:4,FWL:4,FS:5,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:3,RA.OA:4,LA:5,CGB.FRR:4,IS:4,FS:5,Periphery:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>Periphery:2</availability>
@@ -1204,7 +1204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,RA.OA:1,LA:2,CLAN:4,IS:2,FWL:4,FS:2,BAN:5,Periphery:1,TC:1,DC:6</availability>
+			<availability>CC:4,RA.OA:1,CLAN:4,IS:2,FWL:4,BAN:5,Periphery:1,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -1761,7 +1761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1821,7 +1821,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
@@ -1897,7 +1897,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1-,MOC:1-,FVC:1,LA:1,MERC:1-,RCM:2-,DA:2-,CDP:1-,TC:1-,Periphery:1-</availability>
+			<availability>CC:1-,FVC:1,LA:1,MERC:1-,RCM:2-,DA:2-,CDP:1-,Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
 				<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
@@ -1970,7 +1970,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:3,CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:3,TC:3,RA.OA:3,LA:6,FWL:3,DC:8</availability>
+			<availability>CEI:2,IS:3,CLAN.IS:2,FS:5,MERC:2,Periphery:3,RA.OA:3,LA:6,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2150,7 +2150,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,LA:4,CGB.FRR:2,IS:2,FWL:3,FS:4,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -2161,7 +2161,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,Periphery:8,TC:5,DC:6</availability>
+			<availability>MOC:6,CC:5,RA.OA:6,ROS:5,IS:4,FWL:8,Periphery:8,TC:5,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,DC:6</availability>
 			</model>
@@ -2624,7 +2624,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:5,IS:5,FS:5,Periphery:5,TC:5,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:5,FWL:8,CJF:2,DC:5</availability>
+			<availability>IS:5,Periphery:5,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:5,FWL:8,CJF:2</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2769,7 +2769,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:2,IS:2,MERC:2,FS:2,Periphery:2,RA.OA:2,CDS:3,LA:2,CGB.FRR:2,PIR:2,CNC:3,FWL:2,DC:3</availability>
+			<availability>IS:2,MERC:2,Periphery:2,RA.OA:2,CDS:3,CGB.FRR:2,PIR:2,CNC:3,DC:3</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8</availability>
 			</model>
@@ -2946,7 +2946,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:3,FWL:6,MSC:6,CGB:5,MOC:3,CC:3,OP:6,IS:4,MERC:4,RA:3,Periphery:3,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CDS:3,FWL:6,MSC:6,CGB:5,CC:3,OP:6,IS:4,MERC:4,RA:3,Periphery:3,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:5,FS:5</availability>
 			</model>
@@ -3144,14 +3144,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>DTA:6,OP:6,RF:4,ROS:4,FWL:5,MH:4,MSC:6,MERC:4,RCM:4,DA:6</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>RF:0,General:4,RCM:0</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:4</availability>
+				<availability>IS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3559,7 +3559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:4,OP:3,FWL:2,MH:3,MERC:1,DA:4,RCM:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>CC:4,OP:3,FWL:2,MH:3,MERC:1,DA:4,RCM:3,Periphery:2,DC:6</availability>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
 				<availability>BAN:2,Periphery:2-</availability>
@@ -4047,7 +4047,7 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
@@ -4056,7 +4056,7 @@
 				<availability>FVC:2,CDP:2,TC:2</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,BAN:3,Periphery:2-</availability>
+				<availability>BAN:3,Periphery:2-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2,BAN:2</availability>
@@ -4694,7 +4694,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,MERC:4,RA:1,CWIE:2,DC.GHO:5,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,CGB:1,DC:5</availability>
+			<availability>CLAN:1,MERC:4,RA:1,CWIE:2,DC.GHO:5,RD:1,CDS:2,CW:2,ROS:5,FWL:4,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -4763,7 +4763,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>DTA:4,OP:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,MERC:4,DA:4,RCM:4,Periphery:4</availability>
+			<availability>DTA:4,OP:4,RF:4,ROS:3,FWL:4,MSC:4,MERC:4,DA:4,RCM:4,Periphery:4</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -4918,7 +4918,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:3,RA.OA:2,MOC:4,RD:4,LA:3,ROS:3,IS:3,FWL:2,FS:3,Periphery:2,TC:2,DC:5</availability>
+			<availability>RA.OA:2,MOC:4,RD:4,ROS:3,IS:3,FWL:2,Periphery:2,DC:5</availability>
 			<model name='CP-10-HQ'>
 				<availability>IS:1</availability>
 			</model>
@@ -4973,7 +4973,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:4,MOC:3,CHH:2-,CEI:2,ROS:6,FR:2,MERC:4,CDP:4,CJF:2-,RA:2,TC:4,Periphery:4</availability>
+			<availability>CC:4,MOC:3,CHH:2-,CEI:2,ROS:6,FR:2,MERC:4,CDP:4,CJF:2-,RA:2,Periphery:4</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:4,ROS:5</availability>
@@ -5338,7 +5338,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,ROS:8,CNC:5,FWL:8,CJF:2,DC:7</availability>
+			<availability>CHH:5,CLAN:4,IS:7,FS:9,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,ROS:8,CNC:5,FWL:8,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,LA:4,CGB.FRR:4,ROS:4,IS:2,FWL:4,FS:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -5435,7 +5435,7 @@
 			</model>
 		</chassis>
 		<chassis name='Devastator Heavy Tank' unitType='Tank'>
-			<availability>MOC:1-,CC:1-,LA:1-,FWL:1-,IS:1-,FS:1-,MERC:1-,Periphery:2-,DC:1-</availability>
+			<availability>MOC:1-,IS:1-,MERC:1-,Periphery:2-</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5686,7 +5686,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:4,RA.OA:2,CLAN:3,IS:3,FWL:4,FS:4,Periphery:3</availability>
 			<model name='EGL-R11'>
 				<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 			</model>
@@ -5845,7 +5845,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,MH:3,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CDP:3,TC:4,CNC:5,MH:3</availability>
 			<model name='EMP-6A'>
 				<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 			</model>
@@ -6005,7 +6005,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,Periphery:2,TC:3,DC:6</availability>
+			<availability>MOC:3,RA.OA:2,IS:5,FS:2,Periphery:2,TC:3,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -6572,7 +6572,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,ROS:3,CLAN:1,FWL:4,MSC:5,CJF:2,CGB:1,DC:4</availability>
+			<availability>DC.GHO:5,RD:2,LA:4,ROS:3,CLAN:1,FWL:4,MSC:5,CJF:2,CGB:1,DC:4</availability>
 			<model name='FLS-8K'>
 				<availability>DC.GHO:5,LA:8,ROS:6,CLAN:8,MERC.SI:5,MSC:6,BAN:8</availability>
 			</model>
@@ -6608,7 +6608,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,MERC:4,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,DA:3,RCM:3</availability>
+			<availability>CC:6,MERC:4,Periphery:4,MERC.WD:4,FVC:4,RF:3,ROS:4,DA:3,RCM:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:5,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,Periphery:6</availability>
 			</model>
@@ -6820,7 +6820,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CHH:2,CLAN:1,IS:4,FS:3,BAN:4,Periphery:3,TC:4,RA.OA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -6892,7 +6892,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:4,FS:8,Periphery:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -6985,7 +6985,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
+			<availability>MOC:2,OP:4,IS:2,MERC:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,MH:2,MSC:4</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -8077,7 +8077,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>MOC:2,Periphery.OS:4,MERC:3,FS:3,TC:2,Periphery:5,RA.OA:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:3</availability>
+			<availability>MOC:2,Periphery.OS:4,MERC:3,FS:3,TC:2,Periphery:5,RA.OA:4,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:3</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8103,7 +8103,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,ROS:3-,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2:3131,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8356,7 +8356,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,Periphery:5</availability>
+			<availability>RA.OA:4,ROS:4,FWL:6,MERC:6,Periphery:5</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -8438,7 +8438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CGB.FRR:1,CNC:2,IS:2-,Periphery.Deep:4,MERC:5,Periphery:6,CWIE:2</availability>
+			<availability>CC:6,RD:2-,CDS:2,CGB.FRR:1,CNC:2,IS:2-,Periphery.Deep:4,MERC:5,Periphery:6,CWIE:2</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>
@@ -8484,9 +8484,9 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:4,MH:4,MERC:4,FS:4,CJF:5,DC:4</availability>
+			<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,MH:4,MERC:4,CJF:5</availability>
 			<model name='HGN-732'>
-				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,BAN:8,DC.GHO:8,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -8588,7 +8588,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -8690,7 +8690,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:3,CC:5,RA.OA:4,LA:6,ROS:2,IS:4,FWL:3,MERC:4,FS:4,Periphery:4,TC:4,DC:2</availability>
+			<availability>MOC:3,CC:5,RA.OA:4,LA:6,ROS:2,IS:4,FWL:3,MERC:4,Periphery:4,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:2-</availability>
@@ -8912,7 +8912,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,BAN:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,BAN:4,Periphery:3,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:3</availability>
@@ -9054,7 +9054,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>CC:4,IS:4,FS:6,MERC:4,Periphery:4,RD:6,LA:4,ROS:5,CGB.FRR:5,FWL:4,CJF:4,CGB:6,DC:4</availability>
+			<availability>IS:4,FS:6,MERC:4,Periphery:4,RD:6,ROS:5,CGB.FRR:5,CJF:4,CGB:6</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>RD:4,IS:8,Periphery:8</availability>
@@ -9141,7 +9141,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:2,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:2,Periphery.CM:2,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:4,RA.OA:4,FVC:4,LA:4,MERC:4,FS:4,CDP:4,DC:4,TC:4</availability>
@@ -9193,7 +9193,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,FVC:7,Periphery.HR:4,ROS:4,FS:7,MERC:4,Periphery.OS:6,Periphery:3,TC:3</availability>
+			<availability>FVC:7,Periphery.HR:4,ROS:4,FS:7,MERC:4,Periphery.OS:6,Periphery:3</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>IS:1-,Periphery:2-</availability>
@@ -9613,7 +9613,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,RD:2,LA:6,ROS:6,FWL:4,MH:4,DC:4,CGB:2</availability>
+			<availability>CLAN:2,IS:4,FS:6,MERC:5,DC.GHO:6,RD:2,LA:6,ROS:6,MH:4,CGB:2</availability>
 			<model name='KGC-000'>
 				<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 			</model>
@@ -10052,7 +10052,7 @@
 			</model>
 			<model name='(3055 Upgrade)'>
 				<roles>fire_support</roles>
-				<availability>CC:8,MOC:8,LA:8,CGB.FRR:8,FWL:8,IS:8,FS:8,DC:8,TC:8,Periphery:6</availability>
+				<availability>MOC:8,CGB.FRR:8,IS:8,TC:8,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -10168,7 +10168,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,RA.OA:8,LA:7,IS:8,Periphery.Deep:6,FWL:7,FS:7,BAN:2,Periphery:8,TC:8,DC:7</availability>
+			<availability>CC:7,RA.OA:8,LA:7,IS:8,Periphery.Deep:6,FWL:7,FS:7,BAN:2,Periphery:8,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2-</availability>
@@ -10950,7 +10950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:4,CC:4,IS:5,MERC:5,FS:5,Periphery:5,TC:5,CWIE:5,RA.OA:5,LA:5,ROS:5,FWL:4,DC:6</availability>
+			<availability>MOC:4,CC:4,IS:5,MERC:5,Periphery:5,CWIE:5,RA.OA:5,ROS:5,FWL:4,DC:6</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -12212,7 +12212,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FS:7,MERC:6</availability>
 			<model name='NGS-4S'>
-				<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,Periphery.Deep:6,FS:4,MERC:4,Periphery:8</availability>
+				<availability>OP:4,RF:4,LA:4,ROS:4,General:8,Periphery.Deep:6,FS:4,MERC:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -12502,7 +12502,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,Periphery:3,TC:3,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:5,Periphery.ME:6,FWL:6,MH:3,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,Periphery:3,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:5,Periphery.ME:6,FWL:6</availability>
 			<model name=''>
 				<availability>General:2-,Periphery:4</availability>
 			</model>
@@ -12559,7 +12559,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:1,CC:2,CW:2,Periphery.MW:3,CLAN:1,Periphery.ME:3,FWL:5,FS:2,Periphery:3,TC:1,DC:3,CWIE:2</availability>
+			<availability>MOC:1,CC:2,CW:2,CLAN:1,FWL:5,FS:2,Periphery:3,TC:1,DC:3,CWIE:2</availability>
 			<model name='ON1-K'>
 				<availability>CLAN:2-,Periphery:2-</availability>
 			</model>
@@ -12847,7 +12847,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,IS:3-,FS:4-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,CGB.FRR:2-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>CC:2-,IS:3-,FS:4-,FS.CrMM:5-,Periphery:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,CGB.FRR:2-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13026,7 +13026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
+			<availability>MOC:2,CC:1,RA.OA:2,IS:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -13370,7 +13370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pike Support Vehicle' unitType='Tank'>
-			<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,CNC:3,MH:2-,CWIE:4,Periphery:2-</availability>
+			<availability>RA.OA:1-,CC:3,CHH:3,MERC.WD:3,CDS:4,CLAN:3,CNC:3,CWIE:4,Periphery:2-</availability>
 			<model name=''>
 				<availability>Periphery:2</availability>
 			</model>
@@ -13798,7 +13798,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:4,CC:5,OP:6,IS:3,FS:5,CDP:3,Periphery:3,TC:2,DTA:6,RA.OA:3,FVC:3,RD:5,RF:6,LA:3,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4,CGB:5</availability>
+			<availability>MOC:4,CC:5,OP:6,IS:3,FS:5,CDP:3,Periphery:3,TC:2,DTA:6,RA.OA:3,FVC:3,RD:5,RF:6,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4,CGB:5</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14085,7 +14085,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -14578,7 +14578,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saladin Assault Hover Tank' unitType='Tank'>
-			<availability>CC:4,Periphery.DD:2,LA:4,DC.AL:8,IS:4,FWL:4,MERC:4,Periphery.OS:2,FS:3,CJF:4,DC:7</availability>
+			<availability>Periphery.DD:2,DC.AL:8,IS:4,MERC:4,Periphery.OS:2,FS:3,CJF:4,DC:7</availability>
 			<model name=''>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -14642,7 +14642,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:3,CC:2-,Periphery.DD:5,IS:2-,Periphery.OS:5,Periphery:3,TC:3,RA.OA:5,CDS:2,LA:2-,ROS:2-,FWL:3-,DC:4-</availability>
+			<availability>Periphery.DD:5,IS:2-,Periphery.OS:5,Periphery:3,RA.OA:5,CDS:2,ROS:2-,FWL:3-,DC:4-</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -14891,7 +14891,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,RA.OA:4-,Periphery.DD:3-,LA:1-,IS:1-,MERC:1-,Periphery.OS:3-,Periphery:2-,TC:2-,DC:4-</availability>
+			<availability>CC:2-,RA.OA:4-,Periphery.DD:3-,IS:1-,MERC:1-,Periphery.OS:3-,Periphery:2-,DC:4-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -15067,11 +15067,11 @@
 			<availability>CC:3,MOC:3,FWL:4,MSC:4,MERC:3</availability>
 			<model name=''>
 				<roles>assault,ba_carrier</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:1,FS:4,MERC:4,CWIE:1,DC.GHO:3,FVC:4,RD:2,CDS:1,CW:1,LA:4,ROS:3,CJF:2,CGB:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CWIE:1,DC.GHO:3,FVC:4,RD:2,LA:4,ROS:3,CJF:2,CGB:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -15197,7 +15197,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>OP:3,CHH:4,IS:3,FS:3,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,CW:4,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3,CGB:4</availability>
+			<availability>OP:3,CHH:4,IS:3,FS:3,CWIE:4,RA:4,DTA:3,RA.OA:3,RD:4,CDS:4,RF:3,CW:4,ROS:4,CNC:4,MSC:3,RCM:3,DA:3,CGB:4</availability>
 			<model name='10'>
 				<availability>CHH:7-,RD:4-,CW:5-</availability>
 			</model>
@@ -15530,7 +15530,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>CC:2,Periphery.DD:3,IS:1,MERC:1,Periphery.OS:3,FS:1,RA.OA:1,FVC:1,LA:1,CGB.FRR:3-,ROS:2-,FWL:2,DC:4</availability>
+			<availability>CC:2,Periphery.DD:3,IS:1,MERC:1,Periphery.OS:3,FS:1,RA.OA:1,FVC:1,CGB.FRR:3-,ROS:2-,FWL:2,DC:4</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:3-</availability>
@@ -15549,7 +15549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
+			<availability>Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7,CGB:6</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -15677,7 +15677,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,ROS:4,MERC:5,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -15829,7 +15829,7 @@
 			<availability>CHH:4</availability>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:4,CC:2,CLAN:2,IS:5,Periphery.Deep:8,FS:4,Periphery:10,TC:6,RA.OA:6,LA:5,ROS:3,FWL:6,DC:2</availability>
+			<availability>MOC:4,CC:2,CLAN:2,IS:5,Periphery.Deep:8,FS:4,Periphery:10,TC:6,RA.OA:6,ROS:3,FWL:6,DC:2</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -16073,7 +16073,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -16085,7 +16085,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -16146,7 +16146,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,IS:2,FS:5,MERC:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,FWL:1,DC:1,CGB:4</availability>
+			<availability>IS:2,FS:5,MERC:3,CWIE:4,FVC:5,RD:4,CDS:3,ROS:3,PIR:3,CNC:4,FWL:1,DC:1,CGB:4</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -16196,7 +16196,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -16674,7 +16674,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,MERC.WD:2,RD:1,CDS:1,CW:1,ROS:3+,CLAN:1,CJF:4,RA:1,BAN:3,CWIE:2,CGB:1</availability>
+			<availability>CHH:5,MERC.WD:2,RD:1,ROS:3+,CLAN:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
 			<model name='A'>
 				<availability>CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CJF:8,CWIE:6,CGB:4</availability>
 			</model>
@@ -16770,7 +16770,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3,FS:4,MERC:3,Periphery:3,TC:5</availability>
+			<availability>CC:8,MOC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,FS:4,MERC:3,Periphery:3,TC:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -16783,7 +16783,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CWIE:4,DC.GHO:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:3,ROS:5,PIR:3,CNC:2,Periphery.ME:3,FWL:4,MH:4,MSC:5,DA:5,CJF:4,CGB:4</availability>
+			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CWIE:4,DC.GHO:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:3,ROS:5,PIR:3,CNC:2,Periphery.ME:3,MH:4,MSC:5,DA:5,CJF:4,CGB:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:2-,RF:2-,PIR:2-,MH:2-,MSC:2-,MERC:2-,DA:2-,Periphery:4</availability>
 			</model>
@@ -16882,7 +16882,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,RA.OA:4,LA:6,CGB.FRR:4,IS:4,FWL:4,FS:5,Periphery:5,TC:5,DC:4</availability>
+			<availability>MOC:4,RA.OA:4,LA:6,CGB.FRR:4,IS:4,FS:5,Periphery:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:2-</availability>
@@ -17254,7 +17254,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:3,MOC:3,RF:6,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MERC:3,Periphery:3,TC:4,DC:4</availability>
+			<availability>CC:3,RF:6,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MERC:3,Periphery:3,TC:4,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,MSC:4,MERC:4</availability>
@@ -17704,7 +17704,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,FS.CMM:5-,IS:4-,FWL:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -17923,7 +17923,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,Periphery:1,TC:1,DC:4</availability>
+			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,Periphery:1,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:2</availability>
@@ -18200,7 +18200,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,MERC.WD:4,RD:5,ROS:4,CLAN:4,MERC:2,CJF:4,BAN:5,CGB:5,CWIE:4,DC:3</availability>
+			<availability>CHH:6,MERC.WD:4,RD:5,ROS:4,CLAN:4,MERC:2,BAN:5,CGB:5,CWIE:4,DC:3</availability>
 			<model name='A'>
 				<availability>RD:4,CDS:7,CW:7,CNC:7,General:6,CGB:4</availability>
 			</model>
@@ -18399,7 +18399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FS:6,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+			<availability>FS.CH:8,IS:6,CC.CHG:8,Periphery:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CWIE:8</availability>
@@ -18520,7 +18520,7 @@
 				<availability>MERC:1,Periphery:1</availability>
 			</model>
 			<model name='WTH-1H'>
-				<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
+				<availability>PIR:5,Periphery:5</availability>
 			</model>
 			<model name='WTH-2'>
 				<roles>fire_support</roles>
@@ -18641,7 +18641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,RD:2,LA:5,CNC:2,IS:5,FWL:8,MH:4,FS:6,DC:5,Periphery:4,CGB:2,TC:4</availability>
+			<availability>RD:2,CNC:2,IS:5,FWL:8,FS:6,Periphery:4,CGB:2</availability>
 			<model name='WVR-10R'>
 				<availability>CC:2:3131,MOC:1:3131,ROS:4,FS:1:3131</availability>
 			</model>
@@ -18755,7 +18755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,CGB.FRR:5,ROS:5,MSC:1,RCM:1,DA:2,DC:6</availability>
+			<availability>OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,CGB.FRR:5,ROS:5,MSC:1,RCM:1,DA:2,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
@@ -19016,7 +19016,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,IS:5,FWL:4,MERC:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,IS:5,FWL:4,MERC:4,Periphery:3,DC:5</availability>
 			<model name=''>
 				<availability>General:4-</availability>
 			</model>

--- a/megamek/data/forcegenerator/3131.xml
+++ b/megamek/data/forcegenerator/3131.xml
@@ -862,8 +862,7 @@
 			<omniMargin>12</omniMargin>
 			<techMargin>12</techMargin>
 			<upgradeMargin>9</upgradeMargin>
-			<salvage pct='6'>
-				MOC:2,CC:8,RT:1,FS:8,Periphery:1,TC:2,DTA:3,RD:5,CDS:1,CW:6,LA:8,RIM:1,ROS:15,CNC:3,FWL:14,MSC:2,CJF:10,DC:10</salvage>
+			<salvage pct='6'>MOC:2,CC:8,RT:1,FS:8,Periphery:1,TC:2,DTA:3,RD:5,CDS:1,CW:6,LA:8,RIM:1,ROS:15,CNC:3,FWL:14,MSC:2,CJF:10,DC:10</salvage>
 		</faction>
 		<faction key='DC.LV'>
 			<pctOmni>17</pctOmni>
@@ -2102,8 +2101,7 @@
 			<availability>RCM:1-,DA:1-,Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
+				<availability>CC:6,MOC:6,MERC:4,FS:4,CDP:6,TC:6,Periphery:4,FVC:4,Periphery.HR:5,PIR:3,MH:4,RCM:4,DA:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -2176,8 +2174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,CEI:2,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>MOC:3,CC:3,CEI:2,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2693,8 +2690,7 @@
 			</model>
 		</chassis>
 		<chassis name='Banshee' unitType='Mek'>
-			<availability>
-				MOC:4-,RA.OA:4-,FVC:2-,RF:2-,LA:2-,FWL:1-,MH:4-,MSC:1-,MERC:1-,CP:1-,Periphery:7-,TC:4-</availability>
+			<availability>MOC:4-,RA.OA:4-,FVC:2-,RF:2-,LA:2-,FWL:1-,MH:4-,MSC:1-,MERC:1-,CP:1-,Periphery:7-,TC:4-</availability>
 			<model name='BNC-12S'>
 				<availability>LA:2</availability>
 			</model>
@@ -2867,8 +2863,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -3210,8 +3205,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MSC:6,MOC:4,CC:4,OP:6,IS:4,MERC:4,CP:5,RA:3,Periphery:4,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MSC:6,MOC:4,CC:4,OP:6,IS:4,MERC:4,CP:5,RA:3,Periphery:4,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:4,FS:4</availability>
 			</model>
@@ -3219,8 +3213,7 @@
 				<availability>CC:2,ROS:2,FWL:2,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3504,8 +3497,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,OP:4,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,DTA:4,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,MOC:3,OP:4,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,DTA:4,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3595,8 +3587,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3853,8 +3844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,ROS:4,Periphery.ME:1,MH:1,FS:3,MERC:3,CDP:3,TC:3</availability>
+			<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,ROS:4,Periphery.ME:1,MH:1,FS:3,MERC:3,CDP:3,TC:3</availability>
 			<model name='CTF-1X'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -4115,8 +4105,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:4,OP:2,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,DTA:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6,MSC:2</availability>
+			<availability>CC:4,OP:2,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,DTA:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6,MSC:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 			</model>
@@ -4350,15 +4339,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:2,OP:10,MERC:3,FS:3,CP:10,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
+			<availability>MOC:5,CC:2,OP:10,MERC:3,FS:3,CP:10,Periphery:3,TC:5,DTA:9,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,MSC:10,DA:8,RCM:10</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:1-,DTA:1-,OP:1-,RF:1-,FWL:1-,MSC:1-,MERC:1-,DA:1-,RCM:1-,CP:1-,Periphery:1-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:4,MOC:4,OP:8,MERC:6,CP:8,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
+				<availability>CC:4,MOC:4,OP:8,MERC:6,CP:8,DTA:8,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MSC:8,RCM:8,DA:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -4756,8 +4743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:1-,Periphery:1-</availability>
@@ -5064,8 +5050,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+			<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -5149,8 +5134,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>
-				OP:4,MERC:4,CP:4,Periphery:4,DTA:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,DA:4,RCM:4</availability>
+			<availability>OP:4,MERC:4,CP:4,Periphery:4,DTA:4,RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MSC:4,DA:4,RCM:4</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -5204,8 +5188,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crow Scout Helicopter' unitType='VTOL'>
-			<availability>
-				CC:3,MOC:3,OP:3,MERC.KH:3,IS:2,FR:2,MERC:3,CP:2,DTA:3,MERC.WD:3,RF:3,ROS:4,CNC:3,FWL:3,MSC:3,DA:3,RCM:3,DC:5</availability>
+			<availability>CC:3,MOC:3,OP:3,MERC.KH:3,IS:2,FR:2,MERC:3,CP:2,DTA:3,MERC.WD:3,RF:3,ROS:4,CNC:3,FWL:3,MSC:3,DA:3,RCM:3,DC:5</availability>
 			<model name=''>
 				<roles>recon,spotter</roles>
 				<availability>MOC:5,MERC.KH:5,MERC.WD:5,IS:5,FR:5,MERC:5,DC:8</availability>
@@ -5216,8 +5199,7 @@
 			</model>
 			<model name='(Export)'>
 				<roles>recon</roles>
-				<availability>
-					CC:6,MOC:6,OP:6,MERC.KH:6,FR:6,CP:2,MERC:6,DTA:6,MERC.WD:6,RF:6,ROS:6,CNC:3,FWL:6,MSC:6,DA:6,RCM:6</availability>
+				<availability>CC:6,MOC:6,OP:6,MERC.KH:6,FR:6,CP:2,MERC:6,DTA:6,MERC.WD:6,RF:6,ROS:6,CNC:3,FWL:6,MSC:6,DA:6,RCM:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Crucible Station' unitType='Space Station'>
@@ -5274,8 +5256,7 @@
 				<availability>DTA:4,FWL.pm:2,MOC:2,OP:4,RF:4,ROS:4,FWL:4,MSC:4,FR:2,DA:4,RCM:2</availability>
 			</model>
 			<model name='CRD-7W'>
-				<availability>
-					DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5:3139,MH:4,MSC:5,MERC:2,RCM:5,CP:5</availability>
+				<availability>DTA:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:5:3139,MH:4,MSC:5,MERC:2,RCM:5,CP:5</availability>
 			</model>
 			<model name='CRD-8L'>
 				<availability>CC:6</availability>
@@ -5325,8 +5306,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
+			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5390,8 +5370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>
-				CC:4,MOC:2,CHH:1-,CEI:2,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4,SE:3,ROS:6,CJF:1-</availability>
+			<availability>CC:4,MOC:2,CHH:1-,CEI:2,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4,SE:3,ROS:6,CJF:1-</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:4,ROS:5</availability>
@@ -5506,8 +5485,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,DC:4+</availability>
+			<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,CW:6,LA:4+,ROS:4+,CNC:5,CJF:5,DC:4+</availability>
 			<model name='A'>
 				<availability>CWE:5,CW:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5763,8 +5741,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CNC:5,FWL:8,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CNC:5,FWL:8,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -5833,8 +5810,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>
-				OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
+			<availability>OP:3,FVC:4,LA:2,ROS:3,Periphery.HR:4,FS:4,MERC:2,Periphery.OS:4,Periphery:3,TC:2,DC:2</availability>
 			<model name='DV-6M'>
 				<availability>CLAN:4,Periphery:2-</availability>
 			</model>
@@ -6718,8 +6694,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
-			<availability>
-				Periphery.R:1,LA:2-,ROS:1-,Periphery.HR:1,Periphery.MW:1,Periphery.CM:1,FWL:1-,FS:2-</availability>
+			<availability>Periphery.R:1,LA:2-,ROS:1-,Periphery.HR:1,Periphery.MW:1,Periphery.CM:1,FWL:1-,FS:2-</availability>
 			<model name=''>
 				<roles>recon,apc</roles>
 				<availability>General:8,FS:2</availability>
@@ -7061,15 +7036,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2:3139,DA:3,RCM:3</availability>
+			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2:3139,DA:3,RCM:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,MERC:5-,CP:2-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,RCM:4-,DA:4-</availability>
+				<availability>MOC:4-,CC:4-,MERC:5-,CP:2-,Periphery:6-,TC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,RCM:4-,DA:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:4</availability>
@@ -7288,8 +7261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7364,8 +7336,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7468,8 +7439,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>
-				CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,CP:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
+			<availability>CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,CP:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -7656,8 +7626,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,OP:2,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,DTA:2,CWE:2,FVC:2,RF:2,CW:2,LA:5,Periphery.MW:2,ROS:4,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
+			<availability>CC:4,MOC:4,OP:2,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,DTA:2,CWE:2,FVC:2,RF:2,CW:2,LA:5,Periphery.MW:2,ROS:4,FWL:6,MH:2,MSC:2,DA:2,RCM:2</availability>
 			<model name='C'>
 				<availability>CW:8</availability>
 			</model>
@@ -7816,8 +7785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,OP:7,FS:4,MERC:4,CP:7,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,MSC:7,DA:7,RCM:7,DC:4</availability>
+			<availability>CC:4,MOC:4,OP:7,FS:4,MERC:4,CP:7,DTA:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,MSC:7,DA:7,RCM:7,DC:4</availability>
 			<model name='T-IT-N10M'>
 				<availability>ROS:3,FWL:3,MERC:3,CP:3,Periphery:3</availability>
 			</model>
@@ -8119,12 +8087,10 @@
 			</model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:8,MOC:2,OP:4,MERC.KH:2,CEI:2,FR:6,MERC:7,Periphery:5,DTA:4,MERC.WD:2,RF:6,ROS:4-,FWL:6,MSC:4,DA:6,RCM:6</availability>
+			<availability>CC:8,MOC:2,OP:4,MERC.KH:2,CEI:2,FR:6,MERC:7,Periphery:5,DTA:4,MERC.WD:2,RF:6,ROS:4-,FWL:6,MSC:4,DA:6,RCM:6</availability>
 			<model name=''>
 				<roles>ground_support</roles>
-				<availability>
-					CC:8-,OP:4,MERC.KH:2,CEI:2-,Periphery:5,DTA:4,MERC.WD:2-,RF:6,ROS:4-,FWL:6-,MSC:4,DA:6,RCM:6</availability>
+				<availability>CC:8-,OP:4,MERC.KH:2,CEI:2-,Periphery:5,DTA:4,MERC.WD:2-,RF:6,ROS:4-,FWL:6-,MSC:4,DA:6,RCM:6</availability>
 			</model>
 			<model name='B'>
 				<availability>DTA:4,CC:6-,OP:4,RF:6,ROS:4-,FWL:4-,MSC:4,DA:2,RCM:6,MERC:7-,Periphery:5</availability>
@@ -8146,8 +8112,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>
-				CC:4,OP:3,CHH:1,FS:4,CP:4,MERC:2,RA:1,Periphery:1,DTA:3,RF:3,ROS:5,FWL:4,MSC:5,DA:3,RCM:3</availability>
+			<availability>CC:4,OP:3,CHH:1,FS:4,CP:4,MERC:2,RA:1,Periphery:1,DTA:3,RF:3,ROS:5,FWL:4,MSC:5,DA:3,RCM:3</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
 				<availability>ROS:6,CLAN:8,MERC.SI:8,BAN:8</availability>
@@ -8483,8 +8448,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,DTA:5,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,MSC:5,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,DTA:5,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,MSC:5,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
@@ -8649,8 +8613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8676,8 +8639,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -9004,8 +8966,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>
-				CC:6,RD:2-,CDS:2,Periphery.CM:6,CNC:2,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
+			<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,CNC:2,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>
@@ -9053,8 +9014,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -9158,8 +9118,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -9218,8 +9177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
+			<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
 			<model name='C'>
 				<availability>RD:3,LA:2</availability>
 			</model>
@@ -9499,11 +9457,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,MERC.WD:8,CEI:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>CEI:6,CLAN:8</availability>
@@ -9756,8 +9712,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,FVC:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -10191,8 +10146,7 @@
 			</model>
 		</chassis>
 		<chassis name='Katya Ground Assault Craft' unitType='Conventional Fighter'>
-			<availability>
-				CC:6-,DTA:3-,OP:3-,RF:3-,ROS:4-,FWL:4,MSC:3-,DA:3-,RCM:3-,MERC:2,CC.CHG:7,Periphery:3</availability>
+			<availability>CC:6-,DTA:3-,OP:3-,RF:3-,ROS:4-,FWL:4,MSC:3-,DA:3-,RCM:3-,MERC:2,CC.CHG:7,Periphery:3</availability>
 			<model name='C-904(RL15)'>
 				<roles>ground_support</roles>
 				<availability>General:6</availability>
@@ -10547,8 +10501,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>
-				CHH:5,CLAN:3,IS:4,CP:3,BAN:4,RA:3,Periphery:3,CWE:4,MERC.WD:3,CDS:3,CW:4,CJF:3,DC:4</availability>
+			<availability>CHH:5,CLAN:3,IS:4,CP:3,BAN:4,RA:3,Periphery:3,CWE:4,MERC.WD:3,CDS:3,CW:4,CJF:3,DC:4</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CWE:4,RD:4,CDS:7,CW:4,General:5,CP:7,CWIE:4</availability>
@@ -10744,8 +10697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,OP:6,FS:3,MERC:4,CP:6,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
+			<availability>CC:4,MOC:4,OP:6,FS:3,MERC:4,CP:6,DTA:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,MSC:6,DA:6,RCM:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
@@ -10835,8 +10787,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10894,15 +10845,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
+			<availability>MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,RR:9-,OP:7,CEI:3-,MERC:8-,BAN:2,Periphery:8-,DTA:7,FVC:7,SE:3-,RF:7,LA:8-,ROS:9-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
+			<availability>CC:7-,RR:9-,OP:7,CEI:3-,MERC:8-,BAN:2,Periphery:8-,DTA:7,FVC:7,SE:3-,RF:7,LA:8-,ROS:9-,FWL:7-,MSC:7,DA:7,RCM:7,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>DTA:5,OP:5,RF:5,FWL:5,MSC:5,DA:7,RCM:5</availability>
 			</model>
@@ -11427,8 +11376,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:3+,CLAN:1,MERC:2+,CP:2,BAN:1,CWIE:4,RA:2,CWE:5,MERC.WD:4,RD:2+,CDS:2,CW:4,ROS:3+,CJF:2</availability>
+			<availability>MERC.KH:3+,CLAN:1,MERC:2+,CP:2,BAN:1,CWIE:4,RA:2,CWE:5,MERC.WD:4,RD:2+,CDS:2,CW:4,ROS:3+,CJF:2</availability>
 			<model name='A'>
 				<availability>CWE:7,RD:8,CDS:8,CW:7,General:7,CP:8,CJF:8</availability>
 			</model>
@@ -11571,8 +11519,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:6,OP:6,Periphery.MM:6,MERC:6,CP:8,DTA:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,MSC:8,RCM:8,DA:8</availability>
+			<availability>CC:6,MOC:6,OP:6,Periphery.MM:6,MERC:6,CP:8,DTA:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,MSC:8,RCM:8,DA:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11694,8 +11641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,CWIE:4,RA.OA:4,LA:4,ROS:4,FWL:3,DC:5</availability>
+			<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,CWIE:4,RA.OA:4,LA:4,ROS:4,FWL:3,DC:5</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -11925,15 +11871,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,OP:4,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4,RCM:4</availability>
+			<availability>Periphery.R:3,OP:4,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4,RCM:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 			</model>
@@ -12204,8 +12148,7 @@
 			<availability>FWL:5,IS:2,CP:4,Periphery:1</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -12987,8 +12930,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FWL:3:3139,FS:7,MERC:6,CP:3</availability>
 			<model name='NGS-4S'>
-				<availability>
-					:0,OP:4,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -13315,8 +13257,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:4,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:4,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13373,8 +13314,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:1,Periphery:3,TC:1,CWIE:2,CWE:2,CW:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:1,Periphery:3,TC:1,CWIE:2,CWE:2,CW:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:2-,CW:2-,FWL:1,MERC:1</availability>
 			</model>
@@ -13573,8 +13513,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2,BAN:1</availability>
@@ -13664,8 +13603,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13751,8 +13689,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
+			<availability>Periphery.DD:5,FS.RR:4,RD:5,ROS:3,FS.DMM:4,MERC:3,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
@@ -14566,8 +14503,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:5,MERC:3+,CP:7,RA:6,BAN:5,CWIE:7,CWE:7,MERC.WD:4,RD:5,CDS:6,CW:7,ROS:4+,CNC:7,CJF:4</availability>
+			<availability>CLAN:5,MERC:3+,CP:7,RA:6,BAN:5,CWIE:7,CWE:7,MERC.WD:4,RD:5,CDS:6,CW:7,ROS:4+,CNC:7,CJF:4</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CWE:5,RD:5,CDS:8,CW:5,CNC:8,General:7,CP:8,CWIE:6</availability>
@@ -14677,8 +14613,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,OP:6,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,DTA:6,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4</availability>
+			<availability>MOC:4,CC:5,OP:6,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,DTA:6,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14686,8 +14621,7 @@
 				<availability>MERC:5,DC:4</availability>
 			</model>
 			<model name='QKD-5M'>
-				<availability>
-					MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+				<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='QKD-5Mr'>
 				<availability>General:6,FWL:8,CP:8</availability>
@@ -14730,16 +14664,14 @@
 			</model>
 		</chassis>
 		<chassis name='R10 Mechanized ICV' unitType='Tank'>
-			<availability>
-				CC:3,OP:4,CLAN.IS:2,MERC:3,CP:4,CWIE:2,DTA:4,RF:4,ROS:3,CNC:2,FWL:4,MSC:4,DA:4,RCM:4</availability>
+			<availability>CC:3,OP:4,CLAN.IS:2,MERC:3,CP:4,CWIE:2,DTA:4,RF:4,ROS:3,CNC:2,FWL:4,MSC:4,DA:4,RCM:4</availability>
 			<model name='(Coolant Truck)'>
 				<roles>apc,support</roles>
 				<availability>General:4</availability>
 			</model>
 		</chassis>
 		<chassis name='R10 Mechanized ICV' unitType='Tank' omni='IS'>
-			<availability>
-				CC:5,OP:6,CLAN.IS:4,MERC:4,CP:4,CWIE:4,DTA:6,CWE:4,RF:6,CW:4,ROS:4,CNC:4,FWL:6,MSC:7,DA:6,RCM:6</availability>
+			<availability>CC:5,OP:6,CLAN.IS:4,MERC:4,CP:4,CWIE:4,DTA:6,CWE:4,RF:6,CW:4,ROS:4,CNC:4,FWL:6,MSC:7,DA:6,RCM:6</availability>
 			<model name='(A)'>
 				<roles>apc</roles>
 				<availability>General:7</availability>
@@ -14912,8 +14844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
-			<availability>
-				Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
+			<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
 			<model name='(LRM)(Sqd4)' mechanized='false'>
 				<availability>General:4,MH:0</availability>
 			</model>
@@ -15044,8 +14975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
+			<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
 			<model name=''>
 				<availability>CWE:1,CHH:1,CW:1,General:8,CNC:1,CP:1</availability>
 			</model>
@@ -15071,8 +15001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,OP:8,FS:2,CP:8,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8</availability>
+			<availability>MOC:1,OP:8,FS:2,CP:8,Periphery:2,TC:1,DTA:8,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,MSC:8,DA:6,RCM:8</availability>
 			<model name='F-100'>
 				<availability>FVC:2-,Periphery:2-</availability>
 			</model>
@@ -15090,8 +15019,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>
-				CC:1,CHH:5,CEI:3,CLAN:1,IS:3,CP:5,FS:1,RA:5,RD:5,SE:2:3141,CDS:5,CNC:5,FWL:1,MH:1</availability>
+			<availability>CC:1,CHH:5,CEI:3,CLAN:1,IS:3,CP:5,FS:1,RA:5,RD:5,SE:2:3141,CDS:5,CNC:5,FWL:1,MH:1</availability>
 			<model name=''>
 				<availability>CC:2,SE:2:3141,CDS:1,CEI:2,CNC:1,FWL:2,MH:2,CP:1,FS:2,RA:2</availability>
 			</model>
@@ -15441,8 +15369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
+			<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:1-</availability>
 			</model>
@@ -15890,8 +15817,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,OP:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,DTA:2,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,MSC:2,RCM:1-,DA:2,DC:4</availability>
+			<availability>CC:2,OP:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,DTA:2,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,MSC:2,RCM:1-,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -15909,8 +15835,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='SCP-1O'>
-				<availability>
-					CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,RCM:1-,MERC:1-,Periphery:1-,DC:1-</availability>
+				<availability>CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,RCM:1-,MERC:1-,Periphery:1-,DC:1-</availability>
 			</model>
 			<model name='SCP-1TB'>
 				<availability>ROS:4,MERC:4</availability>
@@ -16039,8 +15964,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,CW:1,LA:3,ROS:3,CJF:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,CW:1,LA:3,ROS:3,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -16064,8 +15988,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:6,ROS:8,MH:2</availability>
 			<model name='SYD-21'>
 				<roles>interceptor</roles>
 				<availability>MERC.KH:1-,Periphery:1-</availability>
@@ -16178,8 +16101,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				OP:3,CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,DTA:3,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,CW:4,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3</availability>
+			<availability>OP:3,CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,DTA:3,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,CW:4,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3</availability>
 			<model name='10'>
 				<availability>CHH:8-,RD:4-,CW:5-</availability>
 			</model>
@@ -16254,8 +16176,7 @@
 				<availability>IS:6,MH:4,FR:4,Merc:6,DA:4,RCM:4,Periphery:6</availability>
 			</model>
 			<model name='SHD-7M'>
-				<availability>
-					CC:4,MOC:3,OP:8,MERC:4,CP:7,CDP:3,TC:3,DTA:8,FVC:3,ROS:4,FWL:7:3139,MSC:8,RCM:8</availability>
+				<availability>CC:4,MOC:3,OP:8,MERC:4,CP:7,CDP:3,TC:3,DTA:8,FVC:3,ROS:4,FWL:7:3139,MSC:8,RCM:8</availability>
 			</model>
 			<model name='SHD-8L'>
 				<availability>CC:8</availability>
@@ -16337,8 +16258,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
+			<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>ROS:0,Periphery:2-</availability>
 			</model>
@@ -16544,8 +16464,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
+			<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:2-</availability>
@@ -16564,8 +16483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -16693,8 +16611,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -16753,8 +16670,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,OP:4,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,DTA:4,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,MSC:3,DA:3,RCM:6,DC:6</availability>
+			<availability>MOC:1,CC:2,OP:4,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,DTA:4,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,MSC:3,DA:3,RCM:6,DC:6</availability>
 			<model name='SDR-10K'>
 				<availability>ROS:4</availability>
 			</model>
@@ -16852,8 +16768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -17071,8 +16986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,OP:6,IS:2,MERC:4,CP:6,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
+			<availability>MOC:3,CC:4,OP:6,IS:2,MERC:4,CP:6,TC:3,DTA:6,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,MSC:6,RCM:6,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -17231,8 +17145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -17570,8 +17483,7 @@
 			</model>
 		</chassis>
 		<chassis name='Tempest' unitType='Mek'>
-			<availability>
-				DTA:8,OP:8,FWL.MM:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,MERC:4,CP:8</availability>
+			<availability>DTA:8,OP:8,FWL.MM:8,RF:8,ROS:5,Periphery.MW:4,Periphery.ME:4,FWL:8,MH:4,MSC:8,MERC:4,CP:8</availability>
 			<model name='TMP-3G'>
 				<availability>ROS:2,FWL:2,MERC:2,CP:2</availability>
 			</model>
@@ -17826,8 +17738,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -17840,14 +17751,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:4,ROS:4,PIR:4,CNC:2,Periphery.ME:4,FWL:4,MH:4,MSC:5,DA:5,CJF:4</availability>
+			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,CW:4,RF:5,Periphery.MW:4,ROS:4,PIR:4,CNC:2,Periphery.ME:4,FWL:4,MH:4,MSC:5,DA:5,CJF:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:1-,RF:1-,PIR:2-,MH:1-,MSC:1-,MERC:1-,DA:1-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>ROS:6,CLAN:4,FWL:6,MSC:6,MERC:6,CP:6,BAN:2</availability>
@@ -17989,8 +17898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:4,MERC.KH:4,CEI:2+,FS:5,MERC:6,Periphery:2,TC:4,CWE:2,SE:2+,FVC:3,MERC.WD:4,CW:2,LA:6,ROS:5,MH:4,DC:3</availability>
+			<availability>CC:4,MERC.KH:4,CEI:2+,FS:5,MERC:6,Periphery:2,TC:4,CWE:2,SE:2+,FVC:3,MERC.WD:4,CW:2,LA:6,ROS:5,MH:4,DC:3</availability>
 			<model name='C'>
 				<availability>SE:2+,CEI:2+</availability>
 			</model>
@@ -18354,8 +18262,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,CP:6,MERC:4,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
+			<availability>CC:4,MOC:4,CP:6,MERC:4,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
@@ -18827,8 +18734,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -19047,8 +18953,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+				<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:1</availability>
@@ -19105,8 +19010,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:2,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:2,FWL:2,DC:4</availability>
+			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:2,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:2,FWL:2,DC:4</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -19572,8 +19476,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CP:6,CWIE:8</availability>
@@ -19828,8 +19731,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolfhound' unitType='Mek'>
-			<availability>
-				MOC:4,OP:3,MERC.KH:7,MERC:4,FS:1,CP:3,CWIE:5,DTA:3,MERC.WD:5,FVC:1,LA:7,ROS:5,FWL:3:3139,MH:4,MSC:3</availability>
+			<availability>MOC:4,OP:3,MERC.KH:7,MERC:4,FS:1,CP:3,CWIE:5,DTA:3,MERC.WD:5,FVC:1,LA:7,ROS:5,FWL:3:3139,MH:4,MSC:3</availability>
 			<model name='WLF-1'>
 				<availability>Periphery.Deep:6,Periphery:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/3131.xml
+++ b/megamek/data/forcegenerator/3131.xml
@@ -1349,7 +1349,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,RA.OA:4,LA:5,IS:4,FWL:4,FS:5,CP:4,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:3,RA.OA:4,LA:5,IS:4,FS:5,CP:4,Periphery:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>Periphery:2</availability>
@@ -1378,7 +1378,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
+			<availability>CC:4,CLAN:4,IS:2,CP:4,BAN:5,Periphery:1,RA.OA:1,FWL:4,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -1937,7 +1937,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -2022,7 +2022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
@@ -2174,7 +2174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:3,CC:3,CEI:2,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>CC:3,CEI:2,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2371,7 +2371,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -2382,7 +2382,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
+			<availability>MOC:6,CC:5,RA.OA:6,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>DTA:4,OP:4,ROS:4,FWL:4,MSC:4,CP:4,DC:6</availability>
 			</model>
@@ -2583,7 +2583,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bandersnatch' unitType='Mek'>
-			<availability>MOC:4,DTA:4,LA:4,ROS:4,FWL:4,MERC:8,FS:4,DA:4,CP:4,Periphery:4</availability>
+			<availability>DTA:4,LA:4,ROS:4,FWL:4,MERC:8,FS:4,DA:4,CP:4,Periphery:4</availability>
 			<model name='BNDR-01A'>
 				<availability>General:8</availability>
 			</model>
@@ -2863,7 +2863,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>IS:5,CP:8,Periphery:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2883,8 +2883,7 @@
 				<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:3,MERC:3,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+				<availability>CC:3,MERC:3,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -3006,7 +3005,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:1,IS:1,MERC:2,FS:2,CP:2,Periphery:2,RA.OA:2,CDS:2,LA:1,PIR:1,CNC:2,FWL:2,DC:2</availability>
+			<availability>IS:1,MERC:2,FS:2,CP:2,Periphery:2,RA.OA:2,CDS:2,PIR:1,CNC:2,FWL:2,DC:2</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 			</model>
@@ -3205,7 +3204,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MSC:6,MOC:4,CC:4,OP:6,IS:4,MERC:4,CP:5,RA:3,Periphery:4,TC:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MSC:6,MOC:4,CC:4,OP:6,IS:4,MERC:4,CP:5,RA:3,Periphery:4,DTA:6,RD:5,FVC:4,CW:5,RF:6,LA:6,ROS:6,CNC:6,RCM:6,DA:6,CJF:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:4,FS:4</availability>
 			</model>
@@ -3213,7 +3212,7 @@
 				<availability>CC:2,ROS:2,FWL:2,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,MERC:6,BAN:6,Periphery:6,DC.GHO:4,RA.OA:6,MERC.SI:3</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>DTA:6,OP:6,LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3436,14 +3435,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>DTA:6,OP:6,RF:5,ROS:4,FWL:5,MH:4,MSC:6,MERC:4,RCM:5,DA:6,CP:5</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>RF:0,General:4,RCM:0</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:4</availability>
+				<availability>IS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3497,7 +3496,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,OP:4,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,DTA:4,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
+			<availability>CC:4,OP:4,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,DTA:4,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,MSC:4,DA:4,RCM:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3587,7 +3586,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3882,7 +3881,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:4,OP:3,FWL:3,MH:3,MERC:1,CP:2,DA:4,RCM:3,Periphery:2,TC:2,DC:6</availability>
+			<availability>CC:4,OP:3,FWL:3,MH:3,MERC:1,CP:2,DA:4,RCM:3,Periphery:2,DC:6</availability>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
 				<availability>BAN:2</availability>
@@ -4240,7 +4239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
-			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4,DC:4</availability>
+			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4</availability>
 			<model name='CLN-7V'>
 				<roles>training</roles>
 				<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
@@ -4397,7 +4396,7 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
@@ -4406,7 +4405,7 @@
 				<availability>FVC:2,CDP:2,TC:2</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,BAN:3,Periphery:2-</availability>
+				<availability>BAN:3,Periphery:2-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2,BAN:2</availability>
@@ -4782,7 +4781,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,FVC:2,LA:3,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
+			<availability>FVC:2,LA:3,ROS:3,IS:2,FS:3,CP:2,Periphery:2</availability>
 			<model name=''>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -5050,7 +5049,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,CW:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+			<availability>CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,CW:2,ROS:5,FWL:4,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -5306,7 +5305,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
+			<availability>MOC:4,IS:3,CP:2,MERC:2,Periphery:2,RA.OA:2,RD:4,MERC.WD:2,ROS:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5370,7 +5369,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:4,MOC:2,CHH:1-,CEI:2,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4,SE:3,ROS:6,CJF:1-</availability>
+			<availability>CC:4,MOC:2,CHH:1-,CEI:2,FR:2,MERC:4,CDP:4,RA:1,Periphery:4,SE:3,ROS:6,CJF:1-</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,CEI:4,ROS:5</availability>
@@ -5741,10 +5740,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CNC:5,FWL:8,CJF:2,DC:7</availability>
+			<availability>CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,CNC:5,FWL:8,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+				<availability>CC:5,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,Periphery:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
@@ -6099,7 +6098,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:4,RA.OA:2,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3</availability>
 			<model name='EGL-R11'>
 				<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 			</model>
@@ -6262,7 +6261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,CNC:5,FWL:4,MH:3,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,CNC:5,MH:3</availability>
 			<model name='EMP-6A'>
 				<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 			</model>
@@ -6425,7 +6424,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
+			<availability>MOC:3,RA.OA:2,IS:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -7036,7 +7035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2:3139,DA:3,RCM:3</availability>
+			<availability>CC:6,MERC:4,CP:2,Periphery:4,MERC.WD:4,FVC:4,RF:3,ROS:4,FWL:2:3139,DA:3,RCM:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,RCM:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
@@ -7261,7 +7260,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7336,7 +7335,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7439,7 +7438,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>CC:2,MOC:2,OP:4,IS:2,MERC:2,FS:2,CP:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,FWL:2,MH:2,MSC:4,DC:2</availability>
+			<availability>MOC:2,OP:4,IS:2,MERC:2,CP:2,TC:2,DTA:4,FVC:2,LA:4,PIR:2,MH:2,MSC:4</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -7465,7 +7464,7 @@
 			</model>
 		</chassis>
 		<chassis name='Gladiator (Executioner)' unitType='Mek' omni='Clan'>
-			<availability>CWE:2:3142,RD:8,CDS:4,CW:2,CEI:1,ROS:4+,CNC:5+,CLAN:4,CJF:3,BAN:4</availability>
+			<availability>CWE:2:3142,RD:8,CW:2,CEI:1,ROS:4+,CNC:5+,CLAN:4,CJF:3,BAN:4</availability>
 			<model name='A'>
 				<availability>CWE:8,RD:7,CDS:5,CW:8,CNC:5,General:6,CP:5,CJF:5,CWIE:8</availability>
 			</model>
@@ -7965,7 +7964,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CWE:2,MERC.WD:5,CDS:6,CW:2,LA:3,CNC:7,IS:3,CP:6,CJF:2,CWIE:4,DC:4</availability>
+			<availability>CWE:2,MERC.WD:5,CDS:6,CW:2,CNC:7,IS:3,CP:6,CJF:2,CWIE:4,DC:4</availability>
 			<model name=''>
 				<availability>MERC.WD:6,CNC:4,CP:4</availability>
 			</model>
@@ -8613,7 +8612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8639,7 +8638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8884,7 +8883,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,CP:6,Periphery:5</availability>
+			<availability>RA.OA:4,ROS:4,FWL:6,MERC:6,CP:6,Periphery:5</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -9012,7 +9011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
+			<availability>CC:5,MOC:4,LA:6,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,CP:5,CJF:5</availability>
 			<model name='HGN-732'>
 				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 			</model>
@@ -9118,7 +9117,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -9227,7 +9226,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,IS:3,MERC:3,FS:3,CP:2,Periphery:3,TC:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:4,IS:3,MERC:3,CP:2,Periphery:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:1-</availability>
@@ -9446,7 +9445,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>MOC:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -9565,7 +9564,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>CC:4,RD:6,LA:4,ROS:5,IS:4,FWL:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
+			<availability>RD:6,ROS:5,IS:4,FS:6,MERC:4,CJF:4,Periphery:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>RD:4,IS:8,Periphery:8</availability>
@@ -9712,7 +9711,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,FVC:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -9764,7 +9763,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
+			<availability>FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>Periphery:2-</availability>
@@ -10193,7 +10192,7 @@
 			<availability>ROS:4</availability>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,FWL:4,MH:4,DC:4</availability>
+			<availability>CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,MH:4</availability>
 			<model name='KGC-000'>
 				<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 			</model>
@@ -10501,7 +10500,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,CLAN:3,IS:4,CP:3,BAN:4,RA:3,Periphery:3,CWE:4,MERC.WD:3,CDS:3,CW:4,CJF:3,DC:4</availability>
+			<availability>CHH:5,CLAN:3,IS:4,CP:3,BAN:4,RA:3,Periphery:3,CWE:4,MERC.WD:3,CW:4,DC:4</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CWE:4,RD:4,CDS:7,CW:4,General:5,CP:7,CWIE:4</availability>
@@ -10787,7 +10786,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10898,7 +10897,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,CP:2,Periphery:4,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:2-</availability>
 			</model>
@@ -11163,7 +11162,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
+			<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -11641,7 +11640,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,CWIE:4,RA.OA:4,LA:4,ROS:4,FWL:3,DC:5</availability>
+			<availability>MOC:3,CC:3,IS:4,MERC:4,CP:3,Periphery:4,CWIE:4,RA.OA:4,ROS:4,FWL:3,DC:5</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -11764,7 +11763,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>CC:4,RA.OA:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='MAD-2R'>
 				<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 			</model>
@@ -12701,7 +12700,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -12930,7 +12929,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>OP:5,Periphery.R:2,RF:5,LA:8,ROS:6,FWL:3:3139,FS:7,MERC:6,CP:3</availability>
 			<model name='NGS-4S'>
-				<availability>:0,OP:4,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>OP:4,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -13257,7 +13256,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:4,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,CNC:4,Periphery.ME:6,FWL:6,MH:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13314,7 +13313,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:1,Periphery:3,TC:1,CWIE:2,CWE:2,CW:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:1,Periphery:3,TC:1,CWIE:2,CWE:2,CW:2,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:2-,CW:2-,FWL:1,MERC:1</availability>
 			</model>
@@ -13603,7 +13602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -14613,7 +14612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:4,CC:5,OP:6,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,DTA:6,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4</availability>
+			<availability>MOC:4,CC:5,OP:6,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,DTA:6,RA.OA:2,FVC:2,RD:5,RF:6,ROS:5,FWL:6,MSC:6,DA:4,RCM:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14910,7 +14909,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -15046,7 +15045,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:4,Clan.IS:4,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
+			<availability>Clan.IS:4,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
 			<model name='C 2'>
 				<availability>CJF:4</availability>
 			</model>
@@ -15234,7 +15233,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CLAN:4,MERC:3+,CP:4,FS:4,RA:6,BAN:5,CWIE:5,MERC.WD:5,CDS:4,CW:4,CJF:4,DC:5</availability>
+			<availability>CLAN:4,MERC:3+,CP:4,FS:4,RA:6,BAN:5,CWIE:5,MERC.WD:5,DC:5</availability>
 			<model name='A'>
 				<availability>CWE:6,RD:3,CDS:9,CW:6,General:6,CP:9,CJF:5</availability>
 			</model>
@@ -15526,7 +15525,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:2,RA.OA:5,Periphery.DD:4,FWL:1-,Periphery.OS:4,CP:1-,Periphery:2,TC:2,DC:2-</availability>
+			<availability>RA.OA:5,Periphery.DD:4,FWL:1-,Periphery.OS:4,CP:1-,Periphery:2,DC:2-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -15817,7 +15816,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:2,OP:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,DTA:2,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,MSC:2,RCM:1-,DA:2,DC:4</availability>
+			<availability>OP:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,DTA:2,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,MSC:2,RCM:1-,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -15960,11 +15959,11 @@
 			<availability>CC:4,MOC:4,RF:4,ROS:4,FWL:5,MSC:5,DA:4,MERC:4,CP:5</availability>
 			<model name=''>
 				<roles>assault,ba_carrier</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,CW:1,LA:3,ROS:3,CJF:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,LA:3,ROS:3,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -16101,7 +16100,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>OP:3,CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,DTA:3,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,CW:4,LA:3,ROS:4,CNC:4,FWL:3,MSC:3,RCM:3,DA:3,DC:3</availability>
+			<availability>OP:3,CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,DTA:3,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,CW:4,ROS:4,CNC:4,MSC:3,RCM:3,DA:3</availability>
 			<model name='10'>
 				<availability>CHH:8-,RD:4-,CW:5-</availability>
 			</model>
@@ -16483,7 +16482,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+			<availability>Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -16611,7 +16610,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,ROS:4,MERC:5,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -16768,7 +16767,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,ROS:2,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -17015,7 +17014,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -17027,7 +17026,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -17095,7 +17094,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,CNC:4,DC:1</availability>
+			<availability>IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,ROS:3,PIR:3,CNC:4,DC:1</availability>
 			<model name=''>
 				<availability>General:1-</availability>
 			</model>
@@ -17145,7 +17144,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -17639,7 +17638,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,MERC.WD:1,RD:1,CDS:1,CW:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
+			<availability>CHH:5,MERC.WD:1,RD:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
 			<model name='A'>
 				<availability>CWE:6,CHH:8,RD:4,CDS:8,CW:6,CNC:6,General:7,CP:7,CJF:8,CWIE:6</availability>
 			</model>
@@ -17738,7 +17737,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -17871,7 +17870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
+			<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:2-</availability>
@@ -18262,7 +18261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:4,MOC:4,CP:6,MERC:4,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
+			<availability>CC:4,MOC:4,CP:6,MERC:4,Periphery:3,TC:4,RF:6,ROS:4,FWL:6,DA:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,FWL:2:3139,MSC:4,MERC:4,CP:2</availability>
@@ -18734,7 +18733,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,FS.CMM:5-,IS:4-,FWL:5-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -18938,7 +18937,7 @@
 		<chassis name='Vedette Medium Tank' unitType='Tank'>
 			<availability>CWE:4,CHH:5,CW:4,IS:10,CJF:4,Periphery:10</availability>
 			<model name='(Cell)'>
-				<availability>CC:6,LA:4,FWL:6,IS:4,FS:4,MERC:5,CP:6,DC:4,Periphery:4</availability>
+				<availability>CC:6,FWL:6,IS:4,MERC:5,CP:6,Periphery:4</availability>
 			</model>
 			<model name='(LB-X)'>
 				<availability>CC:5,MOC:5,DTA:5,RF:5,FWL:4:3139,DA:5,RCM:5,CP:4,CDP:5,TC:5</availability>
@@ -18966,7 +18965,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
+			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:2</availability>
@@ -19010,7 +19009,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:2,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:2,FWL:2,DC:4</availability>
+			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:2,Periphery:3,TC:2,RA.OA:2,Periphery.HR:2,ROS:2,FWL:2,DC:4</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -19249,7 +19248,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,MERC.WD:4,RD:4,ROS:4,CLAN:3,MERC:2,CJF:3,BAN:5,CWIE:4,DC:3</availability>
+			<availability>CHH:6,MERC.WD:4,RD:4,ROS:4,CLAN:3,MERC:2,BAN:5,CWIE:4,DC:3</availability>
 			<model name='A'>
 				<availability>CWE:7,RD:4,CDS:7,CW:7,CNC:7,General:6,CP:7</availability>
 			</model>
@@ -19476,7 +19475,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,MH:6,DC:4</availability>
+			<availability>FS.CH:8,IS:6,FWL.FWG:7,CP:4,CC.CHG:8,Periphery:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,CNC:4,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,CNC:8,FWL:4,CP:6,CWIE:8</availability>
@@ -19762,7 +19761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,RD:2,LA:5,CNC:2,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
+			<availability>RD:2,CNC:2,IS:5,FWL:8,MH:4,FS:6,CP:6,Periphery:4</availability>
 			<model name='WVR-10D'>
 				<availability>FS:3,MERC:2</availability>
 			</model>
@@ -19906,7 +19905,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CC:1,OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,ROS:5,MSC:1,DA:1,RCM:1,DC:6</availability>
+			<availability>OP:1,IS:1,FS:7,MERC:5,DC.GHO:2,DTA:1,FVC:2,RF:1,ROS:5,MSC:1,DA:1,RCM:1,DC:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>DC.GHO:3,ROS:6,FS:8,MERC:8,BAN:1,DC:3</availability>
@@ -20178,7 +20177,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,Periphery:3,DC:5</availability>
 			<model name=''>
 				<availability>General:3-</availability>
 			</model>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -1918,8 +1918,7 @@
 			<availability>Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
+				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1995,8 +1994,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2697,8 +2695,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2715,8 +2712,7 @@
 				<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+				<availability>CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -3040,8 +3036,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:3,FS:8</availability>
 			</model>
@@ -3334,8 +3329,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,DA:4,DC:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,FWL:4,DA:4,DC:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3425,8 +3419,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3720,8 +3713,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,ROS:5,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
+			<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,ROS:5,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
 			<model name='CTF-1X'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -3982,8 +3974,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:4,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6</availability>
+			<availability>CC:4,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6</availability>
 			<model name='CN10-B'>
 				<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 			</model>
@@ -4217,15 +4208,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
+			<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:1-,RF:1-,FWL:1-,MERC:1-,DA:1-,CP:1-,Periphery:1-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
+				<availability>CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -4623,8 +4612,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:1-,Periphery:1-</availability>
@@ -4941,8 +4929,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+			<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -5201,8 +5188,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
+			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5381,8 +5367,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,LA:4+,ROS:4+,CJF:5,DC:4+</availability>
+			<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,LA:4+,ROS:4+,CJF:5,DC:4+</availability>
 			<model name='A'>
 				<availability>CWE:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5644,8 +5629,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -6972,15 +6956,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
+				<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:4</availability>
@@ -7199,8 +7181,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7278,8 +7259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7569,8 +7549,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,CWE:2,FVC:2,RF:4,LA:5,Periphery.MW:2,ROS:6,FWL:6,MH:2,DA:4,DC:2</availability>
+			<availability>CC:4,MOC:4,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,CWE:2,FVC:2,RF:4,LA:5,Periphery.MW:2,ROS:6,FWL:6,MH:2,DA:4,DC:2</availability>
 			<model name='GOL-2H'>
 				<roles>fire_support</roles>
 				<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
@@ -7725,8 +7704,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
+			<availability>CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
 			<model name='T-IT-N10M'>
 				<availability>ROS:2,FWL:2,MERC:2,CP:2,Periphery:2</availability>
 			</model>
@@ -8392,8 +8370,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
@@ -8561,8 +8538,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8588,8 +8564,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -9082,8 +9057,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -9142,8 +9116,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
+			<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
 			<model name='C'>
 				<availability>RD:3,LA:2</availability>
 			</model>
@@ -9439,11 +9412,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>SE:6,CLAN:8</availability>
@@ -9736,8 +9707,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -10708,8 +10678,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
+			<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
@@ -10799,8 +10768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10858,15 +10826,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
+			<availability>MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,RR:9-,MERC:8-,BAN:2,Periphery:8-,FVC:7,SE:3-,RF:7,LA:8-,ROS:9-,FWL:7-,DA:7,DC:7-</availability>
+			<availability>CC:7-,RR:9-,MERC:8-,BAN:2,Periphery:8-,FVC:7,SE:3-,RF:7,LA:8-,ROS:9-,FWL:7-,DA:7,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>RF:5,FWL:5,DA:7</availability>
 			</model>
@@ -11320,8 +11286,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>
-				CC:3:3147,MOC:3:3147,CDS:4:3147,FWL:3:3147,MERC:4:3147,BAN:1,CWIE:4:3147,TC:3:3147</availability>
+			<availability>CC:3:3147,MOC:3:3147,CDS:4:3147,FWL:3:3147,MERC:4:3147,BAN:1,CWIE:4:3147,TC:3:3147</availability>
 			<model name='A'>
 				<availability>CLAN:6</availability>
 			</model>
@@ -11401,8 +11366,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				MERC.KH:3+,CLAN:1,MERC:2+,CP:2,BAN:1,CWIE:4,RA:2,CWE:6,MERC.WD:4,RD:2,CDS:2,ROS:3+,CJF:2</availability>
+			<availability>MERC.KH:3+,CLAN:1,MERC:2+,CP:2,BAN:1,CWIE:4,RA:2,CWE:6,MERC.WD:4,RD:2,CDS:2,ROS:3+,CJF:2</availability>
 			<model name='A'>
 				<availability>CWE:7,RD:8,CDS:8,General:7,CP:8,CJF:8</availability>
 			</model>
@@ -11545,8 +11509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:6,Periphery.MM:6,MERC:6,CP:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,DA:8</availability>
+			<availability>CC:6,MOC:6,Periphery.MM:6,MERC:6,CP:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,DA:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11892,15 +11855,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4</availability>
+			<availability>Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 			</model>
@@ -12189,8 +12150,7 @@
 			<availability>FWL:5,IS:2,CP:4,Periphery:1</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -12993,8 +12953,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,RF:5,LA:8,ROS:6,FWL:4,FS:7,MERC:6,CP:4</availability>
 			<model name='NGS-4S'>
-				<availability>
-					:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -13344,8 +13303,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13402,8 +13360,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:3-,FWL:2,MERC:2</availability>
 			</model>
@@ -13620,8 +13577,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2,BAN:1</availability>
@@ -13711,8 +13667,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13798,8 +13753,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				Periphery.DD:5,FS.RR:4,RD:4,ROS:2,FS.DMM:4,MERC:2,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
+			<availability>Periphery.DD:5,FS.RR:4,RD:4,ROS:2,FS.DMM:4,MERC:2,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
@@ -14712,8 +14666,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
+			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14721,8 +14674,7 @@
 				<availability>MERC:5,DC:4</availability>
 			</model>
 			<model name='QKD-5M'>
-				<availability>
-					MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+				<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='QKD-5Mr'>
 				<availability>General:6,FWL:8,CP:8</availability>
@@ -14945,8 +14897,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
-			<availability>
-				Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
+			<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
 			<model name='(LRM)(Sqd4)' mechanized='false'>
 				<availability>General:4,MH:0</availability>
 			</model>
@@ -15095,8 +15046,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
+			<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
 			<model name=''>
 				<availability>CWE:1,CHH:1,General:8,CP:1</availability>
 			</model>
@@ -15122,8 +15072,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
+			<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 			<model name='F-100'>
 				<availability>FVC:2-,Periphery:2-</availability>
 			</model>
@@ -15543,8 +15492,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
+			<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:1-</availability>
 			</model>
@@ -15992,8 +15940,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
+			<availability>CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -16011,8 +15958,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='SCP-1O'>
-				<availability>
-					CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,MERC:1-,Periphery:1-,DC:1-</availability>
+				<availability>CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,MERC:1-,Periphery:1-,DC:1-</availability>
 			</model>
 			<model name='SCP-1TB'>
 				<availability>ROS:4,MERC:4</availability>
@@ -16141,8 +16087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -16166,8 +16111,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
 			<model name='SYD-Z1'>
 				<roles>interceptor</roles>
 				<availability>Periphery:2-</availability>
@@ -16276,8 +16220,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
+			<availability>CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
 			<model name='10'>
 				<availability>CWE:5-,CHH:8-,RD:4-</availability>
 			</model>
@@ -16431,8 +16374,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
+			<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>ROS:0,Periphery:2-</availability>
 			</model>
@@ -16638,8 +16580,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
+			<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:1-</availability>
@@ -16658,8 +16599,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -16805,8 +16745,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -16865,8 +16804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,DA:3,DC:6</availability>
+			<availability>MOC:1,CC:2,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,DA:3,DC:6</availability>
 			<model name='SDR-10K'>
 				<availability>ROS:4</availability>
 			</model>
@@ -16964,8 +16902,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -17185,8 +17122,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
+			<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -17366,8 +17302,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -17960,8 +17895,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -17974,14 +17908,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,ROS:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
+			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,ROS:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:1-,PIR:2-,MH:1-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>ROS:6,CLAN:4,FWL:6,MERC:6,CP:6,BAN:2</availability>
@@ -18123,8 +18055,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:4,MERC.KH:4,FS:5,MERC:6,Periphery:2,TC:4,CWE:4,SE:2+,FVC:3,MERC.WD:4,LA:6,ROS:5,MH:4,DC:3</availability>
+			<availability>CC:4,MERC.KH:4,FS:5,MERC:6,Periphery:2,TC:4,CWE:4,SE:2+,FVC:3,MERC.WD:4,LA:6,ROS:5,MH:4,DC:3</availability>
 			<model name='C'>
 				<availability>SE:2+</availability>
 			</model>
@@ -18478,8 +18409,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
+			<availability>CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
@@ -18935,8 +18865,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -19158,8 +19087,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+				<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:1</availability>
@@ -19216,8 +19144,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:2,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:3,FWL:2,DC:4</availability>
+			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:2,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:3,FWL:2,DC:4</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -19701,8 +19628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,FWL:4,CP:6,CWIE:8</availability>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -1160,7 +1160,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,RA.OA:4,LA:5,IS:4,FWL:4,FS:5,CP:4,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:3,RA.OA:4,LA:5,IS:4,FS:5,CP:4,Periphery:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>Periphery:2</availability>
@@ -1189,7 +1189,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
+			<availability>CC:4,CLAN:4,IS:2,CP:4,BAN:5,Periphery:1,RA.OA:1,FWL:4,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -1839,7 +1839,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
@@ -1918,7 +1918,7 @@
 			<availability>Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
+				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1994,7 +1994,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2200,7 +2200,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -2211,7 +2211,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
+			<availability>MOC:6,CC:5,RA.OA:6,ROS:5,IS:4,FWL:8,CP:8,Periphery:8,TC:5,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>ROS:4,FWL:4,CP:4,DC:6</availability>
 			</model>
@@ -2695,7 +2695,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>IS:5,CP:8,Periphery:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2837,7 +2837,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:1,RA.OA:2,LA:1,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
+			<availability>RA.OA:2,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 			</model>
@@ -3036,7 +3036,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:3,FS:8</availability>
 			</model>
@@ -3044,8 +3044,7 @@
 				<availability>CC:2,ROS:4,FWL:4,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,MERC:6,BAN:6,Periphery:6,DC.GHO:4,RA.OA:6,MERC.SI:3</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3268,14 +3267,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>RF:5,ROS:4,FWL:6,MH:4,MERC:4,DA:6,CP:6</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>RF:0,General:4</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:4</availability>
+				<availability>IS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3419,7 +3418,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -4109,7 +4108,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
-			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4,DC:4</availability>
+			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4</availability>
 			<model name='CLN-7V'>
 				<roles>training</roles>
 				<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
@@ -4266,7 +4265,7 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
@@ -4275,7 +4274,7 @@
 				<availability>FVC:2,CDP:2,TC:2</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,BAN:3,Periphery:2-</availability>
+				<availability>BAN:3,Periphery:2-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2,BAN:2</availability>
@@ -4654,7 +4653,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,FVC:2,LA:2,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
+			<availability>FVC:2,ROS:3,IS:2,FS:3,CP:2,Periphery:2</availability>
 			<model name=''>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -4929,7 +4928,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+			<availability>CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -5013,7 +5012,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
+			<availability>RF:4,ROS:3,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -5188,7 +5187,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
+			<availability>MOC:4,IS:3,CP:2,MERC:2,Periphery:2,RA.OA:2,RD:4,MERC.WD:2,ROS:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5199,7 +5198,7 @@
 				<availability>General:2-</availability>
 			</model>
 			<model name='CP-11-A'>
-				<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
+				<availability>MOC:4,IS:4,MH:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
 			</model>
 			<model name='CP-11-A-DC'>
 				<roles>command</roles>
@@ -5252,7 +5251,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:4,MOC:2,CHH:1-,SE:3,ROS:6,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4</availability>
+			<availability>CC:4,MOC:2,CHH:1-,SE:3,ROS:6,FR:2,MERC:4,CDP:4,RA:1,Periphery:4</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,ROS:5</availability>
@@ -5629,10 +5628,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
+			<availability>CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+				<availability>CC:5,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,Periphery:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
@@ -6012,7 +6011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:4,RA.OA:2,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3</availability>
 			<model name='EGL-R11'>
 				<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 			</model>
@@ -6175,7 +6174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,FWL:4,MH:3,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,MH:3</availability>
 			<model name='EMP-6A'>
 				<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 			</model>
@@ -6335,7 +6334,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
+			<availability>MOC:3,RA.OA:2,IS:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -6917,7 +6916,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,CP:2,MERC:2,CWIE:2,DC.GHO:5,RD:2,CDS:1,LA:4,ROS:2,FWL:4,CJF:2,DC:4</availability>
+			<availability>CLAN:1,CP:2,MERC:2,CWIE:2,DC.GHO:5,RD:2,CDS:1,LA:4,ROS:2,FWL:4,CJF:2,DC:4</availability>
 			<model name='FLS-10E'>
 				<availability>CDS:2-,LA:2,MERC:2,CWIE:2</availability>
 			</model>
@@ -6956,7 +6955,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+			<availability>CC:6,MERC:4,CP:2,Periphery:4,MERC.WD:4,FVC:4,RF:3,ROS:4,FWL:2,DA:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
@@ -7181,7 +7180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7259,7 +7258,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7362,7 +7361,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>CC:2,MOC:2,IS:2,MERC:2,FS:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2,DC:2</availability>
+			<availability>MOC:2,IS:2,MERC:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -8538,7 +8537,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8564,7 +8563,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8803,7 +8802,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,CP:6,Periphery:5</availability>
+			<availability>RA.OA:4,ROS:4,FWL:6,MERC:6,CP:6,Periphery:5</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -8950,10 +8949,9 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,CP:5,CJF:5</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CLAN:6,IS:6,MERC:6,CP:6,BAN:8,DC.GHO:8,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -9057,7 +9055,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -9401,7 +9399,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>MOC:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -9539,7 +9537,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>CC:4,RD:6,LA:4,ROS:5,IS:4,FWL:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
+			<availability>RD:6,ROS:5,IS:4,FS:6,MERC:4,CJF:4,Periphery:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>RD:4,IS:8,Periphery:8</availability>
@@ -9707,7 +9705,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -9759,7 +9757,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
+			<availability>FVC:6,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>Periphery:2-</availability>
@@ -10182,7 +10180,7 @@
 			<availability>ROS:5</availability>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,FWL:4,MH:4,DC:4</availability>
+			<availability>CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,MH:4</availability>
 			<model name='KGC-000'>
 				<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 			</model>
@@ -10476,7 +10474,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CWE:4,CHH:5,MERC.WD:3,CDS:3,CLAN:4,IS:5,CP:3,CJF:4,BAN:4,RA:3,Periphery:4,DC:4</availability>
+			<availability>CWE:4,CHH:5,MERC.WD:3,CDS:3,CLAN:4,IS:5,CP:3,BAN:4,RA:3,Periphery:4,DC:4</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CWE:4,RD:4,CDS:7,General:5,CP:7,CWIE:4</availability>
@@ -10637,7 +10635,7 @@
 			</model>
 			<model name='(3055 Upgrade)'>
 				<roles>fire_support</roles>
-				<availability>CC:8,MOC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,Periphery:6</availability>
+				<availability>MOC:8,IS:8,CP:8,TC:8,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -10768,7 +10766,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -11147,7 +11145,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
+			<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -11631,7 +11629,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,RA.OA:4,LA:4,ROS:3,FWL:3,DC:5</availability>
+			<availability>MOC:3,CC:3,IS:4,MERC:4,CP:3,Periphery:4,RA.OA:4,ROS:3,FWL:3,DC:5</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -11754,7 +11752,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,RA.OA:2,MOC:2,RD:2,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>CC:4,RA.OA:2,RD:2,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='MAD-2R'>
 				<availability>MOC:4,RA.OA:4,MH:4,MERC:4,BAN:1,TC:5</availability>
 			</model>
@@ -12718,7 +12716,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -12953,7 +12951,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,RF:5,LA:8,ROS:6,FWL:4,FS:7,MERC:6,CP:4</availability>
 			<model name='NGS-4S'>
-				<availability>:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -13303,7 +13301,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13360,7 +13358,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:3-,FWL:2,MERC:2</availability>
 			</model>
@@ -13368,7 +13366,7 @@
 				<availability>CLAN:2-,Periphery:2-</availability>
 			</model>
 			<model name='ON1-M'>
-				<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
+				<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8</availability>
 			</model>
 			<model name='ON1-M-DC'>
 				<roles>command</roles>
@@ -13435,7 +13433,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>MOC:4,CC:3,CDS:2,LA:4,ROS:4,IS:4,MERC:4,TC:4,DC:5,Periphery:2</availability>
+			<availability>MOC:4,CC:3,CDS:2,ROS:4,IS:4,MERC:4,TC:4,DC:5,Periphery:2</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>Periphery:2-</availability>
@@ -13667,7 +13665,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13866,7 +13864,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
+			<availability>MOC:2,CC:1,RA.OA:2,IS:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
 			<model name='(AC2)'>
 				<roles>anti_aircraft</roles>
 				<availability>Periphery:2-</availability>
@@ -14565,7 +14563,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CWE:7,MERC.WD:4,RD:5,CDS:5,ROS:4+,CLAN:5,MERC:3+,CP:7,CJF:4,RA:6,BAN:5,CWIE:7</availability>
+			<availability>CWE:7,MERC.WD:4,RD:5,ROS:4+,CLAN:5,MERC:3+,CP:7,CJF:4,RA:6,BAN:5,CWIE:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CWE:5,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
@@ -14666,7 +14664,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
+			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,ROS:5,FWL:6,DA:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14963,7 +14961,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -15649,7 +15647,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:2,RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,TC:2,DC:1-</availability>
+			<availability>RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,DC:1-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -15940,7 +15938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
+			<availability>MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:2-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -16083,11 +16081,11 @@
 			<availability>CC:4,MOC:4,RF:4,ROS:4,FWL:5,DA:4,MERC:4,CP:5</availability>
 			<model name=''>
 				<roles>assault,ba_carrier</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,LA:2,ROS:3,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -16220,7 +16218,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
+			<availability>CHH:4,IS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,ROS:4,FWL:3,DA:3</availability>
 			<model name='10'>
 				<availability>CWE:5-,CHH:8-,RD:4-</availability>
 			</model>
@@ -16599,7 +16597,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+			<availability>Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -16745,7 +16743,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,ROS:4,MERC:5,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -17122,7 +17120,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
+			<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,FWL:6,MH:3,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -17151,7 +17149,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -17163,7 +17161,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -17252,7 +17250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,DC:1</availability>
+			<availability>IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,ROS:3,PIR:3,DC:1</availability>
 			<model name=''>
 				<availability>General:1-</availability>
 			</model>
@@ -17302,7 +17300,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -17796,7 +17794,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,MERC.WD:1,RD:1,CDS:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
+			<availability>CHH:5,MERC.WD:1,RD:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
 			<model name='A'>
 				<availability>CWE:6,CHH:8,RD:4,CDS:8,General:7,CP:7,CJF:8,CWIE:6</availability>
 			</model>
@@ -18028,7 +18026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
+			<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,DC:4</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:2-</availability>
@@ -18409,7 +18407,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
+			<availability>CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,FWL:6,DA:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
@@ -18865,7 +18863,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,FS.CMM:5-,IS:4-,FWL:5-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -18897,7 +18895,7 @@
 			</model>
 			<model name='UM-R80'>
 				<roles>urban,spotter</roles>
-				<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+				<availability>MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
 			</model>
 			<model name='UM-R93'>
 				<roles>urban</roles>
@@ -19168,7 +19166,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='VTR-9K'>
-				<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
+				<availability>FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,Periphery:4</availability>
 			</model>
 			<model name='VTR-9Ka'>
 				<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
@@ -19383,7 +19381,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vulture (Mad Dog)' unitType='Mek' omni='Clan'>
-			<availability>CHH:6,MERC.WD:4,RD:4,ROS:4,CLAN:3,MERC:2,CJF:3,BAN:5,CWIE:4,DC:3</availability>
+			<availability>CHH:6,MERC.WD:4,RD:4,ROS:4,CLAN:3,MERC:2,BAN:5,CWIE:4,DC:3</availability>
 			<model name='A'>
 				<availability>CWE:7,RD:4,CDS:7,General:6,CP:7</availability>
 			</model>
@@ -19628,7 +19626,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
+			<availability>FS.CH:8,IS:6,FWL.FWG:7,CP:4,CC.CHG:8,Periphery:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,FWL:4,CP:6,CWIE:8</availability>
@@ -19800,7 +19798,7 @@
 		<chassis name='Whitworth' unitType='Mek'>
 			<availability>FVC:1,FS.CMM:1,MERC:1,DC:1,Periphery:1</availability>
 			<model name='WTH-1H'>
-				<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
+				<availability>PIR:5,Periphery:5</availability>
 			</model>
 			<model name='WTH-2'>
 				<roles>fire_support</roles>
@@ -19921,7 +19919,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,RD:2,LA:5,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
+			<availability>RD:2,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4</availability>
 			<model name='WVR-10D'>
 				<availability>FS:4,MERC:3</availability>
 			</model>
@@ -20352,7 +20350,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>

--- a/megamek/data/forcegenerator/3150.xml
+++ b/megamek/data/forcegenerator/3150.xml
@@ -1968,8 +1968,7 @@
 			<availability>Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
+				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -2045,8 +2044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2747,8 +2745,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2765,8 +2762,7 @@
 				<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
+				<availability>CC:2,MERC:2,CP:2,Periphery:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,ROS:4,PIR:5,Periphery.ME:4,FWL:2,MH:5</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -2979,8 +2975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bishop Transport VTOL' unitType='VTOL'>
-			<availability>
-				CC:4,FS:6,MERC:5,RA:5,RD:4,RF:4,LA:4,TamPact:4,ROS:5,FWL:4,SL3.CSJ:5,DC:4,VesMar:4</availability>
+			<availability>CC:4,FS:6,MERC:5,RA:5,RD:4,RF:4,LA:4,TamPact:4,ROS:5,FWL:4,SL3.CSJ:5,DC:4,VesMar:4</availability>
 			<model name=''>
 				<roles>cargo</roles>
 				<availability>General:6</availability>
@@ -3088,8 +3083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:3,FS:8</availability>
 			</model>
@@ -3097,8 +3091,7 @@
 				<availability>CC:2,ROS:4,FWL:4,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3382,8 +3375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,TamPact:4,FWL:4,DA:4,DC:4,VesMar:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,TamPact:4,FWL:4,DA:4,DC:4,VesMar:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3473,8 +3465,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3765,8 +3756,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,ROS:5,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
+			<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,ROS:5,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
 			<model name='CTF-1X'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -4027,8 +4017,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:4,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6</availability>
+			<availability>CC:4,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2,FVC:8,LA:3,Periphery.HR:4,ROS:5,FWL:1,MH:6</availability>
 			<model name='CN10-B'>
 				<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 			</model>
@@ -4262,15 +4251,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
+			<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,ROS:5,Periphery.ME:4,FWL:10,DA:8</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:1-,RF:1-,FWL:1-,MERC:1-,DA:1-,CP:1-,Periphery:1-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
+				<availability>CC:4,MOC:4,RF:8,ROS:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -4668,8 +4655,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
+			<availability>MERC.KH:8,MERC:5,FS:1,TC:6,Periphery:2,Periphery.R:4,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,ROS:3,Periphery.ME:4,MH:5</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:1-,Periphery:1-</availability>
@@ -4986,8 +4972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>
-				CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+			<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -5246,8 +5231,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
+			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5426,8 +5410,7 @@
 			</model>
 		</chassis>
 		<chassis name='Daishi (Dire Wolf)' unitType='Mek' omni='Clan'>
-			<availability>
-				CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,LA:4+,ROS:4+,CJF:5,DC:4+</availability>
+			<availability>CLAN:4,FS:4+,MERC:4+,CP:5,BAN:3,CWIE:6,CWE:6,MERC.WD:6,RD:5,CDS:5,LA:4+,ROS:4+,CJF:5,DC:4+</availability>
 			<model name='A'>
 				<availability>CWE:5,General:7,CJF:8,CWIE:5</availability>
 			</model>
@@ -5689,8 +5672,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -7032,15 +7014,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
+				<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,ROS:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:4</availability>
@@ -7259,8 +7239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7338,8 +7317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7629,8 +7607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,CWE:2,FVC:2,RF:2,LA:5,Periphery.MW:2,ROS:4,FWL:6,MH:2,DA:2,DC:2</availability>
+			<availability>CC:4,MOC:4,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,CWE:2,FVC:2,RF:2,LA:5,Periphery.MW:2,ROS:4,FWL:6,MH:2,DA:2,DC:2</availability>
 			<model name='GOL-2H'>
 				<roles>fire_support</roles>
 				<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
@@ -7791,8 +7768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
+			<availability>CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,ROS:6,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
 			<model name='T-IT-N10M'>
 				<availability>ROS:2,FWL:2,MERC:2,CP:2,Periphery:2</availability>
 			</model>
@@ -8091,8 +8067,7 @@
 			</model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:8,MOC:2,MERC.KH:2,SE:2,MERC.WD:2,RF:6,ROS:4-,FWL:6,FR:6,MERC:7,DA:6,Periphery:5</availability>
+			<availability>CC:8,MOC:2,MERC.KH:2,SE:2,MERC.WD:2,RF:6,ROS:4-,FWL:6,FR:6,MERC:7,DA:6,Periphery:5</availability>
 			<model name=''>
 				<roles>ground_support</roles>
 				<availability>CC:8-,MERC.KH:2,SE:2-,MERC.WD:2-,RF:6,ROS:4-,FWL:6-,DA:6,Periphery:5</availability>
@@ -8459,8 +8434,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,DC:4</availability>
+			<availability>MERC.KH:4,TC.PL:3,FS:5,MERC:3,CP:4,Periphery:2,Periphery.R:3,FVC:5,LA:6,ROS:5,Periphery.MW:3,FWL:4,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
@@ -8628,8 +8602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8655,8 +8628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -9047,8 +9019,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -9152,8 +9123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -9212,8 +9182,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
+			<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,ROS:3,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
 			<model name='C'>
 				<availability>RD:3,LA:2</availability>
 			</model>
@@ -9509,11 +9478,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>SE:6,CLAN:8</availability>
@@ -9815,8 +9782,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -10203,8 +10169,7 @@
 			<availability>RF:2,FWL:2</availability>
 		</chassis>
 		<chassis name='Karnov UR Transport' unitType='VTOL'>
-			<availability>
-				CC:4,IS:5,MERC:5,Periphery:4,RA:4,SL3.CJF:5,LA:4,TamPact:4,ROS:5,MH:3,SL3:4,SL3.CSJ:5,DA:3,DC:4,VesMar:4</availability>
+			<availability>CC:4,IS:5,MERC:5,Periphery:4,RA:4,SL3.CJF:5,LA:4,TamPact:4,ROS:5,MH:3,SL3:4,SL3.CSJ:5,DA:3,DC:4,VesMar:4</availability>
 			<model name=''>
 				<roles>apc,cargo</roles>
 				<availability>General:4</availability>
@@ -10785,8 +10750,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
+			<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,ROS:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
@@ -10876,8 +10840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10935,15 +10898,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
+			<availability>MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7-,RR:9-,MERC:8-,BAN:2,Periphery:8-,FVC:7,SE:3-,RF:7,LA:8-,TamPact:5-,ROS:9-,FWL:7-,DA:7,DC:7-</availability>
+			<availability>CC:7-,RR:9-,MERC:8-,BAN:2,Periphery:8-,FVC:7,SE:3-,RF:7,LA:8-,TamPact:5-,ROS:9-,FWL:7-,DA:7,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>RF:5,FWL:5,DA:7</availability>
 			</model>
@@ -11394,8 +11355,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>
-				CC:3:3147,MOC:3:3147,CDS:4:3147,FWL:3:3147,MERC:4:3147,BAN:1,CWIE:4:3147,TC:3:3147</availability>
+			<availability>CC:3:3147,MOC:3:3147,CDS:4:3147,FWL:3:3147,MERC:4:3147,BAN:1,CWIE:4:3147,TC:3:3147</availability>
 			<model name='A'>
 				<availability>CLAN:6</availability>
 			</model>
@@ -11618,8 +11578,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:6,Periphery.MM:6,MERC:6,CP:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,DA:8</availability>
+			<availability>CC:6,MOC:6,Periphery.MM:6,MERC:6,CP:8,RF:8,LA:6,ROS:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,DA:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11968,15 +11927,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4</availability>
+			<availability>Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,ROS:4,Periphery.ME:3,DA:4,FS:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 			</model>
@@ -12265,8 +12222,7 @@
 			<availability>FWL:5,IS:2,CP:4,Periphery:1</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -13069,8 +13025,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,RF:5,LA:8,ROS:6,FWL:4,FS:7,MERC:6,CP:4</availability>
 			<model name='NGS-4S'>
-				<availability>
-					:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -13420,8 +13375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13478,8 +13432,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:3-,FWL:2,MERC:2</availability>
 			</model>
@@ -13696,8 +13649,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2,BAN:1</availability>
@@ -13787,8 +13739,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13874,8 +13825,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>
-				Periphery.DD:5,FS.RR:4,RD:4,ROS:2,FS.DMM:4,MERC:2,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
+			<availability>Periphery.DD:5,FS.RR:4,RD:4,ROS:2,FS.DMM:4,MERC:2,Periphery.OS:5,RA:4,Periphery:2,DC:6</availability>
 			<model name='PNT-10K'>
 				<roles>fire_support</roles>
 				<availability>FS.RR:2,FVC:3,PIR:3,FS.DMM:2,MERC:2,DC:2,TC:3</availability>
@@ -14792,8 +14742,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
+			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14801,8 +14750,7 @@
 				<availability>MERC:5,DC:4</availability>
 			</model>
 			<model name='QKD-5M'>
-				<availability>
-					MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+				<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='QKD-5Mr'>
 				<availability>General:6,FWL:8,CP:8</availability>
@@ -15025,8 +14973,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
-			<availability>
-				Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
+			<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
 			<model name='(LRM)(Sqd4)' mechanized='false'>
 				<availability>General:4,MH:0</availability>
 			</model>
@@ -15175,8 +15122,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
+			<availability>MOC:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,RA.OA:7,LA:7,ROS:7,DC:6</availability>
 			<model name=''>
 				<availability>CWE:1,CHH:1,General:8,CP:1</availability>
 			</model>
@@ -15202,8 +15148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
+			<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,ROS:5,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 			<model name='F-100'>
 				<availability>FVC:2-,Periphery:2-</availability>
 			</model>
@@ -15623,8 +15568,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sabre' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
+			<availability>CC:4,MOC:4,CLAN:2,IS:3-,FS:3,MERC:4,CP:2-,Periphery:3-,RA.OA:2-,LA:4,ROS:4,FWL:2-,DC:5</availability>
 			<model name='SB-27'>
 				<availability>General:1-</availability>
 			</model>
@@ -16072,8 +16016,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
+			<availability>CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -16091,8 +16034,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='SCP-1O'>
-				<availability>
-					CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,MERC:1-,Periphery:1-,DC:1-</availability>
+				<availability>CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,MERC:1-,Periphery:1-,DC:1-</availability>
 			</model>
 			<model name='SCP-1TB'>
 				<availability>ROS:4,MERC:4</availability>
@@ -16221,8 +16163,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>
-				CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -16246,8 +16187,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,ROS:8,MH:2</availability>
 			<model name='SYD-Z1'>
 				<roles>interceptor</roles>
 				<availability>Periphery:2-</availability>
@@ -16356,8 +16296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>
-				CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
+			<availability>CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
 			<model name='10'>
 				<availability>CWE:5-,CHH:8-,RD:4-</availability>
 			</model>
@@ -16511,8 +16450,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shilone' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
+			<availability>RA.OA:4,Periphery.DD:4,FVC:2,RD:6,ROS:5,MERC:4,Periphery.OS:4,RA:4,DC:7,Periphery:2</availability>
 			<model name='SL-17'>
 				<availability>ROS:0,Periphery:2-</availability>
 			</model>
@@ -16718,8 +16656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
+			<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,ROS:1-,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:1-</availability>
@@ -16738,8 +16675,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -16885,8 +16821,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -16945,8 +16880,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,DA:3,DC:6</availability>
+			<availability>MOC:1,CC:2,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,RF:5,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,DA:3,DC:6</availability>
 			<model name='SDR-10K'>
 				<availability>ROS:4</availability>
 			</model>
@@ -17044,8 +16978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -17284,8 +17217,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
+			<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -17465,8 +17397,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>
-				RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -18062,8 +17993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -18076,14 +18006,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,ROS:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
+			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CP:2,CWIE:4,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,ROS:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:1-,PIR:2-,MH:1-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,ROS:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>ROS:6,CLAN:4,FWL:6,MERC:6,CP:6,BAN:2</availability>
@@ -18225,8 +18153,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:4,MERC.KH:4,FS:5,MERC:6,Periphery:2,TC:4,CWE:5,SE:2+,FVC:3,MERC.WD:4,LA:6,ROS:5,MH:4,DC:3</availability>
+			<availability>CC:4,MERC.KH:4,FS:5,MERC:6,Periphery:2,TC:4,CWE:5,SE:2+,FVC:3,MERC.WD:4,LA:6,ROS:5,MH:4,DC:3</availability>
 			<model name='C'>
 				<availability>SE:2+</availability>
 			</model>
@@ -18577,8 +18504,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
+			<availability>CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
@@ -19034,8 +18960,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -19257,8 +19182,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+				<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:1</availability>
@@ -19315,8 +19239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:3,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:3,FWL:2,DC:4</availability>
+			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:3,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,ROS:3,FWL:2,DC:4</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -19803,8 +19726,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,FWL:4,CP:6,CWIE:8</availability>

--- a/megamek/data/forcegenerator/3150.xml
+++ b/megamek/data/forcegenerator/3150.xml
@@ -1189,7 +1189,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,RA.OA:4,LA:5,IS:4,FWL:4,FS:5,CP:4,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:3,RA.OA:4,LA:5,IS:4,FS:5,CP:4,Periphery:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>Periphery:2</availability>
@@ -1218,7 +1218,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
+			<availability>CC:4,CLAN:4,IS:2,CP:4,BAN:5,Periphery:1,RA.OA:1,FWL:4,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -1804,7 +1804,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
-			<availability>MOC:8,MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
+			<availability>MERC.KH:5,MERC.WD:5,CLAN:4,IS:8,MERC:7,Periphery:8,BAN:3</availability>
 			<model name='Mark VII'>
 				<availability>IS:8</availability>
 			</model>
@@ -1889,7 +1889,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
@@ -1968,7 +1968,7 @@
 			<availability>Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
+				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -2044,7 +2044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2250,7 +2250,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -2261,7 +2261,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:6,CC:5,RA.OA:6,LA:4,ROS:5,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
+			<availability>MOC:6,CC:5,RA.OA:6,ROS:5,IS:4,FWL:8,CP:8,Periphery:8,TC:5,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>ROS:4,FWL:4,CP:4,DC:6</availability>
 			</model>
@@ -2745,7 +2745,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>IS:5,CP:8,Periphery:4,DC.GHO:4,RD:2,LA:7,ROS:6,PIR:4,FWL:8,CJF:2</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,ROS:4,FS:4</availability>
 			</model>
@@ -2887,7 +2887,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:1,RA.OA:2,LA:1,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
+			<availability>RA.OA:2,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 			</model>
@@ -3083,7 +3083,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,CWIE:6,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,RD:5,FVC:4,RF:6,LA:6,ROS:6,DA:6,CJF:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>ROS:3,FS:8</availability>
 			</model>
@@ -3091,7 +3091,7 @@
 				<availability>CC:2,ROS:4,FWL:4,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,MERC:6,BAN:6,Periphery:6,DC.GHO:4,RA.OA:6,MERC.SI:3</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>LA:6,ROS:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3314,14 +3314,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>RF:5,ROS:4,FWL:6,MH:4,MERC:4,DA:6,CP:6</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>RF:0,General:4</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:4</availability>
+				<availability>IS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3465,7 +3465,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>RD:4,LA:5,ROS:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3794,7 +3794,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:2,CC:4,FWL:3,MH:3,MERC:1,CP:2,DA:4,Periphery:2,TC:2,DC:6</availability>
+			<availability>CC:4,FWL:3,MH:3,MERC:1,CP:2,DA:4,Periphery:2,DC:6</availability>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
 				<availability>BAN:2</availability>
@@ -4152,7 +4152,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
-			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4,DC:4</availability>
+			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4</availability>
 			<model name='CLN-7V'>
 				<roles>training</roles>
 				<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
@@ -4309,7 +4309,7 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
@@ -4318,7 +4318,7 @@
 				<availability>FVC:2,CDP:2,TC:2</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,BAN:3,Periphery:2-</availability>
+				<availability>BAN:3,Periphery:2-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2,BAN:2</availability>
@@ -4697,7 +4697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
-			<availability>CC:2,FVC:2,LA:2,ROS:3,IS:2,FWL:2,FS:3,CP:2,TC:2,DC:2,Periphery:2</availability>
+			<availability>FVC:2,ROS:3,IS:2,FS:3,CP:2,Periphery:2</availability>
 			<model name=''>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -4972,7 +4972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,CJF:1,DC:5</availability>
+			<availability>CLAN:1,MERC:4,CP:3,RA:1,CWIE:2,DC.GHO:5,CWE:2,RD:1,CDS:2,ROS:5,FWL:4,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,ROS:2,CLAN:6,BAN:8,DC:8</availability>
@@ -5056,7 +5056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>RF:4,Periphery.MW:4,ROS:3,Periphery.ME:4,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
+			<availability>RF:4,ROS:3,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -5231,7 +5231,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,ROS:3,FWL:2,DC:5</availability>
+			<availability>MOC:4,IS:3,CP:2,MERC:2,Periphery:2,RA.OA:2,RD:4,MERC.WD:2,ROS:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5295,7 +5295,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:4,MOC:2,CHH:1-,SE:3,ROS:6,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4</availability>
+			<availability>CC:4,MOC:2,CHH:1-,SE:3,ROS:6,FR:2,MERC:4,CDP:4,RA:1,Periphery:4</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4,ROS:5</availability>
@@ -5672,10 +5672,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
+			<availability>CHH:5,CLAN:4,IS:7,FS:9,CP:6,CWIE:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+				<availability>CC:5,MOC:4,LA:4,ROS:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,Periphery:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,ROS:4,CLAN:8</availability>
@@ -6055,7 +6055,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:4,RA.OA:2,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3</availability>
 			<model name='EGL-R11'>
 				<availability>RF:6,LA:6,ROS:6,MERC:6,FS:6</availability>
 			</model>
@@ -6218,7 +6218,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,FWL:4,MH:3,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,MH:3</availability>
 			<model name='EMP-6A'>
 				<availability>CC:4,LA:4,ROS:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 			</model>
@@ -6378,7 +6378,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
+			<availability>MOC:3,RA.OA:2,IS:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -6975,7 +6975,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:1,CLAN:1,CP:2,MERC:2,CWIE:2,DC.GHO:5,RD:2,CDS:1,LA:4,ROS:2,FWL:4,CJF:2,DC:4</availability>
+			<availability>CLAN:1,CP:2,MERC:2,CWIE:2,DC.GHO:5,RD:2,LA:4,ROS:2,FWL:4,CJF:2,DC:4</availability>
 			<model name='FLS-10E'>
 				<availability>CDS:4-,LA:4,MERC:4,CWIE:4</availability>
 			</model>
@@ -7014,7 +7014,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,ROS:4,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+			<availability>CC:6,MERC:4,CP:2,Periphery:4,MERC.WD:4,FVC:4,RF:3,ROS:4,FWL:2,DA:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,ROS:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
@@ -7239,7 +7239,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7317,7 +7317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7420,7 +7420,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>CC:2,MOC:2,IS:2,MERC:2,FS:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2,DC:2</availability>
+			<availability>MOC:2,IS:2,MERC:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -8602,7 +8602,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8628,7 +8628,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,RR:2,MERC.KH:2-,IS:3,FR:2,MERC:2,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,ROS:4-,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8870,7 +8870,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,ROS:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,CP:6,Periphery:5</availability>
+			<availability>RA.OA:4,ROS:4,FWL:6,MERC:6,CP:6,Periphery:5</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -8952,7 +8952,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
+			<availability>CC:6,RD:2-,CDS:2,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6,CWIE:2</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -9017,9 +9017,9 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,CP:5,CJF:5</availability>
 			<model name='HGN-732'>
-				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CLAN:6,IS:6,MERC:6,CP:6,BAN:8,DC.GHO:8,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -9123,7 +9123,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -9232,7 +9232,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,IS:3,MERC:3,FS:3,CP:2,Periphery:3,TC:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
+			<availability>MOC:2,CC:4,IS:3,MERC:3,CP:2,Periphery:3,RA.OA:3,LA:5,ROS:2,FWL:2,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:1-</availability>
@@ -9467,7 +9467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>MOC:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -9614,7 +9614,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>CC:4,RD:6,LA:4,ROS:5,IS:4,FWL:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
+			<availability>RD:6,ROS:5,IS:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>RD:4,IS:8,Periphery:8</availability>
@@ -9782,7 +9782,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,ROS:4,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -9834,7 +9834,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,FVC:6,Periphery.HR:3,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
+			<availability>FVC:6,ROS:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>Periphery:2-</availability>
@@ -10257,7 +10257,7 @@
 			<availability>ROS:5</availability>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,FWL:4,MH:4,DC:4</availability>
+			<availability>CLAN:2,IS:4,FS:6,MERC:5,CP:4,DC.GHO:6,RD:2,LA:7,ROS:6,MH:4</availability>
 			<model name='KGC-000'>
 				<availability>ROS:6,CLAN:6,BAN:8,DC:8</availability>
 			</model>
@@ -10551,7 +10551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CWE:4,CHH:5,MERC.WD:3,CDS:3,CLAN:4,IS:5,CP:3,CJF:4,BAN:4,RA:3,Periphery:4,DC:4</availability>
+			<availability>CWE:4,CHH:5,MERC.WD:3,CDS:3,CLAN:4,IS:5,CP:3,BAN:4,RA:3,Periphery:4,DC:4</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
 				<availability>CWE:4,RD:4,CDS:7,General:5,CP:7,CWIE:4</availability>
@@ -10709,7 +10709,7 @@
 			</model>
 			<model name='(3055 Upgrade)'>
 				<roles>fire_support</roles>
-				<availability>CC:8,MOC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,Periphery:6</availability>
+				<availability>MOC:8,IS:8,CP:8,TC:8,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -10840,7 +10840,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10951,7 +10951,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,CP:2,Periphery:4,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:2-</availability>
 			</model>
@@ -11216,7 +11216,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7,DC:6</availability>
+			<availability>MOC:6,CC:4,IS:6,FS:5,CP:7,Periphery:7,TC:6,RA.OA:6,RD:4,LA:5,ROS:6,FWL:7</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -11231,7 +11231,7 @@
 			</model>
 			<model name='LGB-12C'>
 				<roles>fire_support</roles>
-				<availability>CC:4,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CP:4,CDP:4,TC:4</availability>
+				<availability>MOC:5,IS:4,MH:4,MERC:4,CP:4,CDP:4,TC:4</availability>
 			</model>
 			<model name='LGB-12R'>
 				<roles>fire_support</roles>
@@ -11700,7 +11700,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:3,IS:4,MERC:4,FS:4,CP:3,Periphery:4,TC:4,RA.OA:4,LA:4,ROS:3,FWL:3,DC:5</availability>
+			<availability>MOC:3,CC:3,IS:4,MERC:4,CP:3,Periphery:4,RA.OA:4,ROS:3,FWL:3,DC:5</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -11823,7 +11823,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>CC:4,RA.OA:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='MAD-11D'>
 				<availability>FS:5,MERC:3</availability>
 			</model>
@@ -12790,7 +12790,7 @@
 			</model>
 		</chassis>
 		<chassis name='Myrmidon Medium Tank' unitType='Tank'>
-			<availability>MOC:2,CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,TC:2,Periphery:2,DC:4</availability>
+			<availability>CC:6,RA.OA:2,LA:5,ROS:5,FS:5,MERC:5,Periphery:2,DC:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -13025,7 +13025,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,RF:5,LA:8,ROS:6,FWL:4,FS:7,MERC:6,CP:4</availability>
 			<model name='NGS-4S'>
-				<availability>:0,RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>RF:4,LA:4,ROS:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -13375,7 +13375,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13432,7 +13432,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWIE:2,CWE:2,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:3-,FWL:2,MERC:2</availability>
 			</model>
@@ -13440,7 +13440,7 @@
 				<availability>CLAN:2-,Periphery:2-</availability>
 			</model>
 			<model name='ON1-M'>
-				<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8,DC:6</availability>
+				<availability>MOC:6,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:8,IS:6,MH:6,CP:8</availability>
 			</model>
 			<model name='ON1-M-DC'>
 				<roles>command</roles>
@@ -13739,7 +13739,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13938,7 +13938,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
+			<availability>MOC:2,CC:1,RA.OA:2,IS:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
 			<model name='(AC2)'>
 				<roles>anti_aircraft</roles>
 				<availability>Periphery:2-</availability>
@@ -14383,7 +14383,7 @@
 			</model>
 		</chassis>
 		<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
-			<availability>CC:5,MOC:5,FVC:4,IS:6,FR:5,CP:5,FS:6,DA:8,MERC:4,DC:5,Periphery:5</availability>
+			<availability>CC:5,FVC:4,IS:6,FR:5,CP:5,DA:8,MERC:4,DC:5,Periphery:5</availability>
 			<model name=''>
 				<roles>cargo,support</roles>
 				<availability>General:6</availability>
@@ -14641,7 +14641,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CWE:7,MERC.WD:4,RD:5,CDS:5,ROS:4+,CLAN:5,MERC:3+,CP:7,CJF:4,RA:6,BAN:5,CWIE:7</availability>
+			<availability>CWE:7,MERC.WD:4,RD:5,ROS:4+,CLAN:5,MERC:3+,CP:7,CJF:4,RA:6,BAN:5,CWIE:7</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CWE:5,RD:5,CDS:8,General:7,CP:8,CWIE:6</availability>
@@ -14742,7 +14742,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,ROS:5,FWL:6,DA:4,DC:4</availability>
+			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,ROS:5,FWL:6,DA:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -15039,7 +15039,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -15199,7 +15199,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CC:4,Clan.IS:5,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
+			<availability>Clan.IS:5,ROS:6,IS:4,FWL:7,FS:8,CP:7,CJF:6,Periphery:2</availability>
 			<model name='C 2'>
 				<availability>CJF:4</availability>
 			</model>
@@ -15725,7 +15725,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:2,RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,TC:2,DC:1-</availability>
+			<availability>RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,DC:1-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -15972,7 +15972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scimitar Medium Hover Tank' unitType='Tank'>
-			<availability>RA.OA:2-,Periphery.DD:2-,Periphery.OS:2-,Periphery:2-,DC:2-</availability>
+			<availability>RA.OA:2-,Periphery:2-,DC:2-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -16016,7 +16016,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,FWL:2,DA:2,DC:4</availability>
+			<availability>MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,ROS:2,PIR:2,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,ROS:6,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -16159,11 +16159,11 @@
 			<availability>CC:4,MOC:4,RF:4,ROS:4,FWL:5,DA:4,MERC:4,CP:5</availability>
 			<model name=''>
 				<roles>assault,ba_carrier</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,ROS:3,CJF:2,DC:2</availability>
+			<availability>CLAN:1,FS:4,MERC:4,CP:1,CWIE:1,DC.GHO:3,CWE:1,FVC:4,RD:2,LA:2,ROS:3,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,ROS:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -16296,7 +16296,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CHH:4,IS:3,FS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,ROS:4,FWL:3,DA:3,DC:3</availability>
+			<availability>CHH:4,IS:3,CP:4,CWIE:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,ROS:4,DA:3</availability>
 			<model name='10'>
 				<availability>CWE:5-,CHH:8-,RD:4-</availability>
 			</model>
@@ -16675,7 +16675,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
+			<availability>Periphery.DD:3,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,RA.OA:5,FVC:4,RD:6,ROS:4,DC:7</availability>
 			<model name='SL-15'>
 				<availability>ROS:0,FS:0,Periphery:2-</availability>
 			</model>
@@ -16821,7 +16821,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,ROS:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,ROS:4,MERC:5,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,ROS:5,FS:8,MERC:5</availability>
 			</model>
@@ -16978,7 +16978,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,ROS:2,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,ROS:2,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -17246,7 +17246,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -17258,7 +17258,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -17347,7 +17347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,LA:2,ROS:3,PIR:3,DC:1</availability>
+			<availability>IS:2,FS:5,MERC:3,CP:3,CWIE:4,FVC:5,RD:4,CDS:3,ROS:3,PIR:3,DC:1</availability>
 			<model name=''>
 				<availability>General:1-</availability>
 			</model>
@@ -17397,7 +17397,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,ROS:5,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,ROS:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -17891,7 +17891,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:5,MERC.WD:1,RD:1,CDS:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
+			<availability>CHH:5,MERC.WD:1,RD:1,ROS:3+,CLAN:1,CP:1,CJF:4,RA:1,BAN:3,CWIE:2</availability>
 			<model name='A'>
 				<availability>CWE:6,CHH:8,RD:4,CDS:8,General:7,CP:7,CJF:8,CWIE:6</availability>
 			</model>
@@ -17993,7 +17993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -18126,7 +18126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
+			<availability>MOC:4,RA.OA:4,LA:6,IS:4,FS:5,CP:4,Periphery:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:2-</availability>
@@ -18504,7 +18504,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,Periphery.MW:3,Periphery.ME:3,FWL:6,DA:6,DC:4</availability>
+			<availability>CC:5,MOC:5,CP:6,MERC:5,Periphery:3,TC:4,RF:6,ROS:4,FWL:6,DA:6,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,ROS:5,FWL:4,MERC:4,CP:4</availability>
@@ -18960,7 +18960,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,FS.CMM:5-,IS:4-,FWL:5-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -18992,7 +18992,7 @@
 			</model>
 			<model name='UM-R80'>
 				<roles>urban,spotter</roles>
-				<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+				<availability>IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
 			</model>
 			<model name='UM-R93'>
 				<roles>urban</roles>
@@ -19195,7 +19195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
+			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:2</availability>
@@ -19263,7 +19263,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='VTR-9K'>
-				<availability>MOC:4,FVC:4,ROS:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
+				<availability>FVC:4,ROS:4,FWL:4,MERC:4,CP:4,DC:8,Periphery:4</availability>
 			</model>
 			<model name='VTR-9Ka'>
 				<availability>CC:4,FVC:4,ROS:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
@@ -19726,7 +19726,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,MH:6,DC:4</availability>
+			<availability>FS.CH:8,IS:6,FWL.FWG:7,CP:4,CC.CHG:8,Periphery:6,CWIE:4,RA:4,RA.OA:6,RD:4,LA:9,ROS:6,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,FWL:4,CP:6,CWIE:8</availability>
@@ -19901,7 +19901,7 @@
 		<chassis name='Whitworth' unitType='Mek'>
 			<availability>FVC:1,FS.CMM:1,MERC:1,DC:1,Periphery:1</availability>
 			<model name='WTH-1H'>
-				<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
+				<availability>PIR:5,Periphery:5</availability>
 			</model>
 			<model name='WTH-2'>
 				<roles>fire_support</roles>
@@ -20022,7 +20022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,RD:2,LA:5,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
+			<availability>RD:2,IS:5,FWL:8,MH:4,FS:6,CP:6,Periphery:4,TC:4</availability>
 			<model name='WVR-10D'>
 				<availability>FS:5,MERC:4</availability>
 			</model>
@@ -20453,7 +20453,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,Periphery:3</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>

--- a/megamek/data/forcegenerator/3160.xml
+++ b/megamek/data/forcegenerator/3160.xml
@@ -1891,8 +1891,7 @@
 			<availability>Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>
-					CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
+				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1958,8 +1957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>
-				MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2660,8 +2658,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>
-				CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,PIR:4,FWL:8,CJF:2,DC:5</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,FS:4</availability>
 			</model>
@@ -2678,8 +2675,7 @@
 				<availability>CC:3,LA:3,FWL:3,FS:3,Periphery:3,DC:3</availability>
 			</model>
 			<model name='BLR-3M'>
-				<availability>
-					CC:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,FWL:2,MH:5,MERC:2,CP:2,Periphery:2</availability>
+				<availability>CC:2,FVC:3,Periphery.MW:4,Periphery.CM:4,Periphery.HR:4,PIR:5,Periphery.ME:4,FWL:2,MH:5,MERC:2,CP:2,Periphery:2</availability>
 			</model>
 			<model name='BLR-3M-DC'>
 				<roles>command</roles>
@@ -2990,8 +2986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>
-				CHH:3,CLAN:4,FS:6,CDP:4,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,DA:6,CJF:3,DC:4</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:8</availability>
 			</model>
@@ -2999,8 +2994,7 @@
 				<availability>CC:2,FWL:4,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>
-					CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>LA:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3255,8 +3249,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>
-				CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,TamPact:4,FWL:4,DA:4,DC:4,VesMar:4</availability>
+			<availability>CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,TamPact:4,FWL:4,DA:4,DC:4,VesMar:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3346,8 +3339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>
-				CC:4,RD:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>CC:4,RD:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3556,8 +3548,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cardinal Transport' unitType='VTOL'>
-			<availability>
-				SL3.CJF:5,MERC.KH:7,MERC.WD:5,CDS:7,LA:6,TamPact:6,SL3.CSJ:4,CP:4,MERC:7,DC:6,VesMar:6</availability>
+			<availability>SL3.CJF:5,MERC.KH:7,MERC.WD:5,CDS:7,LA:6,TamPact:6,SL3.CSJ:4,CP:4,MERC:7,DC:6,VesMar:6</availability>
 			<model name=''>
 				<roles>apc</roles>
 				<availability>General:8</availability>
@@ -3626,8 +3617,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cataphract' unitType='Mek'>
-			<availability>
-				CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
+			<availability>CC:4,MOC:3,FVC:3,Periphery.CM:2,Periphery.HR:1,Periphery.ME:1,MH:1,FS:2,MERC:3,CDP:3,TC:3</availability>
 			<model name='CTF-1X'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -3854,8 +3844,7 @@
 			</model>
 		</chassis>
 		<chassis name='Centurion' unitType='Mek'>
-			<availability>
-				CC:4,FVC:8,LA:3,Periphery.HR:4,FWL:1,MH:6,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2</availability>
+			<availability>CC:4,FVC:8,LA:3,Periphery.HR:4,FWL:1,MH:6,Periphery.OS:4,FS:6,MERC:2,CP:1,CDP:4,Periphery:2</availability>
 			<model name='CN10-B'>
 				<availability>LA:3,IS:4,FS:3,Periphery:4</availability>
 			</model>
@@ -4086,15 +4075,13 @@
 			</model>
 		</chassis>
 		<chassis name='Cheetah' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,Periphery.ME:4,FWL:10,DA:8</availability>
+			<availability>MOC:5,CC:2,MERC:3,FS:3,CP:10,Periphery:3,TC:5,RA.OA:4,FVC:3,RF:8,Periphery.MW:4,Periphery.ME:4,FWL:10,DA:8</availability>
 			<model name='F-10'>
 				<roles>recon</roles>
 				<availability>CC:1-,RF:1-,FWL:1-,MERC:1-,DA:1-,CP:1-,Periphery:1-</availability>
 			</model>
 			<model name='F-11'>
-				<availability>
-					CC:4,MOC:4,RF:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
+				<availability>CC:4,MOC:4,RF:8,Periphery.MW:4,PIR:4,Periphery.ME:3,FWL:8,MH:3,MERC:6,DA:8,CP:8</availability>
 			</model>
 			<model name='F-11-R'>
 				<roles>recon</roles>
@@ -4484,8 +4471,7 @@
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>
-				Periphery.R:4,MERC.KH:8,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5,MERC:5,FS:1,TC:6,Periphery:2</availability>
+			<availability>Periphery.R:4,MERC.KH:8,FVC:4,LA:9,Periphery.CM:5,Periphery.HR:5,Periphery.ME:4,MH:5,MERC:5,FS:1,TC:6,Periphery:2</availability>
 			<model name='COM-1A'>
 				<roles>recon</roles>
 				<availability>FVC:1-,Periphery:1-</availability>
@@ -5040,8 +5026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>
-				CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,FWL:2,DC:5</availability>
+			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5482,8 +5467,7 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
+			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:4,LA:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
@@ -6784,15 +6768,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>
-				CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
 			<model name='FLE-19'>
 				<roles>urban</roles>
-				<availability>
-					MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
+				<availability>MOC:4-,CC:4-,RA.OA:4-,FVC:4-,RF:4-,FWL:4-,MERC:5-,CP:2-,DA:4-,Periphery:6-,TC:4-</availability>
 			</model>
 			<model name='FLE-20'>
 				<availability>CC:4,MOC:4</availability>
@@ -7008,8 +6990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>
-				MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7087,8 +7068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7367,8 +7347,7 @@
 			</model>
 		</chassis>
 		<chassis name='Goliath' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,CWE:2,FVC:2,RF:2,LA:5,Periphery.MW:2,FWL:6,MH:2,DA:2,DC:2</availability>
+			<availability>CC:4,MOC:4,FR:2,MERC:4,FS:3,TC:4,Periphery:3,RA.OA:3,CWE:2,FVC:2,RF:2,LA:5,Periphery.MW:2,FWL:6,MH:2,DA:2,DC:2</availability>
 			<model name='GOL-2H'>
 				<roles>fire_support</roles>
 				<availability>Periphery.MW:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,MH:5,Periphery:4</availability>
@@ -7523,8 +7502,7 @@
 			</model>
 		</chassis>
 		<chassis name='Grand Titan' unitType='Mek'>
-			<availability>
-				CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
+			<availability>CC:4,MOC:4,FS:4,MERC:4,CP:7,FVC:5,RF:7,Periphery.MW:4,Periphery.ME:4,FWL:7,MH:4,DA:7,DC:4</availability>
 			<model name='T-IT-N10M'>
 				<availability>FWL:2,MERC:2,CP:2,Periphery:2</availability>
 			</model>
@@ -8183,8 +8161,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hatchetman' unitType='Mek'>
-			<availability>
-				Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,Periphery.MW:3,FWL:4,FS:5,MERC:3,CP:4,Periphery:2,DC:4</availability>
+			<availability>Periphery.R:3,MERC.KH:4,FVC:5,TC.PL:3,LA:6,Periphery.MW:3,FWL:4,FS:5,MERC:3,CP:4,Periphery:2,DC:4</availability>
 			<model name='HCT-3F'>
 				<roles>urban</roles>
 				<availability>FVC:1-,TC.PL:1-,Periphery:1-</availability>
@@ -8349,8 +8326,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>
-				Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8376,8 +8352,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3-,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,DA:2,DC:4-</availability>
+			<availability>CC:2,MOC:2,MERC.KH:2-,IS:3,FR:2,MERC:2,FS:3-,CDP:2,Periphery:4,TC:2,BAN:2,FVC:2,DA:2,DC:4-</availability>
 			<model name='Bat Hawk'>
 				<availability>CC:2,MOC:7,FR:6,DA:2,CDP:5,TC:7,Periphery:6</availability>
 			</model>
@@ -8756,8 +8731,7 @@
 		<chassis name='Highlander' unitType='Mek'>
 			<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
 			<model name='HGN-732'>
-				<availability>
-					MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -8861,8 +8835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>
-				MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -8921,8 +8894,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>
-				MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
+			<availability>MOC:1,CC:1,FS:2,CP:6,Periphery:3,TC:1,RA.OA:1,RD:2-,LA:6,Periphery.MW:4,Periphery.ME:4,FWL:6,DC:1</availability>
 			<model name='C'>
 				<availability>RD:3,LA:2</availability>
 			</model>
@@ -9206,11 +9178,9 @@
 			</model>
 		</chassis>
 		<chassis name='Invader Jumpship' unitType='Jumpship'>
-			<availability>
-				MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
+			<availability>MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:8,IS:8,Periphery.Deep:6,MERC:6,BAN:6,Periphery:8</availability>
 			<model name='(2631)'>
-				<availability>
-					MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
+				<availability>MERC.KH:6,SE:8,MERC.WD:8,PIR:5,CLAN:2-,IS:8,Periphery.Deep:6,MERC:6,Periphery:8,BAN:6</availability>
 			</model>
 			<model name='(2631) (LF)'>
 				<availability>SE:6,CLAN:8</availability>
@@ -9512,8 +9482,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>
-				MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -9900,8 +9869,7 @@
 			<availability>RF:2,FWL:2</availability>
 		</chassis>
 		<chassis name='Karnov UR Transport' unitType='VTOL'>
-			<availability>
-				CC:4,IS:5,MERC:5,Periphery:4,RA:4,SL3.CJF:5,LA:4,TamPact:4,MH:3,SL3:4,SL3.CSJ:5,DA:3,DC:4,VesMar:4</availability>
+			<availability>CC:4,IS:5,MERC:5,Periphery:4,RA:4,SL3.CJF:5,LA:4,TamPact:4,MH:3,SL3:4,SL3.CSJ:5,DA:3,DC:4,VesMar:4</availability>
 			<model name=''>
 				<roles>apc,cargo</roles>
 				<availability>General:4</availability>
@@ -10455,8 +10423,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lancer' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
+			<availability>CC:4,MOC:4,FS:3,MERC:4,CP:6,FVC:4,RF:6,LA:4,Periphery.MW:4,Periphery.CM:4,Periphery.ME:4,FWL:6,MH:4,DA:6</availability>
 			<model name='LX-2'>
 				<availability>General:8</availability>
 			</model>
@@ -10542,8 +10509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>
-				MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10594,15 +10560,13 @@
 			</model>
 		</chassis>
 		<chassis name='Light SRM Carrier' unitType='Tank'>
-			<availability>
-				MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
+			<availability>MOC:7,CC:4,RA.OA:5,FVC:4,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,MH:6,Periphery.OS:5,TC:8,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Light Strike Fighter' unitType='Conventional Fighter'>
-			<availability>
-				CC:7,FVC:7,SE:3-,RF:7,LA:8-,TamPact:5-,FWL:7,MERC:8-,DA:7,BAN:2,Periphery:8-,DC:7-</availability>
+			<availability>CC:7,FVC:7,SE:3-,RF:7,LA:8-,TamPact:5-,FWL:7,MERC:8-,DA:7,BAN:2,Periphery:8-,DC:7-</availability>
 			<model name='Andurien'>
 				<availability>RF:5,FWL:5,DA:7</availability>
 			</model>
@@ -11273,8 +11237,7 @@
 			</model>
 		</chassis>
 		<chassis name='Main Gauche Light Support Tank' unitType='Tank'>
-			<availability>
-				CC:6,MOC:6,Periphery.MM:6,RF:8,LA:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,MERC:6,CP:8,DA:8</availability>
+			<availability>CC:6,MOC:6,Periphery.MM:6,RF:8,LA:6,Periphery.CM:6,Periphery.ME:6,FWL:8,MH:6,MERC:6,CP:8,DA:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -11617,15 +11580,13 @@
 			</model>
 		</chassis>
 		<chassis name='Marsden MBT' unitType='Tank'>
-			<availability>
-				Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,Periphery.ME:3,DA:4,FS:4</availability>
+			<availability>Periphery.R:3,RF:4,LA:6,Periphery.HR:3,Periphery.CM:3,Periphery.MW:3,Periphery.ME:3,DA:4,FS:4</availability>
 			<model name='II-A (LB-X)'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marshal' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
+			<availability>CC:5,MOC:5,FVC:4,Periphery.HR:4,Periphery.CM:4,Periphery.ME:3,MH:4,MERC:4,Periphery:2,TC:7</availability>
 			<model name='MHL-2L'>
 				<availability>CC:5,MOC:4,PIR:4,MERC:4,TC:4,Periphery:4</availability>
 			</model>
@@ -11914,8 +11875,7 @@
 			<availability>FWL:5,IS:2,CP:4,Periphery:1</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Defender' unitType='Conventional Fighter'>
-			<availability>
-				MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
+			<availability>MOC:6,CC:4,CLAN:4,IS:5,Periphery.Deep:4,MERC:6,FS:5,CP:5,BAN:4,Periphery:6,TC:6,RA.OA:5,LA:6,FWL:5,DC:5</availability>
 		</chassis>
 		<chassis name='Medium Strike Fighter Kaiseradler' unitType='Conventional Fighter'>
 			<availability>Periphery.R:2,LA:5,MERC:1</availability>
@@ -13027,8 +12987,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>
-				MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13085,8 +13044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:3-,FWL:2,MERC:2</availability>
 			</model>
@@ -13300,8 +13258,7 @@
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
-			<availability>
-				MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
+			<availability>MOC:5,CC:6,CHH:7,CLAN:8,IS:5,FS:6,CP:6,BAN:5,Periphery:4,TC:5,RA.OA:5,LA:6,FWL:6,MH:5,DC:6</availability>
 			<model name='(2762)'>
 				<roles>mek_carrier</roles>
 				<availability>General:2,BAN:1</availability>
@@ -13382,8 +13339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>
-				MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -14324,8 +14280,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>
-				MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,FWL:6,DA:4,DC:4</availability>
+			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,FWL:6,DA:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14333,8 +14288,7 @@
 				<availability>MERC:5,DC:4</availability>
 			</model>
 			<model name='QKD-5M'>
-				<availability>
-					MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
+				<availability>MOC:8,FVC:8,Periphery.CM:8,Periphery.ME:8,FWL:6,IS:8,MH:8,CP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='QKD-5Mr'>
 				<availability>General:6,FWL:8,CP:8</availability>
@@ -14530,8 +14484,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ravager Assault Battle Armor' unitType='BattleArmor'>
-			<availability>
-				Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
+			<availability>Periphery.MW:6,Periphery.CM:6,Periphery.ME:6,FWL:4,MH:8,MERC:4,CP:4,TC:6,Periphery:4</availability>
 			<model name='(LRM)(Sqd4)' mechanized='false'>
 				<availability>General:4,MH:0</availability>
 			</model>
@@ -14654,8 +14607,7 @@
 			</model>
 		</chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
-			<availability>
-				MOC:7,RA.OA:7,LA:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,DC:6</availability>
+			<availability>MOC:7,RA.OA:7,LA:7,CLAN:4,Periphery.Deep:8,IS:5,FS:6,MERC:7,CP:5,Periphery:10,TC:7,DC:6</availability>
 			<model name=''>
 				<availability>CWE:1,CHH:1,General:8,CP:1</availability>
 			</model>
@@ -14681,8 +14633,7 @@
 			</model>
 		</chassis>
 		<chassis name='Riever' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:1,FVC:2,RF:7,Periphery.MW:3,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
+			<availability>MOC:1,FVC:2,RF:7,Periphery.MW:3,Periphery.ME:3,FWL:8,FS:2,DA:6,CP:8,Periphery:2,TC:1</availability>
 			<model name='F-100'>
 				<availability>FVC:2-,Periphery:2-</availability>
 			</model>
@@ -15467,8 +15418,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>
-				CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,PIR:2,FWL:2,DA:2,DC:4</availability>
+			<availability>CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,PIR:2,FWL:2,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -15486,8 +15436,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='SCP-1O'>
-				<availability>
-					CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,MERC:1-,Periphery:1-,DC:1-</availability>
+				<availability>CC:1-,MERC.KH:2-,MERC.WD:2-,RF:1-,Periphery.Deep:1-,FWL:1-,MERC:1-,Periphery:1-,DC:1-</availability>
 			</model>
 			<model name='SCP-1TB'>
 				<availability>MERC:4</availability>
@@ -15637,8 +15586,7 @@
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,MH:2</availability>
+			<availability>MOC:4,CC:4,MERC.KH:5,MERC:4,FS:3,TC:7,Periphery:6,RA:5,RA.OA:7,Periphery.R:5,FVC:3,RD:2,LA:5,MH:2</availability>
 			<model name='SYD-Z1'>
 				<roles>interceptor</roles>
 				<availability>Periphery:2-</availability>
@@ -16068,8 +16016,7 @@
 			</model>
 		</chassis>
 		<chassis name='Skulker Wheeled Scout Tank' unitType='Tank'>
-			<availability>
-				CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
+			<availability>CC:1,RA.OA:1,Periphery.DD:3,FVC:1,LA:1,FWL:1,MERC:1,Periphery.OS:3,FS:1,CP:1,DC:3</availability>
 			<model name=''>
 				<roles>recon</roles>
 				<availability>General:1-</availability>
@@ -16088,8 +16035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:5,Periphery.DD:3,FVC:4,RD:6,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,DC:7</availability>
+			<availability>MOC:2,RA.OA:5,Periphery.DD:3,FVC:4,RD:6,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,DC:7</availability>
 			<model name='SL-15'>
 				<availability>FS:0,Periphery:2-</availability>
 			</model>
@@ -16232,8 +16178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,FS:8,MERC:5</availability>
 			</model>
@@ -16292,8 +16237,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>
-				MOC:1,CC:2,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,RF:5,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,DA:3,DC:6</availability>
+			<availability>MOC:1,CC:2,FR:1,MERC:2,FS:2,CP:6,Periphery:2,TC:1,FVC:2,RF:5,Periphery.MW:4,Periphery.ME:4,FWL:6,MH:1,DA:3,DC:6</availability>
 			<model name='SDR-5V'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -16388,8 +16332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>
-				MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -16631,8 +16574,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
-			<availability>
-				MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
+			<availability>MOC:3,CC:4,IS:2,MERC:4,CP:6,TC:3,RF:5,LA:4,Periphery.MW:2,Periphery.ME:2,FWL:6,MH:3,DA:5,DC:4</availability>
 			<model name='F-90'>
 				<availability>IS:2-,Periphery:2-</availability>
 			</model>
@@ -17378,8 +17320,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
-			<availability>
-				CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
+			<availability>CC:8,MOC:5,FS:4,MERC:3,CP:5,Periphery:3,TC:5,RA.OA:3,FVC:4,Periphery.CM:4,Periphery.ME:4,FWL:5,MH:3</availability>
 			<model name='TR-7'>
 				<roles>escort,interceptor</roles>
 				<availability>FVC:2-,Periphery:2-</availability>
@@ -17392,14 +17333,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>
-				MOC:4,CHH:2,CLAN:3,IS:4,CP:2,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
+			<availability>MOC:4,CHH:2,CLAN:3,IS:4,CP:2,DC.GHO:4,CWE:4,RA.OA:4,RD:4,CDS:2,RF:5,Periphery.MW:4,PIR:4,Periphery.ME:4,FWL:4,MH:4,DA:5,CJF:4</availability>
 			<model name='THG-10E'>
 				<availability>MOC:1-,PIR:2-,MH:1-,Periphery:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>
-					MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
+				<availability>MOC:8,CLAN:6,IS:8,FS:8,CP:8,BAN:8,DC.GHO:8,RA.OA:8,Periphery.MW:8,PIR:8,Periphery.ME:8,FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>CLAN:4,FWL:6,MERC:6,CP:6,BAN:2</availability>
@@ -17541,8 +17480,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>
-				CC:4,MERC.KH:4,FS:5,MERC:6,Periphery:2,TC:4,CWE:5,SE:2+,FVC:3,MERC.WD:4,LA:6,MH:4,DC:3</availability>
+			<availability>CC:4,MERC.KH:4,FS:5,MERC:6,Periphery:2,TC:4,CWE:5,SE:2+,FVC:3,MERC.WD:4,LA:6,MH:4,DC:3</availability>
 			<model name='C'>
 				<availability>SE:2+</availability>
 			</model>
@@ -17844,8 +17782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>
-				CC:5,MOC:5,RF:6,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,MERC:5,DA:6,Periphery:3,TC:4,DC:4</availability>
+			<availability>CC:5,MOC:5,RF:6,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,MERC:5,DA:6,Periphery:3,TC:4,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,FWL:4,MERC:4,CP:4</availability>
@@ -18275,8 +18212,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>
-				MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -18495,8 +18431,7 @@
 				<availability>IS:4,FS:6</availability>
 			</model>
 			<model name='(Ultra)'>
-				<availability>
-					CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
+				<availability>CC:8,MOC:8,FVC:6,Periphery.CM:6,Periphery.HR:6,PIR:6,MH:6,CDP:6,TC:8,Periphery:4</availability>
 			</model>
 			<model name='V-G7X'>
 				<availability>LA:1</availability>
@@ -18553,8 +18488,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>
-				MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:3,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,DC:4</availability>
+			<availability>MOC:2,CC:5,FS:7,Periphery.OS:2,CP:2,MERC:3,Periphery:3,TC:2,RA.OA:2,LA:3,Periphery.HR:2,FWL:2,DC:4</availability>
 			<model name='C'>
 				<availability>CLAN:8</availability>
 			</model>
@@ -19038,8 +18972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>
-				MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,RA:4,RA.OA:6,RD:4,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,RA:4,RA.OA:6,RD:4,LA:9,FWL:5,MH:6,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,FWL:4,CP:6</availability>

--- a/megamek/data/forcegenerator/3160.xml
+++ b/megamek/data/forcegenerator/3160.xml
@@ -1159,7 +1159,7 @@
 			</model>
 		</chassis>
 		<chassis name='AC/2 Carrier' unitType='Tank'>
-			<availability>MOC:3,CC:4,RA.OA:4,LA:5,IS:4,FWL:4,FS:5,CP:4,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:3,RA.OA:4,LA:5,IS:4,FS:5,CP:4,Periphery:4,DC:5</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>Periphery:2</availability>
@@ -1188,7 +1188,7 @@
 			</model>
 		</chassis>
 		<chassis name='Achilles' unitType='Dropship'>
-			<availability>MOC:1,CC:4,CLAN:4,IS:2,FS:2,CP:4,BAN:5,Periphery:1,TC:1,RA.OA:1,LA:2,FWL:4,DC:6</availability>
+			<availability>CC:4,CLAN:4,IS:2,CP:4,BAN:5,Periphery:1,RA.OA:1,FWL:4,DC:6</availability>
 			<model name='(2582)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -1812,7 +1812,7 @@
 			</model>
 		</chassis>
 		<chassis name='Armored Personnel Carrier' unitType='Tank'>
-			<availability>CC:10,MOC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10,TC:10</availability>
+			<availability>CC:10,CHH:8,CLAN:6,IS:9,Periphery.Deep:8,DC:8,Periphery:10</availability>
 			<model name='(Hover LRM)'>
 				<roles>recon,fire_support</roles>
 				<availability>PIR:4-,IS.pm:3,Periphery:3-</availability>
@@ -1891,7 +1891,7 @@
 			<availability>Periphery:1-</availability>
 			<model name='ASN-23'>
 				<roles>fire_support</roles>
-				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MH:4,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
+				<availability>CC:6,MOC:6,FVC:4,Periphery.HR:5,PIR:3,MERC:4,FS:4,DA:4,CDP:6,TC:6,Periphery:4</availability>
 			</model>
 			<model name='ASN-30'>
 				<availability>LA:2,MERC:2</availability>
@@ -1957,7 +1957,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:3,CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,TC:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
+			<availability>CC:3,IS:2,CLAN.IS:2,FS:5,CP:3,MERC:2,Periphery:3,RA.OA:3,SE:2,LA:6,FWL:3,DC:8</availability>
 			<model name='AS7-C'>
 				<availability>MERC:2,DC:2</availability>
 			</model>
@@ -2163,7 +2163,7 @@
 			</model>
 		</chassis>
 		<chassis name='Avenger' unitType='Dropship'>
-			<availability>MOC:2,CC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
+			<availability>MOC:2,RA.OA:2,LA:4,IS:2,FWL:3,FS:4,CP:3,TC:2,Periphery:1,DC:3</availability>
 			<model name='(2816)'>
 				<roles>assault</roles>
 				<availability>General:4</availability>
@@ -2174,7 +2174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:6,CC:5,RA.OA:6,LA:4,IS:4,FWL:8,FS:4,CP:8,Periphery:8,TC:5,DC:6</availability>
+			<availability>MOC:6,CC:5,RA.OA:6,IS:4,FWL:8,CP:8,Periphery:8,TC:5,DC:6</availability>
 			<model name='AWS-10KM'>
 				<availability>FWL:4,CP:4,DC:6</availability>
 			</model>
@@ -2658,7 +2658,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:5,MOC:4,IS:5,FS:5,CP:8,Periphery:4,TC:4,DC.GHO:4,RD:2,LA:7,PIR:4,FWL:8,CJF:2,DC:5</availability>
+			<availability>IS:5,CP:8,Periphery:4,DC.GHO:4,RD:2,LA:7,PIR:4,FWL:8,CJF:2</availability>
 			<model name='BLR-10S'>
 				<availability>LA:6,FS:4</availability>
 			</model>
@@ -2791,7 +2791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth Heavy Tank' unitType='Tank'>
-			<availability>CC:1,RA.OA:2,LA:1,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
+			<availability>RA.OA:2,PIR:1,IS:1,FWL:2,MERC:2,FS:2,CP:2,Periphery:2,DC:2</availability>
 			<model name=''>
 				<availability>FVC:4,CDS:4,General:8,CP:4</availability>
 			</model>
@@ -2986,7 +2986,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:3,CLAN:4,FS:6,CDP:4,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,MOC:4,CC:4,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,TC:4,RD:5,FVC:4,RF:6,LA:6,DA:6,CJF:3,DC:4</availability>
+			<availability>CHH:3,CLAN:4,FS:6,CDP:4,DC.GHO:3,RA.OA:3,CWE:5,CDS:3,FWL:6,IS:4,FWL.OH:6,MERC:4,CP:5,RA:3,Periphery:4,RD:5,FVC:4,RF:6,LA:6,DA:6,CJF:3</availability>
 			<model name='BL-12-KNT'>
 				<availability>FS:8</availability>
 			</model>
@@ -2994,7 +2994,7 @@
 				<availability>CC:2,FWL:4,MERC:2</availability>
 			</model>
 			<model name='BL-6-KNT'>
-				<availability>CLAN:6,IS:6,CP:6,FS:6,MERC:6,BAN:6,TC:6,Periphery:6,DC.GHO:4,RA.OA:6,LA:6,FWL:6,MERC.SI:3,DC:6</availability>
+				<availability>CLAN:6,IS:6,CP:6,MERC:6,BAN:6,Periphery:6,DC.GHO:4,RA.OA:6,MERC.SI:3</availability>
 			</model>
 			<model name='BL-6b-KNT'>
 				<availability>LA:6,CLAN:5,FWL:6,DA:6,MERC:6,FS:6,CP:6,BAN:2,DC:6</availability>
@@ -3210,14 +3210,14 @@
 		<chassis name='Bloodhound' unitType='Mek'>
 			<availability>RF:5,FWL:6,MH:4,MERC:4,DA:6,CP:6</availability>
 			<model name='B1-HND'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 			<model name='B2-HND'>
 				<availability>RF:0,General:4</availability>
 			</model>
 			<model name='B3-HND'>
 				<roles>anti_infantry</roles>
-				<availability>:0,IS:4</availability>
+				<availability>IS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Bluehawk Combat Support Fighter' unitType='Conventional Fighter'>
@@ -3249,7 +3249,7 @@
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
-			<availability>CC:4,MOC:3,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,TamPact:4,FWL:4,DA:4,DC:4,VesMar:4</availability>
+			<availability>CC:4,MERC.KH:3,FR:2,CP:2,FS:6,MERC:6,Periphery:3,RD:4,MERC.WD:5,RF:4,LA:5,TamPact:4,FWL:4,DA:4,DC:4,VesMar:4</availability>
 			<model name=''>
 				<availability>General:8-</availability>
 			</model>
@@ -3339,7 +3339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Brutus Assault Tank' unitType='Tank'>
-			<availability>CC:4,RD:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
+			<availability>RD:4,LA:5,Periphery.CM:5,Periphery.HR:5,Periphery.ME:5,IS:4,FS:7,Periphery:4</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -3979,7 +3979,7 @@
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
-			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4,DC:4</availability>
+			<availability>MOC:5,CC:5,RA.OA:5,LA:6,IS:4,FWL:5,FS:5,CP:5,TC:5,Periphery:4</availability>
 			<model name='CLN-7V'>
 				<roles>training</roles>
 				<availability>IS:8,Periphery.Deep:4,Periphery:6</availability>
@@ -4125,7 +4125,7 @@
 				<availability>General:8,FWL:0</availability>
 			</model>
 			<model name='CMA-C'>
-				<availability>:0,IS:4,DC:8</availability>
+				<availability>IS:4,DC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
@@ -4134,7 +4134,7 @@
 				<availability>FVC:2,CDP:2,TC:2</availability>
 			</model>
 			<model name='CHP-W5'>
-				<availability>:0,BAN:3,Periphery:2-</availability>
+				<availability>BAN:3,Periphery:2-</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>CLAN:2,BAN:2</availability>
@@ -4779,7 +4779,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>DC.GHO:5,CWE:2,CHH:1,RD:1,CDS:2,CLAN:1,FWL:4,MERC:4,CP:3,CJF:1,RA:1,DC:5</availability>
+			<availability>DC.GHO:5,CWE:2,RD:1,CDS:2,CLAN:1,FWL:4,MERC:4,CP:3,RA:1,DC:5</availability>
 			<model name='CRB-27'>
 				<roles>raider</roles>
 				<availability>DC.GHO:5-,CLAN:6,BAN:8,DC:8</availability>
@@ -4851,7 +4851,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cronus' unitType='Mek'>
-			<availability>RF:4,Periphery.MW:4,Periphery.ME:4,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
+			<availability>RF:4,FWL:4,MERC:4,DA:4,CP:4,Periphery:4</availability>
 			<model name='CNS-3M'>
 				<availability>General:4</availability>
 			</model>
@@ -5026,7 +5026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:3,MOC:4,IS:3,FS:3,CP:2,MERC:2,Periphery:2,TC:2,RA.OA:2,RD:4,MERC.WD:2,LA:3,FWL:2,DC:5</availability>
+			<availability>MOC:4,IS:3,CP:2,MERC:2,Periphery:2,RA.OA:2,RD:4,MERC.WD:2,FWL:2,DC:5</availability>
 			<model name='C'>
 				<availability>MERC.WD:1,RD:3-,IS:1,MERC:1</availability>
 			</model>
@@ -5037,7 +5037,7 @@
 				<availability>General:2-</availability>
 			</model>
 			<model name='CP-11-A'>
-				<availability>CC:4,MOC:4,LA:4,FWL:4,IS:4,MH:4,FS:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
+				<availability>MOC:4,IS:4,MH:4,CP:4,CDP:4,TC:4,Periphery:2</availability>
 			</model>
 			<model name='CP-11-A-DC'>
 				<roles>command</roles>
@@ -5062,7 +5062,7 @@
 				<availability>MOC:4,IS:4,MERC:4,CDP:4,TC:4</availability>
 			</model>
 			<model name='CP-11-H'>
-				<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,TC:6,Periphery:6</availability>
+				<availability>FVC:6,PIR:6,Periphery.Deep:4,MH:6,CDP:6,Periphery:6</availability>
 			</model>
 			<model name='CP-12-K'>
 				<availability>MERC:8,DC:8</availability>
@@ -5090,7 +5090,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
-			<availability>CC:4,MOC:2,CHH:1-,SE:3,FR:2,MERC:4,CDP:4,RA:1,TC:4,Periphery:4</availability>
+			<availability>CC:4,MOC:2,CHH:1-,SE:3,FR:2,MERC:4,CDP:4,RA:1,Periphery:4</availability>
 			<model name=''>
 				<roles>recon,escort</roles>
 				<availability>CC:4</availability>
@@ -5467,10 +5467,10 @@
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
-			<availability>MOC:10,CC:7,CHH:5,CLAN:4,IS:7,FS:9,CP:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2,DC:7</availability>
+			<availability>CHH:5,CLAN:4,IS:7,FS:9,CP:6,Periphery:10,TC:9,RA.OA:9,FVC:8,LA:4,FWL:8,CJF:2</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
-				<availability>CC:5,MOC:4,LA:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,TC:4,Periphery:4,DC:4</availability>
+				<availability>CC:5,LA:4,IS:2,FWL:4,FS:4,CP:4,CDP:4,Periphery:4,DC:4</availability>
 			</model>
 			<model name='(Clan)'>
 				<availability>MERC.WD:8,CLAN:8</availability>
@@ -5809,7 +5809,7 @@
 			</model>
 		</chassis>
 		<chassis name='Eagle' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:3,RA.OA:2,LA:3,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3,TC:3,DC:3</availability>
+			<availability>MOC:4,RA.OA:2,CLAN:3,IS:3,FWL:4,FS:4,CP:4,Periphery:3</availability>
 			<model name='EGL-R11'>
 				<availability>RF:6,LA:6,MERC:6,FS:6</availability>
 			</model>
@@ -5972,7 +5972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,LA:4,FWL:4,MH:3,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:2,IS:4,FS:5,MERC:4,CP:4,CDP:3,TC:4,MH:3</availability>
 			<model name='EMP-6A'>
 				<availability>CC:4,LA:4,CLAN:8,IS:8,Periphery.Deep:6,FWL:4,FS:4,BAN:4,Periphery:8</availability>
 			</model>
@@ -6132,7 +6132,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,CC:5,RA.OA:2,LA:5,IS:5,FWL:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
+			<availability>MOC:3,RA.OA:2,IS:5,FS:2,CP:5,Periphery:2,TC:3,DC:6</availability>
 			<model name='&apos;Pocket Warship&apos;'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -6729,7 +6729,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>DC.GHO:5,CHH:1,RD:2,CDS:1,LA:4,CLAN:1,FWL:4,CP:2,MERC:2,CJF:2,DC:4</availability>
+			<availability>DC.GHO:5,RD:2,LA:4,CLAN:1,FWL:4,CP:2,MERC:2,CJF:2,DC:4</availability>
 			<model name='FLS-10E'>
 				<availability>CDS:4-,LA:4,MERC:4</availability>
 			</model>
@@ -6768,7 +6768,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flea' unitType='Mek'>
-			<availability>CC:6,MOC:4,MERC:4,CP:2,Periphery:4,TC:4,MERC.WD:4,FVC:4,RF:3,Periphery.MW:4,Periphery.ME:4,FWL:2,DA:3</availability>
+			<availability>CC:6,MERC:4,CP:2,Periphery:4,MERC.WD:4,FVC:4,RF:3,FWL:2,DA:3</availability>
 			<model name='FLE-17'>
 				<availability>CC:4,RF:8,FWL:8,MERC:8,DA:8,CP:8,Periphery:6</availability>
 			</model>
@@ -6990,7 +6990,7 @@
 			</model>
 		</chassis>
 		<chassis name='Fury' unitType='Dropship'>
-			<availability>MOC:4,CC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,LA:4,FWL:5,DC:3</availability>
+			<availability>MOC:4,CHH:2,CLAN:1,IS:4,FS:3,CP:5,BAN:4,Periphery:3,TC:4,RA.OA:4,FWL:5,DC:3</availability>
 			<model name='(2638)'>
 				<roles>vee_carrier,infantry_carrier</roles>
 				<availability>CC:2-,General:8</availability>
@@ -7068,7 +7068,7 @@
 			</model>
 		</chassis>
 		<chassis name='Galleon Light Tank' unitType='Tank'>
-			<availability>MOC:6,CC:6,CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,TC:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
+			<availability>CLAN:5,IS:6,Periphery.Deep:4,FS:8,CP:8,Periphery:6,RA.OA:8,LA:7,FWL:8,CJF:2,DC:8</availability>
 			<model name='GAL-100'>
 				<deployedWith>Harasser</deployedWith>
 				<availability>General:5-</availability>
@@ -7171,7 +7171,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ghost' unitType='Mek'>
-			<availability>CC:2,MOC:2,IS:2,MERC:2,FS:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2,DC:2</availability>
+			<availability>MOC:2,IS:2,MERC:2,CP:3,TC:2,FVC:2,LA:4,PIR:2,FWL:3,MH:2</availability>
 			<model name='GST-10'>
 				<availability>General:8</availability>
 			</model>
@@ -8326,7 +8326,7 @@
 			</model>
 		</chassis>
 		<chassis name='Heavy LRM Carrier' unitType='Tank'>
-			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.MW:5,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
+			<availability>Periphery.OS:4,MERC:3,FS:3,CP:3,TC:2,Periphery:5,RA.OA:3,Periphery.CM:7,Periphery.HR:7,Periphery.ME:7,FWL:3,MH:1</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -8588,7 +8588,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hercules' unitType='Mek'>
-			<availability>RA.OA:4,Periphery.MW:5,Periphery.ME:5,FWL:6,MERC:6,CP:6,Periphery:5</availability>
+			<availability>RA.OA:4,FWL:6,MERC:6,CP:6,Periphery:5</availability>
 			<model name='HRC-LS-9000'>
 				<availability>General:8</availability>
 			</model>
@@ -8670,7 +8670,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
-			<availability>CC:6,RD:2-,CDS:2,Periphery.CM:6,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6</availability>
+			<availability>CC:6,RD:2-,CDS:2,IS:2-,Periphery.Deep:4,MERC:4,Periphery:6</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -8729,9 +8729,9 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:5,MOC:4,LA:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,FS:4,CP:5,CJF:5,DC:4</availability>
+			<availability>CC:5,MOC:4,CLAN:4,IS:4,FWL:5,MH:4,MERC:4,CP:5,CJF:5,DC:4</availability>
 			<model name='HGN-732'>
-				<availability>MOC:6,CC:6,CLAN:6,IS:6,MERC:6,FS:6,CP:6,BAN:8,DC.GHO:8,LA:6,FWL:6,MERC.SI:8,MH:6,DC:6</availability>
+				<availability>MOC:6,CLAN:6,IS:6,MERC:6,CP:6,BAN:8,DC.GHO:8,MERC.SI:8,MH:6</availability>
 			</model>
 			<model name='HGN-732b'>
 				<availability>LA:4,CLAN:4,IS:4,FWL:4,MH:4,FS:4,BAN:2</availability>
@@ -8835,7 +8835,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
-			<availability>MOC:2,FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2,TC:2</availability>
+			<availability>FVC:8,FS.PMM:6,Periphery.HR:4,FS.CMM:6,FS.DMM:6,FS:4,MERC:2,Periphery.OS:4,FS.CrMM:6,Periphery:2</availability>
 			<model name='HNT-151'>
 				<roles>recon,urban</roles>
 				<availability>General:1-</availability>
@@ -8940,7 +8940,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hunter Light Support Tank' unitType='Tank'>
-			<availability>MOC:2,CC:4,RA.OA:3,LA:5,IS:3,FWL:2,MERC:3,FS:3,CP:2,Periphery:3,TC:3,DC:2</availability>
+			<availability>MOC:2,CC:4,RA.OA:3,LA:5,IS:3,FWL:2,MERC:3,CP:2,Periphery:3,DC:2</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>General:1-</availability>
@@ -9167,7 +9167,7 @@
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
-			<availability>MOC:4,CC:4,LA:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,TC:3,DC:6</availability>
+			<availability>MOC:4,CLAN:1,IS:4,FWL:6,FS:3,CP:6,BAN:4,Periphery:3,DC:6</availability>
 			<model name='(2655)'>
 				<roles>assault</roles>
 				<availability>General:2</availability>
@@ -9314,7 +9314,7 @@
 			</model>
 		</chassis>
 		<chassis name='JES II Strategic Missile Carrier' unitType='Tank'>
-			<availability>CC:4,RD:6,LA:4,IS:4,FWL:4,FS:6,MERC:4,CJF:4,Periphery:4,DC:4</availability>
+			<availability>RD:6,IS:4,FS:6,MERC:4,CJF:4,Periphery:4</availability>
 			<model name=''>
 				<roles>fire_support</roles>
 				<availability>RD:4,IS:8,Periphery:8</availability>
@@ -9482,7 +9482,7 @@
 			</model>
 		</chassis>
 		<chassis name='JagerMech' unitType='Mek'>
-			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,Periphery.HR:3,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
+			<availability>MOC:2,MERC:3,Periphery.OS:2,FS:6,TC:2,Periphery:3,RA.OA:2,FVC:6,LA:1,Periphery.CM:2,PIR:3,Periphery.ME:2,MH:2,DC:2</availability>
 			<model name='JM6-DD'>
 				<roles>anti_aircraft</roles>
 				<availability>MOC:6,RA.OA:4,LA:4,FS:4,MERC:4,CDP:6,DC:4,TC:6</availability>
@@ -9534,7 +9534,7 @@
 			</model>
 		</chassis>
 		<chassis name='Javelin' unitType='Mek'>
-			<availability>MOC:3,FVC:6,Periphery.HR:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3,TC:3</availability>
+			<availability>FVC:6,Periphery.HR:3,FS:7,MERC:3,Periphery.OS:6,Periphery:3</availability>
 			<model name='JVN-10N'>
 				<roles>recon</roles>
 				<availability>Periphery:2-</availability>
@@ -9954,7 +9954,7 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CC:4,DC.GHO:6,RD:2,LA:7,CLAN:2,IS:4,FWL:4,MH:4,FS:6,MERC:5,CP:4,DC:4</availability>
+			<availability>DC.GHO:6,RD:2,LA:7,CLAN:2,IS:4,MH:4,FS:6,MERC:5,CP:4</availability>
 			<model name='KGC-000'>
 				<availability>CLAN:6,BAN:8,DC:8</availability>
 			</model>
@@ -10400,7 +10400,7 @@
 			</model>
 			<model name='(3055 Upgrade)'>
 				<roles>fire_support</roles>
-				<availability>CC:8,MOC:8,LA:8,FWL:8,IS:8,FS:8,CP:8,DC:8,TC:8,Periphery:6</availability>
+				<availability>MOC:8,IS:8,CP:8,TC:8,Periphery:6</availability>
 			</model>
 		</chassis>
 		<chassis name='LTV-4 Hover Tank' unitType='Tank'>
@@ -10509,7 +10509,7 @@
 			</model>
 		</chassis>
 		<chassis name='Leopard' unitType='Dropship'>
-			<availability>MOC:8,CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,TC:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
+			<availability>CC:7,IS:8,Periphery.Deep:6,FS:7,CP:7,BAN:2,Periphery:8,RA.OA:8,LA:7,FWL:7,DC:7</availability>
 			<model name='(2537)'>
 				<roles>mek_carrier</roles>
 				<availability>General:5-</availability>
@@ -10610,7 +10610,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lightning' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,FS:3,CP:2,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:5,CC:4,RA.OA:6,LA:2,CLAN:2,IS:3,FWL:2,CP:2,Periphery:4,DC:5</availability>
 			<model name='LTN-G15'>
 				<availability>General:2-</availability>
 			</model>
@@ -10875,7 +10875,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>MOC:6,CC:4,RA.OA:6,RD:4,LA:5,IS:6,FWL:7,FS:5,CP:7,Periphery:7,TC:6,DC:6</availability>
+			<availability>MOC:6,CC:4,RA.OA:6,RD:4,LA:5,IS:6,FWL:7,FS:5,CP:7,Periphery:7,TC:6</availability>
 			<model name='LGB-0H'>
 				<availability>PIR:3,MH:5</availability>
 			</model>
@@ -10890,7 +10890,7 @@
 			</model>
 			<model name='LGB-12C'>
 				<roles>fire_support</roles>
-				<availability>CC:4,MOC:5,LA:4,FWL:4,IS:4,MH:4,FS:4,MERC:4,CP:4,CDP:4,TC:4</availability>
+				<availability>MOC:5,IS:4,MH:4,MERC:4,CP:4,CDP:4,TC:4</availability>
 			</model>
 			<model name='LGB-12R'>
 				<roles>fire_support</roles>
@@ -11356,7 +11356,7 @@
 			</model>
 		</chassis>
 		<chassis name='Manticore Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:3,RA.OA:4,LA:4,IS:4,FWL:3,MERC:4,FS:4,CP:3,Periphery:4,TC:4,DC:5</availability>
+			<availability>MOC:3,CC:3,RA.OA:4,IS:4,FWL:3,MERC:4,CP:3,Periphery:4,DC:5</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:2</availability>
 			</model>
@@ -11479,7 +11479,7 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:4,RA.OA:2,MOC:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
+			<availability>CC:4,RA.OA:2,RD:3,LA:5,FWL:3,FS:6,CP:3,TC:3,Periphery:2,DC:2</availability>
 			<model name='MAD-11D'>
 				<availability>FS:5,MERC:3</availability>
 			</model>
@@ -12660,7 +12660,7 @@
 		<chassis name='Nightsky' unitType='Mek'>
 			<availability>Periphery.R:2,RF:5,LA:8,FWL:4,FS:7,MERC:6,CP:4</availability>
 			<model name='NGS-4S'>
-				<availability>:0,RF:4,LA:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
+				<availability>RF:4,LA:4,General:8,FWL:4,Periphery.Deep:6,FS:4,MERC:4,CP:4,Periphery:8</availability>
 			</model>
 			<model name='NGS-4T'>
 				<availability>LA:4,FS:4,MERC:4</availability>
@@ -12987,7 +12987,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
-			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2,DC:2</availability>
+			<availability>MOC:6,CC:4,IS:2,MERC:2,FS:5,CP:5,Periphery:3,TC:2,FVC:5,CDS:5,LA:5,Periphery.MW:6,PIR:6,Periphery.ME:6,FWL:6,MH:2</availability>
 			<model name=''>
 				<availability>General:1-,Periphery:4</availability>
 			</model>
@@ -13044,7 +13044,7 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWE:2,Periphery.MW:3,Periphery.ME:3,FWL:5,DC:3</availability>
+			<availability>MOC:1,CC:2,CLAN:1,FS:2,CP:5,MERC:2,Periphery:3,TC:1,CWE:2,FWL:5,DC:3</availability>
 			<model name='C 2'>
 				<availability>CWE:3-,FWL:2,MERC:2</availability>
 			</model>
@@ -13339,7 +13339,7 @@
 			</model>
 		</chassis>
 		<chassis name='Packrat LRPV' unitType='Tank'>
-			<availability>MOC:2-,CC:2-,IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,TC:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-,FWL:2-,DC:2-</availability>
+			<availability>IS:2-,FS:4-,CP:2-,FS.CrMM:5-,Periphery:2-,RA.OA:2-,FVC:5-,LA:4-,FS.PMM:5-,FS.CMM:5-,FS.DMM:5-</availability>
 			<model name='&apos;Gespenst&apos;'>
 				<roles>recon,specops</roles>
 				<availability>LA:2</availability>
@@ -13531,7 +13531,7 @@
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
-			<availability>MOC:2,CC:1,RA.OA:2,LA:2,IS:2,FWL:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
+			<availability>MOC:2,CC:1,RA.OA:2,IS:2,FS:3,Periphery:2-,DC:1,TC:3</availability>
 			<model name='(AC2)'>
 				<roles>anti_aircraft</roles>
 				<availability>Periphery:2-</availability>
@@ -13970,7 +13970,7 @@
 			</model>
 		</chassis>
 		<chassis name='Planetlifter Air Transport' unitType='Conventional Fighter'>
-			<availability>CC:5,MOC:5,FVC:4,IS:6,FR:5,CP:5,FS:6,DA:8,MERC:4,DC:5,Periphery:5</availability>
+			<availability>CC:5,FVC:4,IS:6,FR:5,CP:5,DA:8,MERC:4,DC:5,Periphery:5</availability>
 			<model name=''>
 				<roles>cargo,support</roles>
 				<availability>General:6</availability>
@@ -14195,7 +14195,7 @@
 			</model>
 		</chassis>
 		<chassis name='Puma (Adder)' unitType='Mek' omni='Clan'>
-			<availability>CWE:7,MERC.WD:4,RD:5,CDS:5,CLAN:5,MERC:3+,CP:7,CJF:4,RA:6,BAN:5</availability>
+			<availability>CWE:7,MERC.WD:4,RD:5,CLAN:5,MERC:3+,CP:7,CJF:4,RA:6,BAN:5</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
 				<availability>CWE:5,RD:5,CDS:8,General:7,CP:8</availability>
@@ -14280,7 +14280,7 @@
 			</model>
 		</chassis>
 		<chassis name='Quickdraw' unitType='Mek'>
-			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,LA:2,FWL:6,DA:4,DC:4</availability>
+			<availability>MOC:4,CC:5,IS:2,FS:5,CP:6,CDP:2,Periphery:3,TC:1,RA.OA:2,FVC:2,RD:5,RF:6,FWL:6,DA:4,DC:4</availability>
 			<model name='QKD-4G'>
 				<availability>MOC:2-,Periphery:2-,TC:2-</availability>
 			</model>
@@ -14550,7 +14550,7 @@
 				<availability>General:8</availability>
 			</model>
 			<model name='RZK-9T'>
-				<availability>:0,General:6</availability>
+				<availability>General:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Recon Infantry' unitType='Infantry'>
@@ -15180,7 +15180,7 @@
 			</model>
 		</chassis>
 		<chassis name='Saracen Medium Hover Tank' unitType='Tank'>
-			<availability>MOC:2,RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,TC:2,DC:1-</availability>
+			<availability>RA.OA:5,Periphery.DD:4,Periphery.OS:4,Periphery:2,DC:1-</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>
@@ -15418,7 +15418,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:2,MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,PIR:2,FWL:2,DA:2,DC:4</availability>
+			<availability>MERC.KH:2-,IS:2,MERC:2,CP:2,Periphery:1-,FVC:2,MERC.WD:2-,RF:1-,LA:4,PIR:2,DA:2,DC:4</availability>
 			<model name='SCP-10M'>
 				<availability>CC:6,MOC:4,FWL:8,MERC:6,CP:8,DC:6</availability>
 			</model>
@@ -15558,11 +15558,11 @@
 			<availability>CC:4,MOC:4,RF:4,FWL:5,DA:4,MERC:4,CP:5</availability>
 			<model name=''>
 				<roles>assault,ba_carrier</roles>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>DC.GHO:3,CWE:1,FVC:4,RD:2,CDS:1,LA:2,CLAN:1,FS:4,MERC:4,CP:1,CJF:2,DC:2</availability>
+			<availability>DC.GHO:3,CWE:1,FVC:4,RD:2,LA:2,CLAN:1,FS:4,MERC:4,CP:1,CJF:2,DC:2</availability>
 			<model name='STN-3L'>
 				<availability>FVC:8,LA:8,CLAN:6,MERC.SI:8,FS:8,MERC:8,BAN:8,DC:8</availability>
 			</model>
@@ -15695,7 +15695,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CHH:4,IS:3,FS:3,CP:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,LA:3,FWL:3,DA:3,DC:3</availability>
+			<availability>CHH:4,IS:3,CP:4,RA:4,RA.OA:3,CWE:4,RD:4,CDS:4,RF:3,DA:3</availability>
 			<model name='10'>
 				<availability>CWE:5-,CHH:8-,RD:4-</availability>
 			</model>
@@ -16035,7 +16035,7 @@
 			</model>
 		</chassis>
 		<chassis name='Slayer' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:5,Periphery.DD:3,FVC:4,RD:6,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,DC:7</availability>
+			<availability>RA.OA:5,Periphery.DD:3,FVC:4,RD:6,MERC:3,Periphery.OS:3,FS:3,Periphery:2,TC:5,RA:3,DC:7</availability>
 			<model name='SL-15'>
 				<availability>FS:0,Periphery:2-</availability>
 			</model>
@@ -16178,7 +16178,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sparrowhawk' unitType='AeroSpaceFighter'>
-			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,Periphery.HR:4,MERC:5,Periphery.OS:4,FS:8,Periphery:4,TC:2</availability>
+			<availability>MOC:2,RA.OA:2,FVC:7,LA:3,MERC:5,FS:8,Periphery:4,TC:2</availability>
 			<model name='SPR-6D'>
 				<availability>FVC:7,LA:5,FS:8,MERC:5</availability>
 			</model>
@@ -16332,7 +16332,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,LA:5,FWL:6,DC:1</availability>
+			<availability>MOC:3,CC:1,CLAN:2,IS:5,Periphery.Deep:8,FS:4,CP:6,Periphery:10,TC:6,RA.OA:5,FWL:6,DC:1</availability>
 			<model name='STK-3F'>
 				<availability>Periphery:2-</availability>
 			</model>
@@ -16603,7 +16603,7 @@
 				<availability>General:7</availability>
 			</model>
 			<model name='D'>
-				<availability>:0,CLAN:6</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='E'>
 				<availability>CLAN:6</availability>
@@ -16615,7 +16615,7 @@
 				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>:0,General:8</availability>
+				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stork Light Refueling Craft' unitType='Conventional Fighter'>
@@ -16704,7 +16704,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker Light Tank' unitType='Tank'>
-			<availability>CC:2,FVC:5,RD:4,CDS:3,LA:2,PIR:3,IS:2,FS:5,MERC:3,CP:3,DC:1</availability>
+			<availability>FVC:5,RD:4,CDS:3,PIR:3,IS:2,FS:5,MERC:3,CP:3,DC:1</availability>
 			<model name=''>
 				<availability>General:1-</availability>
 			</model>
@@ -16754,7 +16754,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
-			<availability>RA.OA:1,FVC:7,Periphery.HR:2,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1,TC:1</availability>
+			<availability>RA.OA:1,FVC:7,Periphery.HR:2,CLAN:3,MERC:4,Periphery.OS:2,FS:7,Periphery:1</availability>
 			<model name='STU-D6'>
 				<availability>FVC:4,LA:6,FS:4,MERC:6,CDP:4</availability>
 			</model>
@@ -17453,7 +17453,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
-			<availability>MOC:4,CC:4,RA.OA:4,LA:6,IS:4,FWL:4,FS:5,CP:4,Periphery:5,TC:5,DC:4</availability>
+			<availability>MOC:4,RA.OA:4,LA:6,IS:4,FS:5,CP:4,Periphery:5</availability>
 			<model name='TRB-D36'>
 				<roles>escort,ground_support</roles>
 				<availability>General:2-</availability>
@@ -17782,7 +17782,7 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,RF:6,Periphery.MW:3,Periphery.ME:3,FWL:6,CP:6,MERC:5,DA:6,Periphery:3,TC:4,DC:4</availability>
+			<availability>CC:5,MOC:5,RF:6,FWL:6,CP:6,MERC:5,DA:6,Periphery:3,TC:4,DC:4</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
 				<availability>RF:4,FWL:4,MERC:4,CP:4</availability>
@@ -18212,7 +18212,7 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>MOC:3-,CC:6-,RA.OA:3-,LA:4-,FS.CMM:5-,IS:4-,FWL:5-,FS:4-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
+			<availability>MOC:3-,CC:6-,RA.OA:3-,FS.CMM:5-,IS:4-,FWL:5-,CP:5-,Periphery:4-,TC:3-,DC:5-</availability>
 			<model name='UM-AIV'>
 				<roles>missile_artillery,urban</roles>
 				<deployedWith>missile artillery,fire support</deployedWith>
@@ -18244,7 +18244,7 @@
 			</model>
 			<model name='UM-R80'>
 				<roles>urban,spotter</roles>
-				<availability>CC:6,MOC:6,IS:6,Periphery.Deep:4,FWL:6,MERC:6,Periphery:6</availability>
+				<availability>IS:6,Periphery.Deep:4,MERC:6,Periphery:6</availability>
 			</model>
 			<model name='UM-R93'>
 				<roles>urban</roles>
@@ -18444,7 +18444,7 @@
 			</model>
 		</chassis>
 		<chassis name='Vengeance' unitType='Dropship'>
-			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,TC:1,DC:4</availability>
+			<availability>MOC:3,CC:4,RA.OA:1,LA:4,IS:1,FWL:4,FS:4,CP:4,Periphery:1,DC:4</availability>
 			<model name='(2682)'>
 				<roles>asf_carrier</roles>
 				<availability>General:2</availability>
@@ -18512,7 +18512,7 @@
 				<availability>Periphery:2-</availability>
 			</model>
 			<model name='VTR-9K'>
-				<availability>MOC:4,FVC:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,TC:4,Periphery:4</availability>
+				<availability>FVC:4,FWL:4,MH:4,MERC:4,CP:4,DC:8,Periphery:4</availability>
 			</model>
 			<model name='VTR-9Ka'>
 				<availability>CC:4,FVC:4,FS:4,MERC:4,DC:4,Periphery:4</availability>
@@ -18972,7 +18972,7 @@
 			</model>
 		</chassis>
 		<chassis name='Warrior Attack Helicopter' unitType='VTOL'>
-			<availability>MOC:6,CC:6,FS.CH:8,IS:6,FWL.FWG:7,FS:6,CP:4,CC.CHG:8,Periphery:6,TC:6,RA:4,RA.OA:6,RD:4,LA:9,FWL:5,MH:6,DC:4</availability>
+			<availability>FS.CH:8,IS:6,FWL.FWG:7,CP:4,CC.CHG:8,Periphery:6,RA:4,RA.OA:6,RD:4,LA:9,FWL:5,DC:4</availability>
 			<model name='H-10'>
 				<roles>apc</roles>
 				<availability>LA:4,FWL:4,CP:6</availability>
@@ -19134,7 +19134,7 @@
 		<chassis name='Whitworth' unitType='Mek'>
 			<availability>FVC:1,FS.CMM:1,MERC:1,DC:1,Periphery:1</availability>
 			<model name='WTH-1H'>
-				<availability>Periphery.CM:5,Periphery.HR:5,PIR:5,Periphery.ME:5,MH:5,Periphery:5</availability>
+				<availability>PIR:5,Periphery:5</availability>
 			</model>
 			<model name='WTH-2'>
 				<roles>fire_support</roles>
@@ -19252,7 +19252,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CC:5,RD:2,LA:5,IS:5,FWL:8,MH:4,FS:6,CP:6,DC:5,Periphery:4,TC:4</availability>
+			<availability>RD:2,IS:5,FWL:8,FS:6,CP:6,Periphery:4</availability>
 			<model name='WVR-10D'>
 				<availability>FS:5,MERC:4</availability>
 			</model>
@@ -19656,7 +19656,7 @@
 			</model>
 		</chassis>
 		<chassis name='Zhukov Heavy Tank' unitType='Tank'>
-			<availability>MOC:3,CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,TC:3,Periphery:3,DC:5</availability>
+			<availability>CC:6,MERC.WD:7,IS:5,FWL:4,MERC:3,CP:4,Periphery:3,DC:5</availability>
 			<model name=''>
 				<availability>General:2-</availability>
 			</model>


### PR DESCRIPTION
Fixes the line wrapping that propagated from the mass naming/line length/general formatting fix.  Great for code, less so for data.

Also consolidates a number of redundant availability values to remove redundant data - lower chance of editing errors later, easier to automatically transcribe contents if at some point this is moved to YAML or other format.

As an example, an availability list of

`... ,CC:6, ... ,IS:6,FS:6, ... ,LA:6,FWL:6, ...`

is simplified down to `... ,IS:6, ...` as the major IS factions are already covered under the IS parent faction with the same availability value.

Similarly, major Periphery factions have been consolidated down under the parent Periphery faction and most of the Clan factions have been consolidated under the CLAN faction.