### PR TITLE
Fix MML #1667: incorrect cargo bay minimum doors (MM side)

### DIFF
--- a/megamek/src/megamek/common/AbstractSmallCraftASFBay.java
+++ b/megamek/src/megamek/common/AbstractSmallCraftASFBay.java
@@ -22,7 +22,7 @@ package megamek.common;
 /**
  * This is a base class for the very similar ASFBay and SmallCraftBay.
  */
-public abstract class AbstractSmallCraftASFBay extends Bay {
+public abstract class AbstractSmallCraftASFBay extends UnitBay {
 
     private final boolean hasArts;
 

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -126,6 +126,7 @@ public class Bay implements Transporter, ITechnology {
     public int getMinDoors() {
         return minDoors;
     }
+
     public void setDoors(int d) {
         doors = d;
         doorsNext = d;

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -37,26 +37,27 @@ public class Bay implements Transporter, ITechnology {
     public static final String FIELD_SEPARATOR = ":";
     public static final String FACING_PREFIX = "f";
 
-    /** Minimum number of doors for all bays (except infantry) is 1 **/
-    int minDoors = 1;
-    int doors = 1;
-    int doorsNext = 1;
-    int currentdoors = doors;
-    private int unloadedThisTurn = 0;
+    // Minimum number of doors for all unit bays (except infantry) is 1
+    // Minimum number of doors for all other bays is 0
+    protected int minDoors = 0;
+    protected int doors = 1;
+    protected int doorsNext = 1;
+    protected int currentdoors = doors;
+    protected int unloadedThisTurn = 0;
     protected int loadedThisTurn = 0;
-    List<Integer> recoverySlots = new ArrayList<>();
-    int bayNumber = 0;
-    transient Game game = null;
-    private double damage;
+    protected List<Integer> recoverySlots = new ArrayList<>();
+    protected int bayNumber = 0;
+    protected transient Game game = null;
+    protected double damage;
 
     /** The troops being carried. */
-    Vector<Integer> troops = new Vector<>();
+    protected Vector<Integer> troops = new Vector<>();
 
     /** The total amount of space available for troops. */
-    double totalSpace;
+    protected double totalSpace;
 
     /** The current amount of space not occupied by troops or cargo. */
-    double currentSpace;
+    protected double currentSpace;
 
     /**
      * The default constructor is only for serialization.

--- a/megamek/src/megamek/common/DropshuttleBay.java
+++ b/megamek/src/megamek/common/DropshuttleBay.java
@@ -17,17 +17,17 @@ package megamek.common;
 /**
  * Implements internal bays for dropships used by primitive jumpships.
  * See rules IO, p. 119.
- * 
+ *
  * @author Neoancient
  *
  */
-public class DropshuttleBay extends Bay {
-    
+public class DropshuttleBay extends UnitBay {
+
     /**
-     * 
+     *
      */
     private static final long serialVersionUID = -6910402023514976670L;
-    
+
     // No more than one bay is allowed per armor facing
     private int facing = Entity.LOC_NONE;
 
@@ -44,7 +44,7 @@ public class DropshuttleBay extends Bay {
      * Create a new dropshuttle bay
      *
      * @param doors     The number of bay doors
-     * @param bayNumber The bay index, unique to the Entity 
+     * @param bayNumber The bay index, unique to the Entity
      * @param facing    The armor facing of the bay
      */
     public DropshuttleBay(int doors, int bayNumber, int facing) {
@@ -65,22 +65,22 @@ public class DropshuttleBay extends Bay {
 
     @Override
     public boolean canLoad(Entity unit) {
-        
+
         return unit.hasETypeFlag(Entity.ETYPE_DROPSHIP)
                 && (unit.getWeight() <= 5000)
                 && (currentSpace >= 1);
     }
-    
+
     @Override
     public double getWeight() {
         return 11000;
     }
-    
+
     @Override
     public int getFacing() {
         return facing;
     }
-    
+
     /**
      * Sets the bay location
      * @param facing The armor facing (location) of the bay
@@ -89,7 +89,7 @@ public class DropshuttleBay extends Bay {
     public void setFacing(int facing) {
         this.facing = facing;
     }
-    
+
     @Override
     public String toString() {
         String bayType = "dropshuttlebay";
@@ -103,12 +103,12 @@ public class DropshuttleBay extends Bay {
                 0
         );
     }
-    
+
     @Override
     public int hardpointCost() {
         return 2;
     }
-    
+
     public static TechAdvancement techAdvancement() {
         return new TechAdvancement(TECH_BASE_IS).setISAdvancement(2110, 2120, DATE_NONE, 2500)
                 .setISApproximate(true, false).setTechRating(RATING_C)

--- a/megamek/src/megamek/common/HeavyVehicleBay.java
+++ b/megamek/src/megamek/common/HeavyVehicleBay.java
@@ -23,7 +23,7 @@ package megamek.common;
  * Represents a Transport Bay (TM p.239) for carrying heavy vehicles (not heavier than 100t) aboard large spacecraft
  * or other units.
  */
-public final class HeavyVehicleBay extends Bay {
+public final class HeavyVehicleBay extends UnitBay {
     private static final long serialVersionUID = 3490408642054662664L;
 
     /**
@@ -88,7 +88,7 @@ public final class HeavyVehicleBay extends Bay {
                 .setAvailability(RATING_B, RATING_B, RATING_B, RATING_B)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return HeavyVehicleBay.techAdvancement();

--- a/megamek/src/megamek/common/LightVehicleBay.java
+++ b/megamek/src/megamek/common/LightVehicleBay.java
@@ -23,7 +23,7 @@ package megamek.common;
  * Represents a Transport Bay (TM p.239) for carrying light vehicles (not heavier than 50t) aboard large spacecraft
  * or other units.
  */
-public final class LightVehicleBay extends Bay {
+public final class LightVehicleBay extends UnitBay {
     private static final long serialVersionUID = -1587851184051479305L;
 
     /**
@@ -88,7 +88,7 @@ public final class LightVehicleBay extends Bay {
                 .setAvailability(RATING_B, RATING_B, RATING_B, RATING_B)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return LightVehicleBay.techAdvancement();

--- a/megamek/src/megamek/common/MekBay.java
+++ b/megamek/src/megamek/common/MekBay.java
@@ -22,7 +22,7 @@ package megamek.common;
 /**
  * Represents a Transport Bay (TM p.239) for carrying Meks or LAMs aboard large spacecraft other units.
  */
-public final class MekBay extends Bay {
+public final class MekBay extends UnitBay {
     private static final long serialVersionUID = 927162989742234173L;
 
     /**

--- a/megamek/src/megamek/common/NavalRepairFacility.java
+++ b/megamek/src/megamek/common/NavalRepairFacility.java
@@ -19,14 +19,14 @@ import java.text.DecimalFormat;
 /**
  * Standard naval repair facilities for space stations (jumpships and warships can also carry a single facility).
  * See TacOps 334-5 for rules.
- * 
+ *
  * @author Neoancient
  *
  */
-public class NavalRepairFacility extends Bay {
-    
+public class NavalRepairFacility extends UnitBay {
+
     private static final long serialVersionUID = -5983197195382933671L;
-    
+
     // No more than one bay is allowed per armor facing
     private int facing = Entity.LOC_NONE;
     private boolean pressurized = false;
@@ -76,7 +76,7 @@ public class NavalRepairFacility extends Bay {
         this.pressurized = pressurized;
         this.arts = arts;
     }
-    
+
     /**
      * Pressurized facility allows crew to work without encumbrance of life support gear. No game effect
      * that I could find.
@@ -94,7 +94,7 @@ public class NavalRepairFacility extends Bay {
     public boolean hasARTS() {
         return arts;
     }
-    
+
     public void setPressurized(boolean pressurized) {
         this.pressurized = pressurized;
     }
@@ -131,7 +131,7 @@ public class NavalRepairFacility extends Bay {
             return false;
         }
     }
-    
+
     @Override
     public double getWeight() {
         double factor;
@@ -145,12 +145,12 @@ public class NavalRepairFacility extends Bay {
         }
         return RoundWeight.nextHalfTon(totalSpace * factor);
     }
-    
+
     @Override
     public int getFacing() {
         return facing;
     }
-    
+
     /**
      * Sets the bay location
      * @param facing The armor facing (location) of the bay
@@ -159,7 +159,7 @@ public class NavalRepairFacility extends Bay {
     public void setFacing(int facing) {
         this.facing = facing;
     }
-    
+
     @Override
     public String toString() {
         return (arts ? "artsnavalrepair" : "navalrepair")
@@ -169,7 +169,7 @@ public class NavalRepairFacility extends Bay {
                 + bayNumber + FIELD_SEPARATOR
                 + FACING_PREFIX + getFacing();
     }
-    
+
     @Override
     public String getUnusedString(boolean showRecovery) {
         StringBuilder sb = new StringBuilder("Standard ");
@@ -185,12 +185,12 @@ public class NavalRepairFacility extends Bay {
         sb.append(DecimalFormat.getInstance().format(totalSpace)).append(" tons");
         return sb.toString();
     }
-    
+
     @Override
     public int hardpointCost() {
         return 2;
     }
-    
+
     public static TechAdvancement techAdvancement() {
         return new TechAdvancement(TECH_BASE_ALL).setAdvancement(DATE_ES, DATE_ES, DATE_ES)
                 .setTechRating(RATING_C)

--- a/megamek/src/megamek/common/ProtoMekBay.java
+++ b/megamek/src/megamek/common/ProtoMekBay.java
@@ -17,7 +17,7 @@ package megamek.common;
  * Represents a volume of space set aside for carrying ProtoMeks aboard large spacecraft and mobile
  * structures
  */
-public final class ProtoMekBay extends Bay {
+public final class ProtoMekBay extends UnitBay {
     private static final long serialVersionUID = 927162989742234173L;
 
     /**

--- a/megamek/src/megamek/common/SuperHeavyVehicleBay.java
+++ b/megamek/src/megamek/common/SuperHeavyVehicleBay.java
@@ -23,7 +23,7 @@ package megamek.common;
  * Represents a Transport Bay (TM p.239) for carrying superheavy vehicles (not heavier than 200t)
  * aboard large spacecraft or other units.
  */
-public final class SuperHeavyVehicleBay extends Bay {
+public final class SuperHeavyVehicleBay extends UnitBay {
     private static final long serialVersionUID = 3490408642054662664L;
 
     /**
@@ -88,7 +88,7 @@ public final class SuperHeavyVehicleBay extends Bay {
                 .setAvailability(RATING_C, RATING_C, RATING_C, RATING_C)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
-    
+
     @Override
     public TechAdvancement getTechAdvancement() {
         return SuperHeavyVehicleBay.techAdvancement();

--- a/megamek/src/megamek/common/UnitBay.java
+++ b/megamek/src/megamek/common/UnitBay.java
@@ -25,14 +25,12 @@ package megamek.common;
  */
 public class UnitBay extends Bay{
 
-    // Minimum number of doors for all unit bays (except infantry) is 1
-    int minDoors = 1;
-
     /**
      * The default constructor is only for serialization.
      */
     protected UnitBay() {
         super();
+        minDoors = 1;
     }
 
     /**
@@ -46,5 +44,6 @@ public class UnitBay extends Bay{
      */
     public UnitBay(double space, int doors, int bayNumber) {
         super(space, doors, bayNumber);
+        minDoors = 1;
     }
 }

--- a/megamek/src/megamek/common/UnitBay.java
+++ b/megamek/src/megamek/common/UnitBay.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2003-2004 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2018-2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+package megamek.common;
+
+/**
+ * Represents a volume of space set aside for carrying units of some sort
+ * aboard large spacecraft and mobile structures
+ */
+public class UnitBay extends Bay{
+
+    // Minimum number of doors for all unit bays (except infantry) is 1
+    int minDoors = 1;
+
+    /**
+     * The default constructor is only for serialization.
+     */
+    protected UnitBay() {
+        super();
+    }
+
+    /**
+     * Create a space for the given tonnage of troops. For this class, only the
+     * weight of the troops (and their equipment) are considered; if you'd like
+     * to think that they are stacked like lumber, be my guest.
+     *
+     * @param space The weight of troops (in tons) this space can carry.
+     * @param doors      The number of bay doors
+     * @param bayNumber  The id number for the bay
+     */
+    public UnitBay(double space, int doors, int bayNumber) {
+        super(space, doors, bayNumber);
+    }
+}

--- a/megamek/src/megamek/common/verifier/BayData.java
+++ b/megamek/src/megamek/common/verifier/BayData.java
@@ -13,6 +13,8 @@
  */
 package megamek.common.verifier;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiFunction;
 
 import megamek.common.*;
@@ -36,19 +38,19 @@ public enum BayData {
     VEHICLE_SH ("Superheavy Vehicle", 200.0, 15, SuperHeavyVehicleBay.techAdvancement(),
             (size, num) -> new SuperHeavyVehicleBay(size, 1, num)),
     INFANTRY_FOOT ("Infantry (Foot)", 5.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 1, num, InfantryBay.PlatoonType.FOOT)),
+            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.FOOT)),
     INFANTRY_JUMP ("Infantry (Jump)", 6.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 1, num, InfantryBay.PlatoonType.JUMP)),
+            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.JUMP)),
     INFANTRY_MOTORIZED ("Infantry (Motorized)", 7.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 1, num, InfantryBay.PlatoonType.MOTORIZED)),
+            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.MOTORIZED)),
     INFANTRY_MECHANIZED ("Infantry (Mek. Squad)", 8.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 1, num, InfantryBay.PlatoonType.MECHANIZED)),
+            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.MECHANIZED)),
     IS_BATTLE_ARMOR ("BattleArmor (IS)", 8.0, 6, BattleArmorBay.techAdvancement(),
-            (size, num) -> new BattleArmorBay(size, 1, num, false, false)),
+            (size, num) -> new BattleArmorBay(size, 0, num, false, false)),
     CLAN_BATTLE_ARMOR ("BattleArmor (Clan)", 10.0, 6, BattleArmorBay.techAdvancement(),
-            (size, num) -> new BattleArmorBay(size, 1, num, true, false)),
+            (size, num) -> new BattleArmorBay(size, 0, num, true, false)),
     CS_BATTLE_ARMOR ("BattleArmor (CS)", 12.0, 6, BattleArmorBay.techAdvancement(),
-            (size, num) -> new BattleArmorBay(size, 1, num, false, true)),
+            (size, num) -> new BattleArmorBay(size, 0, num, false, true)),
     FIGHTER ("Fighter", 150.0, 2, ASFBay.techAdvancement(),
             (size, num) -> new ASFBay(size, 1, num)),
     SMALL_CRAFT ("Small Craft", 200.0, 5, SmallCraftBay.techAdvancement(),
@@ -70,21 +72,31 @@ public enum BayData {
     ARTS_REPAIR_PRESSURIZED ("ARTS Standard Repair Facility (Pressurized)", 0.09375, 0, Bay.artsTechAdvancement(),
             (size, num) -> new NavalRepairFacility(size, 1, num, 0, true, true)),
     CARGO ("Cargo", 1.0, 0, CargoBay.techAdvancement(),
-            (size, num) -> new CargoBay(size, 1, num)),
+            (size, num) -> new CargoBay(size, 0, num)),
     LIQUID_CARGO ("Cargo (Liquid)", 1/0.91, 0, CargoBay.techAdvancement(),
-            (size, num) -> new LiquidCargoBay(size, 1, num)),
+            (size, num) -> new LiquidCargoBay(size, 0, num)),
     REFRIGERATED_CARGO ("Cargo (Refrigerated)", 1/0.87, 0, CargoBay.techAdvancement(),
-            (size, num) -> new RefrigeratedCargoBay(size, 1, num)),
+            (size, num) -> new RefrigeratedCargoBay(size, 0, num)),
     INSULATED_CARGO ("Cargo (Insulated)", 1/0.87, 0, CargoBay.techAdvancement(),
-            (size, num) -> new InsulatedCargoBay(size, 1, num)),
+            (size, num) -> new InsulatedCargoBay(size, 0, num)),
     LIVESTOCK_CARGO ("Cargo Livestock)", 1/0.83, 0, CargoBay.techAdvancement(),
-            (size, num) -> new LivestockCargoBay(size, 1, num));
+            (size, num) -> new LivestockCargoBay(size, 0, num));
 
     private final String name;
     private final double weight;
     private final int personnel;
     private final TechAdvancement techAdvancement;
     private final BiFunction<Double,Integer,Bay> init;
+
+    static final List<Enum> noMinDoorBayTypes = new ArrayList<>();
+
+    static {
+         noMinDoorBayTypes.addAll(List.of(
+             INFANTRY_FOOT, INFANTRY_JUMP, INFANTRY_MECHANIZED, INFANTRY_MOTORIZED,
+             IS_BATTLE_ARMOR, CLAN_BATTLE_ARMOR, CS_BATTLE_ARMOR,
+             CARGO, INSULATED_CARGO, LIQUID_CARGO, LIVESTOCK_CARGO, REFRIGERATED_CARGO
+         ));
+    }
 
     BayData(String name, double weight, int personnel,
             TechAdvancement techAdvancement, BiFunction<Double,Integer,Bay> init) {
@@ -117,6 +129,15 @@ public enum BayData {
      */
     public int getPersonnel() {
         return personnel;
+    }
+
+    /**
+     * Return the minimum number of doors required for the Bay type this BayType
+     * encapsulates.
+     * @return 0 if no minimum door count applies, or 1 otherwise.
+     */
+    public int getMinDoors() {
+        return noMinDoorBayTypes.contains(this) ? 0 : 1;
     }
 
     /**


### PR DESCRIPTION
Fix for MegaMek/megameklab#1667, "Incorrect minimum doors required for cargo bays".

Corrects default minimum door # for Bay, derived Cargo and Infantry bays, and a new base class UnitBay from which all transport bays which require a minimum of 1 door will inherit.

NOTE: merging this PR alone will not fix the above issue; also merge https://github.com/MegaMek/megameklab/pull/1669.

Testing:

- Loaded units from original issue successfully.
- Added various bays with 0 doors as default.
- Reduced existing cargo bay doors to 0 without issue.
- Saved and loaded updated units.
- Ran all 3 projects' unit tests (with MM and MML patches applied)
