### PR TITLE
#6013: Mine Clearance Missile fixes

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -13694,8 +13694,10 @@ public class AmmoType extends EquipmentType {
     }
 
     public static boolean canClearMinefield(AmmoType at) {
-        // first the normal munition types
         if (at != null) {
+            if (at.getMunitionType().contains(Munitions.M_MINE_CLEARANCE)) {
+                return true;
+            }
             // LRM-20's, RL-20's, and MRM 20, 30, and 40 can clear minefields
             if (((at.getAmmoType() == T_LRM) || (at.getAmmoType() == T_LRM_IMP)
                     || (at.getAmmoType() == T_LRM_STREAK)

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005 - Ben Mazur (bmazur@sev.org)
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -40,11 +40,14 @@ import megamek.common.weapons.MissileMineClearanceHandler;
 import megamek.common.weapons.missiles.MissileWeapon;
 import megamek.server.totalwarfare.TWGameManager;
 
+import java.io.Serial;
+
 /**
  * @author Sebastian Brocks
  */
 public abstract class LRMWeapon extends MissileWeapon {
 
+    @Serial
     private static final long serialVersionUID = 8755275511561446251L;
 
     public LRMWeapon() {
@@ -69,42 +72,8 @@ public abstract class LRMWeapon extends MissileWeapon {
     }
 
     @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, Game game, TWGameManager manager) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FRAGMENTATION)) {
-            return new LRMFragHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_ANTI_TSM)) {
-            return new LRMAntiTSMHandler(toHit, waa, game, manager);
-        }
-        if ((atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER))
-                || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_ACTIVE))
-                || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_AUGMENTED))
-                || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_INFERNO))
-                || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_VIBRABOMB))) {
-            return new LRMScatterableHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SWARM)) {
-            return new LRMSwarmHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SWARM_I)) {
-            return new LRMSwarmIHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
-            return new LRMDeadFireHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FOLLOW_THE_LEADER)) {
-            return new LRMFollowTheLeaderHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
-            return new LRMSmokeWarheadHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_MINE_CLEARANCE)) {
-            return new MissileMineClearanceHandler(toHit, waa, game, manager);
-        }
-        return new LRMHandler(toHit, waa, game, manager);
+    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, TWGameManager manager) {
+        return getLRMHandler(toHit, waa, game, manager);
     }
 
     @Override
@@ -142,5 +111,41 @@ public abstract class LRMWeapon extends MissileWeapon {
             }
             return "LRM " + oneShotTag + ((rackSize < 10) ? "0" + rackSize : rackSize);
         }
+    }
+
+    public static AttackHandler getLRMHandler(ToHitData toHit, WeaponAttackAction waa, Game game, TWGameManager manager) {
+        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId()).getEquipment(waa.getWeaponId()).getLinked().getType();
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FRAGMENTATION)) {
+            return new LRMFragHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_ANTI_TSM)) {
+            return new LRMAntiTSMHandler(toHit, waa, game, manager);
+        }
+        if ((atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER))
+            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_ACTIVE))
+            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_AUGMENTED))
+            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_INFERNO))
+            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_VIBRABOMB))) {
+            return new LRMScatterableHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SWARM)) {
+            return new LRMSwarmHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SWARM_I)) {
+            return new LRMSwarmIHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
+            return new LRMDeadFireHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FOLLOW_THE_LEADER)) {
+            return new LRMFollowTheLeaderHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
+            return new LRMSmokeWarheadHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_MINE_CLEARANCE)) {
+            return new MissileMineClearanceHandler(toHit, waa, game, manager);
+        }
+        return new LRMHandler(toHit, waa, game, manager);
     }
 }

--- a/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
@@ -1,15 +1,21 @@
 /*
- * MegaMek - Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2005 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
  */
 package megamek.common.weapons.missiles;
 
@@ -20,107 +26,34 @@ import megamek.common.actions.WeaponAttackAction;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.AttackHandler;
-import megamek.common.weapons.LRMAntiTSMHandler;
-import megamek.common.weapons.LRMDeadFireHandler;
-import megamek.common.weapons.LRMFollowTheLeaderHandler;
-import megamek.common.weapons.LRMFragHandler;
-import megamek.common.weapons.LRMHandler;
-import megamek.common.weapons.LRMScatterableHandler;
-import megamek.common.weapons.LRMSmokeWarheadHandler;
-import megamek.common.weapons.LRMSwarmHandler;
-import megamek.common.weapons.LRMSwarmIHandler;
-import megamek.common.weapons.SRMAXHandler;
-import megamek.common.weapons.SRMAntiTSMHandler;
-import megamek.common.weapons.SRMDeadFireHandler;
-import megamek.common.weapons.SRMFragHandler;
-import megamek.common.weapons.SRMHandler;
-import megamek.common.weapons.SRMInfernoHandler;
-import megamek.common.weapons.SRMSmokeWarheadHandler;
-import megamek.common.weapons.SRMTandemChargeHandler;
+import megamek.common.weapons.lrms.LRMWeapon;
+import megamek.common.weapons.srms.SRMWeapon;
 import megamek.server.totalwarfare.TWGameManager;
