### PR TITLE
Fix loading of old resizable equipment

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
@@ -276,6 +276,9 @@ public class BLKAeroSpaceFighterFile extends BLKFile implements IMekLoader {
                             }
                         }
                         if (etype.isVariableSize()) {
+                            if (size == 0) {
+                                size = MtfFile.extractLegacySize(equipName);
+                            }
                             mount.setSize(size);
                         }
                         if (etype.hasFlag(MiscType.F_CARGO)) {

--- a/megamek/src/megamek/common/loaders/BLKBattleArmorFile.java
+++ b/megamek/src/megamek/common/loaders/BLKBattleArmorFile.java
@@ -238,6 +238,9 @@ public class BLKBattleArmorFile extends BLKFile implements IMekLoader {
                         }
                         m.setSquadSupportWeapon(sswMounted);
                         if (etype.isVariableSize()) {
+                            if (size == 0) {
+                                size = MtfFile.extractLegacySize(equipName);
+                            }
                             m.setSize(size);
                         }
                     } catch (LocationFullException ex) {

--- a/megamek/src/megamek/common/loaders/BLKConvFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKConvFighterFile.java
@@ -222,6 +222,9 @@ public class BLKConvFighterFile extends BLKFile implements IMekLoader {
                             }
                         }
                         if (etype.isVariableSize()) {
+                            if (size == 0) {
+                                size = MtfFile.extractLegacySize(equipName);
+                            }
                             mount.setSize(size);
                         }
                     } catch (LocationFullException ex) {

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -251,6 +251,10 @@ public class BLKFile {
                             }
                         }
                         if (etype.isVariableSize()) {
+                            if (size == 0) {
+                                size = MtfFile.extractLegacySize(equipName);
+                            }
+
                             mount.setSize(size);
                         } else if (t.isSupportVehicle() && (mount.getType() instanceof InfantryWeapon)
                                 && size > 1) {

--- a/megamek/src/megamek/common/loaders/BLKFixedWingSupportFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFixedWingSupportFile.java
@@ -224,6 +224,9 @@ public class BLKFixedWingSupportFile extends BLKFile implements IMekLoader {
                             }
                         }
                         if (etype.isVariableSize()) {
+                            if (size == 0) {
+                                size = MtfFile.extractLegacySize(equipName);
+                            }
                             mount.setSize(size);
                         } else if (t.isSupportVehicle() && (mount.getType() instanceof InfantryWeapon)
                                 && size > 1) {

--- a/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
@@ -249,6 +249,9 @@ public class BLKSmallCraftFile extends BLKFile implements IMekLoader {
                             }
                         }
                         if (etype.isVariableSize()) {
+                            if (size == 0) {
+                                size = MtfFile.extractLegacySize(equipName);
+                            }
                             mount.setSize(size);
                         }
                     } catch (LocationFullException ex) {

--- a/megamek/src/megamek/common/loaders/BLKWarshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKWarshipFile.java
@@ -384,6 +384,9 @@ public class BLKWarshipFile extends BLKFile implements IMekLoader {
                         }
                     }
                     if (etype.isVariableSize()) {
+                        if (size == 0) {
+                            size = MtfFile.extractLegacySize(equipName);
+                        }
                         newmount.setSize(size);
                     }
                 } else if (!equipName.isBlank()) {


### PR DESCRIPTION
Fixes #6179.

Fixes old mtf/blk files with cargo, liquid storage, communications equipment, ladders, mission equipment, or other resizable gear.

New unit files store resizable gear in a format like `Cargo:SIZE:5`. 

Old unit files store them in a format like `Cargo (5 tons)`, and this was never addressed when the switch to the new format was made.

This reintroduces support for unit files made in this older style, which includes _most_ of the unit files presently in MM's data.