### PR TITLE
Added Font Scaling Helper Methods to `FlatLafStyleBuilder`

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MMToggleButton.java
+++ b/megamek/src/megamek/client/ui/swing/MMToggleButton.java
@@ -19,10 +19,10 @@
 package megamek.client.ui.swing;
 
 import megamek.MMConstants;
-import megamek.client.ui.swing.util.FlatLafStyleBuilder;
 
 import javax.swing.*;
-import java.awt.*;
+
+import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
 
 /**
  * A JToggleButton that shows a check mark and cross mark to make its
@@ -42,7 +42,7 @@ public class MMToggleButton extends JToggleButton {
         super();
         setText(text);
         // The standard UI font doesn't show unicode characters (on Win10)
-        new FlatLafStyleBuilder().font(MMConstants.FONT_DIALOG).apply(this);
+        setFontScaling(this, MMConstants.FONT_DIALOG, false, 1);
         addActionListener(event -> setText(getText()));
     }
 

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
@@ -18,7 +18,10 @@
  */
 package megamek.client.ui.swing.scenario;
 
-import megamek.client.ui.swing.util.*;
+import megamek.client.ui.swing.util.DashedSeparator;
+import megamek.client.ui.swing.util.FontHandler;
+import megamek.client.ui.swing.util.LocationBorder;
+import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.scenario.Scenario;
 import megamek.common.scenario.ScenarioV1;
 
