### PR TITLE
Allow pausing a Princess-only game

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1972,6 +1972,10 @@ KeyBinds.cmdNames.undoSingleStep=Undo Single Step
 KeyBinds.cmdDesc.undoSingleStep=Undo single step in movement phase
 KeyBinds.cmdNames.extendTurnTimer=Activates Turn Timer Extension
 KeyBinds.cmdDesc.extendTurnTimer=When Turn Timer gets to 2 seconds left, reset timer.
+KeyBinds.cmdNames.pause=Pause the Game
+KeyBinds.cmdDesc.pause=Pauses the game. Works only when only Princess players with active units remain.
+KeyBinds.cmdNames.unpause=Unpause the Game
+KeyBinds.cmdDesc.unpause=Unpauses the game
 
 #Key Bindings Overlay
 KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -1,491 +1,504 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<KeyBindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="keyBindingSchema.xsd">
+<KeyBindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="keyBindingSchema.xsd">
     <KeyBind>
-        <command>scrollN</command> <!-- W -->
+         <command>scrollN</command> <!-- W -->
         <keyCode>87</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>scrollS</command> <!-- S -->
+         <command>scrollS</command> <!-- S -->
         <keyCode>83</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>scrollE</command> <!-- D -->
+         <command>scrollE</command> <!-- D -->
         <keyCode>68</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>scrollW</command> <!-- A -->
+         <command>scrollW</command> <!-- A -->
         <keyCode>65</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleChat</command> <!-- Enter -->
+         <command>toggleChat</command> <!-- Eingabe -->
         <keyCode>10</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleChatCmd</command> <!-- Slash -->
+         <command>toggleChatCmd</command> <!-- Schrägstrich -->
         <keyCode>47</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>turnLeft</command> <!-- Shift-A -->
+         <command>turnLeft</command> <!-- Umschalt-A -->
         <keyCode>65</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>turnRight</command> <!-- Shift-D -->
+         <command>turnRight</command> <!-- Umschalt-D -->
         <keyCode>68</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>twistLeft</command> <!-- Shift-A -->
+         <command>twistLeft</command> <!-- Umschalt-A -->
         <keyCode>65</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>twistRight</command> <!-- Shift-D -->
+         <command>twistRight</command> <!-- Umschalt-D -->
         <keyCode>68</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>fire</command> <!-- F -->
+         <command>fire</command> <!-- F -->
         <keyCode>70</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextWeapon</command> <!-- Down -->
-        <keyCode>40</keyCode>
+         <command>nextWeapon</command> <!-- Plus -->
+        <keyCode>521</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevWeapon</command> <!-- Up -->
-        <keyCode>38</keyCode>
+         <command>prevWeapon</command> <!-- Nummernzeichen -->
+        <keyCode>520</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextUnit</command> <!-- Tab -->
+         <command>nextUnit</command> <!-- Tabulator -->
         <keyCode>9</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevUnit</command> <!-- Shift-Tab -->
+         <command>prevUnit</command> <!-- Umschalt-Tabulator -->
         <keyCode>9</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextTarget</command> <!-- Right -->
+         <command>nextTarget</command> <!-- Rechts -->
         <keyCode>39</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevTarget</command> <!-- Left -->
+         <command>prevTarget</command> <!-- Links -->
         <keyCode>37</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextTargetValid</command> <!-- Shift-Right -->
+         <command>nextTargetValid</command> <!-- Umschalt-Rechts -->
         <keyCode>39</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevTargetValid</command> <!-- Shift-Left -->
+         <command>prevTargetValid</command> <!-- Umschalt-Links -->
         <keyCode>37</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextTargetNoAllies</command> <!-- Ctrl-Right -->
+         <command>nextTargetNoAllies</command> <!-- Strg-Rechts -->
         <keyCode>39</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevTargetNoAllies</command> <!-- Ctrl-Left -->
+         <command>prevTargetNoAllies</command> <!-- Strg-Links -->
         <keyCode>37</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextTargetValidNoAllies</command> <!-- Ctrl+Shift-Right -->
+         <command>nextTargetValidNoAllies</command> <!-- Strg+Umschalt-Rechts -->
         <keyCode>39</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevTargetValidNoAllies</command> <!-- Ctrl+Shift-Left -->
+         <command>prevTargetValidNoAllies</command> <!-- Strg+Umschalt-Links -->
         <keyCode>37</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>viewActingUnit</command> <!-- V -->
