### PR TITLE
Issue 1437: Check for stacking for elevation 0 Aeros during deployment

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -22,6 +22,7 @@ import megamek.common.actions.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.AimingMode;
 import megamek.common.enums.BasementType;
+import megamek.common.enums.GamePhase;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
@@ -419,8 +420,8 @@ public class Compute {
             return null;
         }
 
-        // no stacking violations for flying aeros
-        if (entering.isAirborne()) {
+        // no stacking violations for flying aeros, except during deployment - no crushing units during deployment!
+        if (entering.isAirborne() && !((game.getPhase().equals(GamePhase.DEPLOYMENT) && elevation == 0))) {
             return null;
         }
 


### PR DESCRIPTION
Fixes #1437 

I believe it's correct to ignore the stacking penalties for airborne units at elevation 0 during the movement phase - this is what allows a dropship to land on top of units. During the deployment phase we don't want to allow the player to "crush" units.