### PR TITLE
GUI scaling fixes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -44,7 +44,6 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
-import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
@@ -1202,22 +1201,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     private static void setLookAndFeel() {
         try {
             UIManager.setLookAndFeel(GUIPreferences.getInstance().getUITheme());
-            updateAfterUiChange();
+            UIUtil.updateAfterUiChange();
         } catch (Exception ex) {
             logger.error("setLookAndFeel() Exception", ex);
-        }
-    }
-
-    /**
-     * Updates all existing windows and frames. Use after a gui scale change or look-and-feel change.
-     */
-    public static void updateAfterUiChange() {
-        for (Window window : Window.getWindows()) {
-            SwingUtilities.updateComponentTreeUI(window);
-            window.invalidate();
-            window.validate();
-            window.pack();
-            window.repaint();
         }
     }
 }

--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -637,6 +637,18 @@ public final class UIUtil {
         }
     }
 
+    /**
+     * Updates all existing windows and frames. Use after a gui scale change or look-and-feel change.
+     */
+    public static void updateAfterUiChange() {
+        for (Window window : Window.getWindows()) {
+            SwingUtilities.updateComponentTreeUI(window);
+            window.invalidate();
+            window.validate();
+            window.repaint();
+        }
+    }
+
     /** A specialized panel for the header of a section. */
     public static class Header extends JPanel {
         private static final long serialVersionUID = -6235772150005269143L;


### PR DESCRIPTION
This and the PRs for MML and MHQ (merge together) fix some remaining gui scaling issues.
- moves the cleanup code to UIUtil
- removes pack() so that windows no longer change size after a scale change