+         <command>viewActingUnit</command> <!-- V -->
         <keyCode>86</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>undoLastStep</command> <!-- Backspace -->
+         <command>undoLastStep</command> <!-- Rücktaste -->
         <keyCode>8</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>undo</command> <!-- Ctrl-Z -->
+         <command>undo</command> <!-- Strg-Z -->
         <keyCode>90</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>redo</command> <!-- Ctrl-Y -->
+         <command>redo</command> <!-- Strg-Y -->
         <keyCode>89</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>centerOnSelected</command> <!-- Space -->
+         <command>centerOnSelected</command> <!-- Leertaste -->
         <keyCode>32</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>autoArtyDeployZone</command> <!-- Shift-Z -->
+         <command>autoArtyDeployZone</command> <!-- Umschalt-Z -->
         <keyCode>90</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>cancel</command> <!-- Escape -->
+         <command>cancel</command> <!-- ESC -->
         <keyCode>27</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>done</command> <!-- Ctrl-Enter -->
+         <command>done</command> <!-- Strg-Eingabe -->
         <keyCode>10</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>doneNoAction</command> <!-- Ctrl+Shift-Enter -->
+         <command>doneNoAction</command> <!-- Strg+Umschalt-Eingabe -->
         <keyCode>10</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>udGeneral</command> <!-- F1 -->
+         <command>udGeneral</command> <!-- F1 -->
         <keyCode>112</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>udPilot</command> <!-- F2 -->
+         <command>udPilot</command> <!-- F2 -->
         <keyCode>113</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>udArmor</command> <!-- F3 -->
+         <command>udArmor</command> <!-- F3 -->
         <keyCode>114</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>udSystems</command> <!-- F4 -->
-        <keyCode>115</keyCode>
-        <modifier>0</modifier>
-        <isRepeatable>false</isRepeatable>
-    </KeyBind>
-
-    <KeyBind>
-        <command>udWeapons</command> <!-- F5 -->
+         <command>udWeapons</command> <!-- F5 -->
         <keyCode>116</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>udExtras</command> <!-- F6 -->
+         <command>udSystems</command> <!-- F4 -->
+        <keyCode>115</keyCode>
+        <modifier>0</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>udExtras</command> <!-- F6 -->
         <keyCode>117</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleJump</command> <!-- J -->
+         <command>toggleJump</command> <!-- J -->
         <keyCode>74</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleConversion</command> <!-- M -->
+         <command>toggleConversion</command> <!-- M -->
         <keyCode>77</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>prevMode</command> <!-- Down -->
+         <command>prevMode</command> <!-- Unten -->
         <keyCode>225</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>nextMode</command> <!-- Up -->
+         <command>nextMode</command> <!-- Oben -->
         <keyCode>224</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleIso</command> <!-- T -->
+         <command>pause</command> <!-- Strg+Umschalt-P -->
+        <keyCode>80</keyCode>
+        <modifier>192</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>unpause</command> <!-- Strg+Alt-P -->
+        <keyCode>80</keyCode>
+        <modifier>640</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+         <command>toggleIso</command> <!-- T -->
         <keyCode>84</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>movementEnvelope</command> <!-- Ctrl-Q -->
+         <command>movementEnvelope</command> <!-- Strg-Q -->
         <keyCode>81</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>fieldOfFire</command> <!-- R -->
+         <command>fieldOfFire</command> <!-- R -->
         <keyCode>82</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleDrawLabels</command> <!-- Ctrl-B -->
+         <command>toggleDrawLabels</command> <!-- Strg-B -->
         <keyCode>66</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleHexCoords</command> <!-- Ctrl-G -->
+         <command>toggleHexCoords</command> <!-- Strg-G -->
         <keyCode>71</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleMinimap</command> <!-- Ctrl-M -->
+         <command>toggleMinimap</command> <!-- Strg-M -->
         <keyCode>77</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>viewLosSetting</command> <!-- Ctrl+Alt-L -->
+         <command>viewLosSetting</command> <!-- Strg+Alt-L -->
         <keyCode>76</keyCode>
         <modifier>640</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleUnitDisplay</command> <!-- Ctrl-D -->
+         <command>toggleUnitDisplay</command> <!-- Strg-D -->
         <keyCode>68</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleUnitOverview</command> <!-- Ctrl-U -->
+         <command>toggleUnitOverview</command> <!-- Strg-U -->
         <keyCode>85</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleKeybinds</command> <!-- Ctrl-K -->
