### PR TITLE
Fix #6259 error spam and deployment hang with combined arms forces

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -654,7 +654,6 @@ public abstract class BotClient extends Client {
             return dest;
         }
 
-        logger.error("Returning no deployment position; THIS IS BAD!");
         // If NONE of them are acceptable, then just return null.
         return null;
     }

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -140,9 +140,12 @@ public abstract class BotClient extends Client {
             public void gamePhaseChange(GamePhaseChangeEvent e) {
                 calculatedTurnThisPhase = false;
                 if (e.getOldPhase().isSimultaneous(getGame())) {
-                    logger.info("%s: Calculated %d / %d turns for phase %s",
+                    logger.info(
+                        String.format("%s: Calculated %d / %d turns for phase %s",
                             getName(), calculatedTurnsThisPhase,
-                            getGame().getEntitiesOwnedBy(getLocalPlayer()), e.getOldPhase());
+                            getGame().getEntitiesOwnedBy(getLocalPlayer()), e.getOldPhase()
+                        )
+                    );
                 }
                 calculatedTurnsThisPhase = 0;
             }

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -803,7 +803,11 @@ public class Princess extends BotClient {
             logger.debug(sb.toString());
         }
         // Fall back on old method
-        return super.getFirstValidCoords(deployedUnit, possibleDeployCoords);
+        Coords bestCandidate = super.getFirstValidCoords(deployedUnit, possibleDeployCoords);
+        if (bestCandidate == null) {
+            logger.error("Returning no deployment position; THIS IS BAD!");
+        }
+        return bestCandidate;
     }
 
     @Override

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -546,9 +546,11 @@ public class EquipmentType implements ITechnology {
         }
 
         // Avoid Concurrent Modification exception with this one simple trick!
-        for (Iterator<EquipmentMode> iterator = modes.iterator(); iterator.hasNext();) {
-            if (iterator.next().getName().equals(modeType)) {
-                return true;
+        synchronized (modes) {
+            for (Iterator<EquipmentMode> iterator = modes.iterator(); iterator.hasNext(); ) {
+                if (iterator.next().getName().equals(modeType)) {
+                    return true;
+                }
             }
         }
 

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1475,6 +1475,9 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
         if (entityPosLookup.isEmpty() && !inGameTWEntities().isEmpty()) {
             resetEntityPositionLookup();
         }
+        // For sanity check
+        GamePhase phase = getPhase();
+
         Set<Integer> posEntities = entityPosLookup.get(c);
         List<Entity> vector = new ArrayList<>();
         if (posEntities != null) {
@@ -1492,9 +1495,9 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
                 if (e.isTargetable() || ignore) {
                     vector.add(e);
 
-                    // Sanity check
+                    // Sanity check: report out-of-place entities if it's not the deployment phase
                     HashSet<Coords> positions = e.getOccupiedCoords();
-                    if (!positions.contains(c)) {
+                    if (!phase.isDeployment() && !positions.contains(c)) {
                         logger.error(e.getDisplayName() + " is not in " + c + "!");
                     }
                 }

--- a/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
@@ -72,7 +72,9 @@ public abstract class LaserWeapon extends EnergyWeapon {
         }
 
         //Only works if laser pulse module's "Pulse" modes are added last.
-        return (int) modes.stream().filter(mode -> !mode.getName().startsWith("Pulse")).count();
+        synchronized (modes) {
+            return (int) modes.stream().filter(mode -> !mode.getName().startsWith("Pulse")).count();
+        }
     }
 
     @Override


### PR DESCRIPTION
This clears up some error spam and Exceptions reported in #6259.  Also fixed a log line that was not getting formatted correctly.

Hopefully also prevents hung games on rare occasions where the deployment hex scoring process and/or path-generating process could result in a null return value, possibly hanging the game (I was not able to reproduce this error after making these changes).

Of note, changes previously made to prevent `ConcurrentModificationException` errors had to be reinforced with explicit `synchronized(modes)` blocks, possibly due to more checks introduced via the Pulse Module updates.  Keep this approach in mind for similar issues seen due to iterator usage causing fail-fast errors.

Testing:
1. ran mission from issue dozens of times.
2. ran all projects' unit tests.

Close #6259 