### PR TITLE
Building type enum

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -124,6 +124,12 @@ WeaponSortOrder.DAMAGE_HIGH_LOW.text=Damage (High-Low)
 WeaponSortOrder.WEAPON_ARC.text=Weapon Arc
 WeaponSortOrder.CUSTOM.text=Custom
 
+BuildingType.UNKNOWN.text=Unknown
+BuildingType.LIGHT.text=Light
+BuildingType.MEDIUM.text=Medium
+BuildingType.HEAVY.text=Heavy
+BuildingType.HARDENED.text=Hardened
+BuildingType.WALL.text=Wall
 
 
 ##### Unsorted Resources

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigDialog.java
@@ -881,7 +881,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
                         final Building bldg = board.getBuildingAt(coords);
                         if (hex.containsTerrain(BUILDING)) {
                             content += Messages.getString("BotConfigDialog.hexListBldg",
-                                    Building.typeName(bldg.getType()),
+                                    bldg.getType().toString(),
                                     Building.className(bldg.getBldgClass()), hex.terrainLevel(BLDG_ELEV),
                                     hex.terrainLevel(BLDG_CF));
                         } else if (hex.containsTerrain(FUEL_TANK)) {
@@ -889,7 +889,7 @@ public class BotConfigDialog extends AbstractButtonDialog implements ActionListe
                                     hex.terrainLevel(FUEL_TANK_CF), hex.terrainLevel(FUEL_TANK_MAGN));
                         } else {
                             content += Messages.getString("BotConfigDialog.hexListBrdg",
-                                    Building.typeName(bldg.getType()),
+                                    bldg.getType().toString(),
                                     hex.terrainLevel(BRIDGE_ELEV), hex.terrainLevel(BRIDGE_CF));
                         }
                         invalid = false;

