### PR TITLE
Issue 2090: /nova chat command now works with non-enemy mechs too, as long as you own at least one

### DIFF
--- a/megamek/src/megamek/client/commands/AssignNovaNetworkCommand.java
+++ b/megamek/src/megamek/client/commands/AssignNovaNetworkCommand.java
@@ -186,7 +186,7 @@ public class AssignNovaNetworkCommand extends ClientCommand {
     private String strUnlinkAll() {
         List<Entity> novaUnits = getMyNovaUnits();
         for (Entity e : novaUnits) {
-            setNewNetworkID(e, e.getOriginalNovaC3NetId());
+            strUnlinkID(e.getId());
         }
         return "Everything unlinked";
     }
@@ -196,7 +196,7 @@ public class AssignNovaNetworkCommand extends ClientCommand {
         StringBuilder returnValue = new StringBuilder();
 
         List<Integer> allReadyReported = new LinkedList<>();
-        List<Entity> novaUnits = getMyNovaUnits();
+        List<Entity> novaUnits = getAlliedNovaUnits();
         List<Entity> network;
 
         for (Entity ent : novaUnits) {
@@ -255,7 +255,7 @@ public class AssignNovaNetworkCommand extends ClientCommand {
      */
     private List<Entity> listNetwork(Entity e, boolean planned) {
         List<Entity> novaNetworkMembers = new LinkedList<>();
-        List<Entity> novaUnits = getMyNovaUnits();
+        List<Entity> novaUnits = getAlliedNovaUnits();
 
         for (Entity ent : novaUnits) {
             if (planned) {
@@ -278,6 +278,22 @@ public class AssignNovaNetworkCommand extends ClientCommand {
         List<Entity> novaUnits = new LinkedList<>();
         for (Entity ent : getClient().getEntitiesVector()) {
             if ((ent.getOwnerId() == getClient().getLocalPlayer().getId()) && ent.hasNovaCEWS()) {
+                novaUnits.add(ent);
+            }
+        }
+        return novaUnits;
+    }
+
+    /**
+     * @return a list of all nova CEWS units the clients could connect with.
+     */
+    private List<Entity> getAlliedNovaUnits() {
+        List<Entity> novaUnits = new LinkedList<>();
+        for (Entity ent : getClient().getEntitiesVector()) {
+            if (ent.hasNovaCEWS()
+                && (ent.getOwnerId() == (getClient().getLocalPlayer().getId())
+                || (getClient().getLocalPlayer()) != null
+                && !getClient().getLocalPlayer().isEnemyOf(ent.getOwner()))){
                 novaUnits.add(ent);
             }
         }

--- a/megamek/src/megamek/client/commands/AssignNovaNetworkCommand.java
+++ b/megamek/src/megamek/client/commands/AssignNovaNetworkCommand.java
@@ -291,9 +291,9 @@ public class AssignNovaNetworkCommand extends ClientCommand {
         List<Entity> novaUnits = new LinkedList<>();
         for (Entity ent : getClient().getEntitiesVector()) {
             if (ent.hasNovaCEWS()
-                && (ent.getOwnerId() == (getClient().getLocalPlayer().getId())
-                || (getClient().getLocalPlayer()) != null
-                && !getClient().getLocalPlayer().isEnemyOf(ent.getOwner()))){
+                && ((ent.getOwnerId() == getClient().getLocalPlayer().getId())
+                    || (getClient().getLocalPlayer() != null
+                        && !getClient().getLocalPlayer().isEnemyOf(ent.getOwner())))){
                 novaUnits.add(ent);
             }
         }

--- a/megamek/src/megamek/server/commands/AssignNovaNetServerCommand.java
+++ b/megamek/src/megamek/server/commands/AssignNovaNetServerCommand.java
@@ -446,10 +446,10 @@ public class AssignNovaNetServerCommand extends ServerCommand {
     private List<Entity> getAlliedNovaUnits(int connID) {
         List<Entity> novaUnits = new LinkedList<>();
         for (Entity ent : gameManager.getGame().getEntitiesVector()) {
-            if ((ent.hasNovaCEWS()
-                && (ent.getOwnerId() == connID)
-                || (gameManager.getGame().getPlayer(connID)) != null
-                && !gameManager.getGame().getPlayer(connID).isEnemyOf(ent.getOwner()))){
+            if (ent.hasNovaCEWS()
+                && ((ent.getOwnerId() == connID)
+                    || (gameManager.getGame().getPlayer(connID) != null
+                        && !gameManager.getGame().getPlayer(connID).isEnemyOf(ent.getOwner())))){
                 novaUnits.add(ent);
             }
         }


### PR DESCRIPTION
Fixes #2090 

Notable "change": 
- OLD: /nova link required the entities you're linking to all be owned by you
- NEW: /nova link requires the entities you're linking to not be enemies AND one must be owned by you.