### PR TITLE
Load BLKs with mekbays, not just mechbays

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1230,6 +1230,7 @@ public class BLKFile {
                                     new SmallCraftBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber(), hasARTS),
                                     isPod);
                             break;
+                        case "mekbay":
                         case "mechbay":
                             pbi = new ParsedBayInfo(numbers, usedBayNumbers);
                             e.addTransporter(new MekBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber()), isPod);


### PR DESCRIPTION
Fixes MegaMek/megameklab#1632.

The Mek refactor causes DropShips to save with MekBays, but BlkFiles can only be loaded with MechBays. This fixes that.