### PR TITLE
Minor changes to allow Capital Missiles to switch modes instantly.

### DIFF
--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -155,13 +155,13 @@ public abstract class Weapon extends WeaponType implements Serializable {
 
             } else {
                 if (getAtClass() == WeaponType.CLASS_TELE_MISSILE) {
-                    setInstantModeSwitch(false);
+                    setInstantModeSwitch(true);
                     addMode(MODE_NORMAL);
                     addMode(MODE_CAP_MISSILE_TELE_OPERATED);
                 }
                 
                 if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_WAYPOINT_LAUNCH)) {
-                    setInstantModeSwitch(false);
+                    setInstantModeSwitch(true);
                     addMode(MODE_NORMAL);
                     addMode(MODE_CAP_MISSILE_WAYPOINT);
                     if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
@@ -180,7 +180,7 @@ public abstract class Weapon extends WeaponType implements Serializable {
                 }
 
                 if (gOp.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_BEARINGS_ONLY_LAUNCH)) {
-                    setInstantModeSwitch(false);
+                    setInstantModeSwitch(true);
                     addMode(MODE_NORMAL);
                     addMode(MODE_CAP_MISSILE_BEARING_EXT);
                     addMode(MODE_CAP_MISSILE_BEARING_LONG);


### PR DESCRIPTION
This updates capital missile bays to be able to change modes instantly instead of at the end of turn to close #5397. 