### PR TITLE
Fix Artemis derivatives getting bonus on indirect fire

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3352,6 +3352,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Missile Munitions
+        boolean isIndirect = weapon.hasModes() && (weapon.curMode().isIndirect());
 
         // Apollo FCS for MRMs
         if (bApollo) {
@@ -3359,7 +3360,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // add Artemis V bonus
-        if (bArtemisV) {
+        if (bArtemisV && !isIndirect) {
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.ArtemisV"));
         }
 

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -229,9 +229,7 @@ public class LRMHandler extends MissileWeaponHandler {
                     || (atype.getAmmoType() == AmmoType.T_SRM_IMP)
                     || (atype.getAmmoType() == AmmoType.T_MML)
                     || (atype.getAmmoType() == AmmoType.T_NLRM))
-                    && (atype.getMunitionType().contains(AmmoType.Munitions.M_NARC_CAPABLE))
-                    && ((weapon.curMode() == null) || !weapon.curMode().equals(
-                    "Indirect"))) {
+                    && (atype.getMunitionType().contains(AmmoType.Munitions.M_NARC_CAPABLE))) {
                     if (bTargetECMAffected) {
                         // ECM prevents bonus
                         Report r = new Report(3330);

--- a/megamek/src/megamek/common/weapons/LRMHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMHandler.java
@@ -134,98 +134,96 @@ public class LRMHandler extends MissileWeaponHandler {
             bECMAffected = true;
         }
 
-        if (((mLinker != null) && (mLinker.getType() instanceof MiscType)
+        if (!weapon.curMode().equals("Indirect")) {
+            if (((mLinker != null) && (mLinker.getType() instanceof MiscType)
                 && !mLinker.isDestroyed() && !mLinker.isMissing()
                 && !mLinker.isBreached() && mLinker.getType().hasFlag(
-                        MiscType.F_ARTEMIS))
-                && (atype.getMunitionType().contains(AmmoType.Munitions.M_ARTEMIS_CAPABLE))
-                && !weapon.curMode().equals("Indirect")) {
-            if (bECMAffected) {
-                // ECM prevents bonus
-                Report r = new Report(3330);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else if (bMekTankStealthActive) {
-                // stealth prevents bonus
-                Report r = new Report(3335);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else {
-                nMissilesModifier += 2;
-            }
-
-        } else if (((mLinker != null)
-                && (mLinker.getType() instanceof MiscType)
-                && !mLinker.isDestroyed() && !mLinker.isMissing()
-                && !mLinker.isBreached() && mLinker.getType().hasFlag(
-                        MiscType.F_ARTEMIS_PROTO))
+                MiscType.F_ARTEMIS))
                 && (atype.getMunitionType().contains(AmmoType.Munitions.M_ARTEMIS_CAPABLE))) {
-            if (bECMAffected) {
-                // ECM prevents bonus
-                Report r = new Report(3330);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else if (bMekTankStealthActive) {
-                // stealth prevents bonus
-                Report r = new Report(3335);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else {
-                nMissilesModifier += 1;
-            }
-
-        } else if (((mLinker != null)
+                if (bECMAffected) {
+                    // ECM prevents bonus
+                    Report r = new Report(3330);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else if (bMekTankStealthActive) {
+                    // stealth prevents bonus
+                    Report r = new Report(3335);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else {
+                    nMissilesModifier += 2;
+                }
+            } else if (((mLinker != null)
                 && (mLinker.getType() instanceof MiscType)
                 && !mLinker.isDestroyed() && !mLinker.isMissing()
                 && !mLinker.isBreached() && mLinker.getType().hasFlag(
-                        MiscType.F_ARTEMIS_V))
+                MiscType.F_ARTEMIS_PROTO))
+                && (atype.getMunitionType().contains(AmmoType.Munitions.M_ARTEMIS_CAPABLE))) {
+                if (bECMAffected) {
+                    // ECM prevents bonus
+                    Report r = new Report(3330);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else if (bMekTankStealthActive) {
+                    // stealth prevents bonus
+                    Report r = new Report(3335);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else {
+                    nMissilesModifier += 1;
+                }
+            } else if (((mLinker != null)
+                && (mLinker.getType() instanceof MiscType)
+                && !mLinker.isDestroyed() && !mLinker.isMissing()
+                && !mLinker.isBreached() && mLinker.getType().hasFlag(
+                MiscType.F_ARTEMIS_V))
                 && (atype.getMunitionType().contains(AmmoType.Munitions.M_ARTEMIS_V_CAPABLE))) {
-            if (bECMAffected) {
-                // ECM prevents bonus
-                Report r = new Report(3330);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else if (bMekTankStealthActive) {
-                // stealth prevents bonus
-                Report r = new Report(3335);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else {
-                nMissilesModifier += 3;
-            }
-        } else if (atype.getAmmoType() == AmmoType.T_ATM) {
-            if (bECMAffected) {
-                // ECM prevents bonus
-                Report r = new Report(3330);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else if (bMekTankStealthActive) {
-                // stealth prevents bonus
-                Report r = new Report(3335);
-                r.subject = subjectId;
-                r.newlines = 0;
-                vPhaseReport.addElement(r);
-            } else {
-                nMissilesModifier += 2;
-            }
-        } else if ((entityTarget != null)
+                if (bECMAffected) {
+                    // ECM prevents bonus
+                    Report r = new Report(3330);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else if (bMekTankStealthActive) {
+                    // stealth prevents bonus
+                    Report r = new Report(3335);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else {
+                    nMissilesModifier += 3;
+                }
+            } else if (atype.getAmmoType() == AmmoType.T_ATM) {
+                if (bECMAffected) {
+                    // ECM prevents bonus
+                    Report r = new Report(3330);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else if (bMekTankStealthActive) {
+                    // stealth prevents bonus
+                    Report r = new Report(3335);
+                    r.subject = subjectId;
+                    r.newlines = 0;
+                    vPhaseReport.addElement(r);
+                } else {
+                    nMissilesModifier += 2;
+                }
+            } else if ((entityTarget != null)
                 && (entityTarget.isNarcedBy(ae.getOwner().getTeam()) || entityTarget
-                        .isINarcedBy(ae.getOwner().getTeam()))) {
-            // only apply Narc bonus if we're not suffering ECM effect
-            // and we are using narc ammo, and we're not firing indirectly.
-            // narc capable missiles are only affected if the narc pod, which
-            // sits on the target, is ECM affected
-            boolean bTargetECMAffected = false;
-            bTargetECMAffected = ComputeECM.isAffectedByECM(ae,
+                .isINarcedBy(ae.getOwner().getTeam()))) {
+                // only apply Narc bonus if we're not suffering ECM effect
+                // and we are using narc ammo, and we're not firing indirectly.
+                // narc capable missiles are only affected if the narc pod, which
+                // sits on the target, is ECM affected
+                boolean bTargetECMAffected = false;
+                bTargetECMAffected = ComputeECM.isAffectedByECM(ae,
                     target.getPosition(), target.getPosition());
-            if (((atype.getAmmoType() == AmmoType.T_LRM)
+                if (((atype.getAmmoType() == AmmoType.T_LRM)
                     || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
                     || (atype.getAmmoType() == AmmoType.T_SRM)
                     || (atype.getAmmoType() == AmmoType.T_SRM_IMP)
@@ -233,15 +231,16 @@ public class LRMHandler extends MissileWeaponHandler {
                     || (atype.getAmmoType() == AmmoType.T_NLRM))
                     && (atype.getMunitionType().contains(AmmoType.Munitions.M_NARC_CAPABLE))
                     && ((weapon.curMode() == null) || !weapon.curMode().equals(
-                            "Indirect"))) {
-                if (bTargetECMAffected) {
-                    // ECM prevents bonus
-                    Report r = new Report(3330);
-                    r.subject = subjectId;
-                    r.newlines = 0;
-                    vPhaseReport.addElement(r);
-                } else {
-                    nMissilesModifier += 2;
+                    "Indirect"))) {
+                    if (bTargetECMAffected) {
+                        // ECM prevents bonus
+                        Report r = new Report(3330);
+                        r.subject = subjectId;
+                        r.newlines = 0;
+                        vPhaseReport.addElement(r);
+                    } else {
+                        nMissilesModifier += 2;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Problem: Artemis controllers _other_ than Artemis IV are getting their bonuses when firing in Indirect mode; this is incorrect:

> per BMM pg 30 Artemis FCS do not confer bonuses when fired indirectly

and BMM page 110, *ARTEMIS V FIRE CONTROL SYSTEM*:
> Indirect fire attacks do not receive these bonuses.

Solution:  move the existing not-indirect check for Artemis IV out to cover _all_ advanced FCS bonus checks within the LRM attack handler (other missile types are not subject to this check):
- Artemis IV
- Artemis V
- Prototype Artemis
- ATM
- NARC-capable missiles

Testing:
- Ran all the projects' unit tests
- Tested indirect fire with Artemis V FCS mek