### PR TITLE
Use elevation of source hex when checking for leaving prohibited terrain

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3806,7 +3806,7 @@ public class MoveStep implements Serializable {
                 // QuadVees can still convert to vehicle mode in prohibited terrain, but cannot
                 // leave
                 && (type != MoveStepType.CONVERT_MODE)
-                && entity.isLocationProhibited(src, getElevation()) && !isPavementStep()) {
+                && entity.isLocationProhibited(src, srcEl) && !isPavementStep()) {
             return false;
         }
         if (type == MoveStepType.UP) {


### PR DESCRIPTION
The MoveStep check that ensures an Entity leaving a prohibited hex only leaves by a road uses the coordinates of the source hex but the elevation of the destination hex. When a mek moves from deeper water into a depth 1 hex, Mek::isLocationProhibited treats it like a mek using UMU (since it is above the hex floor) breaking the surface of the water.

Fixes #6124