### PR TITLE
Fix 6240: era-illegal asf bombs [Note: breaks MHQ]

### DIFF
--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -1565,7 +1565,7 @@ public class TeamLoadOutGenerator {
      *         enums as the lookup e.g. [BombUnit.HE] will get the number of HE
      *         bombs.
      */
-    private int[] generateExternalOrdnance(
+     public int[] generateExternalOrdnance(
         int bombUnits,
         boolean airOnly,
         boolean isPirate,

--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -1771,8 +1771,8 @@ public class TeamLoadOutGenerator {
         }
 
         // Oops, nothing left - rocket launchers are always popular
-        // XXX: Add prototype RLs as well.
         if (Arrays.stream(bombLoad).sum() == 0) {
+            // Rocket Launchers are a good option after CI era
             if (
                 checkLegality(
                     BombType.createBombByType(BombType.B_RL),
@@ -1782,6 +1782,18 @@ public class TeamLoadOutGenerator {
                 )
             ) {
                 bombLoad[BombType.B_RL] = bombUnits;
+                return bombLoad;
+            }
+            // Otherwise, Prototype Rocket Launchers are almost always in style.
+            if (
+                checkLegality(
+                    BombType.createBombByType(BombType.B_RLP),
+                    faction,
+                    techBase,
+                    mixedTech
+                )
+            ){
+                bombLoad[BombType.B_RLP] = bombUnits;
                 return bombLoad;
             }
         }

--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -340,6 +340,11 @@ public class TeamLoadOutGenerator {
         boolean legal = false;
         boolean clan = techBase.equals("CL");
 
+        // Null-type is illegal!
+        if (null == aType) {
+            return false;
+        }
+
         // Check if tech exists at all (or is explicitly allowed despite being extinct)
         // and whether it is available at the current tech level.
         legal = aType.isAvailableIn(allowedYear, showExtinct)
@@ -1111,7 +1116,9 @@ public class TeamLoadOutGenerator {
                 reconfigurationParameters.groundMap
                         || reconfigurationParameters.enemyCount > reconfigurationParameters.enemyFliers,
                 reconfigurationParameters.friendlyQuality,
-                reconfigurationParameters.isPirate);
+                reconfigurationParameters.isPirate,
+                faction
+            );
     }
 
     /**
@@ -1388,11 +1395,14 @@ public class TeamLoadOutGenerator {
      * @param quality          IUnitRating enum for force quality (A/A* through F)
      * @param isPirate         true to use specific pirate ordnance loadouts
      */
-    public static void populateAeroBombs(List<Entity> entityList,
-            int year,
-            boolean hasGroundTargets,
-            int quality,
-            boolean isPirate) {
+    public void populateAeroBombs(
+        List<Entity> entityList,
+        int year,
+        boolean hasGroundTargets,
+        int quality,
+        boolean isPirate,
+        String faction
+        ) {
 
         // Get all valid bombers, and sort unarmed ones to the front
         // Ignore VTOLs for now, as they suffer extra penalties for mounting bomb
@@ -1438,6 +1448,8 @@ public class TeamLoadOutGenerator {
 
             Entity curBomber = bomberList.get(i);
             boolean isUnarmed = curBomber.getIndividualWeaponList().isEmpty();
+            String techBase = (curBomber.isClan()) ? "CL" : "IS";
+            boolean mixedTech = curBomber.isMixedTech();
 
             // Some fighters on ground attack may be flying air cover rather than strictly
             // air-to-ground
@@ -1477,7 +1489,11 @@ public class TeamLoadOutGenerator {
                     isCAP,
                     isPirate,
                     quality,
-                    year);
+                    year,
+                    faction,
+                    techBase,
+                    mixedTech
+            );
             // Whoops, go yell at the ordnance technician
             if (Arrays.stream(generatedBombs).sum() == 0) {
                 continue;
@@ -1549,11 +1565,16 @@ public class TeamLoadOutGenerator {
      *         enums as the lookup e.g. [BombUnit.HE] will get the number of HE
      *         bombs.
      */
-    private static int[] generateExternalOrdnance(int bombUnits,
-            boolean airOnly,
-            boolean isPirate,
-            int quality,
-            int year) {
+    private int[] generateExternalOrdnance(
+        int bombUnits,
+        boolean airOnly,
+        boolean isPirate,
+        int quality,
+        int year,
+        String faction,
+        String techBase,
+        boolean mixedTech
+    ) {
 
         int[] bombLoad = new int[BombType.B_NUM];
 
@@ -1658,6 +1679,18 @@ public class TeamLoadOutGenerator {
         // rockets or HE
         Map<Integer, Integer> workingBombMap = new HashMap<>();
         for (int curBombType : bombMap.keySet()) {
+            // Make sure the bomb type is even legal for the current scenario
+            if (
+                !checkLegality(
+                    BombType.createBombByType(curBombType),
+                    faction,
+                    techBase,
+                    mixedTech
+                )
+            ) {
+                continue;
+            }
+
             String typeName = BombType.getBombInternalName(curBombType);
             if (curBombType == BombType.B_RL ||
                     curBombType == BombType.B_HE ||

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -42,6 +42,8 @@ public class BombType extends AmmoType {
     public static final int B_FAE_SMALL = 15;
     public static final int B_FAE_LARGE = 16;
     public static final int B_NUM     = 17;
+    // Prototype Rocket Launcher Pod
+    public static final int B_PRL     = 18;
 
     public static final String[] bombNames = { "HE Bomb","Cluster Bomb","Laser-guided Bomb",
                                               "Rocket", "TAG", "AAA Missile", "AS Missile",
@@ -242,6 +244,8 @@ public class BombType extends AmmoType {
                 return createSmallFuelAirBomb();
             case B_FAE_LARGE:
                 return createLargeFuelAirBomb();
+            case B_PRL:
+                return createPrototypeRocketBomb();
             default:
                 return null;
         }
@@ -619,6 +623,30 @@ public class BombType extends AmmoType {
         bomb.rackSize = 10;
         bomb.ammoType = AmmoType.T_RL_BOMB;
         bomb.bombType = BombType.B_RL;
+        bomb.shots = 1;
+        bomb.bv = 18;
+        bomb.cost = 15000;
+        bomb.rulesRefs = "229, TM";
+        bomb.techAdvancement.setTechBase(TechAdvancement.TECH_BASE_IS);
+        bomb.techAdvancement.setISAdvancement(3055, 3064, 3067);
+        bomb.techAdvancement.setTechRating(RATING_B);
+        bomb.techAdvancement.setAvailability(RATING_X, RATING_X, RATING_B, RATING_B);
+
+        return bomb;
+    }
+
+    private static BombType createPrototypeRocketBomb() {
+        BombType bomb = new BombType();
+
+        bomb.name = "Prototype Rocket Launcher Pod";
+        bomb.setInternalName("P" + BombType.getBombInternalName(BombType.B_RL));
+        bomb.addLookupName("PRL 10 (Bomb)");
+        bomb.damagePerShot = 1;
+        // This works but is fragile
+        bomb.flags = bomb.flags.or(AmmoType.F_OTHER_BOMB).or(WeaponType.F_PROTOTYPE);
+        bomb.rackSize = 10;
+        bomb.ammoType = AmmoType.T_RL_BOMB;
+        bomb.bombType = BombType.B_PRL;
         bomb.shots = 1;
         bomb.bv = 18;
         bomb.cost = 15000;

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -178,6 +178,7 @@ public class BombType extends AmmoType {
         EquipmentType.addType(BombType.createLaserGuidedBomb());
 //        EquipmentType.addType(BombType.createCLLaserGuidedBomb());
         EquipmentType.addType(BombType.createRocketBomb());
+        EquipmentType.addType(BombType.createPrototypeRocketBomb());
         EquipmentType.addType(BombType.createTAGBomb());
 //        EquipmentType.addType(BombType.createCLTAGBomb());
         EquipmentType.addType(BombType.createAAAMissileBomb());

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -41,16 +41,17 @@ public class BombType extends AmmoType {
     public static final int B_ALAMO   = 14;
     public static final int B_FAE_SMALL = 15;
     public static final int B_FAE_LARGE = 16;
-    public static final int B_NUM     = 17;
-    // Prototype Rocket Launcher Pod
-    public static final int B_PRL     = 18;
+    // Rocket Launcher (Prototype) Pod
+    public static final int B_RLP = 17;
+    public static final int B_NUM     = 18;
 
     public static final String[] bombNames = { "HE Bomb","Cluster Bomb","Laser-guided Bomb",
                                               "Rocket", "TAG", "AAA Missile", "AS Missile",
                                               "ASEW Missile", "Arrow IV Missile",
                                               "Arrow IV Homing Missile", "Inferno Bomb",
                                               "LAA Missile", "Thunder Bomb", "Torpedo Bomb",
-                                              "Alamo Missile", "Fuel-Air Bomb (small)", "Fuel-Air Bomb (large)" };
+                                              "Alamo Missile", "Fuel-Air Bomb (small)", "Fuel-Air Bomb (large)",
+                                              "Prototype Rocket"};
 
     public static final String[] bombInternalNames = { "HEBomb","ClusterBomb","LGBomb",
                                                       "RL 10 Ammo (Bomb)", "TAGBomb", "AAAMissile Ammo",
@@ -58,13 +59,15 @@ public class BombType extends AmmoType {
                                                       "ASEWMissile Ammo", "ArrowIVMissile Ammo",
                                                       "ArrowIVHomingMissile Ammo", "InfernoBomb",
                                                       "LAAMissile Ammo", "ThunderBomb", "TorpedoBomb",
-                                                      "AlamoMissile Ammo", "FABombSmall Ammo", "FABombLarge Ammo" };
+                                                      "AlamoMissile Ammo", "FABombSmall Ammo", "FABombLarge Ammo",
+                                                      "RL 10 Ammo (Bomb)" };
 
     public static final String[] bombWeaponNames = { null, null, null, "BombRL", "BombTAG", "AAA Missile",
                                                     "AS Missile", "ASEWMissile", "BombArrowIV", "BombArrowIV",
-                                                    null, "LAAMissile", null, null, "AlamoMissile", null, null };
+                                                    null, "LAAMissile", null, null, "AlamoMissile", null, null,
+                                                    "BombRLP"};
 
-    public static final int[] bombCosts = { 1, 1, 1, 1, 1, 5, 6, 6, 5, 5, 1, 2, 1, 1, 10, 1, 2 };
+    public static final int[] bombCosts = { 1, 1, 1, 1, 1, 5, 6, 6, 5, 5, 1, 2, 1, 1, 10, 1, 2, 1 };
 
     public static final Map<String, Integer> blastRadius;
     private int bombType;
@@ -244,7 +247,7 @@ public class BombType extends AmmoType {
                 return createSmallFuelAirBomb();
             case B_FAE_LARGE:
                 return createLargeFuelAirBomb();
-            case B_PRL:
+            case B_RLP:
                 return createPrototypeRocketBomb();
             default:
                 return null;
@@ -638,24 +641,29 @@ public class BombType extends AmmoType {
     private static BombType createPrototypeRocketBomb() {
         BombType bomb = new BombType();
 
-        bomb.name = "Prototype Rocket Launcher Pod";
-        bomb.setInternalName("P" + BombType.getBombInternalName(BombType.B_RL));
-        bomb.addLookupName("PRL 10 (Bomb)");
+        bomb.name = "Rocket Launcher (Prototype) Pod";
+        bomb.setInternalName(BombType.getBombInternalName(BombType.B_RLP));
+        bomb.addLookupName("RL-P 10 (Bomb)");
         bomb.damagePerShot = 1;
         // This works but is fragile
         bomb.flags = bomb.flags.or(AmmoType.F_OTHER_BOMB).or(WeaponType.F_PROTOTYPE);
         bomb.rackSize = 10;
         bomb.ammoType = AmmoType.T_RL_BOMB;
-        bomb.bombType = BombType.B_PRL;
+        bomb.bombType = BombType.B_RLP;
         bomb.shots = 1;
-        bomb.bv = 18;
+        bomb.bv = 15;
         bomb.cost = 15000;
-        bomb.rulesRefs = "229, TM";
-        bomb.techAdvancement.setTechBase(TechAdvancement.TECH_BASE_IS);
-        bomb.techAdvancement.setISAdvancement(3055, 3064, 3067);
-        bomb.techAdvancement.setTechRating(RATING_B);
-        bomb.techAdvancement.setAvailability(RATING_X, RATING_X, RATING_B, RATING_B);
-
+        bomb.rulesRefs = "73, 195, 217, IO";
+        bomb.techAdvancement.setTechBase(TECH_BASE_ALL)
+            .setIntroLevel(false)
+            .setUnofficial(false)
+            .setTechRating(RATING_B)
+            .setAvailability(RATING_D, RATING_F, RATING_X, RATING_X)
+            .setISAdvancement(DATE_ES, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
+            .setISApproximate(true, false, false, false, false)
+            .setClanAdvancement(DATE_ES, DATE_NONE, DATE_NONE, 2823, DATE_NONE)
+            .setClanApproximate(true, false, false, true, false)
+            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
         return bomb;
     }
 

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -60,7 +60,7 @@ public class BombType extends AmmoType {
                                                       "ArrowIVHomingMissile Ammo", "InfernoBomb",
                                                       "LAAMissile Ammo", "ThunderBomb", "TorpedoBomb",
                                                       "AlamoMissile Ammo", "FABombSmall Ammo", "FABombLarge Ammo",
-                                                      "RL 10 Ammo (Bomb)" };
+                                                      "RL-P 10 Ammo (Bomb)" };
 
     public static final String[] bombWeaponNames = { null, null, null, "BombRL", "BombTAG", "AAA Missile",
                                                     "AS Missile", "ASEWMissile", "BombArrowIV", "BombArrowIV",

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -2061,7 +2061,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new ISBombTAG());
         EquipmentType.addType(new CLBombTAG());
         EquipmentType.addType(new BombISRL10());
-        EquipmentType.addType(new BombISPRL10());
+        EquipmentType.addType(new BombISRLP10());
         EquipmentType.addType(new AlamoMissileWeapon());
         EquipmentType.addType(new SpaceBombAttack());
         EquipmentType.addType(new DiveBombAttack());

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -2061,6 +2061,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new ISBombTAG());
         EquipmentType.addType(new CLBombTAG());
         EquipmentType.addType(new BombISRL10());
+        EquipmentType.addType(new BombISPRL10());
         EquipmentType.addType(new AlamoMissileWeapon());
         EquipmentType.addType(new SpaceBombAttack());
         EquipmentType.addType(new DiveBombAttack());

--- a/megamek/src/megamek/common/weapons/RLHandler.java
+++ b/megamek/src/megamek/common/weapons/RLHandler.java
@@ -1,14 +1,14 @@
 /**
  * MegaMek - Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
- * 
- *  This program is free software; you can redistribute it and/or modify it 
- *  under the terms of the GNU General Public License as published by the Free 
- *  Software Foundation; either version 2 of the License, or (at your option) 
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
  *  any later version.
- * 
- *  This program is distributed in the hope that it will be useful, but 
- *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY 
- *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License 
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  *  for more details.
  */
 package megamek.common.weapons;
@@ -17,20 +17,14 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Vector;
 
-import megamek.common.Coords;
-import megamek.common.Entity;
-import megamek.common.Game;
-import megamek.common.Minefield;
-import megamek.common.Report;
-import megamek.common.Targetable;
-import megamek.common.ToHitData;
+import megamek.common.*;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.server.totalwarfare.TWGameManager;
 
 public class RLHandler extends MissileWeaponHandler {
 
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -3848472655779311898L;
 
@@ -46,7 +40,7 @@ public class RLHandler extends MissileWeaponHandler {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.WeaponHandler#specialResolution(java.util.Vector,
      * megamek.common.Entity, boolean)

--- a/megamek/src/megamek/common/weapons/bombs/BombISPRL10.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombISPRL10.java
@@ -15,21 +15,22 @@ package megamek.common.weapons.bombs;
 
 import megamek.common.AmmoType;
 import megamek.common.BombType;
+import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import megamek.common.weapons.missiles.MissileWeapon;
 
 /**
  * @author Jay Lawson
  */
-public class BombISRL10 extends MissileWeapon {
+public class BombISPRL10 extends MissileWeapon {
     private static final long serialVersionUID = 5763858241912399084L;
 
-    public BombISRL10() {
+    public BombISPRL10() {
         super();
 
-        this.name = "Rocket Launcher Pod";
-        this.setInternalName(BombType.getBombWeaponName(BombType.B_RL));
-        addLookupName("RL 10 (Bomb)");
+        this.name = "Prototype Rocket Launcher Pod";
+        this.setInternalName(BombType.getBombWeaponName(BombType.B_PRL));
+        addLookupName("PRL 10 (Bomb)");
         this.heat = 0;
         this.rackSize = 10;
         this.shortRange = 5;
@@ -41,21 +42,22 @@ public class BombISRL10 extends MissileWeapon {
         this.hittable = false;
         this.bv = 0;
         this.cost = 0;
-        this.flags = flags.or(F_MISSILE).or(F_BOMB_WEAPON).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        this.flags = flags.or(F_MISSILE).or(F_BOMB_WEAPON).or(F_PROTOTYPE).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         this.shortAV = 6;
         this.medAV = 6;
         this.maxRange = RANGE_MED;
         this.toHitModifier = 1;
         this.ammoType = AmmoType.T_RL_BOMB;
         rulesRefs = "229, TM";
-        new TechAdvancement(TECH_BASE_IS)
+        techAdvancement.setTechBase(TECH_BASE_ALL)
             .setIntroLevel(false)
             .setUnofficial(false)
             .setTechRating(RATING_B)
-            .setAvailability(RATING_X, RATING_X, RATING_B, RATING_B)
-            .setISAdvancement(3060, 3064, 3067, DATE_NONE, DATE_NONE)
+            .setAvailability(RATING_D, RATING_F, RATING_X, RATING_X)
+            .setISAdvancement(DATE_ES, DATE_NONE, DATE_NONE, DATE_NONE, DATE_NONE)
             .setISApproximate(true, false, false, false, false)
-            .setPrototypeFactions(F_MH)
-            .setProductionFactions(F_MH);
+            .setClanAdvancement(DATE_ES, DATE_NONE, DATE_NONE, 2823, DATE_NONE)
+            .setClanApproximate(true, false, false, true, false)
+            .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
     }
 }

--- a/megamek/src/megamek/common/weapons/bombs/BombISPRL10.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombISPRL10.java
@@ -16,7 +16,6 @@ package megamek.common.weapons.bombs;
 import megamek.common.AmmoType;
 import megamek.common.BombType;
 import megamek.common.SimpleTechLevel;
-import megamek.common.TechAdvancement;
 import megamek.common.weapons.missiles.MissileWeapon;
 
 /**
@@ -28,9 +27,9 @@ public class BombISPRL10 extends MissileWeapon {
     public BombISPRL10() {
         super();
 
-        this.name = "Prototype Rocket Launcher Pod";
-        this.setInternalName(BombType.getBombWeaponName(BombType.B_PRL));
-        addLookupName("PRL 10 (Bomb)");
+        this.name = "Rocket Launcher (Prototype) Pod";
+        this.setInternalName(BombType.getBombWeaponName(BombType.B_RLP));
+        addLookupName("RL-P 10 (Bomb)");
         this.heat = 0;
         this.rackSize = 10;
         this.shortRange = 5;
@@ -48,7 +47,7 @@ public class BombISPRL10 extends MissileWeapon {
         this.maxRange = RANGE_MED;
         this.toHitModifier = 1;
         this.ammoType = AmmoType.T_RL_BOMB;
-        rulesRefs = "229, TM";
+        rulesRefs = "73, 195, 217, IO";
         techAdvancement.setTechBase(TECH_BASE_ALL)
             .setIntroLevel(false)
             .setUnofficial(false)

--- a/megamek/src/megamek/common/weapons/bombs/BombISRL10.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombISRL10.java
@@ -13,10 +13,13 @@
  */
 package megamek.common.weapons.bombs;
 
-import megamek.common.AmmoType;
-import megamek.common.BombType;
-import megamek.common.TechAdvancement;
+import megamek.common.*;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.weapons.AttackHandler;
+import megamek.common.weapons.PrototypeRLHandler;
+import megamek.common.weapons.RLHandler;
 import megamek.common.weapons.missiles.MissileWeapon;
+import megamek.server.totalwarfare.TWGameManager;
 
 /**
  * @author Jay Lawson
@@ -57,5 +60,11 @@ public class BombISRL10 extends MissileWeapon {
             .setISApproximate(true, false, false, false, false)
             .setPrototypeFactions(F_MH)
             .setProductionFactions(F_MH);
+    }
+
+    @Override
+    protected AttackHandler getCorrectHandler(ToHitData toHit,
+                                              WeaponAttackAction waa, Game game, TWGameManager manager) {
+        return new RLHandler(toHit, waa, game, manager);
     }
 }

--- a/megamek/src/megamek/common/weapons/bombs/BombISRLP10.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombISRLP10.java
@@ -13,10 +13,12 @@
  */
 package megamek.common.weapons.bombs;
 
-import megamek.common.AmmoType;
-import megamek.common.BombType;
-import megamek.common.SimpleTechLevel;
+import megamek.common.*;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.weapons.AttackHandler;
+import megamek.common.weapons.PrototypeRLHandler;
 import megamek.common.weapons.missiles.MissileWeapon;
+import megamek.server.totalwarfare.TWGameManager;
 
 /**
  * @author Jay Lawson
@@ -58,5 +60,11 @@ public class BombISRLP10 extends MissileWeapon {
             .setClanAdvancement(DATE_ES, DATE_NONE, DATE_NONE, 2823, DATE_NONE)
             .setClanApproximate(true, false, false, true, false)
             .setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL);
+    }
+
+    @Override
+    protected AttackHandler getCorrectHandler(ToHitData toHit,
+                                              WeaponAttackAction waa, Game game, TWGameManager manager) {
+        return new PrototypeRLHandler(toHit, waa, game, manager);
     }
 }

--- a/megamek/src/megamek/common/weapons/bombs/BombISRLP10.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombISRLP10.java
@@ -21,10 +21,10 @@ import megamek.common.weapons.missiles.MissileWeapon;
 /**
  * @author Jay Lawson
  */
-public class BombISPRL10 extends MissileWeapon {
+public class BombISRLP10 extends MissileWeapon {
     private static final long serialVersionUID = 5763858241912399084L;
 
-    public BombISPRL10() {
+    public BombISRLP10() {
         super();
 
         this.name = "Rocket Launcher (Prototype) Pod";

--- a/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
@@ -19,6 +19,7 @@
 package megamek.client.generator;
 
 import megamek.client.Client;
+import megamek.client.ratgenerator.ForceDescriptor;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.common.*;
 import megamek.common.AmmoType.Munitions;
@@ -28,15 +29,13 @@ import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import org.apache.commons.collections4.IteratorUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -431,20 +430,20 @@ class TeamLoadOutGeneratorTest {
         tlg.updateOptionValues();
 
         // Should not be available to anyone
-        assertFalse(tlg.checkLegality(mType, "CC", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", false));
-        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CC", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CLAN", "CL", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
 
         // Should be available to everyone
         when(mockGameOptions.stringOption(OptionsConstants.ALLOWED_TECHLEVEL)).thenReturn("Advanced");
         tlg.updateOptionValues();
-        assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
-        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
+        Assertions.assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
+        Assertions.assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
     }
 
     @Test
@@ -454,30 +453,30 @@ class TeamLoadOutGeneratorTest {
         AmmoType mType = AmmoType.getMunitionsFor(aType.getAmmoType()).stream()
                 .filter(m -> m.getSubMunitionName().contains("ADA")).findFirst().orElse(null);
         // Should be available by default in 3151, including to Clans (using MixTech)
-        assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
-        assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "FS", "IS", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "IS", "IS", false));
         // Check mixed-tech and regular Clan tech, which should match IS at this point
-        assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
-        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", false));
+        Assertions.assertTrue(tlg.checkLegality(mType, "CLAN", "CL", true));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CLAN", "CL", false));
 
         // Set year back to 3025
         when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3025);
         tlg.updateOptionValues();
-        assertFalse(tlg.checkLegality(mType, "CC", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CC", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
 
         // Move up to 3070. Because of game settings and lack of "Common" year, ADA
         // becomes available
         // everywhere (at least in the IS) immediately after its inception.
         when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3070);
         tlg.updateOptionValues();
-        assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
-        assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
+        Assertions.assertTrue(tlg.checkLegality(mType, "CC", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "FS", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "IS", "IS", false));
+        Assertions.assertFalse(tlg.checkLegality(mType, "CLAN", "CL", true));
     }
 
     @Test
@@ -596,5 +595,34 @@ class TeamLoadOutGeneratorTest {
         tlg.clampAmmoShots(mockMek, 1.5f);
         assertEquals(8, bin1.getUsableShotsLeft());
         assertEquals(8, bin2.getUsableShotsLeft());
+    }
+
+    @Test
+    void testGenerateExternalOrdnanceCAP3SWEraPirates() {
+        // Game setup
+        int year = 2875;
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(year);
+        TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(game);
+        // Bomber info
+        int bombUnits = 20;
+        boolean airOnly = true;
+        boolean isPirate = true;
+        int quality = ForceDescriptor.RATING_5;
+        String faction = "PIR";
+        String techBase = "IS";
+        boolean mixedTech = false;
+        int[] generatedBombs = tlg.generateExternalOrdnance(
+            bombUnits,
+            airOnly,
+            isPirate,
+            quality,
+            year,
+            faction,
+            techBase,
+            mixedTech
+        );
+        int[] expected = new int[17];
+        assertArrayEquals(expected, generatedBombs);
+
     }
 }

--- a/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
@@ -598,7 +598,7 @@ class TeamLoadOutGeneratorTest {
     }
 
     /**
-     * We expect CAP Pirate flights in the 3SW era to mount no ordnance.
+     * We expect CAP Pirate flights in the 3SW era to mount ordnance only RL-P pods.
      */
     @Test
     void testGenerateExternalOrdnanceCAP3SWEraPirates() {
@@ -624,8 +624,72 @@ class TeamLoadOutGeneratorTest {
             techBase,
             mixedTech
         );
-        int[] expected = new int[17];
+        int[] expected = new int[BombType.B_NUM];
+        expected[BombType.B_RLP] = bombUnits;
         assertArrayEquals(expected, generatedBombs);
+    }
 
+    /**
+     * We expect CAP Pirate flights in the 3SW era to mount ordnance only RL-P pods.
+     */
+    @Test
+    void testGenerateExternalOrdnanceCAPPostCIEraPirates() {
+        // Game setup
+        int year = 3075;
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(year);
+        TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(game);
+        // Bomber info
+        int bombUnits = 20;
+        boolean airOnly = true;
+        boolean isPirate = true;
+        int quality = ForceDescriptor.RATING_5;
+        String faction = "PIR";
+        String techBase = "IS";
+        boolean mixedTech = false;
+        int[] generatedBombs = tlg.generateExternalOrdnance(
+            bombUnits,
+            airOnly,
+            isPirate,
+            quality,
+            year,
+            faction,
+            techBase,
+            mixedTech
+        );
+        // Should always get some regular rocket launchers
+        assertTrue(generatedBombs[BombType.B_RL] > 0);
+        // Should not use RL-Ps when RLs are available
+        assertEquals(0, generatedBombs[BombType.B_RLP]);
+    }
+
+    /**
+     * We expect CAP Pirate flights in the 3SW era to mount ordnance only RL-P pods.
+     */
+    @Test
+    void testGenerateExternalOrdnanceCAP2800Clan() {
+        // Game setup
+        int year = 2800;
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(year);
+        TeamLoadOutGenerator tlg = new TeamLoadOutGenerator(game);
+        // Bomber info
+        int bombUnits = 20;
+        boolean airOnly = true;
+        boolean isPirate = false;
+        int quality = ForceDescriptor.RATING_1;
+        String faction = "CSJ";
+        String techBase = "CL";
+        boolean mixedTech = false;
+        int[] generatedBombs = tlg.generateExternalOrdnance(
+            bombUnits,
+            airOnly,
+            isPirate,
+            quality,
+            year,
+            faction,
+            techBase,
+            mixedTech
+        );
+        // Pre-2823, Clan units can take RL-P bombs
+        assertTrue(generatedBombs[BombType.B_RLP] > 0);
     }
 }

--- a/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
@@ -597,6 +597,9 @@ class TeamLoadOutGeneratorTest {
         assertEquals(8, bin2.getUsableShotsLeft());
     }
 
+    /**
+     * We expect CAP Pirate flights in the 3SW era to mount no ordnance.
+     */
     @Test
     void testGenerateExternalOrdnanceCAP3SWEraPirates() {
         // Game setup


### PR DESCRIPTION
Fixes the long-standing issue where automatically-generated ASF munitions ignore era restrictions, leading to e.g. early CI enemy forces with Thunder bombs.
The implementation re-uses existing era legality checks from the non-ASF munitions generation code.
Auto-generated ASF munitions should now all be restricted to era-appropriate options in both MM and MHQ.

As a sop to Princess, however, this also implements Rocket Launcher (Prototype), or RL-P, bomb pods.
This will allow Clan ASFs to be equipped with RL-P pods through 2823, and IS ASFs from the Early Spaceflight period on.  

Testing:
- Ran all 3 suites' unit tests (This breaks MHQ, requiring a separate patch there)
- Added unit tests to confirm era-appropriate munition selection for IS and Clan units.

NOTE: https://github.com/MegaMek/mekhq/pull/5337 needs to be pulled in close conjunction with this PR.

Close #6240 