### PR TITLE
TacOps BAP rule offboard checks

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1736,10 +1736,10 @@ public class Compute {
      * @return if target si in range and entity is not affected
      */
     public static boolean bapInRange(Game game, Entity entity, Entity target) {
-        return (target != null)
-                && entity.hasBAP()
-                && (entity.getBAPRange() >= Compute.effectiveDistance(game, entity, target))
-                && !ComputeECM.isAffectedByECM(entity, entity.getPosition(), target.getPosition());
+        return entity.hasBAP()
+            && (target != null) && !target.isOffBoard() && (target.getPosition() != null)
+            && (entity.getBAPRange() >= Compute.effectiveDistance(game, entity, target))
+            && !ComputeECM.isAffectedByECM(entity, entity.getPosition(), target.getPosition());
     }
 
     /**

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4703,10 +4703,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // we have BAP in range or C3 member has BAP in range
         // we reduce the BTH by 1
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BAP)) {
-            boolean targetWoodsAffectModifier = te != null
-                    && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER)
-                    && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS)
-                            || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE));
+            boolean targetWoodsAffectModifier = (te != null) && !te.isOffBoard() && (te.getPosition() != null)
+                && (game.getBoard().getHex(te.getPosition()) != null)
+                && game.getBoard().getHex(te.getPosition()).hasVegetation()
+                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER);
             if (los.canSee() && (targetWoodsAffectModifier || los.thruWoods())) {
                 boolean bapInRange = Compute.bapInRange(game, ae, te);
                 boolean c3BAP = false;


### PR DESCRIPTION
The usual, guard against offboard and null positions for TacOps BAP rule (I'm making the assumption that BAP range will never include offboard units)
should fix #6083