### PR TITLE
feat: adds the players team in the BV report

### DIFF
--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -46,7 +46,6 @@ public final class Player extends TurnOrdered {
     public static final int TEAM_NONE = 0;
     public static final int TEAM_UNASSIGNED = -1;
     public static final String[] TEAM_NAMES = {"No Team", "Team 1", "Team 2", "Team 3", "Team 4", "Team 5"};
-
     private transient IGame game;
 
     private String name;
@@ -650,6 +649,11 @@ public final class Player extends TurnOrdered {
 
     public String getColorForPlayer() {
         return "<B><font color='" + getColour().getHexString(0x00F0F0F0) + "'>" + getName() + "</font></B>";
+    }
+
+    public String getColoredPlayerNameWithTeam() {
+        return "<B><font color='" + getColour().getHexString(0x00F0F0F0) + "'>" + getName() +
+            " (" + TEAM_NAMES[team] + ")</font></B>";
     }
 
     /**

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -1579,7 +1579,7 @@ public class TWGameManager extends AbstractGameManager {
             bvcPlayer.ejectedCrewKilledCount = ServerReportsHelper.getEjectedCrewKilledCount(player, game);
             bvcPlayer.ejectedCrewFledCount = ServerReportsHelper.getFledEjectedCrew(player, game);
 
-            playerReport.addAll(bvReport(player.getColorForPlayer(), player.getId(), bvcPlayer, checkBlind));
+            playerReport.addAll(bvReport(player.getColoredPlayerNameWithTeam(), player.getId(), bvcPlayer, checkBlind));
 
             int playerTeam = player.getTeam();
 
@@ -1611,7 +1611,8 @@ public class TWGameManager extends AbstractGameManager {
         if (!(checkBlind && doBlind() && suppressBlindBV())) {
             for (Map.Entry<Integer, BVCountHelper> e : teamsInfo.entrySet()) {
                 BVCountHelper bvc = e.getValue();
-                teamReport.addAll(bvReport(Player.TEAM_NAMES[e.getKey()], Player.PLAYER_NONE, bvc, false));
+                var coloredTeamName = "<B>"+ Player.TEAM_NAMES[e.getKey()] + "</B>";
+                teamReport.addAll(bvReport(coloredTeamName, Player.PLAYER_NONE, bvc, false));
             }
         }
 


### PR DESCRIPTION
Adds the team after the name of each player in the BV Report phase, it also adds Bold for the team name in the BV Team report.

![image](https://github.com/user-attachments/assets/211d920c-674f-486f-a689-c9d424b7c967)
