### PR TITLE
Fixing bug report #4315 as per updated Errata for TO:AR for IR Sensor

### DIFF
--- a/megamek/src/megamek/common/Sensor.java
+++ b/megamek/src/megamek/common/Sensor.java
@@ -489,10 +489,11 @@ public class Sensor implements Serializable {
 
         // If you have infrared, then each increment of 5 heat will increase the range
         if ((type == TYPE_MEK_IR) || (type == TYPE_VEE_IR)) {
-            // If the target isn't overheating then you can't detect it
-            if (target.heat < 1) {
-                return 0;
-            }
+
+            // Issue #4315, TO:AR errata changed this. As long as the unit is activated, it can be detected via IR.
+            // Removed check for heat 1 or higher.
+            // Note: This does not check if a unit is activating after a scenario begins.
+            // That is a much larger concern to do with Transport Bays (Extended), TO: AR P.185/186
 
             range += target.heat / 5;
 


### PR DESCRIPTION
Fixing bug report #4315 as per updated Errata for TO:AR for IR Sensors. They can now detect all units.

Note: This does not implement the lack of detection for "activating" units as per scenario / TacOps: AR Transport Bays (Extended), as that would be a much larger scope to specify units which are/aren't "activated" (eg: Crewed/fully powered on) in the scenario. MM does not cover this kind of activation yet.