### PR TITLE
Rfe 6295: teach princess that leaping is dangerous

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4824,3 +4824,7 @@ Bot.commands.aggression=Aggression
 Bot.commands.bravery=Bravery
 Bot.commands.avoid=Self-Preservation
 Bot.commands.caution=Piloting Caution
+
+#### TacOps movement and damage descriptions
+TacOps.leaping.leg_damage=leaping (leg damage)
+TacOps.leaping.fall_damage=leaping (fall)

--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -600,7 +600,3 @@ BeastSize.monstrous=Monstrous
 
 ArtilleryMessage.drifted=Artillery drifted here from
 BombMessage.drifted=Bomb drifted here from
-
-#### TacOps movement and damage descriptions
-TacOps.movement.leaping.leg_damage=leaping (leg damage)
-TacOps.movement.leaping.fall_damage=leaping (fall)

--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -600,3 +600,7 @@ BeastSize.monstrous=Monstrous
 
 ArtilleryMessage.drifted=Artillery drifted here from
 BombMessage.drifted=Bomb drifted here from
+
+#### TacOps movement and damage descriptions
+TacOps.movement.leaping.leg_damage=leaping (leg damage)
+TacOps.movement.leaping.fall_damage=leaping (fall)

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -504,7 +504,7 @@ public class BasicPathRanker extends PathRanker {
         double utility = -calculateFallMod(successProbability, formula);
 
         // Worry about how badly we can damage ourselves on this path!
-        double expectedDamageTaken = calculateMovePathPSRDamage(movingUnit, fallTolerance, pathCopy, formula);
+        double expectedDamageTaken = calculateMovePathPSRDamage(movingUnit, pathCopy, formula);
         expectedDamageTaken += checkPathForHazards(pathCopy, movingUnit, game);
         expectedDamageTaken += MinefieldUtil.checkPathForMinefieldHazards(pathCopy);
 

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -503,12 +503,13 @@ public class BasicPathRanker extends PathRanker {
         double successProbability = getMovePathSuccessProbability(pathCopy, formula);
         double utility = -calculateFallMod(successProbability, formula);
 
+        // Worry about how badly we can damage ourselves on this path!
+        double expectedDamageTaken = calculateMovePathPSRDamage(movingUnit, fallTolerance, pathCopy, formula);
+        expectedDamageTaken += checkPathForHazards(pathCopy, movingUnit, game);
+        expectedDamageTaken += MinefieldUtil.checkPathForMinefieldHazards(pathCopy);
+
         // look at all of my enemies
         FiringPhysicalDamage damageEstimate = new FiringPhysicalDamage();
-
-        double expectedDamageTaken = checkPathForHazards(pathCopy, movingUnit, game);
-
-        expectedDamageTaken += MinefieldUtil.checkPathForMinefieldHazards(pathCopy);
 
         boolean extremeRange = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE);
         boolean losRange = game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_LOS_RANGE);

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -590,7 +590,7 @@ public class BasicPathRanker extends PathRanker {
         // firing position (successProbability), how much damage I can do
         // (weighted by bravery), less the damage I might take.
         double braveryValue = getOwner().getBehaviorSettings().getBraveryValue();
-        double braveryMod = successProbability * ((maximumDamageDone * braveryValue) - expectedDamageTaken);
+        double braveryMod = (successProbability * (maximumDamageDone * braveryValue)) - expectedDamageTaken;
         formula.append(" + braveryMod [")
                 .append(LOG_DECIMAL.format(braveryMod)).append(" = ")
                 .append(LOG_PERCENT.format(successProbability))

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -548,4 +548,40 @@ public class PathEnumerator {
 
         return mapHasBridges.get();
     }
+
+    /**
+     * Find paths with a similar direction and step count to the provided path, within the selected unit's
+     * already-computed unit paths.
+     * @param moverId
+     * @param prunedPath
+     * @return
+     */
+    protected List<MovePath> getSimilarUnitPaths(int moverId, BulldozerMovePath prunedPath) {
+        int mpDelta = 2;
+        int distanceDelta = 2;
+
+        List<MovePath> paths = new ArrayList<>();
+        if (!getUnitPaths().containsKey(moverId)) {
+            return paths;
+        }
+        List<MovePath> unitPaths = getUnitPaths().get(moverId);
+
+        Coords target = prunedPath.getDestination();
+        int prunedDistance = target.distance(prunedPath.getFinalCoords());
+
+        for (MovePath movePath: unitPaths) {
+            // We want unit paths that use similar amounts of MP to get similarly close to the BMP's destination
+            if (Math.abs((target.distance(movePath.getFinalCoords()) - prunedDistance)) > distanceDelta) {
+                continue;
+            }
+
+            if (Math.abs(movePath.getMpUsed() - prunedPath.getMpUsed()) > mpDelta ) {
+                continue;
+            }
+
+            paths.add(movePath);
+        }
+
+        return paths;
+    }
 }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -379,18 +379,17 @@ public abstract class PathRanker implements IPathRanker {
     /**
      * Estimates the most expected damage that a path could cause, given the pilot skill of the path ranker
      * and various conditions.
-     *
+     * <p>
      * Note:
+     *
      * @param movingEntity
-     * @param fallTolerance
      * @param path
      * @param msg
      * @return
      */
-    protected double calculateMovePathPSRDamage(Entity movingEntity, double fallTolerance, MovePath path, StringBuilder msg) {
+    protected double calculateMovePathPSRDamage(Entity movingEntity, MovePath path, StringBuilder msg) {
         double damage = 0.0;
 
-        // MovePath pathCopy = path.clone();
         List<TargetRoll> pilotingRolls = getPSRList(path);
         for (TargetRoll roll : pilotingRolls) {
             // Have to use if/else as switch/case won't allow runtime loading of strings without SDK 17 LTS support

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -396,11 +396,11 @@ public abstract class PathRanker implements IPathRanker {
             // Have to use if/else as switch/case won't allow runtime loading of strings without SDK 17 LTS support
             String description = roll.getLastPlainDesc().toLowerCase();
             if (
-                description.contains(Messages.getString("TacOps.movement.leaping.leg_damage"))
+                description.contains(Messages.getString("TacOps.leaping.leg_damage"))
             ) {
                 damage += predictLeapDamage(movingEntity, roll, msg);
             } else if (
-                description.contains(Messages.getString("TacOps.movement.leaping.fall_damage"))
+                description.contains(Messages.getString("TacOps.leaping.fall_damage"))
             ) {
                 damage += predictLeapFallDamage(movingEntity, roll, msg);
             }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -379,8 +379,8 @@ public abstract class PathRanker implements IPathRanker {
     /**
      * Estimates the most expected damage that a path could cause, given the pilot skill of the path ranker
      * and various conditions.
-     * <p>
-     * Note:
+     *
+     * XXX Sleet01: add fall pilot damage, skid damage, and low-gravity overspeed damage calcs
      *
      * @param movingEntity
      * @param path

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2490,6 +2490,8 @@ public class Princess extends BotClient {
                     // also return some paths that go a little slower than max speed
                     // in case the faster path would force an unwanted PSR or MASC check
                     prunedPaths.addAll(PathDecorator.decoratePath(prunedPath));
+                    // Return some of the already-computed unit paths as well.
+                    prunedPaths.addAll(getPrecognition().getPathEnumerator().getSimilarUnitPaths(mover.getId(), prunedPath));
                 }
                 return prunedPaths;
             }

--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -25,7 +25,11 @@ import megamek.common.annotations.Nullable;
 import megamek.common.options.OptionsConstants;
 import megamek.server.totalwarfare.TWGameManager;
 
+import static java.util.List.of;
+
 public class SharedUtility {
+
+    private static int CRIT_VALUE = 100;
 
     public static String doPSRCheck(MovePath md) {
         return (String) doPSRCheck(md, true);
@@ -46,7 +50,7 @@ public class SharedUtility {
 
     /**
      * Function that carries out PSR checks specific only to airborne aero units
-     * 
+     *
      * @param md           The path to check
      * @param stringResult Whether to return the report as a string
      * @return Collection of PSRs that will be required for this activity
@@ -256,11 +260,22 @@ public class SharedUtility {
                 if (leapDistance > 2) {
                     rollTarget = entity.getBasePilotingRoll(moveType);
                     entity.addPilotingModifierForTerrain(rollTarget, curPos);
-                    rollTarget.append(new PilotingRollData(entity.getId(), 2 * leapDistance, "leaping (leg damage)"));
+                    rollTarget.append(
+                        new PilotingRollData(
+                            entity.getId(),
+                            2 * leapDistance,
+                            Messages.getString("TacOps.movement.leaping.leg_damage")
+                        )
+                    );
                     SharedUtility.checkNag(rollTarget, nagReport, psrList);
                     rollTarget = entity.getBasePilotingRoll(moveType);
                     entity.addPilotingModifierForTerrain(rollTarget, curPos);
-                    rollTarget.append(new PilotingRollData(entity.getId(), leapDistance, "leaping (fall)"));
+                    rollTarget.append(
+                        new PilotingRollData(
+                            entity.getId(),
+                            leapDistance,
+                            Messages.getString("TacOps.movement.leaping.fall_damage"))
+                    );
                     SharedUtility.checkNag(rollTarget, nagReport, psrList);
                 }
             }
@@ -928,4 +943,45 @@ public class SharedUtility {
             return targets.stream().filter(t -> chosenDisplayName.equals(t.getDisplayName())).findAny().orElse(null);
         }
     }
+
+    public static double predictLeapFallDamage(Entity movingEntity, TargetRoll data, StringBuilder msg) {
+        // Rough guess based on normal pilots
+        double odds = Compute.oddsAbove(data.getValue(), false) / 100d;
+        int fallHeight = data.getModifiers().get(data.getModifiers().size()-1).getValue();
+        double fallDamage = Math.round(movingEntity.getWeight() / 10.0)
+            * (fallHeight + 1);
+        return fallDamage * (1 - odds);
+    }
+
+    /** Per TacOps p 20, a leap carries the following risks:
+     * 1. risk of damaging each leg by distance leaped (3 or more per leg); mod is 2 x distance leaped.
+     * 1.a 1 critical roll _per leg_.
+     * 1.b 1 _additional_ critical per leg that takes internal structure damage due to leaping damage.
+     * 2. risk of falling; mod is distance leaped.
+     * @param movingEntity
+     * @param data
+     * @param msg
+     * @return
+     */
+    public static double predictLeapDamage(Entity movingEntity, TargetRoll data, StringBuilder msg) {
+        int legMultiplier = (movingEntity.isQuadMek()) ? 4 : 2;
+        double odds = Compute.oddsAbove(data.getValue(), false) / 100d;
+        int fallHeight = data.getModifiers().get(data.getModifiers().size()-1).getValue() / 2;
+        double legDamage = fallHeight * (legMultiplier);
+        int[] legLocations = {BipedMek.LOC_LLEG, BipedMek.LOC_RLEG, QuadMek.LOC_LARM, QuadMek.LOC_RARM};
+
+        // Add required crits; say the effective leg "damage" from a crit is 100 for now.
+        legDamage += legMultiplier * CRIT_VALUE;
+
+        // Add additional crits for each leg that would take internal damage
+        for (int i=0;i<legMultiplier; i++) {
+            if (movingEntity.getArmor(legLocations[i]) < fallHeight) {
+                legDamage += CRIT_VALUE;
+            }
+        }
+
+        // Calculate odds of receiving this damage and return
+        return legDamage * (1 - odds);
+    }
+
 }

--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -264,7 +264,7 @@ public class SharedUtility {
                         new PilotingRollData(
                             entity.getId(),
                             2 * leapDistance,
-                            Messages.getString("TacOps.movement.leaping.leg_damage")
+                            Messages.getString("TacOps.leaping.leg_damage")
                         )
                     );
                     SharedUtility.checkNag(rollTarget, nagReport, psrList);
@@ -274,7 +274,7 @@ public class SharedUtility {
                         new PilotingRollData(
                             entity.getId(),
                             leapDistance,
-                            Messages.getString("TacOps.movement.leaping.fall_damage"))
+                            Messages.getString("TacOps.leaping.fall_damage"))
                     );
                     SharedUtility.checkNag(rollTarget, nagReport, psrList);
                 }
@@ -950,6 +950,10 @@ public class SharedUtility {
         int fallHeight = data.getModifiers().get(data.getModifiers().size()-1).getValue();
         double fallDamage = Math.round(movingEntity.getWeight() / 10.0)
             * (fallHeight + 1);
+        msg.append("\nPredicting expected Leap fall damage:")
+            .append(String.format("\n\tFall height: %d", fallHeight))
+            .append(String.format("\n\tChance of taking damage: %.2f", ((1-odds)*100d))).append('%')
+            .append(String.format("\n\tExpected total damage from fall: %.2f", fallDamage * (1 - odds) ));
         return fallDamage * (1 - odds);
     }
 
@@ -968,14 +972,22 @@ public class SharedUtility {
         double odds = Compute.oddsAbove(data.getValue(), false) / 100d;
         int fallHeight = data.getModifiers().get(data.getModifiers().size()-1).getValue() / 2;
         double legDamage = fallHeight * (legMultiplier);
+        msg.append("\nPredicting expected Leap damage:")
+            .append(String.format("\n\tFall height: %d", fallHeight))
+            .append(String.format("\n\tChance of taking damage: %.2f", ((1-odds)*100d))).append('%');
+
         int[] legLocations = {BipedMek.LOC_LLEG, BipedMek.LOC_RLEG, QuadMek.LOC_LARM, QuadMek.LOC_RARM};
 
-        // Add required crits; say the effective leg "damage" from a crit is 100 for now.
+        // Add required crits; say the effective leg "damage" from a crit is 20 for now.
         legDamage += legMultiplier * CRIT_VALUE;
+        msg.append(
+            String.format("\n\tAdding %d leg critical chances as %d additional damage", legMultiplier, legMultiplier * CRIT_VALUE)
+        );
 
         // Add additional crits for each leg that would take internal damage
         for (int i=0;i<legMultiplier; i++) {
             if (movingEntity.getArmor(legLocations[i]) < fallHeight) {
+                msg.append("\n\tAdditional critical due to internal structure damage...");
                 legDamage += CRIT_VALUE;
             }
         }

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -29,7 +29,7 @@ import megamek.common.pathfinder.BoardClusterTracker.MovementType;
  * An extension of the MovePath class that stores information about terrain that
  * needs
  * to be destroyed in order to move along the specified route.
- * 
+ *
  * @author NickAragua
  */
 public class BulldozerMovePath extends MovePath {
@@ -41,6 +41,7 @@ public class BulldozerMovePath extends MovePath {
     Map<Coords, Integer> additionalCosts = new HashMap<>();
     List<Coords> coordsToLevel = new ArrayList<>();
     double maxPointBlankDamage = -1;
+    Coords destination = null;
 
     public BulldozerMovePath(Game game, Entity entity) {
         super(game, entity);
@@ -174,6 +175,7 @@ public class BulldozerMovePath extends MovePath {
         copy.additionalCosts = new HashMap<>(additionalCosts);
         copy.coordsToLevel = new ArrayList<>(coordsToLevel);
         copy.maxPointBlankDamage = maxPointBlankDamage;
+        copy.destination = (destination == null) ? destination : new Coords(destination.getX(), destination.getY());
         return copy;
     }
 
@@ -288,6 +290,14 @@ public class BulldozerMovePath extends MovePath {
         return coordsToLevel;
     }
 
+    public Coords getDestination() {
+        return destination;
+    }
+
+    public void setDestination(Coords d) {
+        destination = d;
+    }
+
     @Override
     public String toString() {
         return super.toString() + " Leveling Cost: " + getLevelingCost() + " Additional Cost: " + getAdditionalCost();
@@ -297,7 +307,7 @@ public class BulldozerMovePath extends MovePath {
      * Comparator implementation useful in comparing two bulldozer move paths by
      * how many MP it'll take to accomplish that path, including time wasted
      * leveling any obstacles
-     * 
+     *
      * @author NickAragua
      *
      */

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -116,6 +116,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
             if (destinationCoords.contains(currentPath.getFinalCoords()) &&
                     ((bestPath == null) || (movePathComparator.compare(bestPath, currentPath) > 0))) {
                 bestPath = currentPath;
+                // Keep a record of where this path is headed
+                bestPath.setDestination(closest);
                 maximumCost = bestPath.getMpUsed() + bestPath.getLevelingCost();
             }
         }
@@ -124,8 +126,8 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
     }
 
     /**
-     * Calculates the closest coordinates to the given entity Coordinates which you
-     * have to blow up to get into are considered to be further
+     * Calculates the closest coordinates to the given entity
+     * Coordinates which you have to blow up to get into are considered to be further
      */
     public static Coords getClosestCoords(Set<Coords> destinationRegion, Entity entity) {
         Coords bestCoords = null;

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -2276,7 +2276,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     rollTarget = entity.getBasePilotingRoll(stepMoveType);
                     entity.addPilotingModifierForTerrain(rollTarget, curPos);
                     rollTarget.append(new PilotingRollData(entity.getId(),
-                            2 * leapDistance, Messages.getString("TacOps.movement.leaping.leg_damage")));
+                            2 * leapDistance, Messages.getString("TacOps.leaping.leg_damage")));
                     if (0 < gameManager.doSkillCheckWhileMoving(entity, lastElevation,
                             lastPos, curPos, rollTarget, false)) {
                         // do leg damage
@@ -2299,7 +2299,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     rollTarget = entity.getBasePilotingRoll(stepMoveType);
                     entity.addPilotingModifierForTerrain(rollTarget, curPos);
                     rollTarget.append(new PilotingRollData(entity.getId(),
-                            leapDistance, Messages.getString("TacOps.movement.leaping.fall_damage")));
+                            leapDistance, Messages.getString("TacOps.leaping.fall_damage")));
                     if (0 < gameManager.doSkillCheckWhileMoving(entity, lastElevation,
                             lastPos, curPos, rollTarget, false)) {
                         entity.setElevation(lastElevation);

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -23,6 +23,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import megamek.MMConstants;
+import megamek.client.ui.Messages;
 import megamek.common.*;
 import megamek.common.actions.AirMekRamAttackAction;
 import megamek.common.actions.AttackAction;
@@ -2275,7 +2276,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     rollTarget = entity.getBasePilotingRoll(stepMoveType);
                     entity.addPilotingModifierForTerrain(rollTarget, curPos);
                     rollTarget.append(new PilotingRollData(entity.getId(),
-                            2 * leapDistance, "leaping (leg damage)"));
+                            2 * leapDistance, Messages.getString("TacOps.movement.leaping.leg_damage")));
                     if (0 < gameManager.doSkillCheckWhileMoving(entity, lastElevation,
                             lastPos, curPos, rollTarget, false)) {
                         // do leg damage
@@ -2298,7 +2299,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     rollTarget = entity.getBasePilotingRoll(stepMoveType);
                     entity.addPilotingModifierForTerrain(rollTarget, curPos);
                     rollTarget.append(new PilotingRollData(entity.getId(),
-                            leapDistance, "leaping (fall)"));
+                            leapDistance, Messages.getString("TacOps.movement.leaping.fall_damage")));
                     if (0 < gameManager.doSkillCheckWhileMoving(entity, lastElevation,
                             lastPos, curPos, rollTarget, false)) {
                         entity.setElevation(lastElevation);

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -536,10 +536,10 @@ class BasicPathRankerTest {
         doReturn(0.5)
                 .when(testRanker)
                 .getMovePathSuccessProbability(any(MovePath.class), any(StringBuilder.class));
-        expected = new RankedPath(-298.125, mockPath, "Calculation: {fall mod ["
+        expected = new RankedPath(-318.125, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(250) + " = " + LOG_DECIMAL.format(0.5) + " * "
                 + LOG_DECIMAL.format(500) + "] + braveryMod ["
-                + LOG_DECIMAL.format(-3.12) + " = " + LOG_PERCENT.format(0.5)
+                + LOG_DECIMAL.format(-23.12) + " = " + LOG_PERCENT.format(0.5)
                 + " * ((" + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5)
                 + ") - " + LOG_DECIMAL.format(40) + "] - aggressionMod ["
                 + LOG_DECIMAL.format(30) + " = " + LOG_DECIMAL.format(12) + " * "
@@ -557,10 +557,10 @@ class BasicPathRankerTest {
         doReturn(0.75)
                 .when(testRanker)
                 .getMovePathSuccessProbability(any(MovePath.class), any(StringBuilder.class));
-        expected = new RankedPath(-174.6875, mockPath, "Calculation: {fall mod ["
+        expected = new RankedPath(-184.6875, mockPath, "Calculation: {fall mod ["
                 + LOG_DECIMAL.format(125) + " = " + LOG_DECIMAL.format(0.25) + " * "
                 + LOG_DECIMAL.format(500) + "] + braveryMod ["
-                + LOG_DECIMAL.format(-4.69) + " = " + LOG_PERCENT.format(0.75)
+                + LOG_DECIMAL.format(-14.69) + " = " + LOG_PERCENT.format(0.75)
                 + " * ((" + LOG_DECIMAL.format(22.5) + " * " + LOG_DECIMAL.format(1.5)
                 + ") - " + LOG_DECIMAL.format(40) + "] - aggressionMod ["
                 + LOG_DECIMAL.format(30) + " = " + LOG_DECIMAL.format(12) + " * "

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -439,6 +439,12 @@ class BasicPathRankerTest {
         when(mockPath.getLastStep()).thenReturn(mockLastStep);
         when(mockPath.getStepVector()).thenReturn(new Vector<>());
 
+        final TargetRoll mockTargetRoll = MockGenerators.mockTargetRoll(8);
+        final TargetRoll mockTargetRollTwo = MockGenerators.mockTargetRoll(5);
+        final List<TargetRoll> testRollList = List.of(mockTargetRoll, mockTargetRollTwo);
+
+        doReturn(testRollList).when(testRanker).getPSRList(eq(mockPath));
+
         final Board mockBoard = mock(Board.class);
         when(mockBoard.contains(any(Coords.class))).thenReturn(true);
         final Coords boardCenter = spy(new Coords(8, 8));
@@ -461,6 +467,7 @@ class BasicPathRankerTest {
         when(mockGame.getArtilleryAttacks()).thenReturn(Collections.emptyEnumeration());
         when(mockGame.getPlanetaryConditions()).thenReturn(mockPC);
         when(mockPrincess.getGame()).thenReturn(mockGame);
+        when(mockMover.getGame()).thenReturn(mockGame);
 
         final List<Entity> testEnemies = new ArrayList<>();
 

--- a/megamek/unittests/megamek/client/ui/SharedUtilityTest.java
+++ b/megamek/unittests/megamek/client/ui/SharedUtilityTest.java
@@ -1,0 +1,145 @@
+package megamek.client.ui;
+
+import megamek.client.Client;
+import megamek.client.ui.swing.ClientGUI;
+import megamek.common.*;
+import megamek.common.options.GameOptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static megamek.client.ui.SharedUtility.predictLeapDamage;
+import static megamek.client.ui.SharedUtility.predictLeapFallDamage;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SharedUtilityTest {
+    static GameOptions mockGameOptions = mock(GameOptions.class);
+    static ClientGUI cg = mock(ClientGUI.class);
+    static Client client = mock(Client.class);
+    static Game game = new Game();
+
+    static Mek bipedMek;
+    static Crew bipedPilot;
+    static Mek quadMek;
+    static Crew quadPilot;
+    static EntityMovementType moveType = EntityMovementType.MOVE_RUN;
+
+    @BeforeAll
+    static void setUpAll() {
+        // Need equipment initialized
+        EquipmentType.initializeTypes();
+        when(cg.getClient()).thenReturn(client);
+        when(cg.getClient().getGame()).thenReturn(game);
+        game.setOptions(mockGameOptions);
+
+        bipedMek = new BipedMek();
+        bipedMek.setGame(game);
+        bipedPilot = new Crew(CrewType.SINGLE);
+        quadMek = new QuadMek();
+        quadMek.setGame(game);
+        quadPilot = new Crew(CrewType.SINGLE);
+        bipedPilot.setPiloting(5);
+        bipedMek.setCrew(bipedPilot);
+        bipedMek.setId(1);
+        quadPilot.setPiloting(5);
+        quadMek.setCrew(quadPilot);
+        quadMek.setId(2);
+    }
+
+    @BeforeEach
+    void setUp() {
+        bipedMek.setArmor(10, Mek.LOC_LLEG);
+        bipedMek.setArmor(10, Mek.LOC_RLEG);
+        bipedMek.setWeight(50.0);
+
+        quadMek.setArmor(10, Mek.LOC_LLEG);
+        quadMek.setArmor(10, Mek.LOC_RLEG);
+        quadMek.setArmor(10, Mek.LOC_LARM);
+        quadMek.setArmor(10, Mek.LOC_RARM);
+        quadMek.setWeight(85.0);
+    }
+
+    TargetRoll generateLeapRoll(Entity entity, int leapDistance) {
+        TargetRoll rollTarget = entity.getBasePilotingRoll(moveType);
+        rollTarget.append(new PilotingRollData(entity.getId(),
+            2 * leapDistance, Messages.getString("TacOps.movement.leaping.leg_damage")));
+        return rollTarget;
+    }
+
+    TargetRoll generateLeapFallRoll(Entity entity, int leapDistance) {
+        TargetRoll rollTarget = entity.getBasePilotingRoll(moveType);
+        rollTarget.append(new PilotingRollData(entity.getId(),
+            leapDistance, Messages.getString("TacOps.movement.leaping.fall_damage")));
+        return rollTarget;
+    }
+
+    @Test
+    void testPredictLeapDamageBipedLeap3AvgPilot() {
+        TargetRoll data = generateLeapRoll(bipedMek, 3);
+        StringBuilder msg = new StringBuilder();
+
+        // Rough math:
+        // Chance of Pilot Skill 5 pilot to successfully Leap down 3 levels:
+        // 1 / 12 = 8.3% = 0.083
+        // Base biped mek damage from leap 3:
+        // + 2 x 3 = 6
+        // Estimate each crit chance expected damage at 100
+        // + 2 x 100 = 200
+        // Chance of extra crits if leg armor is greater than base damage is 0:
+        // + 0 * 100 = 0
+        // Times chance of this happening
+        // * (1 - 0.083)
+        // Approximately 188 damage expected.
+        double expectedDamage = 188.0;
+        double predictedDamage = predictLeapDamage(bipedMek, data, msg);
+
+        assertEquals(expectedDamage, predictedDamage, 1.0);
+    }
+
+    @Test
+    void testPredictLeapDamageQuadLeap3AvgPilot() {
+        TargetRoll data = generateLeapRoll(quadMek, 3);
+        StringBuilder msg = new StringBuilder();
+
+        // Rough math:
+        // Chance of Pilot Skill 5 pilot to successfully Leap down 3 levels:
+        // 3 / 12 = 0.277
+        // Base biped mek damage from leap 3:
+        // + 4 x 3 = 12
+        // Estimate each crit chance expected damage at 100
+        // + 4 x 100 = 400
+        // Chance of extra crits if leg armor is greater than base damage is 0:
+        // + 0 * 100 = 0
+        // Times chance of this happening
+        // * (1 - 0.277)
+        // Approximately 298 damage expected.
+        double expectedDamage = 298.0;
+        double predictedDamage = predictLeapDamage(quadMek, data, msg);
+
+        assertEquals(expectedDamage, predictedDamage, 1.0);
+    }
+
+    @Test
+    void testPredictLeapFallDamageBipedLeap3AvgPilot() {
+        TargetRoll data = generateLeapFallRoll(bipedMek, 3);
+        StringBuilder msg = new StringBuilder();
+
+        double expectedDamage = 12.0;
+        double predictedDamage = predictLeapFallDamage(bipedMek, data, msg);
+
+        assertEquals(expectedDamage, predictedDamage, 1.0);
+    }
+
+    @Test
+    void testPredictLeapFallDamageQuadLeap3AvgPilot() {
+        TargetRoll data = generateLeapFallRoll(quadMek, 3);
+        StringBuilder msg = new StringBuilder();
+
+        double expectedDamage = 10.0;
+        double predictedDamage = predictLeapFallDamage(quadMek, data, msg);
+
+        assertEquals(expectedDamage, predictedDamage, 1.0);
+    }
+}

--- a/megamek/unittests/megamek/client/ui/SharedUtilityTest.java
+++ b/megamek/unittests/megamek/client/ui/SharedUtilityTest.java
@@ -64,14 +64,14 @@ class SharedUtilityTest {
     TargetRoll generateLeapRoll(Entity entity, int leapDistance) {
         TargetRoll rollTarget = entity.getBasePilotingRoll(moveType);
         rollTarget.append(new PilotingRollData(entity.getId(),
-            2 * leapDistance, Messages.getString("TacOps.movement.leaping.leg_damage")));
+            2 * leapDistance, Messages.getString("TacOps.leaping.leg_damage")));
         return rollTarget;
     }
 
     TargetRoll generateLeapFallRoll(Entity entity, int leapDistance) {
         TargetRoll rollTarget = entity.getBasePilotingRoll(moveType);
         rollTarget.append(new PilotingRollData(entity.getId(),
-            leapDistance, Messages.getString("TacOps.movement.leaping.fall_damage")));
+            leapDistance, Messages.getString("TacOps.leaping.fall_damage")));
         return rollTarget;
     }
 

--- a/megamek/unittests/megamek/utils/MockGenerators.java
+++ b/megamek/unittests/megamek/utils/MockGenerators.java
@@ -190,6 +190,7 @@ public class MockGenerators {
 		final TargetRoll mockTargetRoll = mock(TargetRoll.class);
 		when(mockTargetRoll.getValue()).thenReturn(value);
 		when(mockTargetRoll.getDesc()).thenReturn("mock");
+        when(mockTargetRoll.getLastPlainDesc()).thenReturn("mock");
 		return mockTargetRoll;
 	}
 


### PR DESCRIPTION
### Summary
This patch looks to fix a long-standing issue with Princess pathing where she needlessly risks her units while attempting to close with opponents.  The title RFE refers to Leaping (from TacOps) but this likely applies to any number of hazards, specifically during the early turns before fire is exchanged.

### Problem
Currently Princess generates a large set of prospective paths for every unit she controls: 
1. first every hex on the map\* is added, 
2. then every invalid / un-occupiable hex is removed, 
3. then every path with invalid steps is removed, 
4. then every path which takes too many MPs is removed.

This produces usually dozens or hundreds of possible paths to choose from, all valid from a movement standpoint.
During most entity behaviour types, such as fighting or retreating, we then rank all these paths to find the best (or least-worst) option among them.
But during the period where Princess's units are closing on but not yet engaging their enemies, we ignore these paths completely and try to create a very few longest-distance-possible paths to guide each unit towards A) a known enemy position, B) a suspected enemy position (esp. for the heat map), C) a strategic target, or D) the opposite map edge.
The problem is that we currently replace _all_ pre-generated paths with these longest-distance paths, which may mean that a myriad of movement options are replaced by a few, or even just one, prospective high-speed movement path meant to close on the destination as soon as possible.  And the way we generate these long-distance paths is ignorant of hazards and PSRs.

Given single, or a small selection of, very bad paths, Princess unfortunately just takes the least-bad option.  In testing this bug I found that if one long-distance path contained a leap step, it was highly likely that _all_ did, because they were selected to maximize movement towards a specific hex in a nearly-straight line; no paths that avoid the leap (or other hazards) completely could be generated.  I warrant that this is true of other hazard types as well based on code inspection.

### Solution
I chose to attack this issue in two ways:
1. Using the generated longest-distance paths (specifically their original destination hex coords), add back some of the already-generated normal paths that provide nearly the same MP usage and progress toward the ultimate destination.  I chose +/- 2 MP usage and +/- 2 hexes from the distance travelled towards the destination; this should restrict alternative paths to those that travel in the same direction but leave some leeway as far as positioning.
2. Add additional expected damage calculations for the Leap PSR itself, and for the Fall PSR that accompanies it.  These take into account leap damage, leap critical damage, and fall damage, but not Pilot Hit damage (yet)

I additionally tweaked the way that the bravery mod and expected success values apply to the expected outgoing and incoming damage values, to prevent the Bravery/Aggression setting from completely overwhelming the damage avoidance setting in the Bot configuration.

So far I have not seen any noticeable difference in path calculation times between the new and old code, likely because:
A) the unit paths I'm selecting from were already pre-calculated and validated by the time they are added back to the prospective paths list, and
B) the new PSR checks only trigger when leaps are included in paths to be ranked, which should happen less often now.

### Testing
1. Added new unit tests to validate the Leap and Leap Fall PSR damage calculations
2. Updated existing path unit test to account for tweaked expected damage values.
3. Ran all 3 projects' unit tests.
4. Ran many Princess vs Princess simulations with Leaping, Sprinting, etc. enabled, using generated maps with large elevation changes:
4.a. Large and small armies
4.b. Large and small maps
4.c. New and old code
Leap instances were definitely reduced, although not completely removed from every simulation run.  They should still be available, after all, just not used inadvertently.

### N.B.
\*There is almost certainly an opportunity to speed up the initial unit path generation process by restricting its radius to the current unit's maximum MP in hexes, although comments in that code state that this process should be relatively fast even when scanning the entire map.
