### PR TITLE
Issue 6264: Destroyed Infantry no longer have negative weight

### DIFF
--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -383,10 +383,8 @@ public class TestInfantry extends TestEntity {
         report.addEmptyLine();
 
         InfantryMount mount = infantry.getMount();
-        int activeTroopers = infantry.getInternal(Infantry.LOC_INFANTRY);
-        if (activeTroopers < 0) {
-            activeTroopers = 0;
-        }
+        int activeTroopers = Math.max(0, infantry.getInternal(Infantry.LOC_INFANTRY));
+
         double weight;
 
         if (mount != null) {

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -384,7 +384,6 @@ public class TestInfantry extends TestEntity {
 
         InfantryMount mount = infantry.getMount();
         int activeTroopers = Math.max(0, infantry.getInternal(Infantry.LOC_INFANTRY));
-
         double weight;
 
         if (mount != null) {

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -385,7 +385,7 @@ public class TestInfantry extends TestEntity {
         InfantryMount mount = infantry.getMount();
         int activeTroopers = infantry.getInternal(Infantry.LOC_INFANTRY);
         if (activeTroopers < 0) {
-            return 0;
+            activeTroopers = 0;
         }
         double weight;
 

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -384,6 +384,9 @@ public class TestInfantry extends TestEntity {
 
         InfantryMount mount = infantry.getMount();
         int activeTroopers = infantry.getInternal(Infantry.LOC_INFANTRY);
+        if (activeTroopers < 0) {
+            return 0;
+        }
         double weight;
 
         if (mount != null) {


### PR DESCRIPTION
Fixes #6264 

infantry.getInternal returns negative values for increasingly destroyed states for the infantry. But for determining weight it should just be 0 tons.