### PR TITLE
fix: the bot should not consider hidden units in the list of available enemies

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -363,9 +363,9 @@ public abstract class BotClient extends Client {
             currentTurnEnemyEntities = new ArrayList<>();
             for (Entity entity : game.getEntitiesVector()) {
                 if (entity.getOwner().isEnemyOf(getLocalPlayer())
-                        && (entity.getPosition() != null) && !entity.isOffBoard()
-                        && (entity.getCrew() != null) && !entity.getCrew().isDead()) {
-
+                    && (entity.getPosition() != null) && !entity.isOffBoard()
+                    && (entity.getCrew() != null) && !entity.getCrew().isDead()
+                    && !entity.isHidden()) {
                     currentTurnEnemyEntities.add(entity);
                 }
             }


### PR DESCRIPTION
Princess is considering hidden units in the list of enemies available for pathing.

This small fix remove hidden units form the list.

Prior to the change Princess would move towards hidden units on the map, after the change princess behaved as "normal", moving to the center of the map waiting an enemy show up.