### PR TITLE
Fix 6032: Filter out Aakar font from Java font family names

### DIFF
--- a/megamek/src/megamek/client/ui/swing/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/swing/util/FontHandler.java
@@ -122,10 +122,13 @@ public final class FontHandler {
 
         logger.info("Loading fonts from Java's GraphicsEnvironment");
         for (String fontName : GraphicsEnvironment.getLocalGraphicsEnvironment().getAvailableFontFamilyNames()) {
-            allFontNames.add(fontName);
-            Font font = Font.decode(fontName);
-            if (font.canDisplayUpTo(SYMBOL_TEST_STRING) == -1) {
-                nonSymbolFontNames.add(fontName);
+            // Skip Aakar specifically; it causes graphical artefacts when present and selected as the default font.
+            if (!fontName.toLowerCase().contains("aakar")) {
+                allFontNames.add(fontName);
+                Font font = Font.decode(fontName);
+                if (font.canDisplayUpTo(SYMBOL_TEST_STRING) == -1) {
+                    nonSymbolFontNames.add(fontName);
+                }
             }
         }
         initialized = true;


### PR DESCRIPTION
We determined that Aakar causes graphical glitches and artefacts when used in MegaMek.
This font has known issues at least in Ubuntu 18 and later ([q.v.](https://github.com/AlloyTools/org.alloytools.alloy/issues/73)) but is not available / installed by default in other OSes, so removing it should be a non-issue.
I've confirmed that this change also makes the font unavailable for MML and MHQ as well, although it should be retained as an MML export option for completeness.

Testing:
- Ran all 3 projects' unit tests
- Started games and confirmed Aakar was removed from font list options.

Close #6032 