### PR TITLE
fix typo and log errors

### DIFF
--- a/megamek/mmconf/skins/flatDarculaSkin.xml
+++ b/megamek/mmconf/skins/flatDarculaSkin.xml
@@ -24,7 +24,7 @@
 			<corner_top_left>FlatDarcula/unit/TLC.gif</corner_top_left>
 			<corner_top_right>FlatDarcula/unit/TRC.gif</corner_top_right>
 			<corner_bottom_left>FlatDarcula/unit/BLC.gif</corner_bottom_left>
-			<corner_bottom_right>FlatDarcula/unit/RRC.gif</corner_bottom_right>
+			<corner_bottom_right>FlatDarcula/unit/BRC.gif</corner_bottom_right>
 			<!-- Border lines: these images will be tiled -->
 			<edge>
 				<edgeIcon>

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -1816,6 +1816,10 @@ public class TWGameManager extends AbstractGameManager {
         r = new Report(7600, Report.PUBLIC);
         reports.add(r);
 
+        r = new Report(1230, Report.PUBLIC);
+        r.add("<BR>");
+        reports.add(r);
+
         for (Entity e : entities) {
             r = new Report(1231);
             r.subject = e.getId();

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -1246,7 +1246,7 @@ public class TWGameManager extends AbstractGameManager {
                         fleeDirection = "North";
                         break;
                     case Board.START_E:
-                        fleeDirection = "Ease";
+                        fleeDirection = "East";
                         break;
                     case Board.START_S:
                         fleeDirection = "South";
@@ -1813,7 +1813,7 @@ public class TWGameManager extends AbstractGameManager {
         r.add("</pre>");
         reports.add(r);
 
-        r = new Report(7600);
+        r = new Report(7600, Report.PUBLIC);
         reports.add(r);
 
         for (Entity e : entities) {


### PR DESCRIPTION
-fix Ease typo
-fix log errors


```
19:00:35,105 ERROR [megamek.server.totalwarfare.TWGameManager] {Packet Pump}
megamek.server.totalwarfare.TWGameManager.filterReport(TWGameManager.java:26249) - Attempting to filter a Report object that is not public yet but has no subject.
		messageId: 7600
```

```
19:07:22,905 ERROR [megamek.client.ui.swing.widget.MegaMekBorder] {AWT-EventQueue-0}
megamek.client.ui.swing.widget.MegaMekBorder.loadIcon(MegaMekBorder.java:98) - MegaMekBorder icon doesn't exist: C:\Users\edslo\OneDrive\Documents\git\kuronekochomusuke\megamek\megamek\data\images\widgets\FlatDarcula\unit\RRC.gif
```

fixes #6309