### PR TITLE
Issue 6359: LAMs now properly consider if they're in fighter mode or not when deploying.

### DIFF
--- a/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/DeploymentDisplay.java
@@ -534,8 +534,9 @@ public class DeploymentDisplay extends StatusBarPhaseDisplay {
                     }
                 }
 
+                // entity.isAero will check if a unit is a LAM in Fighter mode
                 if ((entity instanceof IAero aero)
-                        && (!(entity instanceof LandAirMek lam) || (lam.getConversionMode() == LandAirMek.CONV_MODE_FIGHTER))) {
+                        && (entity.isAero())) {
                     entity.setAltitude(finalElevation);
                     if (finalElevation == 0) {
                         aero.land();

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -9287,7 +9287,8 @@ public class TWGameManager extends AbstractGameManager {
         entity.setFacing(nFacing);
         entity.setSecondaryFacing(nFacing);
 
-        if (entity instanceof IAero aero) {
+        // entity.isAero will check if a unit is a LAM in Fighter mode
+        if (entity instanceof IAero aero && entity.isAero()) {
             entity.setAltitude(elevation);
             if ((elevation == 0) && !entity.isSpaceborne()) {
                 aero.land();


### PR DESCRIPTION
Fixes #6359 
Fixes #6423 

LAMs and other Aero both implement IAero therefore we can't consider something an aircraft just based on it being an instance of IAero. Fortunately, there's already a method implemented isAero() that will check if a LAM is in Fighter mode before returning true.