--- a/megamek/src/megamek/client/ui/dialogs/BotConfigTargetHexDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotConfigTargetHexDialog.java
@@ -160,13 +160,13 @@ public class BotConfigTargetHexDialog extends AbstractButtonDialog {
                 final Hex hex = board.getHex(coords);
                 final Building bldg = board.getBuildingAt(coords);
                 if (hex.containsTerrain(BUILDING)) {
-                    content += Messages.getString("BotConfigDialog.hexListBldg", Building.typeName(bldg.getType()),
+                    content += Messages.getString("BotConfigDialog.hexListBldg", bldg.getType().toString(),
                             Building.className(bldg.getBldgClass()), hex.terrainLevel(BLDG_ELEV), hex.terrainLevel(BLDG_CF));
                 } else if (hex.containsTerrain(FUEL_TANK)) {
                     content += Messages.getString("BotConfigDialog.hexListFuel",
                             hex.terrainLevel(FUEL_TANK_CF), hex.terrainLevel(FUEL_TANK_MAGN));
                 } else {
-                    content += Messages.getString("BotConfigDialog.hexListBrdg", Building.typeName(bldg.getType()),
+                    content += Messages.getString("BotConfigDialog.hexListBrdg",bldg.getType().toString(),
                             hex.terrainLevel(BRIDGE_ELEV), hex.terrainLevel(BRIDGE_CF));
                 }
             }

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -1488,7 +1488,7 @@ public class Board implements Serializable {
 
         // Add rubble terrain that matches the building type.
         if (type > 0) {
-            int rubbleLevel = bldg.getBldgClass() == Building.FORTRESS ? 2 : 1;
+            int rubbleLevel = bldg.getType().getTypeValue();
             curHex.addTerrain(new Terrain(Terrains.RUBBLE, rubbleLevel));
         }
 

--- a/megamek/src/megamek/common/Building.java
+++ b/megamek/src/megamek/common/Building.java
@@ -52,12 +52,6 @@ public class Building implements Serializable {
      */
     protected static final int UNKNOWN = -1;
 
-    // The Building Types
-    public static final int LIGHT = 1;
-    public static final int MEDIUM = 2;
-    public static final int HEAVY = 3;
-    public static final int HARDENED = 4;
-    public static final int WALL = 5;
 
     /**
      * The Building Type of the building; equal to the terrain elevation of the
@@ -582,7 +576,7 @@ public class Building implements Serializable {
      */
     public static int getDefaultCF(BuildingType type) 
     {
-        return getDefaultCF(type.getTypeValue());
+        return type.getDefaultCF();
     }
     
     /**
@@ -596,23 +590,7 @@ public class Building implements Serializable {
      *         <code>Building.UNKNOWN</code> will be returned instead.
      */
     public static int getDefaultCF(int type) {
-        int retval = Building.UNKNOWN;
-        switch (type) {
-            case LIGHT:
-                retval = 15;
-                break;
-            case MEDIUM:
-                retval = 40;
-                break;
-            case HEAVY:
-                retval = 90;
-                break;
-            case HARDENED:
-            case WALL:
-                retval = 120;
-                break;
-        }
-        return retval;
+        return getDefaultCF(BuildingType.getType(type));
     }
 
     /**
@@ -643,24 +621,6 @@ public class Building implements Serializable {
     @Override
     public int hashCode() {
         return id;
-    }
-
-    /**
-     * Returns a string representation of the given building type, e.g. "Hardened".
-     */
-    public static String typeName(int type) {
-        switch (type) {
-            case Building.LIGHT:
-                return "Light";
-            case Building.MEDIUM:
-                return "Medium";
-            case Building.HEAVY:
-                return "Heavy";
-            case Building.HARDENED:
-                return "Hardened";
-            default:
-                return "Unknown";
-        }
     }
 
     /**

--- a/megamek/src/megamek/common/Building.java
+++ b/megamek/src/megamek/common/Building.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.Vector;
 
 import megamek.common.enums.BasementType;
+import megamek.common.enums.BuildingType;
 import megamek.logging.MMLogger;
 
 /**
@@ -62,7 +63,7 @@ public class Building implements Serializable {
      * The Building Type of the building; equal to the terrain elevation of the
      * BUILDING terrain of a hex.
      */
-    private int type = Building.UNKNOWN;
+    private BuildingType type = BuildingType.UNKNOWN;
 
     // The Building Classes
     public static final int STANDARD = 0;
@@ -193,7 +194,7 @@ public class Building implements Serializable {
         if (structureType == Terrains.BUILDING) {
             // Error if the Building Type (Light, Medium...) or Building Class (Standard,
             // Hangar...) is off.
-            if (type != nextHex.terrainLevel(Terrains.BUILDING)) {
+            if (getType().getTypeValue() != nextHex.terrainLevel(Terrains.BUILDING)) {
                 throw new IllegalArgumentException("The coordinates, "
                         + coords.getBoardNum()
                         + ", should contain the same type of building as "
@@ -283,7 +284,7 @@ public class Building implements Serializable {
             throw new IllegalArgumentException("The coordinates, "
                     + coords.getBoardNum() + ", do not contain a building.");
         }
-        type = startHex.terrainLevel(structureType);
+        type = BuildingType.getType(startHex.terrainLevel(structureType));
         bldgClass = startHex.terrainLevel(Terrains.BLDG_CLASS);
 
         // Insure that we've got a good type (and initialize our CF).
@@ -332,7 +333,7 @@ public class Building implements Serializable {
         StringBuilder sb = new StringBuilder();
         if (structureType == Terrains.FUEL_TANK) {
             sb.append("Fuel Tank #");
-        } else if (getType() == Building.WALL) {
+        } else if (getType() == BuildingType.WALL) {
             sb.append("Wall #");
         } else if (structureType == Terrains.BUILDING) {
             sb.append("Building #");
@@ -396,11 +397,11 @@ public class Building implements Serializable {
 
     /**
      * Get the construction type of the building. This value will be one of the
-     * constants, LIGHT, MEDIUM, HEAVY, or HARDENED.
+     * values defined in megamek.common.enums.BuildingType
      *
      * @return the <code>int</code> code of the building's construction type.
      */
-    public int getType() {
+    public BuildingType getType() {
         return type;
     }
 
@@ -578,6 +579,15 @@ public class Building implements Serializable {
 
     /**
      * Get the default construction factor for the given type of building.
+     */
+    public static int getDefaultCF(BuildingType type) 
+    {
+        return getDefaultCF(type.getTypeValue());
+    }
+    
+    /**
+     * Get the default construction factor for the given type of building.
+     * Retained for backwards compatibility
      *
      * @param type
      *             - the <code>int</code> construction type of the building.
@@ -588,17 +598,17 @@ public class Building implements Serializable {
     public static int getDefaultCF(int type) {
         int retval = Building.UNKNOWN;
         switch (type) {
-            case Building.LIGHT:
+            case LIGHT:
                 retval = 15;
                 break;
-            case Building.MEDIUM:
+            case MEDIUM:
                 retval = 40;
                 break;
-            case Building.HEAVY:
+            case HEAVY:
                 retval = 90;
                 break;
-            case Building.HARDENED:
-            case Building.WALL:
+            case HARDENED:
+            case WALL:
                 retval = 120;
                 break;
         }
@@ -671,7 +681,7 @@ public class Building implements Serializable {
 
     @Override
     public String toString() {
-        return typeName(getType()) + " " + className(getBldgClass()) + " " + name;
+        return getType().toString() + " " + className(getBldgClass()) + " " + name;
     }
 
     /**
@@ -787,12 +797,12 @@ public class Building implements Serializable {
      */
     public double getInfDmgFromInside() {
         switch (getType()) {
-            case Building.LIGHT:
-            case Building.MEDIUM:
+            case LIGHT:
+            case MEDIUM:
                 return 0.0;
-            case Building.HEAVY:
+            case HEAVY:
                 return 0.5;
-            case Building.HARDENED:
+            case HARDENED:
                 return 0.75;
             default:
                 return 0;
@@ -807,11 +817,11 @@ public class Building implements Serializable {
      */
     public float getDamageReductionFromOutside() {
         switch (getType()) {
-            case Building.LIGHT:
+            case LIGHT:
                 return 0.75f;
-            case Building.MEDIUM:
+            case MEDIUM:
                 return 0.5f;
-            case Building.HEAVY:
+            case HEAVY:
                 return 0.25f;
             default:
                 return 0f;

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -44,6 +44,7 @@ import megamek.common.annotations.Nullable;
 import megamek.common.battlevalue.BVCalculator;
 import megamek.common.enums.AimingMode;
 import megamek.common.enums.BasementType;
+import megamek.common.enums.BuildingType;
 import megamek.common.enums.GamePhase;
 import megamek.common.enums.MPBoosters;
 import megamek.common.enums.WeaponSortOrder;
@@ -7980,7 +7981,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if (rv > 1) {
             Building bldgEntered;
             bldgEntered = game.getBoard().getBuildingAt(curPos);
-            if (bldgEntered.getType() == Building.WALL) {
+            if (bldgEntered.getType() == BuildingType.WALL) {
                 return 4;
             }
         }
@@ -8027,10 +8028,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         }
 
         switch (bldg.getType()) {
-            case Building.LIGHT:
+            case LIGHT:
                 desc = "Light";
                 break;
-            case Building.MEDIUM:
+            case MEDIUM:
                 if (bldg.getBldgClass() != Building.HANGAR) {
                     mod = 1;
                     desc = "Medium";
@@ -8041,7 +8042,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     desc = desc + " Fortress";
                 }
                 break;
-            case Building.HEAVY:
+            case HEAVY:
                 mod = 2;
                 desc = "Heavy";
                 if (bldg.getBldgClass() == Building.HANGAR) {
@@ -8054,7 +8055,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     desc = desc + " Fortress";
                 }
                 break;
-            case Building.HARDENED:
+            case HARDENED:
                 mod = 5;
                 desc = "Hardened";
                 if (bldg.getBldgClass() == Building.HANGAR) {
@@ -8066,7 +8067,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                     desc = desc + " Fortress";
                 }
                 break;
-            case Building.WALL:
+            case WALL:
                 mod = 12;
                 desc = "";
                 break;

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -27,6 +27,7 @@ import java.util.TreeMap;
 import java.util.Vector;
 
 import megamek.common.MovePath.MoveStepType;
+import megamek.common.enums.BuildingType;
 import megamek.common.enums.MPBoosters;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.CachedEntityState;
@@ -671,7 +672,7 @@ public class MoveStep implements Serializable {
                     maxElevation++;
                 }
 
-                if (bld.getType() == Building.WALL) {
+                if (bld.getType() == BuildingType.WALL) {
                     if (maxElevation >= hex.terrainLevel(Terrains.BLDG_ELEV)) {
                         setElevation(Math.max(getElevation(),
                                 hex.terrainLevel(Terrains.BLDG_ELEV)));
@@ -3291,7 +3292,7 @@ public class MoveStep implements Serializable {
             } else if (!isInfantry && !isSuperHeavyMek) {
                 if (!isProto) {
                     // non-protos pay extra according to the building type
-                    mp += bldg.getType();
+                    mp += bldg.getType().getTypeValue();
                     if (bldg.getBldgClass() == Building.HANGAR) {
                         mp--;
                     }
@@ -3427,7 +3428,7 @@ public class MoveStep implements Serializable {
             int maxElevation = (2 + entity.getElevation() + game.getBoard()
                     .getHex(entity.getPosition()).getLevel()) - hex.getLevel();
 
-            if ((bld.getType() == Building.WALL)
+            if ((bld.getType() == BuildingType.WALL)
                     && (maxElevation < hex.terrainLevel(Terrains.BLDG_ELEV))) {
                 return false;
             }

--- a/megamek/src/megamek/common/actions/FindClubAction.java
+++ b/megamek/src/megamek/common/actions/FindClubAction.java
@@ -21,6 +21,7 @@ import megamek.common.Hex;
 import megamek.common.Mek;
 import megamek.common.Terrains;
 import megamek.common.TripodMek;
+import megamek.common.enums.BuildingType;
 import megamek.common.options.OptionsConstants;
 
 /**
@@ -71,7 +72,7 @@ public class FindClubAction extends AbstractEntityAction {
         // or a blown off limb
         if ((hex.terrainLevel(Terrains.WOODS) < 1)
             && (hex.terrainLevel(Terrains.JUNGLE) < 1)
-            && (hex.terrainLevel(Terrains.RUBBLE) < Building.MEDIUM)
+            && (hex.terrainLevel(Terrains.RUBBLE) < BuildingType.MEDIUM.getTypeValue())
             && (hex.terrainLevel(Terrains.ARMS) < 1)
             && (hex.terrainLevel(Terrains.LEGS) < 1)) {
             return false;

--- a/megamek/src/megamek/common/enums/BuildingType.java
+++ b/megamek/src/megamek/common/enums/BuildingType.java
@@ -25,21 +25,27 @@ import java.util.ResourceBundle;
 import megamek.MegaMek;
 
 public enum BuildingType {
-    UNKNOWN("BuildingType.UNKNOWN.text", -1),
-    LIGHT("BuildingType.LIGHT.text", 1),
-    MEDIUM("BuildingType.MEDIUM.text", 2),
-    HEAVY("BuildingType.HEAVY.text", 3),
-    HARDENED("BuildingType.HARDENED.text", 4),
-    WALL("BuildingType.WALL.text", 5);
+    UNKNOWN("BuildingType.UNKNOWN.text", -1, -1),
+    LIGHT("BuildingType.LIGHT.text", 1, 15),
+    MEDIUM("BuildingType.MEDIUM.text", 2, 40),
+    HEAVY("BuildingType.HEAVY.text", 3, 90),
+    HARDENED("BuildingType.HARDENED.text", 4, 120),
+    WALL("BuildingType.WALL.text", 5, 120);
     
     private final String name;
     private final int type;
+    private final int defaultCF;
     
-    private BuildingType(String name, int type) {
+    private BuildingType(String name, int type, int defaultCF) {
         final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
                 MegaMek.getMMOptions().getLocale());
         this.name = resources.getString(name);
         this.type = type;
+        this.defaultCF = defaultCF;
+    }
+    
+    public int getDefaultCF() {
+        return defaultCF;
     }
     
     public int getTypeValue() {

--- a/megamek/src/megamek/common/enums/BuildingType.java
+++ b/megamek/src/megamek/common/enums/BuildingType.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package megamek.common.enums;
+
+import java.util.Arrays;
+import java.util.ResourceBundle;
+
+import megamek.MegaMek;
+
+public enum BuildingType {
+    UNKNOWN("BuildingType.UNKNOWN.text", -1),
+    LIGHT("BuildingType.LIGHT.text", 1),
+    MEDIUM("BuildingType.MEDIUM.text", 2),
+    HEAVY("BuildingType.HEAVY.text", 3),
+    HARDENED("BuildingType.HARDENED.text", 4),
+    WALL("BuildingType.WALL.text", 5);
+    
+    private final String name;
+    private final int type;
+    
+    private BuildingType(String name, int type) {
+        final ResourceBundle resources = ResourceBundle.getBundle("megamek.common.messages",
+                MegaMek.getMMOptions().getLocale());
+        this.name = resources.getString(name);
+        this.type = type;
+    }
+    
+    public int getTypeValue() {
+        return type;
+    }
+    
+    public static BuildingType getType(final int ordinal) {
+        return Arrays.stream(BuildingType.values()).filter(type -> type.ordinal() == ordinal).findFirst().orElse(UNKNOWN);
+    }
+    
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -18,6 +18,7 @@ package megamek.common.util;
 import megamek.client.bot.princess.CardinalEdge;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
+import megamek.common.enums.BuildingType;
 import megamek.common.planetaryconditions.Weather;
 import megamek.common.planetaryconditions.Wind;
 import megamek.common.util.generator.ElevationGenerator;
@@ -396,7 +397,7 @@ public class BoardUtilities {
     }
 
     private static void placeBuilding(Board board, BuildingTemplate building) {
-        int type = building.getType();
+        BuildingType type = building.getType();
         int cf = building.getCF();
         int height = building.getHeight();
         ArrayList<Hex> hexes = new ArrayList<>();
@@ -415,7 +416,7 @@ public class BoardUtilities {
             // remove everything
             hex.removeAllTerrains();
             hex.addTerrain(new Terrain(Terrains.PAVEMENT, 1));
-            hex.addTerrain(new Terrain(Terrains.BUILDING, type, true, exits));
+            hex.addTerrain(new Terrain(Terrains.BUILDING, type.getTypeValue(), true, exits));
             hex.addTerrain(new Terrain(Terrains.BLDG_CF, cf));
             hex.addTerrain(new Terrain(Terrains.BLDG_ELEV, height));
             hexes.add(hex);

--- a/megamek/src/megamek/common/util/BuildingTemplate.java
+++ b/megamek/src/megamek/common/util/BuildingTemplate.java
@@ -24,18 +24,18 @@ public class BuildingTemplate implements Serializable {
     public static final int BASEMENT_RANDOM = -1;
 
     private ArrayList<Coords> coordsList = new ArrayList<>();
-    private int type = Building.LIGHT;
+    private BuildingType type = BuildingType.LIGHT;
     private int CF = 15;
     private int height = 2;
     private int basement = BASEMENT_RANDOM;
 
     public BuildingTemplate(BuildingType type, ArrayList<Coords> coords) {
-        this.type = type.getTypeValue();
+        this.type = type;
         coordsList = coords;
         CF = Building.getDefaultCF(type);
     }
 
-    public BuildingTemplate(int type, ArrayList<Coords> coords, int CF,
+    public BuildingTemplate(BuildingType type, ArrayList<Coords> coords, int CF,
             int height, int basement) {
         this.type = type;
         this.coordsList = coords;
@@ -54,7 +54,7 @@ public class BuildingTemplate implements Serializable {
     /**
      * @return type of the building (Building.LIGHT - Building.HARDENED)
      */
-    public int getType() {
+    public BuildingType getType() {
         return type;
     }
 

--- a/megamek/src/megamek/common/util/BuildingTemplate.java
+++ b/megamek/src/megamek/common/util/BuildingTemplate.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 
 import megamek.common.Building;
 import megamek.common.Coords;
+import megamek.common.enums.BuildingType;
 
 /**
  * Building template, for placing on the map during map generation. Currently
@@ -28,8 +29,8 @@ public class BuildingTemplate implements Serializable {
     private int height = 2;
     private int basement = BASEMENT_RANDOM;
 
-    public BuildingTemplate(int type, ArrayList<Coords> coords) {
-        this.type = type;
+    public BuildingTemplate(BuildingType type, ArrayList<Coords> coords) {
+        this.type = type.getTypeValue();
         coordsList = coords;
         CF = Building.getDefaultCF(type);
     }

--- a/megamek/src/megamek/common/util/CityBuilder.java
+++ b/megamek/src/megamek/common/util/CityBuilder.java
@@ -20,6 +20,7 @@ import java.util.Vector;
 
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.BuildingType;
 
 /**
  * @author Torren + Coelocanth
@@ -147,7 +148,7 @@ public class CityBuilder {
                     totalCF = Compute.randomInt(totalCF + 1) + mapSettings.getCityMinCF();
                 }
 
-                int type = getBuildingTypeByCF(totalCF);
+                BuildingType type = getBuildingTypeByCF(totalCF);
 
                 buildingList.add(new BuildingTemplate(type, coordList, totalCF, floors, -1));
             }
@@ -360,7 +361,7 @@ public class CityBuilder {
     private void addBridge(Hex hex, int exits, int altitude, int cf) {
         int bridgeElevation = altitude - hex.getLevel();
 
-        hex.addTerrain(new Terrain(Terrains.BRIDGE, getBuildingTypeByCF(cf), true, (exits & 63)));
+        hex.addTerrain(new Terrain(Terrains.BRIDGE, getBuildingTypeByCF(cf).getTypeValue(), true, (exits & 63)));
         hex.addTerrain(new Terrain(Terrains.BRIDGE_ELEV, bridgeElevation));
         hex.addTerrain(new Terrain(Terrains.BRIDGE_CF, cf));
     }
@@ -493,15 +494,15 @@ public class CityBuilder {
      * @param cf
      * @return building type
      */
-    public static int getBuildingTypeByCF(int cf) {
+    public static BuildingType getBuildingTypeByCF(int cf) {
         if (cf <= 15) {
-            return Building.LIGHT;
+            return BuildingType.LIGHT;
         } else if (cf <= 40) {
-            return Building.MEDIUM;
+            return BuildingType.MEDIUM;
         } else if (cf <= 90) {
-            return Building.HEAVY;
+            return BuildingType.HEAVY;
         } else {
-            return Building.HARDENED;
+            return BuildingType.HARDENED;
         }
     }
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -37,6 +37,7 @@ import megamek.common.actions.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.containers.PlayerIDandList;
 import megamek.common.enums.BasementType;
+import megamek.common.enums.BuildingType;
 import megamek.common.enums.GamePhase;
 import megamek.common.enums.WeaponSortOrder;
 import megamek.common.equipment.AmmoMounted;
@@ -4095,7 +4096,7 @@ public class TWGameManager extends AbstractGameManager {
             if (nextHex.containsTerrain(Terrains.BLDG_ELEV)) {
                 Building bldg = game.getBoard().getBuildingAt(nextPos);
 
-                if (bldg.getType() == Building.WALL) {
+                if (bldg.getType() == BuildingType.WALL) {
                     crashedIntoTerrain = true;
                 }
 
@@ -4138,7 +4139,7 @@ public class TWGameManager extends AbstractGameManager {
                     // If you crash into a wall you want to stop in the hex
                     // before the wall not in the wall
                     // Like a building.
-                    if (bldg.getType() == Building.WALL) {
+                    if (bldg.getType() == BuildingType.WALL) {
                         r = new Report(2047);
                     } else if (bldg.getBldgClass() == Building.GUN_EMPLACEMENT) {
                         r = new Report(2049);
@@ -4193,7 +4194,7 @@ public class TWGameManager extends AbstractGameManager {
                         // If you crash into a wall you want to stop in the hex
                         // before the wall not in the wall
                         // Like a building.
-                        if (bldg.getType() == Building.WALL) {
+                        if (bldg.getType() == BuildingType.WALL) {
                             addReport(destroyEntity(entity, "crashed into a wall"));
                             break;
                         }
@@ -5176,7 +5177,7 @@ public class TWGameManager extends AbstractGameManager {
             int direction = entity.getFacing();
             // first check for buildings
             Building bldg = game.getBoard().getBuildingAt(hitCoords);
-            if ((null != bldg) && (bldg.getType() == Building.HARDENED)) {
+            if ((null != bldg) && (bldg.getType() == BuildingType.HARDENED)) {
                 crash_damage *= 2;
             }
             if (null != bldg) {
@@ -9319,7 +9320,7 @@ public class TWGameManager extends AbstractGameManager {
             }
         } else {
             Building bld = game.getBoard().getBuildingAt(entity.getPosition());
-            if ((bld != null) && (bld.getType() == Building.WALL)) {
+            if ((bld != null) && (bld.getType() == BuildingType.WALL)) {
                 entity.setElevation(hex.terrainLevel(Terrains.BLDG_ELEV));
             }
 
@@ -10971,7 +10972,7 @@ public class TWGameManager extends AbstractGameManager {
         // building modifiers
         Building bldg = game.getBoard().getBuildingAt(c);
         if (null != bldg) {
-            nTargetRoll.addModifier(bldg.getType() - 3, "building");
+            nTargetRoll.addModifier(bldg.getType().getTypeValue() - 3, "building");
         }
 
         // add in any modifiers for planetary conditions
@@ -27874,7 +27875,7 @@ public class TWGameManager extends AbstractGameManager {
                 // Infantry and Battle armor take different amounts of damage
                 // then Meks and vehicles.
                 if (entity instanceof Infantry) {
-                    damage = bldg.getType() + 1;
+                    damage = bldg.getType().getTypeValue() + 1;
                 }
                 // It is possible that the unit takes no damage.
                 if (damage == 0) {
@@ -28767,7 +28768,7 @@ public class TWGameManager extends AbstractGameManager {
                         vPhaseReport.addAll(vRep);
                         return vPhaseReport;
                     }
-                    if (bldg.getType() == Building.WALL) {
+                    if (bldg.getType() == BuildingType.WALL) {
                         r = new Report(3442);
                         r.type = Report.PUBLIC;
                         r.indent(0);
@@ -28964,7 +28965,7 @@ public class TWGameManager extends AbstractGameManager {
                     vDesc.addAll(vRep);
                     return vPhaseReport;
                 }
-                if (bldg.getType() == Building.WALL) {
+                if (bldg.getType() == BuildingType.WALL) {
                     r = new Report(3442);
                 } else {
                     r = new Report(3440);
@@ -31255,7 +31256,7 @@ public class TWGameManager extends AbstractGameManager {
 
                 if (isFuelAirBomb) {
                     // light buildings take 1.5x damage from fuel-air bombs
-                    if (bldg.getType() == Building.LIGHT) {
+                    if (bldg.getType() == BuildingType.LIGHT) {
                         actualDamage = (int) Math.ceil(actualDamage * 1.5);
 
                         r = new Report(9991);

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -10811,30 +10811,30 @@ public class TWGameManager extends AbstractGameManager {
 
         // Is there the rubble of a medium, heavy,
         // or hardened building in the hex?
-        else if (Building.LIGHT < curHex.terrainLevel(Terrains.RUBBLE)) {
+        else if (BuildingType.LIGHT.getTypeValue() < curHex.terrainLevel(Terrains.RUBBLE)) {
 
             // Finding a club is not guaranteed. The chances are
             // based on the type of building that produced the
             // rubble.
             boolean found = false;
             int roll = Compute.d6(2);
-            switch (curHex.terrainLevel(Terrains.RUBBLE)) {
-                case Building.MEDIUM:
+            switch (BuildingType.getType(curHex.terrainLevel(Terrains.RUBBLE))) {
+                case MEDIUM:
                     if (roll >= 7) {
                         found = true;
                     }
                     break;
-                case Building.HEAVY:
+                case HEAVY:
                     if (roll >= 6) {
                         found = true;
                     }
                     break;
-                case Building.HARDENED:
+                case HARDENED:
                     if (roll >= 5) {
                         found = true;
                     }
                     break;
-                case Building.WALL:
+                case WALL:
                     if (roll >= 13) {
                         found = true;
                     }
@@ -25687,8 +25687,8 @@ public class TWGameManager extends AbstractGameManager {
             // Have to check if it's inferno smoke or from a heavy/hardened
             // building
             // - heavy smoke from those
-            if (bInferno || (Building.MEDIUM < smokeHex.terrainLevel(Terrains.FUEL_TANK))
-                    || (Building.MEDIUM < smokeHex.terrainLevel(Terrains.BUILDING))) {
+            if (bInferno || (BuildingType.MEDIUM.getTypeValue() < smokeHex.terrainLevel(Terrains.FUEL_TANK))
+                    || (BuildingType.MEDIUM.getTypeValue() < smokeHex.terrainLevel(Terrains.BUILDING))) {
                 if (smokeHex.terrainLevel(Terrains.SMOKE) == SmokeCloud.SMOKE_HEAVY) {
                     // heavy smoke fills hex
                     r = new Report(5180, Report.PUBLIC);

--- a/megamek/src/megamek/utilities/BoardsTagger.java
+++ b/megamek/src/megamek/utilities/BoardsTagger.java
@@ -28,6 +28,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import megamek.common.*;
+import megamek.common.enums.BuildingType;
 import megamek.logging.MMLogger;
 
 /**
@@ -276,8 +277,8 @@ public class BoardsTagger {
                 water += hex.containsTerrain(WATER) ? 1 : 0;
                 if (hex.containsTerrain(BUILDING)
                         && (!hex.containsTerrain(BLDG_CLASS) || hex.terrainLevel(BLDG_CLASS) == Building.STANDARD)
-                        && ((hex.terrainLevel(BUILDING) == Building.LIGHT)
-                                || (hex.terrainLevel(BUILDING) == Building.MEDIUM))) {
+                        && ((hex.terrainLevel(BUILDING) == BuildingType.LIGHT.getTypeValue())
+                                || (hex.terrainLevel(BUILDING) == BuildingType.MEDIUM.getTypeValue()))) {
                     stdBuildings++;
                     int height = hex.terrainLevel(BLDG_ELEV);
                     lowBuildings += (height <= 2) ? 1 : 0;
@@ -287,8 +288,8 @@ public class BoardsTagger {
                     hangar += hex.terrainLevel(BLDG_CLASS) == Building.HANGAR ? 1 : 0;
                     fortress += hex.terrainLevel(BLDG_CLASS) == Building.FORTRESS ? 1 : 0;
                     gunEnplacement += hex.terrainLevel(BLDG_CLASS) == Building.GUN_EMPLACEMENT ? 1 : 0;
-                    heavyBuilding += hex.terrainLevel(BUILDING) == Building.HEAVY ? 1 : 0;
-                    hardenedBuilding += hex.terrainLevel(BUILDING) == Building.HARDENED ? 1 : 0;
+                    heavyBuilding += hex.terrainLevel(BUILDING) == BuildingType.HEAVY.getTypeValue() ? 1 : 0;
+                    hardenedBuilding += hex.terrainLevel(BUILDING) == BuildingType.HARDENED.getTypeValue() ? 1 : 0;
                     armoredBuilding += hex.containsTerrain(BLDG_ARMOR) && hex.terrainLevel(Terrains.BLDG_ARMOR) > 0 ? 1 : 0;
                 }
                 impassable += hex.containsTerrain(IMPASSABLE) ? 1 : 0;


### PR DESCRIPTION
To prepare for some work regarding allowing players to put down buildings per scenario rules (a lot of scenarios call for a player to be able to "place X buildings of height Y and CF Z"), I've moved BuildingType to an enum, as that will make the UI and other relevant work a lot easier down the line.

Also fix a long-standing bug where buildings turned to rubble wouldn't actually allow picking up clubs.