### PR TITLE
#6063: Fix targeting choice with iNarcs

### DIFF
--- a/megamek/src/megamek/client/ui/swing/TargetChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/TargetChoiceDialog.java
@@ -17,6 +17,7 @@ import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
+import megamek.common.actions.BrushOffAttackAction;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
 
@@ -90,15 +91,25 @@ public class TargetChoiceDialog extends AbstractChoiceDialog<Targetable> {
         String result = "";
 
         if (firingEntity != null) {
-            ToHitData thd = WeaponAttackAction.toHit(clientGUI.getClient().getGame(), firingEntity.getId(), target);
-            thd.setLocation(target.getPosition());
-            thd.setRange(firingEntity.getPosition().distance(target.getPosition()));
+            ToHitData thd;
+            if (target instanceof INarcPod) {
+                // must not call getPosition() on INarcPods! Check both arms if necessary
+                thd = BrushOffAttackAction.toHit(clientGUI.getClient().getGame(),
+                    firingEntity.getId(), target, BrushOffAttackAction.RIGHT);
+                if (thd.getValue() == TargetRoll.IMPOSSIBLE) {
+                    thd = BrushOffAttackAction.toHit(clientGUI.getClient().getGame(),
+                        firingEntity.getId(), target, BrushOffAttackAction.LEFT);
+                }
+            } else {
+                thd = WeaponAttackAction.toHit(clientGUI.getClient().getGame(), firingEntity.getId(), target);
+                thd.setLocation(target.getPosition());
+                thd.setRange(firingEntity.getPosition().distance(target.getPosition()));
+            }
             if (thd.needsRoll()) {
                 int mod = thd.getValue();
                 result += "<br>Target To Hit Mod: <b>" + (mod < 0 ? "" : "+") + mod + "</b>";
             } else {
                 result += "<br><b>" + thd.getValueAsString() + " To Hit</b>: " + thd.getDesc();
-
             }
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -855,7 +855,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         int aElev = ae.getElevation();
         int tElev = target.getElevation();
         int targEl;
-        if (te == null) {
+        if (target instanceof INarcPod) {
+            // brush off attached INarcs on oneself; use left arm as a placeholder here as no choice has been made
+            return BrushOffAttackAction.toHit(game, attackerId, target, BrushOffAttackAction.LEFT);
+        } else if (te == null) {
             targEl = game.getBoard().getHex(target.getPosition()).floor();
         } else {
             targEl = te.relHeight();


### PR DESCRIPTION
Prevents calling getPosition() on INarcPods; use BrushOffAttackAction
This would only become apparent when an iNarc-ed unit had the iNarc pod and another target in its own hex for a physical attack
Fixes #6063 