+
+import java.io.Serial;
 
 /**
  * @author Sebastian Brocks
  */
 public abstract class MMLWeapon extends MissileWeapon {
+    @Serial
     private static final long serialVersionUID = 110779423352325731L;
 
     public MMLWeapon() {
         super();
-        this.ammoType = AmmoType.T_MML;
-        this.atClass = CLASS_MML;
+        ammoType = AmmoType.T_MML;
+        atClass = CLASS_MML;
         flags = flags.or(F_ARTEMIS_COMPATIBLE);
     }
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * megamek.common.weapons.Weapon#getCorrectHandler(megamek.common.ToHitData,
-     * megamek.common.actions.WeaponAttackAction, megamek.common.Game,
-     * megamek.server.Server)
-     */
     @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit,
-            WeaponAttackAction waa, Game game, TWGameManager manager) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
+    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, TWGameManager manager) {
+        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId()).getEquipment(waa.getWeaponId()).getLinked().getType();
         if (atype.hasFlag(AmmoType.F_MML_LRM)) {
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_FRAGMENTATION)) {
-                return new LRMFragHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_ANTI_TSM)) {
-                return new LRMAntiTSMHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER)
-                    || atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_ACTIVE)
-                    || atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_AUGMENTED)
-                    || atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_INFERNO)
-                    || atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_VIBRABOMB)) {
-                return new LRMScatterableHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_SWARM)) {
-                return new LRMSwarmHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_SWARM_I)) {
-                return new LRMSwarmIHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
-                return new LRMDeadFireHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_FOLLOW_THE_LEADER)) {
-                return new LRMFollowTheLeaderHandler(toHit, waa, game, manager);
-            }
-            if (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
-                return new LRMSmokeWarheadHandler(toHit, waa, game, manager);
-            }
-
-            return new LRMHandler(toHit, waa, game, manager);
-
+            return LRMWeapon.getLRMHandler(toHit, waa, game, manager);
+        } else {
+            return SRMWeapon.getSRMHandler(toHit, waa, game, manager);
         }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FRAGMENTATION)) {
-            return new SRMFragHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_AX_HEAD)) {
-            return new SRMAXHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_ANTI_TSM)) {
-            return new SRMAntiTSMHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_INFERNO)) {
-            return new SRMInfernoHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
-            return new SRMDeadFireHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_TANDEM_CHARGE)) {
-            return new SRMTandemChargeHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
-            return new SRMSmokeWarheadHandler(toHit, waa, game, manager);
-        }
-
-        return new SRMHandler(toHit, waa, game, manager);
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005 - Ben Mazur (bmazur@sev.org)
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2024 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -38,10 +38,13 @@ import megamek.common.weapons.SRMTandemChargeHandler;
 import megamek.common.weapons.missiles.MissileWeapon;
 import megamek.server.totalwarfare.TWGameManager;
 
+import java.io.Serial;
+
 /**
  * @author Sebastian Brocks
  */
 public abstract class SRMWeapon extends MissileWeapon {
+    @Serial
     private static final long serialVersionUID = 3636219178276978444L;
 
     public SRMWeapon() {
@@ -61,36 +64,8 @@ public abstract class SRMWeapon extends MissileWeapon {
     }
 
     @Override
-    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game,
-            TWGameManager manager) {
-        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId())
-                .getEquipment(waa.getWeaponId()).getLinked().getType();
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FRAGMENTATION)) {
-            return new SRMFragHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_AX_HEAD)) {
-            return new SRMAXHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_ANTI_TSM)) {
-            return new SRMAntiTSMHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_INFERNO)) {
-            return new SRMInfernoHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
-            return new SRMDeadFireHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_TANDEM_CHARGE)) {
-            return new SRMTandemChargeHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
-            return new SRMSmokeWarheadHandler(toHit, waa, game, manager);
-        }
-        if (atype.getMunitionType().contains(AmmoType.Munitions.M_MINE_CLEARANCE)) {
-            return new MissileMineClearanceHandler(toHit, waa, game, manager);
-        }
-        return new SRMHandler(toHit, waa, game, manager);
-
+    protected AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, TWGameManager manager) {
+        return getSRMHandler(toHit, waa, game, manager);
     }
 
     @Override
@@ -119,5 +94,34 @@ public abstract class SRMWeapon extends MissileWeapon {
             }
             return "SRM " + oneShotTag + rackSize;
         }
+    }
+
+    public static AttackHandler getSRMHandler(ToHitData toHit, WeaponAttackAction waa, Game game, TWGameManager manager) {
+        AmmoType atype = (AmmoType) game.getEntity(waa.getEntityId()).getEquipment(waa.getWeaponId()).getLinked().getType();
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_FRAGMENTATION)) {
+            return new SRMFragHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_AX_HEAD)) {
+            return new SRMAXHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_ANTI_TSM)) {
+            return new SRMAntiTSMHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_INFERNO)) {
+            return new SRMInfernoHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE)) {
+            return new SRMDeadFireHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_TANDEM_CHARGE)) {
+            return new SRMTandemChargeHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
+            return new SRMSmokeWarheadHandler(toHit, waa, game, manager);
+        }
+        if (atype.getMunitionType().contains(AmmoType.Munitions.M_MINE_CLEARANCE)) {
+            return new MissileMineClearanceHandler(toHit, waa, game, manager);
+        }
+        return new SRMHandler(toHit, waa, game, manager);
     }
 }


### PR DESCRIPTION
Fixes #6013 
MC missiles now count as being able to clear mines. Also, MML MC missiles now use the correct handler to actually clear mines.