+         <command>toggleKeybinds</command> <!-- Strg-K -->
         <keyCode>75</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>togglePlanetaryConditions</command> <!-- Ctrl-P -->
+         <command>togglePlanetaryConditions</command> <!-- Strg-P -->
         <keyCode>80</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleTurnDetails</command> <!-- Ctrl-T -->
+         <command>toggleTurnDetails</command> <!-- Strg-T -->
         <keyCode>84</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>clientSettings</command> <!-- Alt-C -->
+         <command>clientSettings</command> <!-- Alt-C -->
         <keyCode>67</keyCode>
         <modifier>512</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>incGuiScale</command> <!-- Ctrl-NumPad + -->
+         <command>incGuiScale</command> <!-- Strg-NumPad + -->
         <keyCode>107</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>decGuiScale</command> <!-- Ctrl-NumPad - -->
+         <command>decGuiScale</command> <!-- Strg-NumPad - -->
         <keyCode>109</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>roundReport</command> <!-- Ctrl-R -->
+         <command>roundReport</command> <!-- Strg-R -->
         <keyCode>82</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>zoomIn</command> <!-- NumPad + -->
+         <command>zoomIn</command> <!-- NumPad + -->
         <keyCode>107</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>zoomOut</command> <!-- NumPad - -->
+         <command>zoomOut</command> <!-- NumPad - -->
         <keyCode>109</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>quickLoad</command> <!-- Ctrl+Shift-L -->
+         <command>quickLoad</command> <!-- Strg+Umschalt-L -->
         <keyCode>76</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>quickSave</command> <!-- Ctrl+Shift-S -->
+         <command>quickSave</command> <!-- Strg+Umschalt-S -->
         <keyCode>83</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>localLoad</command> <!-- Ctrl-L -->
+         <command>localLoad</command> <!-- Strg-L -->
         <keyCode>76</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>localSave</command> <!-- Ctrl-S -->
+         <command>localSave</command> <!-- Strg-S -->
         <keyCode>83</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>replacePlayer</command> <!-- Ctrl+Shift-R -->
+         <command>replacePlayer</command> <!-- Strg+Umschalt-R -->
         <keyCode>82</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>viewModEnvelope</command> <!-- Ctrl-W -->
+         <command>viewModEnvelope</command> <!-- Strg-W -->
         <keyCode>87</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>sensorRange</command> <!-- C -->
+         <command>sensorRange</command> <!-- C -->
         <keyCode>67</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>undoSingleStep</command> <!-- Ctrl-Backspace -->
+         <command>undoSingleStep</command> <!-- Strg-Rücktaste -->
         <keyCode>8</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>toggleForceDisplay</command> <!-- Ctrl-F -->
+         <command>toggleForceDisplay</command> <!-- Strg-F -->
         <keyCode>70</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-        <command>extendTurnTimer</command> <!-- Ctrl-F4 -->
+         <command>extendTurnTimer</command> <!-- Strg-F4 -->
         <keyCode>115</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -1,504 +1,505 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<KeyBindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="keyBindingSchema.xsd">
+<KeyBindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:noNamespaceSchemaLocation="keyBindingSchema.xsd">
     <KeyBind>
-         <command>scrollN</command> <!-- W -->
+        <command>scrollN</command> <!-- W -->
         <keyCode>87</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>scrollS</command> <!-- S -->
+        <command>scrollS</command> <!-- S -->
         <keyCode>83</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>scrollE</command> <!-- D -->
+        <command>scrollE</command> <!-- D -->
         <keyCode>68</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>scrollW</command> <!-- A -->
+        <command>scrollW</command> <!-- A -->
         <keyCode>65</keyCode>
         <modifier>0</modifier>
         <isRepeatable>true</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleChat</command> <!-- Eingabe -->
+        <command>toggleChat</command> <!-- Enter -->
         <keyCode>10</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleChatCmd</command> <!-- Schrägstrich -->
+        <command>toggleChatCmd</command> <!-- Slash -->
         <keyCode>47</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>turnLeft</command> <!-- Umschalt-A -->
+        <command>turnLeft</command> <!-- Shift-A -->
         <keyCode>65</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>turnRight</command> <!-- Umschalt-D -->
+        <command>turnRight</command> <!-- Shift-D -->
         <keyCode>68</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>twistLeft</command> <!-- Umschalt-A -->
