### PR TITLE
Added missing comma to 3075.xml

### DIFF
--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -5498,7 +5498,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
-			<availability>CC:1,FS:7,MERC:4,CDP:2,Periphery:2,FVC:7LA:2,DC:1</availability>
+			<availability>CC:1,FS:7,MERC:4,CDP:2,Periphery:2,FVC:7,LA:2,DC:1</availability>
 			<model name='ENF-4R'>
 				<availability>FVC:4-,General:2-,FS:4-,TC:4-</availability>
 			</model>


### PR DESCRIPTION
See [MHQ issue #5198](https://github.com/MegaMek/mekhq/issues/5198). Note that the file is fine under MM, but missing the comma under MHQ. I do not understand why, but this should fix it.