### PR TITLE
Fixed dirt and gravel roads landing modifiers and interactioins with moderate+ rain

### DIFF
--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -515,7 +515,15 @@ public interface IAero {
         boolean clear = false;
         for (Coords pos : landingPositions) {
             Hex hex = ((Entity) this).getGame().getBoard().getHex(pos);
-            if ((hex == null) || hex.hasPavementOrRoad()) {
+            if (hex == null) {
+                continue;
+            }
+            if (hex.hasPavementOrRoad()) {
+                if (hex.containsTerrain(Terrains.ROAD)) { //Check for dirt or gravel road, they're harder to land on
+                    if (Terrains.landingModifier(Terrains.ROAD, hex.terrainLevel(Terrains.ROAD)) > 0) {
+                        terrains.add(List.of(Terrains.ROAD, hex.terrainLevel(Terrains.ROAD)));
+                    }
+                }
                 continue;
             }
             if (hex.getBaseTerrainType() == 0) {

--- a/megamek/src/megamek/common/Terrains.java
+++ b/megamek/src/megamek/common/Terrains.java
@@ -550,6 +550,15 @@ public class Terrains implements Serializable {
                 return 2;
             case BUILDING:
                 return terrainLevel + 1;
+            case ROAD:
+                switch (terrainLevel) {
+                    case ROAD_LVL_DIRT:
+                        return 2;
+                    case ROAD_LVL_GRAVEL:
+                        return 1;
+                    default:
+                        return 0;
+                }
             case SNOW:
                 return (terrainLevel == 2) ? 1 : 0;
             case ICE:

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -195,7 +195,7 @@ public class BoardUtilities {
                     mapSettings.getMinForestSize(),
                     mapSettings.getMaxForestSize(), reverseHex, true);
         }
-        
+
         // Add foliage (1 elevation high woods)
         count = mapSettings.getMinFoliageSpots();
         if (mapSettings.getMaxFoliageSpots() > 0) {
@@ -220,7 +220,7 @@ public class BoardUtilities {
                     mapSettings.getMinJungleSize(),
                     mapSettings.getMaxJungleSize(), reverseHex, true);
         }
-        
+
         // Add the rough
         count = mapSettings.getMinRoughSpots();
         if (mapSettings.getMaxRoughSpots() > 0) {
@@ -559,7 +559,7 @@ public class BoardUtilities {
             field.addTerrain(new Terrain(Terrains.FOLIAGE_ELEV, 3));
         }
     }
-    
+
     /**
      * Places randomly some connected foliage.
      *
@@ -609,7 +609,7 @@ public class BoardUtilities {
             findAllUnused(board, terrainType, alreadyUsed, unUsed, field, reverseHex);
         }
 
-        
+
     }
 
     /**
@@ -1121,9 +1121,11 @@ public class BoardUtilities {
                 Coords c = new Coords(x, y);
                 Hex hex = board.getHex(c);
 
-                //moderate rain - mud in clear hexes, depth 0 water, and dirt roads (not implemented yet)
+                //moderate rain - mud in clear hexes, depth 0 water, and dirt roads
                 if (weatherCond.isModerateRainOrLightningStorm()) {
-                    if ((hex.terrainsPresent() == 0) || (hex.containsTerrain(Terrains.WATER) && (hex.depth() == 0))) {
+                    if ((hex.terrainsPresent() == 0)
+                            || (hex.containsTerrain(Terrains.WATER) && (hex.depth() == 0))
+                            || (hex.containsTerrain(Terrains.ROAD) && hex.terrainLevel(Terrains.ROAD) == Terrains.ROAD_LVL_DIRT)) {
                         hex.addTerrain(new Terrain(Terrains.MUD, 1));
                         if (hex.containsTerrain(Terrains.WATER)) {
                             hex.removeTerrain(Terrains.WATER);
@@ -1131,14 +1133,16 @@ public class BoardUtilities {
                     }
                 }
 
-                //heavy rain - mud in all hexes except buildings, depth 1+ water, and non-dirt roads
+                //heavy rain - mud in all hexes except buildings, depth 1+ water, pavement, and standard roads
                 //rapids in all depth 1+ water
                 if (weatherCond.isHeavyRainOrGustingRain()) {
                     if (hex.containsTerrain(Terrains.WATER) && !hex.containsTerrain(Terrains.RAPIDS) && (hex.depth() > 0)) {
                         hex.addTerrain(new Terrain(Terrains.RAPIDS, 1));
                     } else if (!hex.containsTerrain(Terrains.BUILDING)
                             && !hex.containsTerrain(Terrains.PAVEMENT)
-                            && !hex.containsTerrain(Terrains.ROAD)) {
+                            && ( !hex.containsTerrain(Terrains.ROAD)
+                                || hex.terrainLevel(Terrains.ROAD) == Terrains.ROAD_LVL_GRAVEL
+                                || hex.terrainLevel(Terrains.ROAD) == Terrains.ROAD_LVL_DIRT)) {
                         hex.addTerrain(new Terrain(Terrains.MUD, 1));
                         if (hex.containsTerrain(Terrains.WATER)) {
                             hex.removeTerrain(Terrains.WATER);
@@ -1156,7 +1160,9 @@ public class BoardUtilities {
                         hex.removeTerrain(Terrains.WATER);
                     } else if (!hex.containsTerrain(Terrains.BUILDING)
                             && !hex.containsTerrain(Terrains.PAVEMENT)
-                            && !hex.containsTerrain(Terrains.ROAD)) {
+                            && ( !hex.containsTerrain(Terrains.ROAD)
+                                || hex.terrainLevel(Terrains.ROAD) == Terrains.ROAD_LVL_GRAVEL
+                                || hex.terrainLevel(Terrains.ROAD) == Terrains.ROAD_LVL_DIRT)) {
                         hex.addTerrain(new Terrain(Terrains.MUD, 1));
                     }
                 }
@@ -1699,7 +1705,7 @@ public class BoardUtilities {
             return closerNorthThanSouth ? CardinalEdge.NORTH : CardinalEdge.SOUTH;
         }
     }
-    
+
     /**
      * Figures out the "opposite" edge for the given entity.
      * @param entity Entity to evaluate


### PR DESCRIPTION
No associated issue for this one. While working on #6302 I noticed some rules for dirt & gravel roads that weren't implemented. This adds the rules for landing modifiers (TO:AR pg. 33) and rain turning tiles to mud (TO:AR pg. 57).

I repeatedly tried preventing the whitespace changes from getting committed but it seems determined to be part of this PR.