### PR TITLE
Add RISC Heat Sink Override Kit (Construction)

### DIFF
--- a/megamek/src/megamek/common/Mek.java
+++ b/megamek/src/megamek/common/Mek.java
@@ -194,6 +194,8 @@ public abstract class Mek extends Entity {
 
     public static final String FULL_HEAD_EJECT_STRING = "Full Head Ejection System";
 
+    public static final String RISC_HEAT_SINK_OVERRIDE_KIT = "RISC Heat Sink Override Kit";
+
     /**
      * Contains a mapping of locations which are blocked when carrying cargo in the
      * "key" location
@@ -296,6 +298,8 @@ public abstract class Mek extends Entity {
     private int levelsFallen = 0;
 
     private boolean fullHeadEject = false;
+
+    private boolean riscHeatSinkKit = false;
 
     protected static int[] EMERGENCY_COOLANT_SYSTEM_FAILURE = { 3, 5, 7, 10, 13, 13, 13 };
 
@@ -3149,6 +3153,16 @@ public abstract class Mek extends Entity {
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
 
+    public static TechAdvancement getRiscHeatSinkOverrideKitAdvancement() {
+        return new TechAdvancement(ITechnology.TECH_BASE_IS)
+            .setAdvancement(3134, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+            .setApproximate(false, false, false, false, false)
+            .setPrototypeFactions(F_RS)
+            .setTechRating(RATING_D)
+            .setAvailability(RATING_X, RATING_X, RATING_X, RATING_F)
+            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
     @Override
     protected void addSystemTechAdvancement(CompositeTechLevel ctl) {
         super.addSystemTechAdvancement(ctl);
@@ -3167,6 +3181,9 @@ public abstract class Mek extends Entity {
         }
         if (hasFullHeadEject()) {
             ctl.addComponent(getFullHeadEjectAdvancement());
+        }
+        if (hasRiscHeatSinkOverrideKit()) {
+            ctl.addComponent(getRiscHeatSinkOverrideKitAdvancement());
         }
         // FIXME: Clan interface cockpit has higher tech rating
         // if (getCockpitType() == COCKPIT_INTERFACE && isClan()) {
@@ -4387,6 +4404,11 @@ public abstract class Mek extends Entity {
         if (hasFullHeadEject()) {
             sb.append(MtfFile.EJECTION);
             sb.append(Mek.FULL_HEAD_EJECT_STRING);
+            sb.append(newLine);
+        }
+        if (hasRiscHeatSinkOverrideKit()) {
+            sb.append(MtfFile.HEAT_SINK_KIT);
+            sb.append(Mek.RISC_HEAT_SINK_OVERRIDE_KIT);
             sb.append(newLine);
         }
         sb.append(newLine);
@@ -5794,6 +5816,14 @@ public abstract class Mek extends Entity {
 
     public boolean hasFullHeadEject() {
         return fullHeadEject;
+    }
+
+    public void setRiscHeatSinkOverrideKit(boolean heatSinkKit) {
+        this.riscHeatSinkKit = heatSinkKit;
+    }
+
+    public boolean hasRiscHeatSinkOverrideKit() {
+        return riscHeatSinkKit;
     }
 
     public abstract boolean hasMPReducingHardenedArmor();

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -412,6 +412,7 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
     @Override
     protected void processSummarize() {
         double cockpitMod = 1;
+        double riscKitMod = 1;
         String modifier = "";
         if ((mek.getCockpitType() == Mek.COCKPIT_SMALL)
                 || (mek.getCockpitType() == Mek.COCKPIT_TORSO_MOUNTED)
@@ -425,17 +426,26 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
             cockpitMod = 1.3;
             modifier = " (" + mek.getCockpitTypeString() + ")";
         }
-        if (cockpitMod != 1) {
+
+        if (mek.hasRiscHeatSinkOverrideKit()) {
+            riscKitMod = 1.01;
+        }
+
+        if ((cockpitMod != 1) || (riscKitMod != 1)) {
             baseBV = defensiveValue + offensiveValue;
             bvReport.addEmptyLine();
             bvReport.addSubHeader("Battle Value:");
             bvReport.addLine("Defensive BR + Offensive BR:",
                     formatForReport(defensiveValue) + " + " + formatForReport(offensiveValue),
                     "= " + formatForReport(baseBV));
-            bvReport.addLine("Cockpit Modifier:",
-                    formatForReport(baseBV) + " x " + formatForReport(cockpitMod) + modifier,
-                    "= " + formatForReport(baseBV * cockpitMod));
-            baseBV *= cockpitMod;
+            if (cockpitMod != 1) {
+                bvReport.addLine("Cockpit Modifier:", formatForReport(baseBV) + " x " + formatForReport(cockpitMod) + modifier, "= " + formatForReport(baseBV * cockpitMod));
+                baseBV *= cockpitMod;
+            }
+            if (riscKitMod != 1) {
+                bvReport.addLine("RISC Heat Sink Override Kit: ", formatForReport(baseBV) + " x " + formatForReport(riscKitMod) + modifier, "= " + formatForReport(baseBV * riscKitMod));
+                baseBV *= riscKitMod;
+            }
             bvReport.addLine("--- Base Unit BV:", "" + (int) Math.round(baseBV));
         } else {
             super.processSummarize();

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -64,6 +64,7 @@ public class MtfFile implements IMekLoader {
     private String lamType;
     private String motiveType;
     private String ejectionType;
+    private String heatSinkKit;
 
     private String heatSinks;
     private String jumpMP;
@@ -110,6 +111,7 @@ public class MtfFile implements IMekLoader {
     public static final String GYRO = "gyro:";
     public static final String MOTIVE = "motive:";
     public static final String EJECTION = "ejection:";
+    public static final String HEAT_SINK_KIT = "heat sink kit:";
     public static final String MASS = "mass:";
     public static final String ENGINE = "engine:";
     public static final String STRUCTURE = "structure:";
@@ -201,6 +203,12 @@ public class MtfFile implements IMekLoader {
             } catch (Exception ignored) {
                 fullHead = false;
             }
+            boolean riscHeatSinkKit;
+            try {
+                riscHeatSinkKit = heatSinkKit.substring(HEAT_SINK_KIT.length()).equals(Mek.RISC_HEAT_SINK_OVERRIDE_KIT);
+            } catch (Exception ignored) {
+                riscHeatSinkKit = false;
+            }
             if (chassisConfig.contains("QuadVee")) {
                 int iMotiveType;
                 try {
@@ -231,6 +239,7 @@ public class MtfFile implements IMekLoader {
                 mek = new BipedMek(iGyroType, iCockpitType);
             }
             mek.setFullHeadEject(fullHead);
+            mek.setRiscHeatSinkOverrideKit(riscHeatSinkKit);
             mek.setChassis(chassis.trim());
             mek.setClanChassisName(clanChassisName);
             mek.setModel(model.trim());
@@ -1130,6 +1139,11 @@ public class MtfFile implements IMekLoader {
 
         if (lineLower.startsWith(EJECTION)) {
             ejectionType = line;
+            return true;
+        }
+
+        if (lineLower.startsWith(HEAT_SINK_KIT)) {
+            heatSinkKit = line;
             return true;
         }
 


### PR DESCRIPTION
Adds construction-only support for the RISC Heat Sink Override Kit.
Since the Kit doesn't have a location, the implementation is identical to the implementation for the Full-Head Ejection System.

In MM, supports save/load and BV calculation.