### PR TITLE
MekHQ Issue 3650 - RFE Add Ability to Link Units in MekHQ - make BA handles Public

### DIFF
--- a/megamek/src/megamek/common/BattleArmorHandles.java
+++ b/megamek/src/megamek/common/BattleArmorHandles.java
@@ -25,7 +25,7 @@ import megamek.common.annotations.Nullable;
  *
  * @see MekFileParser#postLoadInit
  */
-class BattleArmorHandles implements Transporter {
+public class BattleArmorHandles implements Transporter {
     private static final long serialVersionUID = -7149931565043762975L;
 
     /** The troopers being carried. */


### PR DESCRIPTION
Fixes [MekHQ PR 5634](https://github.com/MegaMek/mekhq/pull/5634)

This PR just makes the BA Handles Transporter class public like the other Transporter classes. This is a problem for MekHQ#5634.