### PR TITLE
fix: fixes a class cast bug and an error in the argument parsing algorithm

### DIFF
--- a/megamek/src/megamek/server/commands/ClientServerCommand.java
+++ b/megamek/src/megamek/server/commands/ClientServerCommand.java
@@ -85,9 +85,9 @@ public abstract class ClientServerCommand extends ServerCommand {
         return server.getGameManager().getGame().getPlayer(connId).getGameMaster();
     }
 
-    private void safeParseArgumentsAndRun(int connId, String[] args) {
+    protected void safeParseArgumentsAndRun(int connId, String[] args) {
         try {
-            var parsedArguments = new Arguments(parseArguments(args));
+            var parsedArguments = new Arguments(parseArguments(args, defineArguments()));
             runCommand(connId, parsedArguments);
         } catch (IllegalArgumentException e) {
             server.sendServerChat(connId, "Invalid arguments: " + e.getMessage() + "\nUsage: " + this.getHelp());
@@ -118,9 +118,7 @@ public abstract class ClientServerCommand extends ServerCommand {
 
 
     // Parses the arguments using the definition
-    private Map<String, Argument<?>> parseArguments(String[] args) {
-
-        List<Argument<?>> argumentDefinitions = defineArguments();
+    protected Map<String, Argument<?>> parseArguments(String[] args, List<Argument<?>> argumentDefinitions) {
         Map<String, Argument<?>> parsedArguments = new HashMap<>();
         List<String> positionalArguments = new ArrayList<>();
 


### PR DESCRIPTION
fixes #6374 
The changes I made to the nuke command originally made it impossible to use the custom nuke command, this change allows the argument parser to discover which is the correct set of arguments to use in case you are writting only positional arguments.

This also fixes an exception that was happening due to a bad cast.