### PR TITLE
Issue 6079: Reworded destroyed aero bay door to avoid indefinite article usage

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -1129,7 +1129,7 @@
 9167=\ No undestroyed <msg:9168,9169> bay found.
 9168=cargo
 9169=transport
-9170=\ <span class='warning'>An <data> bay door is destroyed!</span>
+9170=\ <span class='warning'>A door for <data> is destroyed!</span>
 9171=\ There are no functioning bay doors on this vessel.
 9172=\ Transport bay hit and units would be destroyed, but Edge used to reroll! <data> Edge remaining.
 9175=\ <span class='warning'>Docking Collar hit. DropShip will be unable to dock.</span>

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8491,7 +8491,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             Bay chosenBay = potential.elementAt(Compute.randomInt(potential.size()));
             chosenBay.destroyDoor();
             chosenBay.resetDoors();
-            bayType = chosenBay.getType();
+            bayType = String.format("%s bay #%s", chosenBay.getType(), chosenBay.getBayNumber());
         }
 
         return bayType;


### PR DESCRIPTION
Fixes #6079 

Determining whether to use a/an isn't in MegaMek, at least from what I could find, so I think this is the simplest way to resolve this while also providing a little more information to the user.

![image](https://github.com/user-attachments/assets/702b2947-c788-4dd2-9cf1-5848521e398a)
