### PR TITLE
Issue 6224: NPE when air fails maneuver and flies off map

### DIFF
--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -1561,6 +1561,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                             a.setStraightMoves(a.getStraightMoves() + 1);
                             // make sure it didn't fly off the map
                             if (!getGame().getBoard().contains(curPos)) {
+                                curPos = curPos.translated(step.getFacing(), -1); //Return its position to on-map so it can be targeted this turn
                                 a.setCurrentVelocity(md.getFinalVelocity());
                                 gameManager.processLeaveMap(md, true, Compute.roundsUntilReturn(getGame(), entity));
                                 return;


### PR DESCRIPTION
Fixes #6224 
Fixes #6248 

Just nudges the aircraft back onto the board. Aircraft that fly off normally still have their final position on the board, so this will work the same as that.