### PR TITLE
prevent player settings crash in-game

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/PlayerSettingsDialog.java
@@ -733,7 +733,10 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
             butStartPos.get(i).setActionCommand(((Integer) i).toString());
         }
 
-        var currentBoard = ServerBoardHelper.getPossibleGameBoard(clientgui.getClient().getMapSettings(), true);
+        var currentBoard =
+                clientgui.getClient().getGame().getPhase().isLounge() ?
+                ServerBoardHelper.getPossibleGameBoard(clientgui.getClient().getMapSettings(), true) :
+                clientgui.getClient().getGame().getBoard();
         var deploymentZones = currentBoard.getCustomDeploymentZones();
         int extraRowCount = (int) Math.ceil(deploymentZones.size() / 3.0);
 


### PR DESCRIPTION
If we're in the lobby, try to get the "possible" game board. If we're in game, then we already have a board so just use that.

Fix #6313 