### PR TITLE
MM Scenarios: story dialogs

### DIFF
--- a/megamek/data/scenarios/Kell Hounds/LoweringTheBoom/LoweringTheBoom.mms
+++ b/megamek/data/scenarios/Kell Hounds/LoweringTheBoom/LoweringTheBoom.mms
@@ -255,12 +255,7 @@ messages:
       Be careful! Some of your Meks have already sustained damage.
     image: loweringboom_map.png
     trigger:
-      type: and
-      triggers:
-        - type: phasestart
-          phase: movement
-        - type: round
-          round: 1
+      type: gamestart
 
   - header: One Unit Safe
     text: Congratulations, one of your Meks has safely left the battlefield!

--- a/megamek/testresources/data/scenarios/test_setups/Messages.mms
+++ b/megamek/testresources/data/scenarios/test_setups/Messages.mms
@@ -21,11 +21,21 @@ end:
       round: 4
 
 messages:
-  - header: Scenario Messages
+  - header: Scenario Messages 1
     text: |
       In this test setup scenario, several messages are shown at various points of the game.
 
       This is supposed to be a test for the message system and the trigger system.
+    trigger:
+      type: gamestart
+
+  - header: Scenario Messages 2
+    text: Second test message
+    trigger:
+      type: gamestart
+
+  - header: Scenario Messages 3
+    text: Second test message
     trigger:
       type: gamestart
 


### PR DESCRIPTION
This makes story dialogs in MM scenarios (or wherever they come from) show one after the other instead of all at once. Also, when another modal dialog is up, a story dialog will be postponed until after the other dialog is closed. Only affects story dialogs.