### PR TITLE
Issue 6271: Offboard units to the North and West will be placed properly

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7636,7 +7636,7 @@ public class Compute {
 
     public static int turnsTilHit(int distance) {
         final int turnsTilHit;
-        // See indirect flight times table, TO p181
+        // See indirect flight times table, TO:AR p149
         if (distance <= Board.DEFAULT_BOARD_HEIGHT) {
             turnsTilHit = 0;
         } else if (distance <= (8 * Board.DEFAULT_BOARD_HEIGHT)) {

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10272,7 +10272,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             case NORTH:
                 setPosition(new Coords((game.getBoard().getWidth() / 2)
                         + (game.getBoard().getWidth() % 2),
-                        -getOffBoardDistance()));
+                        -getOffBoardDistance() - 1));
                 setFacing(3);
                 break;
             case SOUTH:
@@ -10290,7 +10290,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 setFacing(5);
                 break;
             case WEST:
-                setPosition(new Coords(-getOffBoardDistance(), (game.getBoard()
+                setPosition(new Coords(-getOffBoardDistance() - 1, (game.getBoard()
                         .getHeight() / 2) + (game.getBoard().getHeight() % 2)));
                 setFacing(1);
                 break;

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -60,20 +60,7 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
                         turnsTilHit = 2;
                     }
                 } else {
-                    // See indirect flight times table, TO p181
-                    if (distance <= Board.DEFAULT_BOARD_HEIGHT) {
-                        turnsTilHit = 0;
-                    } else if (distance <= (8 * Board.DEFAULT_BOARD_HEIGHT)) {
-                        turnsTilHit = 1;
-                    } else if (distance <= (15 * Board.DEFAULT_BOARD_HEIGHT)) {
-                        turnsTilHit = 2;
-                    } else if (distance <= (21 * Board.DEFAULT_BOARD_HEIGHT)) {
-                        turnsTilHit = 3;
-                    } else if (distance <= (26 * Board.DEFAULT_BOARD_HEIGHT)) {
-                        turnsTilHit = 4;
-                    } else {
-                        turnsTilHit = 5;
-                    }
+                    turnsTilHit = Compute.turnsTilHit(distance);
                 }
             }
             return;


### PR DESCRIPTION
Fixes #6271 

Offboard units to the North and West will be placed properly; use one method for determining artillery travel time

Units placed to the South and East will be placed at coordinates (0 indexed!) map-dimension (1-indexed!) + offboard distance. 

Units placed to the North and West **were** placed at coordinates (0 indexed!) -offboard distance. 

This resulted in units to the North and West being one hex closer than they should be, allowing users to fire artillery at less than a mapsheet despite being offboard, which shouldn't be possible. This was already accounted for with the South and East because they use the 1-indexed map dimension. 

I also noticed an identical artillery flight time algorithm in Entity.java and ArtilleryAttackAction.java. The one in Entity was already a method, so I changed ArtilleryAttackAction.java to use that method rather than implementing it on its own.