+        <command>twistLeft</command> <!-- Shift-A -->
         <keyCode>65</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>twistRight</command> <!-- Umschalt-D -->
+        <command>twistRight</command> <!-- Shift-D -->
         <keyCode>68</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>fire</command> <!-- F -->
+        <command>fire</command> <!-- F -->
         <keyCode>70</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextWeapon</command> <!-- Plus -->
-        <keyCode>521</keyCode>
+        <command>pause</command> <!-- Ctrl+Shift-P -->
+        <keyCode>80</keyCode>
+        <modifier>192</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+        <command>unpause</command> <!-- Ctrl+Alt-P -->
+        <keyCode>80</keyCode>
+        <modifier>640</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+        <command>nextWeapon</command> <!-- Down -->
+        <keyCode>40</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevWeapon</command> <!-- Nummernzeichen -->
-        <keyCode>520</keyCode>
+        <command>prevWeapon</command> <!-- Up -->
+        <keyCode>38</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextUnit</command> <!-- Tabulator -->
+        <command>nextUnit</command> <!-- Tab -->
         <keyCode>9</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevUnit</command> <!-- Umschalt-Tabulator -->
+        <command>prevUnit</command> <!-- Shift-Tab -->
         <keyCode>9</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTarget</command> <!-- Rechts -->
+        <command>nextTarget</command> <!-- Right -->
         <keyCode>39</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTarget</command> <!-- Links -->
+        <command>prevTarget</command> <!-- Left -->
         <keyCode>37</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTargetValid</command> <!-- Umschalt-Rechts -->
+        <command>nextTargetValid</command> <!-- Shift-Right -->
         <keyCode>39</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTargetValid</command> <!-- Umschalt-Links -->
+        <command>prevTargetValid</command> <!-- Shift-Left -->
         <keyCode>37</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTargetNoAllies</command> <!-- Strg-Rechts -->
+        <command>nextTargetNoAllies</command> <!-- Ctrl-Right -->
         <keyCode>39</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTargetNoAllies</command> <!-- Strg-Links -->
+        <command>prevTargetNoAllies</command> <!-- Ctrl-Left -->
         <keyCode>37</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextTargetValidNoAllies</command> <!-- Strg+Umschalt-Rechts -->
+        <command>nextTargetValidNoAllies</command> <!-- Ctrl+Shift-Right -->
         <keyCode>39</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevTargetValidNoAllies</command> <!-- Strg+Umschalt-Links -->
+        <command>prevTargetValidNoAllies</command> <!-- Ctrl+Shift-Left -->
         <keyCode>37</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>viewActingUnit</command> <!-- V -->
+        <command>viewActingUnit</command> <!-- V -->
         <keyCode>86</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>undoLastStep</command> <!-- Rücktaste -->
+        <command>undoLastStep</command> <!-- Backspace -->
         <keyCode>8</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>undo</command> <!-- Strg-Z -->
+        <command>undo</command> <!-- Ctrl-Z -->
         <keyCode>90</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>redo</command> <!-- Strg-Y -->
+        <command>redo</command> <!-- Ctrl-Y -->
         <keyCode>89</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>centerOnSelected</command> <!-- Leertaste -->
+        <command>centerOnSelected</command> <!-- Space -->
         <keyCode>32</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>autoArtyDeployZone</command> <!-- Umschalt-Z -->
+        <command>autoArtyDeployZone</command> <!-- Shift-Z -->
         <keyCode>90</keyCode>
         <modifier>64</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>cancel</command> <!-- ESC -->
+        <command>cancel</command> <!-- Escape -->
         <keyCode>27</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>done</command> <!-- Strg-Eingabe -->
+        <command>done</command> <!-- Ctrl-Enter -->
         <keyCode>10</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>doneNoAction</command> <!-- Strg+Umschalt-Eingabe -->
+        <command>doneNoAction</command> <!-- Ctrl+Shift-Enter -->
         <keyCode>10</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udGeneral</command> <!-- F1 -->
+        <command>udGeneral</command> <!-- F1 -->
         <keyCode>112</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udPilot</command> <!-- F2 -->
+        <command>udPilot</command> <!-- F2 -->
         <keyCode>113</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udArmor</command> <!-- F3 -->
+        <command>udArmor</command> <!-- F3 -->
         <keyCode>114</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udWeapons</command> <!-- F5 -->
