### PR TITLE
feat: create unit list at the end of every encounter, not just the ones you have survivor units

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1839,6 +1839,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
     public boolean doYesNoDialog(String title, String question) {
         ConfirmDialog confirm = new ConfirmDialog(frame, title, question);
         confirm.setVisible(true);
+        confirm.setAlwaysOnTop(true);
         return confirm.getAnswer();
     }
 
@@ -2280,12 +2281,9 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
                 }
             }
 
-            // Allow players to save their living units to a file.
-            // Don't bother asking if none survived.
-            if (!living.isEmpty()
-                    && doYesNoDialog(Messages.getString("ClientGUI.SaveUnitsDialog.title"),
+            // Ask if you want to persist the final unit list from a battle encounter
+            if (doYesNoDialog(Messages.getString("ClientGUI.SaveUnitsDialog.title"),
                             Messages.getString("ClientGUI.SaveUnitsDialog.message"))) {
-                // Allow the player to save the units to a file.
                 saveVictoryList();
             }
 


### PR DESCRIPTION
at the end of encounters, if you are playing bot against bot it does not ask if you want to save the unit list, the same if you have no surviving units, this happens because it looks for the PLAYERS list of surviving units at the end of the fight, I removed this check because the trouble of clicking cancel is lower than the trouble of not having the file when you need.