### PR TITLE
added null check for lastUnitMember

### DIFF
--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -26740,9 +26740,11 @@ public class TWGameManager extends AbstractGameManager {
                                         && (lastUnitNum == entity.getUnitNumber());
                             }
                         });
+                        if(lastUnit.next() != null){
                         Entity lastUnitMember = lastUnit.next();
                         lastUnitMember.setUnitNumber(deletedUnitNum);
                         entityUpdate(lastUnitMember.getId());
+                        }
                     } // End update-unit-number
                 } // End added-ProtoMek
 


### PR DESCRIPTION
closes #6211.

Check to see if lastUnit.next() is null before trying to setUnitNumber doing entityUpdate.
Fixed crash when removing protos in provided mul and was able to deploy force