@@ -56,7 +59,7 @@ public class ScenarioInfoPanel extends JPanel {
         add(new DashedSeparator(UIUtil.uiLightGreen(), 0.9f, 2f));
         add(Box.createVerticalStrut(10));
 
-        new FlatLafStyleBuilder().font(FontHandler.notoFont()).apply(textDescription2);
+        setFontScaling(textDescription2, FontHandler.notoFont().getFontName(), false, 1);
         textDescription2.setAlignmentX(0.5f);
         textDescription2.setVerticalAlignment(SwingConstants.TOP);
         textDescription2.setBorder(new EmptyBorder(0, 10, 0, 10));

--- a/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
+++ b/megamek/src/megamek/client/ui/swing/scenario/ScenarioInfoPanel.java
@@ -19,12 +19,14 @@
 package megamek.client.ui.swing.scenario;
 
 import megamek.client.ui.swing.util.*;
-import megamek.common.scenario.ScenarioV1;
 import megamek.common.scenario.Scenario;
+import megamek.common.scenario.ScenarioV1;
 
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
+
+import static megamek.client.ui.swing.util.FlatLafStyleBuilder.setFontScaling;
 
 /**
  * This panel displays a single {@link ScenarioV1} object in a well-formatted manner for display in the
@@ -48,7 +50,7 @@ public class ScenarioInfoPanel extends JPanel {
         lblTitle.setName("lblTitle");
         lblTitle.setAlignmentX(Component.CENTER_ALIGNMENT);
         lblTitle.setForeground(UIUtil.uiLightGreen());
-        new FlatLafStyleBuilder().font("Exo 2").bold().size(1.4).apply(lblTitle);
+        setFontScaling(lblTitle, "Exo 2", true, 1.4);
         add(lblTitle);
         add(Box.createVerticalStrut(10));
         add(new DashedSeparator(UIUtil.uiLightGreen(), 0.9f, 2f));

--- a/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
+++ b/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
@@ -18,6 +18,7 @@
  */
 package megamek.client.ui.swing.util;
 
+import megamek.MMConstants;
 import megamek.common.annotations.Nullable;
 
 import javax.swing.*;
@@ -110,34 +111,34 @@ public final class FlatLafStyleBuilder {
     }
 
     /**
-     * Sets the default font scaling for the given component using the default font ("MekHQ"), no
+     * Sets the default font scaling for the given component using the default dialog font, no
      * bold text, and a default size of 1.
      *
      * @param component The component for which the default font scaling needs to be set.
      */
     public static void setFontScaling(JComponent component) {
-        setFontScaling(component, "MekHQ", false, 1);
+        setFontScaling(component, MMConstants.FONT_DIALOG, false, 1);
     }
 
     /**
-     * Sets the font scaling for the given component using the default font ("MekHQ") and no bold text.
+     * Sets the font scaling for the given component using the default dialog font and no bold text.
      *
      * @param component The component for which the font scaling needs to be set.
      * @param size      The desired size of font scaling.
      */
     public static void setFontScaling(JComponent component, double size) {
-        setFontScaling(component, "MekHQ", false, size);
+        setFontScaling(component, MMConstants.FONT_DIALOG, false, size);
     }
 
     /**
-     * Sets the font scaling for the given component using the default font ("MekHQ").
+     * Sets the font scaling for the given component using the default dialog font.
      *
      * @param component The component for which the font scaling needs to be set.
      * @param boldText  boolean determining if the text should be displayed in bold.
      * @param size      The desired size of font scaling.
      */
     public static void setFontScaling(JComponent component, boolean boldText, double size) {
-        setFontScaling(component, "MekHQ", boldText, size);
+        setFontScaling(component, MMConstants.FONT_DIALOG, boldText, size);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
+++ b/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
@@ -110,7 +110,17 @@ public final class FlatLafStyleBuilder {
     }
 
     /**
-     * Sets the font scaling for the given component using the default font ("MekHQ") and standard text.
+     * Sets the default font scaling for the given component using the default font ("MekHQ"), no
+     * bold text, and a default size of 1.
+     *
+     * @param component The component for which the default font scaling needs to be set.
+     */
+    public static void setFontScaling(JComponent component) {
+        setFontScaling(component, "MekHQ", false, 1);
+    }
+
+    /**
+     * Sets the font scaling for the given component using the default font ("MekHQ") and no bold text.
      *
      * @param component The component for which the font scaling needs to be set.
      * @param size      The desired size of font scaling.

--- a/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
+++ b/megamek/src/megamek/client/ui/swing/util/FlatLafStyleBuilder.java
@@ -98,14 +98,51 @@ public final class FlatLafStyleBuilder {
     public void apply(JComponent component) {
         String styleText = "font:";
         if ((size != 1) && (size > 0)) {
-            styleText += " " + (int) (100 * size) + "%";
+            styleText += " " + (int) (100 * size) + '%';
         }
         if (bold) {
             styleText += " bold";
         }
         if ((fontName != null) && !fontName.isBlank()) {
-            styleText += " \"" + fontName + "\"";
+            styleText += " \"" + fontName + '"';
         }
         component.putClientProperty("FlatLaf.style", styleText);
+    }
+
+    /**
+     * Sets the font scaling for the given component using the default font ("MekHQ") and standard text.
+     *
+     * @param component The component for which the font scaling needs to be set.
+     * @param size      The desired size of font scaling.
+     */
+    public static void setFontScaling(JComponent component, double size) {
+        setFontScaling(component, "MekHQ", false, size);
+    }
+
+    /**
+     * Sets the font scaling for the given component using the default font ("MekHQ").
+     *
+     * @param component The component for which the font scaling needs to be set.
+     * @param boldText  boolean determining if the text should be displayed in bold.
+     * @param size      The desired size of font scaling.
+     */
+    public static void setFontScaling(JComponent component, boolean boldText, double size) {
+        setFontScaling(component, "MekHQ", boldText, size);
+    }
+
+    /**
+     * Sets the font scaling for the given component using the specified font.
+     *
+     * @param component The component for which the font scaling needs to be set.
+     * @param font      The name of the font.
+     * @param boldText  boolean determining if the text should be displayed in bold.
+     * @param size      the desired size of font scaling.
+     */
+    public static void setFontScaling(JComponent component, String font, boolean boldText, double size) {
+        if (boldText) {
+            new FlatLafStyleBuilder().font(font).bold().size(size).apply(component);
+        } else {
+            new FlatLafStyleBuilder().font(font).size(size).apply(component);
+        }
     }
 }


### PR DESCRIPTION
Implemented new static methods to allow setting font scaling for `JComponents`. These helper functions are designed to streamline usage of the `FlatLafStyleBuilder`.