### PR TITLE
add indicators heat in the weapon display

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1256,10 +1256,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         String heatMessage = heatText + " (" + heatCapacityStr + ')' + sheatOverCapacity;
         String tempIndicatoer = "";
 
-        if (game.getPlanetaryConditions().isExtremeTemperature()) {
+        if ((game != null) && (game.getPlanetaryConditions().isExtremeTemperature())) {
             tempIndicatoer = " " + game.getPlanetaryConditions().getTemperatureIndicator();
         }
-        
+
         heatMessage += cambatComputerIndicator + tempIndicatoer;
 
         currentHeatBuildupR.setForeground(GUIP.getColorForHeat(heatOverCapacity, Color.WHITE));

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1097,6 +1097,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                 + Math.min(max_ext_heat, en.heatFromExternal) // heat from external sources
                 + en.heatBuildup) // heat we're building up this round
                 - Math.min(9, en.coolFromExternal); // cooling from external
+
         // sources
         if (en instanceof Mek) {
             if (en.infernos.isStillBurning()) { // hit with inferno ammo
@@ -1229,8 +1230,10 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             currentHeatBuildup++;
         }
 
+        String cambatComputerIndicator = "";
         if (en.hasQuirk(OptionsConstants.QUIRK_POS_COMBAT_COMPUTER)) {
             currentHeatBuildup -= 4;
+            cambatComputerIndicator = " \uD83D\uDCBB";
         }
 
         // check for negative values due to extreme temp
@@ -1250,8 +1253,17 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             sheatOverCapacity = " " + heatOverCapacity + " " + msg_over;
         }
 
+        String heatMessage = heatText + " (" + heatCapacityStr + ')' + sheatOverCapacity;
+        String tempIndicatoer = "";
+
+        if (game.getPlanetaryConditions().isExtremeTemperature()) {
+            tempIndicatoer = " " + game.getPlanetaryConditions().getTemperatureIndicator();
+        }
+        
+        heatMessage += cambatComputerIndicator + tempIndicatoer;
+
         currentHeatBuildupR.setForeground(GUIP.getColorForHeat(heatOverCapacity, Color.WHITE));
-        currentHeatBuildupR.setText(heatText + " (" + heatCapacityStr + ')' + sheatOverCapacity);
+        currentHeatBuildupR.setText(heatMessage);
 
         // change what is visible based on type
         if (entity.usesWeaponBays()) {
@@ -1270,7 +1282,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
             wArcHeatL.setVisible(true);
             wArcHeatR.setVisible(true);
         }
-
 
         wDamageTrooperL.setVisible(false);
         wDamageTrooperR.setVisible(false);


### PR DESCRIPTION
- add indicators heat in the weapon display
- indicator for when unit has a combat computer and the display is factoring it in
- indicators for extreme temps and the display is factoring it in
- these are factored in on the unit display to make checking heat for TSM easier

![image](https://github.com/user-attachments/assets/94a74d38-7ec4-4006-9b04-9df56e84116f)
![Screenshot 2024-12-26 230420](https://github.com/user-attachments/assets/4dba419c-a1ae-49af-b6fc-9a95e86d2233)
