### PR TITLE
Fix: Tank armor and invalid builds

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -15839,7 +15839,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public boolean canonUnitWithInvalidBuild() {
-        if (this.isCanon() || mulId > -1)
+        if (this.isCanon() && mulId > -1)
         {
             return !this.getInvalidSourceBuildReasons().isEmpty();
         }

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1146,7 +1146,7 @@ public class BLKFile {
         if (t.getFluff().hasEmbeddedFluffImage()) {
             blk.writeBlockData("fluffimage", t.getFluff().getBase64FluffImage().getBase64String());
         }
-        if (!t.getInvalidSourceBuildReasons().isEmpty()) {
+        if (t.canonUnitWithInvalidBuild()) {
             blk.writeBlockData("invalidSourceBuildReasons", t.getInvalidSourceBuildReasons().stream().map(Enum::name).toList());
         }
         return blk;

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -14,16 +14,6 @@
  */
 package megamek.common.loaders;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.Vector;
-import java.util.stream.Collectors;
-
 import megamek.common.*;
 import megamek.common.InfantryBay.PlatoonType;
 import megamek.common.equipment.AmmoMounted;
@@ -36,8 +26,14 @@ import megamek.common.util.BuildingBlock;
 import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
+import megamek.logging.MMLogger;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class BLKFile {
+    private static final MMLogger logger = MMLogger.create(BLKFile.class);
 
     BuildingBlock dataFile;
 
@@ -122,9 +118,28 @@ public class BLKFile {
             entity.setIcon(dataFile.getDataAsString("icon")[0]);
         }
 
+        if (dataFile.exists("invalidSourceBuildReasons")) {
+            loadInvalidSourceBuildReasons(entity);
+        }
+
         setTechLevel(entity);
         setFluff(entity);
         checkManualBV(entity);
+    }
+
+    protected void loadInvalidSourceBuildReasons(Entity entity) {
+        String[] reasons = dataFile.getDataAsString("invalidSourceBuildReasons");
+        var invalidSourceBuildReasons = new ArrayList<Entity.InvalidSourceBuildReason>();
+        if (reasons != null) {
+            for (var reason : reasons) {
+                try {
+                    invalidSourceBuildReasons.add(Entity.InvalidSourceBuildReason.valueOf(reason));
+                } catch (Exception e) {
+                    logger.warn("Unable to load reason {}", reason);
+                }
+            }
+        }
+        entity.setInvalidSourceBuildReasons(invalidSourceBuildReasons);
     }
 
     protected void loadQuirks(Entity entity) throws EntityLoadingException {
@@ -291,21 +306,35 @@ public class BLKFile {
                                 TechConstants.isClan(dataFile.getDataAsInt(sv.getLocationName(i) + "_armor_tech")[0]));
                 sv.setArmorType(armor.getArmorType(), i);
                 sv.setBARRating(armor.getBAR(), i);
-                sv.setArmorTechLevel(armor.getStaticTechLevel().getCompoundTechLevel(false), i);
+                sv.setArmorTechLevel(armor.getStaticTechLevel().getCompoundTechLevel(sv.isClan()), i);
             }
         } else {
             if (dataFile.exists("barrating")) {
                 megamek.common.equipment.ArmorType armor = ArmorType.svArmor(dataFile.getDataAsInt("barrating")[0]);
-                sv.setArmorType(armor.getArmorType());
+                if (dataFile.exists("armor_type")) {
+                    sv.setArmorType(dataFile.getDataAsInt("armor_type")[0]);
+                } else {
+                    sv.setArmorType(armor.getArmorType());
+                }
+                if (dataFile.exists("armor_tech_level")) {
+                    sv.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
+                } else {
+                    sv.setArmorTechLevel(armor.getStaticTechLevel().getCompoundTechLevel(sv.isClan()));
+                }
                 sv.setBARRating(armor.getBAR());
-                sv.setArmorTechLevel(armor.getStaticTechLevel().getCompoundTechLevel(false));
             } else {
                 if (dataFile.exists("armor_type")) {
                     sv.setArmorType(dataFile.getDataAsInt("armor_type")[0]);
                 } else {
                     throw new EntityLoadingException("could not find armor_type block.");
                 }
+                if (dataFile.exists("armor_tech_level")) {
+                    sv.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
+                } else {
+                    sv.setArmorTechLevel(sv.getStaticTechLevel().getCompoundTechLevel(sv.isClan()));
+                }
             }
+
             if (dataFile.exists("armor_tech")) {
                 sv.setArmorTechRating(dataFile.getDataAsInt("armor_tech")[0]);
             } else if (dataFile.exists("armor_tech_rating")) {
@@ -754,14 +783,15 @@ public class BLKFile {
             if (!t.hasPatchworkArmor() && (t.getArmorType(1) != ArmorType.T_ARMOR_UNKNOWN)) {
                 blk.writeBlockData("armor_type", t.getArmorType(1));
                 blk.writeBlockData("armor_tech_rating", t.getArmorTechRating());
+                blk.writeBlockData("armor_tech_level", t.getArmorTechLevel(1));
             } else if (t.hasPatchworkArmor()) {
                 blk.writeBlockData("armor_type",
                         EquipmentType.T_ARMOR_PATCHWORK);
                 for (int i = 1; i < t.locations(); i++) {
                     ArmorType armor = ArmorType.forEntity(t, i);
-                    blk.writeBlockData(t.getLocationName(i) + "_armor_type", t.getArmorType(i));
-                    blk.writeBlockData(t.getLocationName(i) + "_armor_tech",
-                            TechConstants.getTechName(t.getArmorTechLevel(i)));
+                    blk.writeBlockData(t.getLocationName(i) + "_armor_type", armor.getArmorType());
+                    blk.writeBlockData(t.getLocationName(i) + "_armor_tech", TechConstants.getTechName(t.getArmorTechLevel(i)));
+                    blk.writeBlockData(t.getLocationName(i) + "_armor_tech_rating", armor.getTechRating());
                     if (armor.hasFlag(MiscType.F_SUPPORT_VEE_BAR_ARMOR)) {
                         blk.writeBlockData(t.getLocationName(i) + "_barrating", armor.getBAR());
                     }
@@ -1115,6 +1145,9 @@ public class BLKFile {
 
         if (t.getFluff().hasEmbeddedFluffImage()) {
             blk.writeBlockData("fluffimage", t.getFluff().getBase64FluffImage().getBase64String());
+        }
+        if (!t.getInvalidSourceBuildReasons().isEmpty()) {
+            blk.writeBlockData("invalidSourceBuildReasons", t.getInvalidSourceBuildReasons().stream().map(Enum::name).toList());
         }
         return blk;
     }

--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -291,7 +291,7 @@ public class TestAdvancedAerospace extends TestAero {
     /**
      * One gunner is required for each capital weapon and each six standard scale
      * weapons, rounding up
-     * 
+     *
      * @return The vessel's minimum gunner requirements.
      */
     public static int requiredGunners(Jumpship vessel) {
@@ -622,7 +622,7 @@ public class TestAdvancedAerospace extends TestAero {
         if (skip()) {
             return true;
         }
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation());
             correct = false;
@@ -648,7 +648,7 @@ public class TestAdvancedAerospace extends TestAero {
         correct &= correctGravDecks(buff);
         correct &= correctBays(buff);
         correct &= correctCriticals(buff);
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;
@@ -865,7 +865,7 @@ public class TestAdvancedAerospace extends TestAero {
 
     /**
      * Checks that the unit meets minimum crew and quarters requirements.
-     * 
+     *
      * @param buffer Where to write messages explaining failures.
      * @return true if the crew data is valid.
      */
@@ -901,7 +901,7 @@ public class TestAdvancedAerospace extends TestAero {
     /**
      * Checks that the unit does not exceed the maximum number or size of gravity
      * decks.
-     * 
+     *
      * @param buffer Where to write messages explaining failures.
      * @return true if the crew data is valid.
      */

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -711,11 +711,12 @@ public class TestAero extends TestEntity {
         if (skip()) {
             return true;
         }
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation());
             correct = false;
         }
+
         if (!engine.engineValid) {
             buff.append(engine.problem.toString()).append("\n\n");
             correct = false;
@@ -749,7 +750,7 @@ public class TestAero extends TestEntity {
         correct &= !hasIllegalEquipmentCombinations(buff);
         correct &= !hasMismatchedLateralWeapons(buff);
         correct &= correctHeatSinks(buff);
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;
@@ -757,7 +758,7 @@ public class TestAero extends TestEntity {
 
     /**
      * Checks that the weapon loads in the wings match each other.
-     * 
+     *
      * @param buff The buffer that contains the collected error messages.
      * @return Whether the lateral weapons are mismatched.
      */
@@ -1236,7 +1237,7 @@ public class TestAero extends TestEntity {
     /**
      * One gunner is required for each capital weapon and each six standard scale
      * weapons, rounding up
-     * 
+     *
      * @return The vessel's minimum gunner requirements.
      */
     public static int requiredGunners(Aero aero) {

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1034,7 +1034,7 @@ public class TestBattleArmor extends TestEntity {
         if (skip()) {
             return true;
         }
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation());
             correct = false;
@@ -1062,7 +1062,7 @@ public class TestBattleArmor extends TestEntity {
         correct &= correctManipulators(buff);
 
         correct &= correctMovement(buff);
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -247,7 +247,7 @@ public abstract class TestEntity implements TestEntityOption {
 
     @Override
     public boolean showIncorrectIntroYear() {
-        return options.showIncorrectIntroYear();
+        return !ignoreEquipmentIntroYear() && options.showIncorrectIntroYear();
     }
 
     @Override
@@ -257,7 +257,7 @@ public abstract class TestEntity implements TestEntityOption {
 
     @Override
     public boolean skip() {
-        return options.skip();
+        return !skipBuildValidation() && options.skip();
     }
 
     @Override
@@ -1808,4 +1808,25 @@ public abstract class TestEntity implements TestEntityOption {
         }
         return slotCount;
     }
+
+    boolean ignoreSlotCount() {
+        var entity = getEntity();
+        return entity.getInvalidSourceBuildReasons().contains(Entity.InvalidSourceBuildReason.NOT_ENOUGH_SLOT_COUNT);
+    }
+
+    boolean ignoreEquipmentIntroYear() {
+        var entity = getEntity();
+        return entity.getInvalidSourceBuildReasons().contains(Entity.InvalidSourceBuildReason.UNIT_OLDER_THAN_EQUIPMENT_INTRO_YEAR);
+    }
+
+    boolean allowOverweightConstruction() {
+        var entity = getEntity();
+        return entity.getInvalidSourceBuildReasons().contains(Entity.InvalidSourceBuildReason.UNIT_OVERWEIGHT);
+    }
+
+    boolean skipBuildValidation() {
+        var entity = getEntity();
+        return entity.getInvalidSourceBuildReasons().contains(Entity.InvalidSourceBuildReason.INVALID_OR_OUTDATED_BUILD);
+    }
+
 } // End class TestEntity

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -145,12 +145,8 @@ public class TestInfantry extends TestEntity {
         if (skip()) {
             return true;
         }
-
-        // We currently have many unit introduction dates that are too early for their gear or anti-mek attacks
-        // enable this when dates have been straightened
-//        if (showIncorrectIntroYear() && hasIncorrectIntroYear(buff)) {
-//            correct = false;
-//        }
+        // Infantry has too many problems with intro date for its equipments therefore we are not testing the
+        // year of introduction of the equipments.
 
         int max = maxSecondaryWeapons(inf);
         if (inf.getSecondaryWeaponsPerSquad() > max) {
@@ -201,7 +197,7 @@ public class TestInfantry extends TestEntity {
             buff.append("Infantry may not have more than one armor kit!\n");
             correct = false;
         }
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -698,7 +698,7 @@ public class TestMek extends TestEntity {
         if (skip()) {
             return true;
         }
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation());
             correct = false;
@@ -740,7 +740,7 @@ public class TestMek extends TestEntity {
             correct = correct && checkMiscSpreadAllocation(mek, misc, buff);
         }
         correct = correct && correctMovement(buff);
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;

--- a/megamek/src/megamek/common/verifier/TestProtoMek.java
+++ b/megamek/src/megamek/common/verifier/TestProtoMek.java
@@ -228,7 +228,7 @@ public class TestProtoMek extends TestEntity {
         if (skip()) {
             return correct;
         }
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation());
             correct = false;
@@ -253,7 +253,7 @@ public class TestProtoMek extends TestEntity {
             correct = false;
         }
         correct = correct && correctMovement(buff);
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -498,7 +498,7 @@ public class TestSmallCraft extends TestAero {
         if (skip()) {
             return true;
         }
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation());
             correct = false;
@@ -522,7 +522,7 @@ public class TestSmallCraft extends TestAero {
         correct &= correctHeatSinks(buff);
         correct &= correctCrew(buff);
         correct &= correctCriticals(buff);
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;
@@ -684,7 +684,7 @@ public class TestSmallCraft extends TestAero {
 
     /**
      * Checks that the unit meets minimum crew and quarters requirements.
-     * 
+     *
      * @param buffer Where to write messages explaining failures.
      * @return true if the crew data is valid.
      */

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -992,7 +992,7 @@ public class TestSupportVehicle extends TestEntity {
             return true;
         }
 
-        if (!correctWeight(buff)) {
+        if (!allowOverweightConstruction() && !correctWeight(buff)) {
             buff.insert(0, printTechLevel() + printShortMovement());
             buff.append(printWeightCalculation()).append("\n");
             correct = false;
@@ -1015,7 +1015,7 @@ public class TestSupportVehicle extends TestEntity {
             correct = false;
         }
 
-        if (occupiedSlotCount() > totalSlotCount()) {
+        if (!ignoreSlotCount() && (occupiedSlotCount() > totalSlotCount())) {
             buff.append("Not enough item slots available! Using ");
             buff.append(Math.abs(occupiedSlotCount() - totalSlotCount()));
             buff.append(" slot(s) too many.\n");
@@ -1210,7 +1210,7 @@ public class TestSupportVehicle extends TestEntity {
             correct = false;
         }
 
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
 

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -391,7 +391,7 @@ public class TestTank extends TestEntity {
         if (!correctCriticals(buff)) {
             correct = false;
         }
-        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN)) {
+        if (getEntity().hasQuirk(OptionsConstants.QUIRK_NEG_ILLEGAL_DESIGN) || getEntity().canonUnitWithInvalidBuild()) {
             correct = true;
         }
         return correct;

--- a/megamek/unittests/megamek/common/loaders/BulkUnitFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BulkUnitFileTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
+package megamek.common.loaders;
+
+import megamek.common.*;
+import megamek.common.equipment.ArmorType;
+import megamek.common.verifier.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+@Disabled
+public class BulkUnitFileTest {
+
+    @BeforeAll
+    public static void initializeStuff() {
+        MekFileParser.initCanonUnitNames();
+        EquipmentType.initializeTypes();
+        AmmoType.initializeTypes();
+        ArmorType.initializeTypes();
+        WeaponType.initializeTypes();
+        MiscType.initializeTypes();
+        BombType.initializeTypes();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allBlkFiles")
+    void loadVerifySaveVerifyBlks(File file) throws EntitySavingException, IOException {
+        checkEntityFile(file);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("allMtfFiles")
+    void loadVerifySaveVerifyMtfs(File file) throws EntitySavingException, IOException {
+        checkEntityFile(file);
+    }
+
+    void checkEntityFile(File file) throws EntitySavingException, IOException {
+        Entity entity = loadUnit(file);
+        var validation = verify(entity);
+        // This print is to make sure you are looking at the file you expected to be looking at
+        System.out.println(file.getAbsoluteFile());
+        assertEquals(UnitValidation.VALID, validation.state(),
+            "The unit is invalid:\n\t" + entity.getDisplayName() + "\n" + validation.report());
+
+        var suffix = entity instanceof Mek ? ".mtf" : ".blk";
+        var tmpFile = File.createTempFile(file.getName(), suffix);
+        tmpFile.deleteOnExit();
+
+        if (persistUnit(tmpFile, entity)) {
+            Entity repersistedEntity = loadUnit(tmpFile);
+            var reValidation = verify(repersistedEntity);
+            assertEquals(UnitValidation.VALID, reValidation.state(),
+                "The unit is invalid after repersisting:\n\t" + tmpFile + "\n\t" + entity.getDisplayName() + "\n" + reValidation.report());
+            assertEquals(reValidation.state(), validation.state());
+        }
+    }
+
+    @Test
+    void loadVerifySaveVerifySpecificFile() throws EntitySavingException, IOException {
+        var file = new File("data/mekfiles/vehicles/3085u/Cutting Edge/Zugvogel Omni Support Aircraft D.blk");
+        checkEntityFile(file);
+    }
+
+    public static List<File> allMtfFiles() {
+        try (Stream<Path> paths = Files.walk(Paths.get("data/mekfiles"))) {
+            return paths
+                .filter(Files::isRegularFile)
+                .filter(path -> path.toString().endsWith(".mtf"))
+                .map(Path::toFile)
+                .toList();
+        } catch (IOException e) {
+            // do nothing
+        }
+        return List.of();
+    }
+
+    public static List<File> allBlkFiles() {
+        try (Stream<Path> paths = Files.walk(Paths.get("data/mekfiles"))) {
+            return paths
+                .filter(Files::isRegularFile)
+                .filter(path -> path.toString().endsWith(".blk"))
+                .map(Path::toFile)
+                .toList();
+        } catch (IOException e) {
+            // do nothing
+        }
+        return List.of();
+    }
+
+    private Entity loadUnit(File file) {
+        try {
+            MekFileParser mfp = new MekFileParser(file);
+            return mfp.getEntity();
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+        throw new IllegalStateException("Should not reach here");
+    }
+
+    public static TestEntity getEntityVerifier(Entity unit) {
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+            "data/mekfiles/UnitVerifierOptions.xml"));
+        TestEntity testEntity = null;
+
+        if (unit.hasETypeFlag(Entity.ETYPE_MEK)) {
+            testEntity = new TestMek((Mek) unit, entityVerifier.mekOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_PROTOMEK)) {
+            testEntity = new TestProtoMek((ProtoMek) unit, entityVerifier.protomekOption, null);
+        } else if (unit.isSupportVehicle()) {
+            testEntity = new TestSupportVehicle(unit, entityVerifier.tankOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_TANK)) {
+            testEntity = new TestTank((Tank) unit, entityVerifier.tankOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_SMALL_CRAFT)) {
+            testEntity = new TestSmallCraft((SmallCraft) unit, entityVerifier.aeroOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_JUMPSHIP)) {
+            testEntity = new TestAdvancedAerospace((Jumpship) unit, entityVerifier.aeroOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_AERO)) {
+            testEntity = new TestAero((Aero) unit, entityVerifier.aeroOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_BATTLEARMOR)) {
+            testEntity = new TestBattleArmor((BattleArmor) unit, entityVerifier.baOption, null);
+        } else if (unit.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
+            testEntity = new TestInfantry((Infantry) unit, entityVerifier.infOption, null);
+        }
+        return testEntity;
+    }
+
+    private enum UnitValidation {
+        VALID,
+        INVALID;
+        public static UnitValidation of(boolean valid) {
+            return valid ? VALID : INVALID;
+        }
+    }
+
+    private record Validation(UnitValidation state, String report) { }
+
+    private static Validation verify(Entity unit) {
+        var sb = new StringBuffer();
+        var testEntity = getEntityVerifier(unit);
+
+        var succeeded = testEntity.correctEntity(sb, unit.getTechLevel());
+
+        var validation = new Validation(UnitValidation.of(succeeded), sb.toString());
+
+        return validation;
+    }
+
+    public static boolean persistUnit(File outFile, Entity entity) throws EntitySavingException {
+        if (entity instanceof Mek) {
+            try (BufferedWriter out = new BufferedWriter(new FileWriter(outFile))) {
+                out.write(((Mek) entity).getMtf());
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+                return false;
+            }
+            return true;
+        }
+
+        BLKFile.encode(outFile, entity);
+        return true;
+    }
+
+}


### PR DESCRIPTION
Fixes issue [MegamekLab #1674](https://github.com/MegaMek/megameklab/issues/1674).

It makes sure the correct armor tech level is loaded when loading the tank or SV.
It also makes sure the correct tech level is persisted when saving the non-mek entity.

This also adds a list of reasons/justifications to why a canon unit build is invalid, and allows it to be loaded.
If the unit is changed in a way to make it lose its canon status (change the MUL to -1 or change the name to something that is not in the canon names list) it will stop saving the reasons list for the build fail.

Also adds a bulk file verification test for all units in MegaMek.

Fixes:

- SV and Tank patchwork (IS and Clan)
- SV and Tank high tech armor level and rating (IS and Clan)

Implements:
- Build specific tag for canon units with the reason for failing build (only for BLK files)
- The invalid build reason tags are lost when making custom units derived from canon units (only for BLK files)

Example of use in a BLK file:

```

<invalidSourceBuildReasons>
UNIT_OLDER_THAN_EQUIPMENT_INTRO_YEAR
</invalidSourceBuildReasons>

```