### PR TITLE
Data update - change faction parent of Randis

### DIFF
--- a/megamek/data/forcegenerator/factions.xml
+++ b/megamek/data/forcegenerator/factions.xml
@@ -260,7 +260,7 @@
 	<faction key='FOR' name='Fiefdom of Randis' minor='true' clan='false' periphery='true'>
 		<years>2988-</years>
 		<ratingLevels>F,D,C,B,A</ratingLevels>
-		<parentFaction>MERC,Periphery.OS</parentFaction>
+		<parentFaction>MERC,Periphery.HR</parentFaction>
 	</faction>
 	<faction key='FVC' name='Filtvelt Coalition' minor='false' clan='false' periphery='true'>
 		<years>3072-</years>


### PR DESCRIPTION
Previous parent was Periphery.OS (Outer Sphere) which is around the Outworlds Alliance.  This changes it to Periphery.HR (Hyades Rim) as Randis is located between the Tortuga Dominions, Taurian Concordat, and Calderon Protectorate which are also child-factions of Periphery.HR.

With this change they will generate units more in line with their trading partners in the Concordat, the Protectorate, and Filtvelt Coalition.