### PR TITLE
Issue 6290: When setting internal for infantry restore field weapons if applicable.

### DIFF
--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -733,7 +733,7 @@ public class Infantry extends Entity {
         super.setInternal(val, loc);
         if (loc == LOC_INFANTRY) {
             activeTroopers = Math.max(val, 0);
-            damageFieldWeapons();
+            damageOrRestoreFieldWeapons();
         }
     }
 

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -733,7 +733,8 @@ public class Infantry extends Entity {
         super.setInternal(val, loc);
         if (loc == LOC_INFANTRY) {
             activeTroopers = Math.max(val, 0);
-            damageOrRestoreFieldWeapons();
+            damageFieldWeapons();
+            restoreUncrewedFieldWeapons();
         }
     }
 
@@ -893,6 +894,22 @@ public class Infantry extends Entity {
             totalCrewNeeded += requiredCrewForFieldWeapon((WeaponType) weapon.getType());
             weapon.setHit(totalCrewNeeded > activeTroopers);
             weapon.setDestroyed(totalCrewNeeded > activeTroopers);
+        }
+    }
+
+    /**
+     * Field guns that are hit (uncrewed) will be set
+     * to not hit if they have the appropriate number
+     * of active troopers. Field guns that are destroyed
+     * will not be un-hit.
+     */
+    public void restoreUncrewedFieldWeapons() {
+        int totalCrewNeeded = 0;
+        for (Mounted<?> weapon : originalFieldWeapons()) {
+            totalCrewNeeded += requiredCrewForFieldWeapon((WeaponType) weapon.getType());
+            if (totalCrewNeeded <= activeTroopers && !weapon.isDestroyed()) {
+                weapon.setHit(false);
+            }
         }
     }
 

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -907,7 +907,7 @@ public class Infantry extends Entity {
         int totalCrewNeeded = 0;
         for (Mounted<?> weapon : originalFieldWeapons()) {
             totalCrewNeeded += requiredCrewForFieldWeapon((WeaponType) weapon.getType());
-            if (totalCrewNeeded <= activeTroopers && !weapon.isDestroyed()) {
+            if (activeTroopers >= totalCrewNeeded && !weapon.isDestroyed()) {
                 weapon.setHit(false);
             }
         }


### PR DESCRIPTION
Fixes #6290 

The existing damageFieldWeapons() does not destroy the guns, it just sets them hit and has a comment that calling applyDamage() will set the weapon to destroyed. If destroyed guns are implemented later as something different than an uncrewed gun, the change to setInternal() should prevent destroyed guns from reappearing while "recrewing" hit guns.

Formerly MegaMek/mekhq#4702