### PR TITLE
fix: makes princess actually ignore ignored targets

### DIFF
--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -19,14 +19,7 @@
  */
 package megamek.client.bot;
 
-import java.util.StringTokenizer;
-import java.util.stream.Collectors;
-
-import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.CardinalEdge;
-import megamek.client.bot.princess.ChatCommands;
-import megamek.client.bot.princess.Princess;
+import megamek.client.bot.princess.*;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Coords;
 import megamek.common.Game;
@@ -38,6 +31,9 @@ import megamek.server.Server;
 import megamek.server.commands.DefeatCommand;
 import megamek.server.commands.GameMasterCommand;
 import megamek.server.commands.JoinTeamCommand;
+
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 public class ChatProcessor {
     private final static MMLogger logger = MMLogger.create(ChatProcessor.class);
@@ -451,7 +447,7 @@ public class ChatProcessor {
         // Specify a priority unit target.
         if (command.toLowerCase().startsWith(ChatCommands.SHOW_DISHONORED.getAbbreviation())) {
             msg = "Dishonored Player ids: " + princess.getHonorUtil().getDishonoredEnemies().stream()
-                    .map(Object::toString).collect(Collectors.joining(", "));
+                .map(Object::toString).collect(Collectors.joining(", "));
             princess.sendChat(msg);
             logger.info(msg);
         }

--- a/megamek/src/megamek/client/bot/princess/RankedPath.java
+++ b/megamek/src/megamek/client/bot/princess/RankedPath.java
@@ -27,7 +27,7 @@ import java.text.DecimalFormat;
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
  * @since 12/5/13 10:19 AM
  */
-class RankedPath implements Comparable<RankedPath> {
+public class RankedPath implements Comparable<RankedPath> {
     private MovePath path;
     private double rank;
     private String reason;

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -1028,7 +1028,7 @@ class BasicPathRankerTest {
         friends.add(mockFriend4);
 
         // Test the default conditions.
-        Coords expected = new Coords(6, 6);
+        Coords expected = new Coords(7, 7);
         Coords actual = BasicPathRanker.calcAllyCenter(myId, friends, mockGame);
         assertCoordsEqual(expected, actual);
 


### PR DESCRIPTION
# Ignore target now ignores target

Turns out princess was very clingy to ignored enemies, and would stick close to them, to the point you would see princess "scouting" fleeing enemies.

This PR makes princess take into consideration that she has an ignored targets list when selecting the closest enemy.

## Small fix on find ally center

<img width="336" alt="Screenshot 2025-01-20 at 11 07 10" src="https://github.com/user-attachments/assets/93c24975-3464-4cb1-ae4b-860f1577f22c" />

The function was doing an integer division and rounding when it was unnecessary since they were both integers, but once I changed one of them to float the center in the test changed. I manually calculate the midpoint of the test and the new value is the "expected correct" value, while the previous one was biased to the "top left" of the map.

In the image the white dot is the old midpoint, the black dot in the middle is the new one.