### PR TITLE
Set Dialog Always on Top in `AbstractIconChooserDialog`

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/AbstractIconChooserDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/AbstractIconChooserDialog.java
@@ -84,6 +84,7 @@ public abstract class AbstractIconChooserDialog extends AbstractButtonDialog {
             });
         }
         initialize();
+        setAlwaysOnTop(true);
     }
     //endregion Constructors
 


### PR DESCRIPTION
Ensured the icon chooser dialog stays above other windows by calling setAlwaysOnTop(true).

This change will resolve certain dialogs (camo and icon pickers, in particular) from initially appearing behind other dialogs.