### PR TITLE
Issue 6385: Incorrect TMM bonus for WiGe

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -256,16 +256,16 @@ public class FireControl {
      *
      * @param hexesMoved The number of hexes the target unit moved.
      * @param jumping    Set TRUE if the target jumped.
-     * @param vtol       Set TRUE if the target is a {@link VTOL}.
+     * @param airborneNonAerospace       Set TRUE if the target is a {@link VTOL} or other airborne, non-aerospace unit.
      * @param game       The current {@link Game}
      * @return The target movement modifier as a {@link ToHitData} object.
      */
     @StaticWrapper()
     protected ToHitData getTargetMovementModifier(final int hexesMoved,
             final boolean jumping,
-            final boolean vtol,
+            final boolean airborneNonAerospace,
             final Game game) {
-        return Compute.getTargetMovementModifier(hexesMoved, jumping, vtol, game);
+        return Compute.getTargetMovementModifier(hexesMoved, jumping, airborneNonAerospace, game);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/boardview/MovementModifierEnvelopeSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/MovementModifierEnvelopeSprite.java
@@ -28,11 +28,7 @@ import java.awt.geom.Point2D;
 
 import megamek.client.ui.swing.util.StringDrawer;
 import megamek.client.ui.swing.util.UIUtil;
-import megamek.common.Compute;
-import megamek.common.CrewType;
-import megamek.common.Facing;
-import megamek.common.MovePath;
-import megamek.common.VTOL;
+import megamek.common.*;
 
 /**
  * Sprite for displaying information about movement modifier that can be
@@ -64,7 +60,10 @@ public class MovementModifierEnvelopeSprite extends HexSprite {
 
         int modi = Compute.getTargetMovementModifier(mp.getHexesMoved(),
                 mp.isJumping(),
-                mp.getEntity() instanceof VTOL,
+                mp.getEntity() instanceof VTOL
+                    || (mp.getLastStepMovementType() == EntityMovementType.MOVE_VTOL_WALK)
+                    || (mp.getLastStepMovementType() == EntityMovementType.MOVE_VTOL_RUN)
+                    || (mp.getLastStepMovementType() == EntityMovementType.MOVE_VTOL_SPRINT),
                 boardView.game).getValue();
         //Add evasion bonus for 'Mek with dual cockpit
         if (mp.getEntity().getCrew().getCrewType().equals(CrewType.DUAL)

--- a/megamek/src/megamek/client/ui/swing/boardview/SBFStepSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/SBFStepSprite.java
@@ -253,9 +253,9 @@ public class SBFStepSprite extends Sprite {
         StringBuilder subscriptStringBuf = new StringBuilder();
 
         int distance = step.getDistance();
-        boolean isVTOL = false; //step.getEntity().;
+        boolean airborneNonAerospace = false; //step.getEntity().;
 
-        ToHitData toHitData = Compute.getTargetMovementModifier(distance, jumped, isVTOL, game);
+        ToHitData toHitData = Compute.getTargetMovementModifier(distance, jumped, airborneNonAerospace, game);
         subscriptStringBuf.append((toHitData.getValue() < 0) ? '-' : '+');
         subscriptStringBuf.append(toHitData.getValue());
 

--- a/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/StepSprite.java
@@ -1,15 +1,15 @@
-/*  
-* MegaMek - Copyright (C) 2020 - The MegaMek Team  
-*  
-* This program is free software; you can redistribute it and/or modify it under  
-* the terms of the GNU General Public License as published by the Free Software  
-* Foundation; either version 2 of the License, or (at your option) any later  
-* version.  
-*  
-* This program is distributed in the hope that it will be useful, but WITHOUT  
-* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  
-* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more  
-* details.  
+/*
+* MegaMek - Copyright (C) 2020 - The MegaMek Team
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 2 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+* details.
 */
 package megamek.client.ui.swing.boardview;
 
@@ -31,8 +31,8 @@ import java.awt.image.BufferedImage;
  * entering, exiting or turning.
  */
 class StepSprite extends Sprite {
-    
-    private final static GUIPreferences GUIP = GUIPreferences.getInstance(); 
+
+    private final static GUIPreferences GUIP = GUIPreferences.getInstance();
     private static AffineTransform shadowOffset = new AffineTransform();
     private static AffineTransform upDownOffset = new AffineTransform();
     private static AffineTransform stepOffset = new AffineTransform();
@@ -297,7 +297,7 @@ class StepSprite extends Sprite {
         tempImage.flush();
     }
 
-    /** Draws the given form in the given Color col with a shadow. */ 
+    /** Draws the given form in the given Color col with a shadow. */
     private void drawArrowShape(Graphics2D graph, Shape form, Color col) {
         graph.setColor(Color.darkGray);
         Shape currentArrow = stepOffset.createTransformedShape(form);
@@ -307,7 +307,7 @@ class StepSprite extends Sprite {
         currentArrow = shadowOffset.createTransformedShape(currentArrow);
         graph.fill(currentArrow);
     }
-    
+
     private void drawAnnouncement(Graphics2D graph, String text, MoveStep step, Color col) {
         if (step.isPastDanger()) {
             text = "(" + text + ")";
@@ -449,9 +449,13 @@ class StepSprite extends Sprite {
         StringBuilder subscriptStringBuf = new StringBuilder();
 
         int distance = step.getDistance();
-        boolean isVTOL = false; //step.getEntity().;
+        boolean airborneNonAerospace = (step.getMovementType(isLastStep) == EntityMovementType.MOVE_VTOL_RUN)
+            || (step.getMovementType(isLastStep) == EntityMovementType.MOVE_VTOL_WALK)
+            || ((step.getMovementMode() == EntityMovementMode.VTOL)
+                && ( ((step.getMovementType(isLastStep) != EntityMovementType.MOVE_NONE)  ||  step.getEntity().isAirborneVTOLorWIGE()))
+            || (step.getMovementType(isLastStep) == EntityMovementType.MOVE_VTOL_SPRINT));
 
-        ToHitData toHitData = Compute.getTargetMovementModifier(distance, jumped, isVTOL, game);
+        ToHitData toHitData = Compute.getTargetMovementModifier(distance, jumped, airborneNonAerospace, game);
         subscriptStringBuf.append((toHitData.getValue() < 0) ? '-' : '+');
         subscriptStringBuf.append(toHitData.getValue());
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2674,8 +2674,13 @@ public class Compute {
         }
     }
 
+
     /**
      * Modifier to attacks due to target movement
+     * @param game current game
+     * @param entityId targetId
+     * @return toHitData for the target's movement modifiers
+     * @see ToHitData
      */
     public static ToHitData getTargetMovementModifier(Game game, int entityId) {
         Entity entity = game.getEntity(entityId);
@@ -2716,16 +2721,17 @@ public class Compute {
                         || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
                         || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT));
 
-        boolean validFlying = (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
+        boolean airborneNonAerospace = (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
                 || (entity.moved == EntityMovementType.MOVE_VTOL_WALK)
-                || (entity.getMovementMode() == EntityMovementMode.VTOL)
+                || ((entity.getMovementMode() == EntityMovementMode.VTOL)
+                    && ( (entity.moved != EntityMovementType.MOVE_NONE)  ||  entity.isAirborneVTOLorWIGE()))
                 || (entity.moved == EntityMovementType.MOVE_VTOL_SPRINT);
 
         ToHitData toHit = Compute
                 .getTargetMovementModifier(
                         entity.delta_distance,
                         jumped,
-                        validFlying,
+                        airborneNonAerospace,
                         game);
 
         if (entity.moved != EntityMovementType.MOVE_JUMP
@@ -2743,10 +2749,6 @@ public class Compute {
         if (entity.moved == EntityMovementType.MOVE_SKID) {
             toHit.addModifier(2, "target skidded");
         }
-        if ((entity.getElevation() > 0)
-                && (entity.getMovementMode() == EntityMovementMode.WIGE)) {
-            toHit.addModifier(1, "target is airborne");
-        }
 
         // did the target sprint?
         if (entity.moved == EntityMovementType.MOVE_SPRINT
@@ -2757,13 +2759,20 @@ public class Compute {
         return toHit;
     }
 
+
     /**
-     * Target movement modifer for the specified delta_distance
+     * Target movement modifier for the specified distance
+     * @param distance how many hexes did the target unit move?
+     * @param jumped did the target unit jump?
+     * @param airborneNonAerospace was the target an airborne, non-aerospace unit?
+     * @param game current game
+     * @return toHitData for the target's movement modifiers
+     * @see ToHitData
      */
     public static ToHitData getTargetMovementModifier(int distance,
-            boolean jumped, boolean isVTOL, Game game) {
+            boolean jumped, boolean airborneNonAerospace, Game game) {
         ToHitData toHit = new ToHitData();
-        if (distance == 0 && !jumped) {
+        if (distance == 0 && !jumped && !airborneNonAerospace) {
             return toHit;
         }
 
@@ -2800,8 +2809,10 @@ public class Compute {
             }
         }
 
-        if (isVTOL && (distance > 0)) {
-            toHit.addModifier(1, "target VTOL used MPs");
+        // TW p. 117 Jumped/Airborne (non-aerospace units) get +1 MP,
+        // calculate that info outside of this method
+        if (airborneNonAerospace) {
+            toHit.addModifier(1, "target was airborne");
         } else if (jumped) {
             toHit.addModifier(1, "target jumped");
         }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2809,7 +2809,7 @@ public class Compute {
             }
         }
 
-        // TW p. 117 Jumped/Airborne (non-aerospace units) get +1 MP,
+        // TW p. 117 Jumped/Airborne (non-aerospace units) get +1 to hit modifier,
         // calculate that info outside of this method
         if (airborneNonAerospace) {
             toHit.addModifier(1, "target was airborne");

--- a/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/CombatVehicleBVCalculator.java
@@ -41,9 +41,9 @@ public class CombatVehicleBVCalculator extends BVCalculator {
             return 0;
         }
         int tmmRan = Compute.getTargetMovementModifier(runMP, entity instanceof VTOL,
-                entity instanceof VTOL, entity.getGame()).getValue();
+                entity instanceof VTOL || (entity.getMovementMode() == EntityMovementMode.WIGE),
+                entity.getGame()).getValue();
         tmmRan += (entity.hasStealth()) ? 2 : 0;
-        tmmRan += (entity.getMovementMode() == EntityMovementMode.WIGE) ? 1 : 0;
         return tmmRan;
     }
 
@@ -54,7 +54,6 @@ public class CombatVehicleBVCalculator extends BVCalculator {
         }
         int tmmJumped = Compute.getTargetMovementModifier(jumpMP, true, false, entity.getGame()).getValue();
         tmmJumped += (entity.hasStealth()) ? 2 : 0;
-        tmmJumped += (entity.getMovementMode() == EntityMovementMode.WIGE) ? 1 : 0;
         return tmmJumped;
     }
 

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -509,8 +509,8 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
             mp = ((LandAirMek) mek).getAirMekFlankMP(MPCalculationSetting.BV_CALCULATION);
             if (mp == 0) {
                 return 0;
-            } else {
-                return 1 + Compute.getTargetMovementModifier(mp, false, false, entity.getGame()).getValue();
+            } else { // IO p. 192 - When determining TMM for a LAM, include the +1 "airborne modifier".
+                return Compute.getTargetMovementModifier(mp, false, true, entity.getGame()).getValue();
             }
         } else {
             if (mp == 0) {


### PR DESCRIPTION
Fixes #6385 

The TMM bonus for jumping, being a VTOL, or being an airborne WiGe are all the same bonus - TW.  pg 117 Jumped/Airborne (non-aerospace units) get +1 to hit modifier, 

Instead of checking and applying this bonus in different locations, the bonus is now applied in 1 location. I checked every usage of public static ToHitData getTargetMovementModifier(int, boolean, boolean, Game) to ensure it's properly utilizing the method. 

I updated JavaDocs and comments to ensure this is conveyed in the code to future contributors.

I verified in game that this is applying the TMM bonus when we want it, and it's not applying it twice.

I verified the BV of WiGes, VTOLs, and glider protomeks did not change. I noticed during this that they don't match the MUL already. I calculated the BV of the Swallow & Fensalir by hand using the TechManual and the BV I got matches what MegaMek has, not what the MUL has - so either the MUL is wrong, or there is a rule for WiGe BV that's not conveyed in the TechManual. I have a hunch it's the same root cause as #5760 but I didn't dig too deep into this. I think this should be treated as a separate issue. 

Finally, I fixed an additional bug: On the map, a unit's TMM shows for its last step as you're selecting where to move. This was not accounting for VTOL/WiGe flight - now it does. I couldn't find a existing issue for this, but I didn't look too hard.