### PR TITLE
Implement RISC laser pulse module

### DIFF
--- a/megamek/i18n/megamek/common/equipmentmessages.properties
+++ b/megamek/i18n/megamek/common/equipmentmessages.properties
@@ -16,6 +16,7 @@ EquipmentMode.Off=Off
 EquipmentMode.Armed=Armed
 EquipmentMode.Normal=Normal
 EquipmentMode.Aimed\ shot=Aimed shot
+EquipmentMode.Pulse=Pulse
 
 EquipmentMode.Bracket\ 80%=Bracket 80%
 EquipmentMode.Bracket\ 60%=Bracket 60%

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -902,8 +902,8 @@ public class FireControl {
         toHit.append(getDamageWeaponMods(shooter, weapon));
 
         // weapon mods
-        if (0 != weaponType.getToHitModifier()) {
-            toHit.addModifier(weaponType.getToHitModifier(), TH_WEAPON_MOD);
+        if (0 != weaponType.getToHitModifier(weapon)) {
+            toHit.addModifier(weaponType.getToHitModifier(weapon), TH_WEAPON_MOD);
         }
 
         // Target size.
@@ -3475,7 +3475,7 @@ public class FireControl {
                 if (!(weaponType instanceof MMLWeapon)) {
                     // Naively assume that easier-hitting is better
                     if (returnAmmo != null) {
-                        AmmoType returnAmmoType = (AmmoType) (returnAmmo.getType());
+                        AmmoType returnAmmoType = returnAmmo.getType();
                         returnAmmo = ((ammoType.getToHitModifier() > returnAmmoType.getToHitModifier()) ? ammo
                                 : returnAmmo);
                     } else {

--- a/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/swing/EquipChoicePanel.java
@@ -1139,7 +1139,7 @@ public class EquipChoicePanel extends JPanel {
                 if (chHotLoad.isSelected() != m_mounted.isHotLoaded()) {
                     m_mounted.setHotLoad(chHotLoad.isSelected());
                     // Set the mode too, so vehicles can switch back
-                    int numModes = m_mounted.getType().getModesCount();
+                    int numModes = m_mounted.getModesCount();
                     for (int m = 0; m < numModes; m++) {
                         if (m_mounted.getType().getMode(m).getName()
                                 .equals("HotLoad")) {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -225,13 +225,18 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         @Override
         public String getElementAt(int index) {
             final WeaponMounted mounted = weapons.get(index);
-            final WeaponType wtype = (WeaponType) mounted.getType();
+            final WeaponType wtype = mounted.getType();
             Game game = null;
             if (unitDisplay.getClientGUI() != null) {
                 game = unitDisplay.getClientGUI().getClient().getGame();
             }
 
             StringBuilder wn = new StringBuilder(mounted.getDesc());
+            if ((mounted.getLinkedBy() != null)
+                    && (mounted.getLinkedBy().getType() instanceof MiscType)
+                    && (mounted.getLinkedBy().getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE))) {
+                wn.append("+").append(mounted.getLinkedBy().getShortName());
+            }
             wn.append(" [");
             wn.append(en.getLocationAbbr(mounted.getLocation()));
             //Check if mixedTech and add Clan or IS tag

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -484,6 +484,10 @@ public class AmmoType extends EquipmentType {
         return ammoType;
     }
 
+    public int getToHitModifier() {
+        return toHitModifier;
+    }
+
     /**
      * Analog to WeaponType.getFireTNRoll(), but based on munitions.
      * See TO:AR pg 42

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7248,6 +7248,7 @@ public class Compute {
             case TARGETING_COMPUTER:
                 if (!wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
                         || wtype.hasFlag(WeaponType.F_PULSE)
+                        || weapon.curMode().getName().equals("Pulse")
                         || (wtype instanceof HAGWeapon)) {
                     return false;
                 }

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -556,6 +556,15 @@ public class EquipmentType implements ITechnology {
     }
 
     /**
+     * @param mounted The equipment mount. In some cases the moudes are affected by linked equipment.
+     * @return the number of modes that this type of equipment can be in or
+     *         <code>0</code> if it doesn't have modes.
+     */
+    public int getModesCount(Mounted<?> mounted) {
+        return getModesCount();
+    }
+
+    /**
      * @return the number of modes that this type of equipment can be in or
      *         <code>0</code> if it doesn't have modes.
      */

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -502,7 +502,7 @@ public class EquipmentType implements ITechnology {
         return spreadable;
     }
 
-    public int getToHitModifier() {
+    public int getToHitModifier(@Nullable Mounted<?> mounted) {
         return toHitModifier;
     }
 

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -17,6 +17,8 @@ package megamek.common;
 import java.math.BigInteger;
 import java.text.NumberFormat;
 
+import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.miscGear.AntiMekGear;
 import megamek.common.weapons.ppc.CLERPPC;
 import megamek.common.weapons.ppc.ISERPPC;
@@ -962,10 +964,9 @@ public class MiscType extends EquipmentType {
                     }
                 }
 
-                for (Mounted<?> mo : entity.getMisc()) {
-                    MiscType mt = (MiscType) mo.getType();
-                    if (mt.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                        fTons += mo.getTonnage();
+                for (MiscMounted mounted : entity.getMisc()) {
+                    if (mounted.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
+                        fTons += mounted.getTonnage();
                     }
                 }
                 if (getInternalName().equals("ISTargeting Computer")) {
@@ -1110,17 +1111,15 @@ public class MiscType extends EquipmentType {
         } else if (hasFlag(F_TARGCOMP)) {
             // based on tonnage of direct_fire weaponry
             double fTons = 0.0;
-            for (Mounted<?> m : entity.getWeaponList()) {
-                WeaponType wt = (WeaponType) m.getType();
-                if (wt.hasFlag(WeaponType.F_DIRECT_FIRE)) {
+            for (WeaponMounted m : entity.getWeaponList()) {
+                if (m.getType().hasFlag(WeaponType.F_DIRECT_FIRE)) {
                     fTons += m.getTonnage();
                 }
             }
 
-            for (Mounted<?> mo : entity.getMisc()) {
-                MiscType mt = (MiscType) mo.getType();
-                if (mt.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                    fTons += mo.getTonnage();
+            for (MiscMounted mounted : entity.getMisc()) {
+                if (mounted.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
+                    fTons += mounted.getTonnage();
                 }
             }
             if (TechConstants.isClan(getTechLevel(entity.getTechLevelYear()))) {

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -229,7 +229,7 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
     }
 
     public int getModesCount() {
-        return getType().getModesCount();
+        return getType().getModesCount(this);
     }
 
     protected EquipmentMode getMode(int mode) {

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -805,8 +805,8 @@ public class WeaponType extends EquipmentType {
                 damage = adjustBattleForceDamageForMinRange(damage);
             }
 
-            if (getToHitModifier() != 0) {
-                damage -= damage * getToHitModifier() * 0.05;
+            if (getToHitModifier(null) != 0) {
+                damage -= damage * getToHitModifier(null) * 0.05;
             }
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3193,8 +3193,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Flat to hit modifiers defined in WeaponType
-        if (wtype.getToHitModifier() != 0) {
-            int modifier = wtype.getToHitModifier();
+        if (wtype.getToHitModifier(weapon) != 0) {
+            int modifier = wtype.getToHitModifier(weapon);
             if (wtype instanceof VariableSpeedPulseLaserWeapon) {
                 int nRange = ae.getPosition().distance(target.getPosition());
                 int[] nRanges = wtype.getRanges(weapon, ammo);
@@ -5243,8 +5243,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
             toHit.addModifier(ae.getHeatFiringModifier(), Messages.getString("WeaponAttackAction.Heat"));
         }
         // weapon to-hit modifier
-        if (wtype.getToHitModifier() != 0) {
-            toHit.addModifier(wtype.getToHitModifier(), Messages.getString("WeaponAttackAction.WeaponMod"));
+        if (wtype.getToHitModifier(weapon) != 0) {
+            toHit.addModifier(wtype.getToHitModifier(weapon), Messages.getString("WeaponAttackAction.WeaponMod"));
         }
         // ammo to-hit modifier
         if (usesAmmo && (atype.getToHitModifier() != 0)) {

--- a/megamek/src/megamek/common/equipment/WeaponMounted.java
+++ b/megamek/src/megamek/common/equipment/WeaponMounted.java
@@ -131,6 +131,9 @@ public class WeaponMounted extends Mounted<WeaponType> {
                 heat++;
             }
         }
+        if (curMode().equals("Pulse")) {
+            heat += 2;
+        }
 
         return heat;
     }

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -32,6 +32,7 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.MPBoosters;
 import megamek.common.equipment.ArmorType;
+import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.battlearmor.BAFlamerWeapon;
@@ -788,16 +789,14 @@ public abstract class TestEntity implements TestEntityOption {
             }
         } else if (mt.hasFlag(MiscType.F_TARGCOMP)) {
             double fTons = 0.0f;
-            for (Mounted<?> mo : getEntity().getWeaponList()) {
-                WeaponType wt = (WeaponType) mo.getType();
-                if (wt.hasFlag(WeaponType.F_DIRECT_FIRE)) {
-                    fTons += mo.getTonnage();
+            for (WeaponMounted mounted : getEntity().getWeaponList()) {
+                if (mounted.getType().hasFlag(WeaponType.F_DIRECT_FIRE)) {
+                    fTons += mounted.getTonnage();
                 }
             }
-            for (Mounted<?> mo : getEntity().getMisc()) {
-                MiscType mt2 = (MiscType) mo.getType();
-                if (mt2.hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-                    fTons += mo.getTonnage();
+            for (MiscMounted mounted : getEntity().getMisc()) {
+               if (mounted.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
+                    fTons += mounted.getTonnage();
                 }
             }
             double weight = 0.0f;

--- a/megamek/src/megamek/common/weapons/PulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/PulseLaserWeaponHandler.java
@@ -19,21 +19,33 @@
  */
 package megamek.common.weapons;
 
-import megamek.common.BattleArmor;
-import megamek.common.Compute;
-import megamek.common.Game;
-import megamek.common.Infantry;
-import megamek.common.RangeType;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 import megamek.server.totalwarfare.TWGameManager;
+
+import java.util.Vector;
 
 public class PulseLaserWeaponHandler extends EnergyWeaponHandler {
     private static final long serialVersionUID = -5701939682138221449L;
 
     public PulseLaserWeaponHandler(ToHitData toHit, WeaponAttackAction waa, Game g, TWGameManager m) {
         super(toHit, waa, g, m);
+    }
+
+    @Override
+    protected boolean doChecks(Vector<Report> vPhaseReport) {
+        if (super.doChecks(vPhaseReport)) {
+            return true;
+        }
+
+        WeaponMounted laser = waa.getEntity(game).getWeapon(waa.getWeaponId());
+
+        if ((roll.getIntValue() == 2) && laser.curMode().equals("Pulse")) {
+            vPhaseReport.addAll(gameManager.explodeEquipment(laser.getEntity(), laser.getLocation(), laser.getLinkedBy()));
+        }
+        return false;
     }
 
     @Override
@@ -70,7 +82,7 @@ public class PulseLaserWeaponHandler extends EnergyWeaponHandler {
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE)
                 && (nRange > wtype.getRanges(weapon)[RangeType.RANGE_EXTREME])) {
             toReturn = (int) Math.floor(toReturn / 3.0);
-        }        
+        }
 
         if (target.isConventionalInfantry()) {
             toReturn = Compute.directBlowInfantryDamage(toReturn,
@@ -81,7 +93,7 @@ public class PulseLaserWeaponHandler extends EnergyWeaponHandler {
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
-        
+
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());
         return (int) Math.ceil(toReturn);
     }

--- a/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
@@ -19,6 +19,7 @@ import megamek.common.MiscType;
 import megamek.common.Mounted;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.annotations.Nullable;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
@@ -63,6 +64,14 @@ public abstract class LaserWeapon extends EnergyWeapon {
         } else {
             return 0;
         }
+    }
+
+    @Override
+    public int getToHitModifier(@Nullable Mounted<?> mounted) {
+        if ((mounted == null) || !(mounted.getLinkedBy() instanceof MiscMounted) || !mounted.getLinkedBy().getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
+            return super.getToHitModifier(mounted);
+        }
+        return mounted.curMode().getName().equals("Pulse") ? -2 : 0;
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/ppc/PPCWeapon.java
+++ b/megamek/src/megamek/common/weapons/ppc/PPCWeapon.java
@@ -73,8 +73,8 @@ public abstract class PPCWeapon extends EnergyWeapon {
             if ((range == AlphaStrikeElement.SHORT_RANGE) && (getMinimumRange() > 0)) {
                 damage = adjustBattleForceDamageForMinRange(damage);
             }
-            if (getToHitModifier() != 0) {
-                damage -= damage * getToHitModifier() * 0.05;
+            if (getToHitModifier(null) != 0) {
+                damage -= damage * getToHitModifier(null) * 0.05;
             }
         }
         return damage / 10.0;

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -24381,7 +24381,7 @@ public class TWGameManager extends AbstractGameManager {
         // attached to
         if ((mounted.getType() instanceof MiscType) && mounted.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
             hit.setEffect(HitData.EFFECT_NO_CRITICALS);
-            Mounted<?> laser = mounted.getLinkedBy();
+            Mounted<?> laser = mounted.getLinked();
             if (en instanceof Mek) {
                 for (int slot = 0; slot < en.getNumberOfCriticals(laser.getLocation()); slot++) {
                     CriticalSlot cs = en.getCritical(laser.getLocation(), slot);

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -1862,13 +1862,13 @@ class FireControlTest {
         when(((Mek) mockTarget).getCockpitType()).thenReturn(Mek.COCKPIT_STANDARD);
 
         // Test weapon mods.
-        when(mockWeaponType.getToHitModifier()).thenReturn(-2);
+        when(mockWeaponType.getToHitModifier(mockWeapon)).thenReturn(-2);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(-2, FireControl.TH_WEAPON_MOD);
         assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
                 mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
-        when(mockWeaponType.getToHitModifier()).thenReturn(0);
+        when(mockWeaponType.getToHitModifier(mockWeapon)).thenReturn(0);
 
         // Test heat mods.
         when(mockShooter.getHeatFiringModifier()).thenReturn(1);


### PR DESCRIPTION
This required changes to method signatures of EquipmentType::getToHitModifier and EquipmentType::getModesCount. getToHitModifier needs to know the weapon's mode and getModesCount needs to know whether the mount is linked by a laser pulse module. I added a getToHitModifier with no parameters to AmmoType (which is the old signature) to reduce the number of changes to the code.