### PR TITLE
Makes PlanetaryConditionsDialog work again after scaling stuff

### DIFF
--- a/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/PlanetaryConditionsDialog.java
@@ -160,6 +160,9 @@ public class PlanetaryConditionsDialog extends ClientDialog {
         getRootPane().getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(escape, closeAction);
         getRootPane().getInputMap(JComponent.WHEN_FOCUSED).put(escape, closeAction);
         getRootPane().getActionMap().put(closeAction, new CloseAction(this));
+
+        pack();
+        center();
     }
 
     private JPanel headerSection() {


### PR DESCRIPTION
Bug: PlanetaryConditionsDialog, the one you get from the button in the map section of the lobby, started spawning 1 pixel wide by about 50 pixels tall in the upper left corner of my screen. This makes it very difficult to use

Cause: Scaling-related changes to ClientDialog, possibly 4e9c487

Fix: Add `pack()` and `center()` to the PlanetaryConditionsDialog like other ClientDialogs have.