-        <keyCode>116</keyCode>
-        <modifier>0</modifier>
-        <isRepeatable>false</isRepeatable>
-    </KeyBind>
-
-    <KeyBind>
-         <command>udSystems</command> <!-- F4 -->
+        <command>udSystems</command> <!-- F4 -->
         <keyCode>115</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>udExtras</command> <!-- F6 -->
+        <command>udWeapons</command> <!-- F5 -->
+        <keyCode>116</keyCode>
+        <modifier>0</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
+    <KeyBind>
+        <command>udExtras</command> <!-- F6 -->
         <keyCode>117</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleJump</command> <!-- J -->
+        <command>toggleJump</command> <!-- J -->
         <keyCode>74</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleConversion</command> <!-- M -->
+        <command>toggleConversion</command> <!-- M -->
         <keyCode>77</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>prevMode</command> <!-- Unten -->
+        <command>prevMode</command> <!-- Down -->
         <keyCode>225</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>nextMode</command> <!-- Oben -->
+        <command>nextMode</command> <!-- Up -->
         <keyCode>224</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>pause</command> <!-- Strg+Umschalt-P -->
-        <keyCode>80</keyCode>
-        <modifier>192</modifier>
-        <isRepeatable>false</isRepeatable>
-    </KeyBind>
-
-    <KeyBind>
-         <command>unpause</command> <!-- Strg+Alt-P -->
-        <keyCode>80</keyCode>
-        <modifier>640</modifier>
-        <isRepeatable>false</isRepeatable>
-    </KeyBind>
-
-    <KeyBind>
-         <command>toggleIso</command> <!-- T -->
+        <command>toggleIso</command> <!-- T -->
         <keyCode>84</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>movementEnvelope</command> <!-- Strg-Q -->
+        <command>movementEnvelope</command> <!-- Ctrl-Q -->
         <keyCode>81</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>fieldOfFire</command> <!-- R -->
+        <command>fieldOfFire</command> <!-- R -->
         <keyCode>82</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleDrawLabels</command> <!-- Strg-B -->
+        <command>toggleDrawLabels</command> <!-- Ctrl-B -->
         <keyCode>66</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleHexCoords</command> <!-- Strg-G -->
+        <command>toggleHexCoords</command> <!-- Ctrl-G -->
         <keyCode>71</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleMinimap</command> <!-- Strg-M -->
+        <command>toggleMinimap</command> <!-- Ctrl-M -->
         <keyCode>77</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>viewLosSetting</command> <!-- Strg+Alt-L -->
+        <command>viewLosSetting</command> <!-- Ctrl+Alt-L -->
         <keyCode>76</keyCode>
         <modifier>640</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleUnitDisplay</command> <!-- Strg-D -->
+        <command>toggleUnitDisplay</command> <!-- Ctrl-D -->
         <keyCode>68</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleUnitOverview</command> <!-- Strg-U -->
+        <command>toggleUnitOverview</command> <!-- Ctrl-U -->
         <keyCode>85</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleKeybinds</command> <!-- Strg-K -->
+        <command>toggleKeybinds</command> <!-- Ctrl-K -->
         <keyCode>75</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>togglePlanetaryConditions</command> <!-- Strg-P -->
+        <command>togglePlanetaryConditions</command> <!-- Ctrl-P -->
         <keyCode>80</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleTurnDetails</command> <!-- Strg-T -->
+        <command>toggleTurnDetails</command> <!-- Ctrl-T -->
         <keyCode>84</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>clientSettings</command> <!-- Alt-C -->
+        <command>clientSettings</command> <!-- Alt-C -->
         <keyCode>67</keyCode>
         <modifier>512</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>incGuiScale</command> <!-- Strg-NumPad + -->
+        <command>incGuiScale</command> <!-- Ctrl-NumPad + -->
         <keyCode>107</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>decGuiScale</command> <!-- Strg-NumPad - -->
+        <command>decGuiScale</command> <!-- Ctrl-NumPad - -->
         <keyCode>109</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>roundReport</command> <!-- Strg-R -->
+        <command>roundReport</command> <!-- Ctrl-R -->
         <keyCode>82</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>zoomIn</command> <!-- NumPad + -->
+        <command>zoomIn</command> <!-- NumPad + -->
         <keyCode>107</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>zoomOut</command> <!-- NumPad - -->
+        <command>zoomOut</command> <!-- NumPad - -->
         <keyCode>109</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>quickLoad</command> <!-- Strg+Umschalt-L -->
