### PR TITLE
Fix Typo in Availability List for Dragonfly (Viper) Chassis

### DIFF
--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -1897,7 +1897,7 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CSV:3,CLAN:4,CFM:5,CSJ:3CGB:3</availability>
+			<availability>CSV:3,CLAN:4,CFM:5,CSJ:3,CGB:3</availability>
 			<model name='A'>
 				<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
 			</model>


### PR DESCRIPTION
Corrected a missing comma in the availability list of the Dragonfly (Viper) chassis in the 2950.xml file.

### Closes #6095