### PR TITLE
Issue 6217 - Too many gunners for aerospace in MekHQ - Unified Aerosp…

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7294,6 +7294,11 @@ public class Compute {
                     continue;
                 }
                 if (type instanceof WeaponType) {
+                    if ((((WeaponType) m.getType()).getLongRange() <= 1)
+                        // MML range depends on ammo, and getLongRange() returns 0
+                        && (((WeaponType) m.getType()).getAmmoType() != AmmoType.T_MML)) {
+                        continue;
+                    }
                     if (((WeaponType) type).isCapital()) {
                         nCapitalW++;
                     } else {

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -1240,28 +1240,7 @@ public class TestAero extends TestEntity {
      * @return The vessel's minimum gunner requirements.
      */
     public static int requiredGunners(Aero aero) {
-        if (!aero.isLargeCraft() && !aero.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
-            return 0;
-        }
-        int capitalWeapons = 0;
-        int stdWeapons = 0;
-        for (Mounted<?> m : aero.getTotalWeaponList()) {
-            if (m.getType() instanceof BayWeapon) {
-                continue;
-            }
-            if ((((WeaponType) m.getType()).getLongRange() <= 1)
-                    // MML range depends on ammo, and getLongRange() returns 0
-                    && (((WeaponType) m.getType()).getAmmoType() != AmmoType.T_MML)) {
-                continue;
-            }
-            if (((WeaponType) m.getType()).isCapital()
-                    || (m.getType() instanceof ScreenLauncherWeapon)) {
-                capitalWeapons++;
-            } else {
-                stdWeapons++;
-            }
-        }
-        return capitalWeapons + (int) Math.ceil(stdWeapons / 6.0);
+        return Compute.getTotalGunnerNeeds(aero);
     }
 
     /**


### PR DESCRIPTION
…ace required gunners logic

Two different places were calculating Aerospace/dropship/small craft gunners with nearly the same algorithm. One was slightly wrong. I ensured one worked, and then made the other method use the working method so we don't need to maintain identical code in two different locations.

This fixes #6217 