+        <command>quickLoad</command> <!-- Ctrl+Shift-L -->
         <keyCode>76</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>quickSave</command> <!-- Strg+Umschalt-S -->
+        <command>quickSave</command> <!-- Ctrl+Shift-S -->
         <keyCode>83</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>localLoad</command> <!-- Strg-L -->
+        <command>localLoad</command> <!-- Ctrl-L -->
         <keyCode>76</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>localSave</command> <!-- Strg-S -->
+        <command>localSave</command> <!-- Ctrl-S -->
         <keyCode>83</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>replacePlayer</command> <!-- Strg+Umschalt-R -->
+        <command>replacePlayer</command> <!-- Ctrl+Shift-R -->
         <keyCode>82</keyCode>
         <modifier>192</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>viewModEnvelope</command> <!-- Strg-W -->
+        <command>viewModEnvelope</command> <!-- Ctrl-W -->
         <keyCode>87</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>sensorRange</command> <!-- C -->
+        <command>sensorRange</command> <!-- C -->
         <keyCode>67</keyCode>
         <modifier>0</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>undoSingleStep</command> <!-- Strg-Rücktaste -->
+        <command>undoSingleStep</command> <!-- Ctrl-Backspace -->
         <keyCode>8</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>toggleForceDisplay</command> <!-- Strg-F -->
+        <command>toggleForceDisplay</command> <!-- Ctrl-F -->
         <keyCode>70</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
     <KeyBind>
-         <command>extendTurnTimer</command> <!-- Strg-F4 -->
+        <command>extendTurnTimer</command> <!-- Ctrl-F4 -->
         <keyCode>115</keyCode>
         <modifier>128</modifier>
         <isRepeatable>false</isRepeatable>

--- a/megamek/src/megamek/client/AbstractClient.java
+++ b/megamek/src/megamek/client/AbstractClient.java
@@ -235,6 +235,16 @@ public abstract class AbstractClient implements IClient {
         flushConn();
     }
 
+    public void sendPause() {
+        send(new Packet(PacketCommand.PAUSE));
+        flushConn();
+    }
+
+    public void sendUnpause() {
+        send(new Packet(PacketCommand.UNPAUSE));
+        flushConn();
+    }
+
     /**
      * Receives player information from the message packet.
      *

--- a/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/StatusBarPhaseDisplay.java
@@ -173,6 +173,7 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         if (liveUnitsRemaining) {
             clientgui.getClient().sendChat("Pausing the game only works when only bot units remain.");
         } else {
+            clientgui.getClient().sendChat("Requesting game pause.");
             ((AbstractClient) clientgui.getClient()).sendPause();
         }
     }

--- a/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
+++ b/megamek/src/megamek/client/ui/swing/util/KeyCommandBind.java
@@ -90,6 +90,8 @@ public enum KeyCommandBind {
     TOGGLE_CONVERSIONMODE("toggleConversion", VK_M),
     PREV_MODE("prevMode", VK_KP_DOWN),
     NEXT_MODE("nextMode", VK_KP_UP),
+    PAUSE("pause", VK_P, CTRL_DOWN_MASK | SHIFT_DOWN_MASK),
+    UNPAUSE("unpause", VK_P, CTRL_DOWN_MASK | ALT_DOWN_MASK),
 
     // --------- The following binds are used by the CommonMenuBar:
     // Toggles isometric view on/off

--- a/megamek/src/megamek/common/net/enums/PacketCommand.java
+++ b/megamek/src/megamek/common/net/enums/PacketCommand.java
@@ -44,6 +44,10 @@ public enum PacketCommand {
     /** A packet setting a Client's ready status (S -> C) or updating the Server on the Client's status (C -> S). */
     PLAYER_READY,
 
+    /** A packet telling the server to pause / unpause packet handling (to interrupt a Princess-only game) */
+    PAUSE,
+    UNPAUSE,
+
     CHAT,
     ENTITY_ADD,
     ENTITY_REMOVE,


### PR DESCRIPTION
Allows pausing the game by using Ctrl-Shift-P and unpausing with Ctrl-Alt-P.
- Both are normal keybinds that can be changed. 
- It only works if only bot units remain. This limitation is artificial and can be removed but that would have little use I guess. 
- This influences server packet handling so it is potentially dangerous; but as long as it isn't used I don't expect any errors from it
- The effect is purely server-side, meaning that Princess will always finish whatever she is doing which may take a while; but if things move fast, the pause happens immediately
- chat messages and log messages show pause/unpause happening
