### PR TITLE
Fix 6395: Add knowledge of smoke zero damage to princess

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -348,11 +348,11 @@
 3181=Succeeds.
 3182=fails, subjecting the unit to particle feedback!
 3185=<newline>    (continuing hit report):
-3186=\ - Glancing Blow -
+3186=\ - Glancing Blow -\ 
 9985=\ - Glancing Blow due to Narrow/Low Profile -
 3187=does nothing (didn't target a unit).
 3188=<span class='success'><B>hits</B></span>, target tagged.
-3189=\ - Direct Blow -
+3189=\ - Direct Blow -\ 
 3190=<span class='success'><B>hits</B></span> the intended hex <data>.
 3191=<span class='success'><B>hits</B></span> the target in hex <data> with FLAK rounds.
 3192=<<span class='miss'><B>misses</B></span> and the FLAK rounds scatter to hex <data>.

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -26,6 +26,7 @@ import java.util.*;
 import megamek.common.*;
 import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.AmmoType.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.BombMounted;
@@ -35,6 +36,8 @@ import megamek.common.weapons.capitalweapons.CapitalMissileWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.infantry.InfantryWeaponHandler;
 import megamek.logging.MMLogger;
+
+import static megamek.common.AmmoType.*;
 
 /**
  * WeaponFireInfo is a wrapper around a WeaponAttackAction that includes
@@ -48,17 +51,6 @@ public class WeaponFireInfo {
 
     private static final NumberFormat LOG_PER = NumberFormat.getPercentInstance();
     private static final NumberFormat LOG_DEC = DecimalFormat.getInstance();
-
-    private static final EnumSet<AmmoType.Munitions> SMOKE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_SMOKE, AmmoType.Munitions.M_SMOKE_WARHEAD);
-    private static final EnumSet<AmmoType.Munitions> FLARE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_FLARE);
-    private static final EnumSet<AmmoType.Munitions> MINE_MUNITIONS = EnumSet.of(
-        AmmoType.Munitions.M_THUNDER,
-        AmmoType.Munitions.M_THUNDER_ACTIVE,
-        AmmoType.Munitions.M_THUNDER_AUGMENTED,
-        AmmoType.Munitions.M_THUNDER_INFERNO,
-        AmmoType.Munitions.M_THUNDER_VIBRABOMB,
-        AmmoType.Munitions.M_FASCAM
-    );
 
     private WeaponAttackAction action;
     private Entity shooter;

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -506,6 +506,12 @@ public class WeaponFireInfo {
 
         }
 
+        // XXX: replace this and other utility munition handling with smarter deployment, a la TAG above
+        var munitionType = (preferredAmmo != null) ? preferredAmmo.getType().getMunitionType() : AmmoType.Munitions.M_STANDARD;
+        if (munitionType.equals(AmmoType.Munitions.M_SMOKE) || munitionType.equals(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
+            return 0D;
+        }
+
         if (getTarget() instanceof Entity) {
             double dmg = Compute.getExpectedDamage(getGame(), getAction(),
                     true, owner.getPrecognition().getECMInfo());

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -50,6 +50,16 @@ public class WeaponFireInfo {
     private static final NumberFormat LOG_DEC = DecimalFormat.getInstance();
 
     private static final EnumSet<AmmoType.Munitions> SMOKE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_SMOKE, AmmoType.Munitions.M_SMOKE_WARHEAD);
+    private static final EnumSet<AmmoType.Munitions> FLARE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_FLARE);
+    private static final EnumSet<AmmoType.Munitions> MINE_MUNITIONS = EnumSet.of(
+        AmmoType.Munitions.M_THUNDER,
+        AmmoType.Munitions.M_THUNDER_ACTIVE,
+        AmmoType.Munitions.M_THUNDER_AUGMENTED,
+        AmmoType.Munitions.M_THUNDER_INFERNO,
+        AmmoType.Munitions.M_THUNDER_VIBRABOMB,
+        AmmoType.Munitions.M_FASCAM
+    );
+
     private WeaponAttackAction action;
     private Entity shooter;
     private Targetable target;
@@ -417,8 +427,16 @@ public class WeaponFireInfo {
         }
 
         // XXX: update this and other utility munition handling with smarter deployment, a la TAG above
-        if (preferredAmmo != null && SMOKE_MUNITIONS.containsAll(preferredAmmo.getType().getMunitionType())){
-            return 0D;
+        if (preferredAmmo != null) {
+            var munitionType = preferredAmmo.getType().getMunitionType();
+            // Handle all 0-damage munitions here
+            if (
+                SMOKE_MUNITIONS.containsAll(munitionType) ||
+                FLARE_MUNITIONS.containsAll(munitionType) ||
+                MINE_MUNITIONS.containsAll(munitionType)
+            ) {
+                return 0D;
+            }
         }
 
         // bay weapons require special consideration, by looping through all weapons and

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -49,6 +49,7 @@ public class WeaponFireInfo {
     private static final NumberFormat LOG_PER = NumberFormat.getPercentInstance();
     private static final NumberFormat LOG_DEC = DecimalFormat.getInstance();
 
+    private static final EnumSet<AmmoType.Munitions> SMOKE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_SMOKE, AmmoType.Munitions.M_SMOKE_WARHEAD);
     private WeaponAttackAction action;
     private Entity shooter;
     private Targetable target;
@@ -416,8 +417,7 @@ public class WeaponFireInfo {
         }
 
         // XXX: update this and other utility munition handling with smarter deployment, a la TAG above
-        EnumSet<AmmoType.Munitions> smokeMunitionTypes = EnumSet.of(AmmoType.Munitions.M_SMOKE, AmmoType.Munitions.M_SMOKE_WARHEAD);
-        if (preferredAmmo != null && smokeMunitionTypes.containsAll(preferredAmmo.getType().getMunitionType())){
+        if (preferredAmmo != null && SMOKE_MUNITIONS.containsAll(preferredAmmo.getType().getMunitionType())){
             return 0D;
         }
 

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -21,10 +21,7 @@ package megamek.client.bot.princess;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import megamek.common.*;
 import megamek.common.actions.ArtilleryAttackAction;
@@ -418,6 +415,12 @@ public class WeaponFireInfo {
             return computeExpectedBombDamage(getShooter(), weapon, getTarget().getPosition());
         }
 
+        // XXX: update this and other utility munition handling with smarter deployment, a la TAG above
+        EnumSet<AmmoType.Munitions> smokeMunitionTypes = EnumSet.of(AmmoType.Munitions.M_SMOKE, AmmoType.Munitions.M_SMOKE_WARHEAD);
+        if (preferredAmmo != null && smokeMunitionTypes.containsAll(preferredAmmo.getType().getMunitionType())){
+            return 0D;
+        }
+
         // bay weapons require special consideration, by looping through all weapons and
         // adding up the damage
         // A bay's weapons may have different ranges, most noticeable in laser bays,
@@ -504,12 +507,6 @@ public class WeaponFireInfo {
                 return computeExpectedTAGDamage(false);
             }
 
-        }
-
-        // XXX: replace this and other utility munition handling with smarter deployment, a la TAG above
-        var munitionType = (preferredAmmo != null) ? preferredAmmo.getType().getMunitionType() : AmmoType.Munitions.M_STANDARD;
-        if (munitionType.equals(AmmoType.Munitions.M_SMOKE) || munitionType.equals(AmmoType.Munitions.M_SMOKE_WARHEAD)) {
-            return 0D;
         }
 
         if (getTarget() instanceof Entity) {

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -339,6 +339,17 @@ public class AmmoType extends EquipmentType {
         M_FAE
     }
 
+    public static final EnumSet<AmmoType.Munitions> SMOKE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_SMOKE, AmmoType.Munitions.M_SMOKE_WARHEAD);
+    public static final EnumSet<AmmoType.Munitions> FLARE_MUNITIONS = EnumSet.of(AmmoType.Munitions.M_FLARE);
+    public static final EnumSet<AmmoType.Munitions> MINE_MUNITIONS = EnumSet.of(
+        AmmoType.Munitions.M_THUNDER,
+        AmmoType.Munitions.M_THUNDER_ACTIVE,
+        AmmoType.Munitions.M_THUNDER_AUGMENTED,
+        AmmoType.Munitions.M_THUNDER_INFERNO,
+        AmmoType.Munitions.M_THUNDER_VIBRABOMB,
+        AmmoType.Munitions.M_FASCAM
+    );
+
     private static Vector<Vector<AmmoType>> m_vaMunitions = new Vector<>(NUM_TYPES);
 
     public static Vector<AmmoType> getMunitionsFor(int nAmmoType) {

--- a/megamek/src/megamek/common/Minefield.java
+++ b/megamek/src/megamek/common/Minefield.java
@@ -36,13 +36,13 @@ public class Minefield implements Serializable, Cloneable {
     public static final int CLEAR_NUMBER_INF_ENG_ACCIDENT = 3;
     public static final int CLEAR_NUMBER_BA_SWEEPER = 6;
     public static final int CLEAR_NUMBER_BA_SWEEPER_ACCIDENT = 2;
-    
+
     public static final int BAP_DETECT_TARGET_PREPLACED = 10;
     public static final int BAP_DETECT_TARGET_WEAPON_DELIVERED = 7;
 
     public static final int TO_HIT_SIDE = ToHitData.SIDE_FRONT;
     public static final int TO_HIT_TABLE = ToHitData.HIT_KICK;
-    
+
     public static final int HOVER_WIGE_DETONATION_TARGET = 12;
 
     public static final int MAX_DAMAGE = 30;
@@ -53,7 +53,7 @@ public class Minefield implements Serializable, Cloneable {
             "Vibrabomb", "Active", "EMP", "Inferno"};
             //"Thunder", "Thunder-Inferno", "Thunder-Active",
             //"Thunder-Vibrabomb" };
-    
+
     public static int TYPE_SIZE = names.length;
 
     private Coords coords = null;
@@ -72,22 +72,22 @@ public class Minefield implements Serializable, Cloneable {
     private Minefield() {
         //Creates a minefield
     }
-    
+
     public static Minefield createMinefield(Coords coords, int playerId, int type, int density) {
         return createMinefield(coords, playerId, type, density, 0);
     }
-    
+
     public static Minefield createMinefield(Coords coords, int playerId, int type, int density, boolean sea, int depth) {
         return createMinefield(coords, playerId, type, density, 0, sea, depth);
     }
-    
+
     public static Minefield createMinefield(Coords coords, int playerId, int type, int density, int setting) {
         return createMinefield(coords, playerId, type, density, setting, false, 0);
     }
 
     public static Minefield createMinefield(Coords coords, int playerId, int type, int density, int setting, boolean sea, int depth) {
         Minefield mf = new Minefield();
-        
+
         mf.type = type;
         mf.density = density;
         mf.coords = coords;
@@ -97,8 +97,24 @@ public class Minefield implements Serializable, Cloneable {
         mf.depth = depth;
         return mf;
     }
-    
-    
+
+    @Override
+    public String toString() {
+        return "Minefield{'" +
+            getDisplayableName(type) +
+            "', coords=" + coords +
+            ", playerId=" + playerId +
+            ", density=" + density +
+            ", type=" + type +
+            ", setting=" + setting +
+            ", oneUse=" + oneUse +
+            ", sea=" + sea +
+            ", depth=" + depth +
+            ", detonated=" + detonated +
+            ", weaponDelivered=" + weaponDelivered +
+            '}';
+    }
+
     public static String getDisplayableName(int type) {
         if (type >= 0 && type < TYPE_SIZE) {
             return names[type];
@@ -131,10 +147,10 @@ public class Minefield implements Serializable, Cloneable {
             return false;
         }
         final Minefield other = (Minefield) obj;
-        return (playerId == other.playerId) && Objects.equals(coords, other.coords) && 
+        return (playerId == other.playerId) && Objects.equals(coords, other.coords) &&
                 (type == other.type);
     }
-    
+
     @Override
     public int hashCode() {
         return Objects.hash(playerId, coords, type);
@@ -156,7 +172,7 @@ public class Minefield implements Serializable, Cloneable {
      * what do we need to roll to trigger this mine
      * @return
      */
-    public int getTrigger() {    
+    public int getTrigger() {
         if (density < 15) {
             return 9;
         } else if (density < 25) {
@@ -181,7 +197,7 @@ public class Minefield implements Serializable, Cloneable {
     public int getType() {
         return type;
     }
-    
+
     public int getDepth() {
         return depth;
     }
@@ -193,23 +209,23 @@ public class Minefield implements Serializable, Cloneable {
     public int getPlayerId() {
         return playerId;
     }
-    
+
     public void setDetonated(boolean b) {
         this.detonated = b;
     }
-    
+
     public boolean hasDetonated() {
         return detonated;
     }
-    
+
     public void setWeaponDelivered(boolean b) {
         this.weaponDelivered = b;
     }
-    
+
     public boolean isWeaponDelivered() {
         return weaponDelivered;
     }
-    
+
     /**
      * check for a reduction in density
      * @param bonus - an <code>int</code> indicating the modifier to the target roll for reduction
@@ -223,16 +239,16 @@ public class Minefield implements Serializable, Cloneable {
             setDensity(getDensity() - 5);
             return;
         }
-        
+
         boolean isReduced = ((Compute.d6(2) + bonus) >= getTrigger()) || (direct && getType() != Minefield.TYPE_CONVENTIONAL && getType() != Minefield.TYPE_INFERNO);
         if (getType() == Minefield.TYPE_CONVENTIONAL && getDensity() < 10) {
             isReduced = false;
         }
         if (isReduced) {
             setDensity(getDensity() - 5);
-        }    
+        }
     }
-    
+
     /**
      * Gets the BAP detection target #
      */

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -7122,19 +7122,20 @@ public class TWGameManager extends AbstractGameManager {
                 continue;
             }
 
-            // Safety check; can't operate on minefields that don't officially exist
-            if (game.getBoard().getHex(mf.getCoords()) == null) {
+            try {
+                // if we are in the water, then the sea mine will only blow up if at
+                // the right depth
+                if (game.getBoard().contains(mf.getCoords()) &&
+                    game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)
+                ) {
+                    if ((Math.abs(curElev) != mf.getDepth())
+                        && (Math.abs(curElev + entity.getHeight()) != mf.getDepth())) {
+                        continue;
+                    }
+                }
+            } catch (NullPointerException _ignored) {
                 logger.warn("Minefield not found on board: " + mf.toString());
                 continue;
-            }
-
-            // if we are in the water, then the sea mine will only blow up if at
-            // the right depth
-            if (game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)) {
-                if ((Math.abs(curElev) != mf.getDepth())
-                        && (Math.abs(curElev + entity.getHeight()) != mf.getDepth())) {
-                    continue;
-                }
             }
 
             // Check for mine-sweeping. Vibramines handled elsewhere
@@ -7602,22 +7603,29 @@ public class TWGameManager extends AbstractGameManager {
         while (e.hasMoreElements()) {
             Minefield mf = e.nextElement();
 
-            // Safety check; can't operate on minefields that don't officially exist
-            if (game.getBoard().getHex(mf.getCoords()) == null) {
-                logger.warn("Minefield not found on board: " + mf.toString());
-                continue;
-            }
+            try {
+                // Safety check; can't operate on minefields that don't officially exist
+                if (game.getBoard().getHex(mf.getCoords()) == null) {
+                    logger.warn("Minefield not found on board: " + mf.toString());
+                    continue;
+                }
 
-            // Bug 954272: Mines shouldn't work underwater, and BMRr says
-            // Vibrabombs are mines
-            if (game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)
+                // Bug 954272: Mines shouldn't work underwater, and BMRr says
+                // Vibrabombs are mines
+                if (game.getBoard().contains(mf.getCoords()) &&
+                    game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)
                     && !game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.PAVEMENT)
                     && !game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.ICE)) {
-                continue;
-            }
+                    continue;
+                }
 
-            // Mek weighing 10 tons or less can't set off the bomb
-            if (mass <= (mf.getSetting() - 10)) {
+                // Mek weighing 10 tons or less can't set off the bomb
+                if (mass <= (mf.getSetting() - 10)) {
+                    continue;
+                }
+
+            } catch (NullPointerException _ignored) {
+                logger.warn("Minefield not found on board: " + mf.toString());
                 continue;
             }
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -7122,6 +7122,12 @@ public class TWGameManager extends AbstractGameManager {
                 continue;
             }
 
+            // Safety check; can't operate on minefields that don't officially exist
+            if (game.getBoard().getHex(mf.getCoords()) == null) {
+                logger.warn("Minefield not found on board: " + mf.toString());
+                continue;
+            }
+
             // if we are in the water, then the sea mine will only blow up if at
             // the right depth
             if (game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)) {
@@ -7595,6 +7601,12 @@ public class TWGameManager extends AbstractGameManager {
 
         while (e.hasMoreElements()) {
             Minefield mf = e.nextElement();
+
+            // Safety check; can't operate on minefields that don't officially exist
+            if (game.getBoard().getHex(mf.getCoords()) == null) {
+                logger.warn("Minefield not found on board: " + mf.toString());
+                continue;
+            }
 
             // Bug 954272: Mines shouldn't work underwater, and BMRr says
             // Vibrabombs are mines

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -7125,7 +7125,7 @@ public class TWGameManager extends AbstractGameManager {
             try {
                 // if we are in the water, then the sea mine will only blow up if at
                 // the right depth
-                if (game.getBoard().contains(mf.getCoords()) &&
+                if (game.getBoard().getHex(mf.getCoords()) != null &&
                     game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)
                 ) {
                     if ((Math.abs(curElev) != mf.getDepth())
@@ -7604,15 +7604,9 @@ public class TWGameManager extends AbstractGameManager {
             Minefield mf = e.nextElement();
 
             try {
-                // Safety check; can't operate on minefields that don't officially exist
-                if (game.getBoard().getHex(mf.getCoords()) == null) {
-                    logger.warn("Minefield not found on board: " + mf.toString());
-                    continue;
-                }
-
                 // Bug 954272: Mines shouldn't work underwater, and BMRr says
                 // Vibrabombs are mines
-                if (game.getBoard().contains(mf.getCoords()) &&
+                if (game.getBoard().getHex(mf.getCoords()) != null &&
                     game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.WATER)
                     && !game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.PAVEMENT)
                     && !game.getBoard().getHex(mf.getCoords()).containsTerrain(Terrains.ICE)) {


### PR DESCRIPTION
Have the `WeaponFireInfo.computeExpectedDamage()` method return 0 if the associated munition is Smoke, Flare, or FASCAM/Thunder type.
This should give Princess a better idea of the utility of some munitions when planning turns and attacks, so she chooses them less often.
Similarly, explicitly set the damage value of Smoke, Flare, or FASCAM/Thunder artillery munitions to 0 for Artillery fire control computations.

We can either replace this with a generalized Smoke or Utility Munition planner, or implement that at a higher level, but for now we don't want Princess to treat zero-damage rounds as if they do damage to targets.

This also fixes an NPE path in minefield handling, when artillery-deployed minefields are used in counter-battery attacks.
Unfortunately it looks like all counter-battery attacks currently compute an expected damage of 0.0, possibly due to the targets being off-board, so Princess still chooses munitions for these attacks randomly.

Additionally, add trailing spaces to the Glancing Blow and Direct Blow messages so that they produce lines like:

`- Glancing Blow - 6 missile(s) hit`

rather than

`- Glancing Blow -6 missile(s) hit`

which can be confusing.

Testing:
- Ran several Princess-on-Princess battles with Smoke (and other) munitions equipped.
- Ran all 3 projects' unit tests.

Close #6395 