### PR TITLE
Princess - Chat Commands fix

### DIFF
--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -298,7 +298,7 @@ public class ChatProcessor {
         // Adjust fall shame.
         if (command.toLowerCase().startsWith(ChatCommands.CAUTION.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid Syntax.  Should be 'princessName : caution : <+/->'.";
+                msg = "Invalid Syntax. " + ChatCommands.CAUTION.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -307,7 +307,11 @@ public class ChatProcessor {
             String adjustment = arguments[0];
             int currentFallShame = princess.getBehaviorSettings().getFallShameIndex();
             int newFallShame = currentFallShame;
-            newFallShame += princess.calculateAdjustment(adjustment);
+            if (StringUtil.isNumeric(adjustment)) {
+                newFallShame = princess.calculateAdjustment(adjustment);
+            } else {
+                newFallShame += princess.calculateAdjustment(adjustment);
+            }
             princess.getBehaviorSettings().setFallShameIndex(newFallShame);
             msg = "Piloting Caution changed from " + currentFallShame + " to " +
                     princess.getBehaviorSettings().getFallShameIndex();
@@ -317,7 +321,7 @@ public class ChatProcessor {
         // Adjust self preservation.
         if (command.toLowerCase().startsWith(ChatCommands.AVOID.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid Syntax.  Should be 'princessName : avoid : <+/->'.";
+                msg = "Invalid Syntax. " + ChatCommands.AVOID.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -326,7 +330,11 @@ public class ChatProcessor {
             String adjustment = arguments[0];
             int currentSelfPreservation = princess.getBehaviorSettings().getSelfPreservationIndex();
             int newSelfPreservation = currentSelfPreservation;
-            newSelfPreservation += princess.calculateAdjustment(adjustment);
+            if (StringUtil.isNumeric(adjustment)) {
+                newSelfPreservation = princess.calculateAdjustment(adjustment);
+            } else {
+                newSelfPreservation += princess.calculateAdjustment(adjustment);
+            }
             princess.getBehaviorSettings().setSelfPreservationIndex(newSelfPreservation);
             msg = "Self Preservation changed from " + currentSelfPreservation + " to " +
                     princess.getBehaviorSettings().getSelfPreservationIndex();
@@ -336,7 +344,7 @@ public class ChatProcessor {
         // Adjust aggression.
         if (command.toLowerCase().startsWith(ChatCommands.AGGRESSION.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid Syntax.  Should be 'princessName : aggression : <+/->'.";
+                msg = "Invalid Syntax. " + ChatCommands.AGGRESSION.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -345,7 +353,11 @@ public class ChatProcessor {
             String adjustment = arguments[0];
             int currentAggression = princess.getBehaviorSettings().getHyperAggressionIndex();
             int newAggression = currentAggression;
-            newAggression += princess.calculateAdjustment(adjustment);
+            if (StringUtil.isNumeric(adjustment)) {
+                newAggression = princess.calculateAdjustment(adjustment);
+            } else {
+                newAggression += princess.calculateAdjustment(adjustment);
+            }
             princess.getBehaviorSettings().setHyperAggressionIndex(newAggression);
             msg = "Aggression changed from " + currentAggression + " to " +
                     princess.getBehaviorSettings().getHyperAggressionIndex();
@@ -356,7 +368,7 @@ public class ChatProcessor {
         // Adjust herd mentality.
         if (command.toLowerCase().startsWith(ChatCommands.HERDING.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid Syntax.  Should be 'princessName : herding : <+/->'.";
+                msg = "Invalid Syntax. " + ChatCommands.HERDING.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -365,7 +377,11 @@ public class ChatProcessor {
             String adjustment = arguments[0];
             int currentHerding = princess.getBehaviorSettings().getHerdMentalityIndex();
             int newHerding = currentHerding;
-            newHerding += princess.calculateAdjustment(adjustment);
+            if (StringUtil.isNumeric(adjustment)) {
+                newHerding = princess.calculateAdjustment(adjustment);
+            } else {
+                newHerding += princess.calculateAdjustment(adjustment);
+            }
             princess.getBehaviorSettings().setHerdMentalityIndex(newHerding);
             msg = "Herding changed from " + currentHerding + " to " +
                     princess.getBehaviorSettings().getHerdMentalityIndex();
@@ -375,7 +391,7 @@ public class ChatProcessor {
         // Adjust bravery.
         if (command.toLowerCase().startsWith(ChatCommands.BRAVERY.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid Syntax.  Should be 'princessName : brave : <+/->'.";
+                msg = "Invalid Syntax. " + ChatCommands.BRAVERY.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -384,7 +400,11 @@ public class ChatProcessor {
             String adjustment = arguments[0];
             int currentBravery = princess.getBehaviorSettings().getBraveryIndex();
             int newBravery = currentBravery;
-            newBravery += princess.calculateAdjustment(adjustment);
+            if (StringUtil.isNumeric(adjustment)) {
+                newBravery = princess.calculateAdjustment(adjustment);
+            } else {
+                newBravery += princess.calculateAdjustment(adjustment);
+            }
             princess.getBehaviorSettings().setBraveryIndex(newBravery);
             msg = "Bravery changed from " + currentBravery + " to " +
                     princess.getBehaviorSettings().getBraveryIndex();
@@ -394,7 +414,7 @@ public class ChatProcessor {
         // Specify a "strategic" building target.
         if (command.toLowerCase().startsWith(ChatCommands.TARGET.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid syntax.  Should be 'princessName : target : hexNumber'.";
+                msg = "Invalid Syntax. " + ChatCommands.TARGET.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -426,7 +446,7 @@ public class ChatProcessor {
         // Specify a priority unit target.
         if (command.toLowerCase().startsWith(ChatCommands.PRIORITIZE.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid syntax.  Should be 'princessName : priority : unitId'.";
+                msg = "Invalid Syntax. " + ChatCommands.PRIORITIZE.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;
@@ -454,7 +474,7 @@ public class ChatProcessor {
 
         if (command.toLowerCase().startsWith(ChatCommands.BLOOD_FEUD.getAbbreviation())) {
             if (arguments == null || arguments.length == 0) {
-                msg = "Invalid syntax.  Should be 'princessName : bf : playerId'.";
+                msg = "Invalid Syntax. " + ChatCommands.BLOOD_FEUD.getSyntax();
                 logger.warn(msg + "\n" + chatEvent.getMessage());
                 princess.sendChat(msg);
                 return;

--- a/megamek/src/megamek/client/bot/princess/ChatCommands.java
+++ b/megamek/src/megamek/client/bot/princess/ChatCommands.java
@@ -23,29 +23,29 @@ package megamek.client.bot.princess;
  * @since 10/24/2014 9:57 AM
  */
 public enum ChatCommands {
-    FLEE("fl", "princessName: flee", "Causes princess-controlled units to start fleeing the board, regardless of " +
+    FLEE("fl", "princessName: fl", "Flee - Causes princess-controlled units to start fleeing the board, regardless of " +
                                      "damage level or Forced Withdrawal setting."),
-    VERBOSE("ve", "princessName: verbose : <error/warning/info/debug>", "Sets princess's verbosity level."),
-    BEHAVIOR("be", "princessName: behavior : behaviorName", "Change's princess's behavior to the named behavior."),
-    CAUTION("ca", "princessName: caution : <+/->", "Modifies princess's Piloting Caution setting. Each '+' increases " +
+    VERBOSE("ve", "princessName: ve: <error/warning/info/debug>", "Sets princess's verbosity level."),
+    BEHAVIOR("be", "princessName: be: behaviorName", "Behavior - Change's princess's behavior to the named behavior."),
+    CAUTION("ca", "princessName: ca: +/-", "Caution - Modifies princess's Piloting Caution setting. Each '+' increases " +
                                                    "it by 1 and each '-' decreases it by one."),
-    AVOID("av", "princessName: avoid : <+/->", "Modifies princess's Self Preservation setting. Each '+' increases it " +
+    AVOID("av", "princessName: av: +/-", "Avoid - Modifies princess's Self Preservation setting. Each '+' increases it " +
                                                "by 1 and each '-' decreases it by one."),
-    AGGRESSION("ag", "princessName: aggression : <+/->", "Modifies princess's Aggression setting. Each '+' increases " +
+    AGGRESSION("ag", "princessName: ag : +/-", "Aggression - Modifies princess's Aggression setting. Each '+' increases " +
                                                          "it by 1 and each '-' decreases it by one."),
-    HERDING("he", "princessName: herd : <+/->", "Modifies princess's Herding setting. Each '+' increases it by 1 and " +
+    HERDING("he", "princessName: he: +/-", "Herd - Modifies princess's Herding setting. Each '+' increases it by 1 and " +
                                                 "each '-' decreases it by one."),
-    BRAVERY("br", "princessName: brave : <+/->", "Modifies princess's Bravery setting. Each '+' increases it by 1 " +
+    BRAVERY("br", "princessName: br: +/-", "Brave - Modifies princess's Bravery setting. Each '+' increases it by 1 " +
                                                  "and each '-' decreases it by one."),
-    TARGET("ta", "princessName: target : hexNumber", "Adds the specified hex to princess's list of Strategic Targets."),
-    PRIORITIZE("pr", "princessName: prioritize : unitId", "Adds the specified unit to princess's Priority Targets " +
+    TARGET("ta", "princessName: ta: hexNumber", "Target Hex - Adds the specified hex to princess's list of Strategic Targets."),
+    PRIORITIZE("pr", "princessName: pr: unitId", "Priority Target - Adds the specified unit to princess's Priority Targets " +
                                                           "list."),
-    SHOW_BEHAVIOR("sh", "princessName: showBehavior", "Princess will state the name of her current behavior."),
-    LIST__COMMANDS("li", "princessName: listCommands", "Displays this list of commands."),
-    IGNORE_TARGET("ig", "princessName: ignoreTarget: unitId", "Will not fire on the entity with this ID."),
-    SHOW_DISHONORED("di", "princessName: dishonored", "Show the players on the dishonored enemies list."),
-    CLEAR_IGNORED_TARGETS("cl", "princessName: clearIgnoredTargets", "Clears the list of ignored targets."),
-    BLOOD_FEUD("bf", "princessName: bloodFeud: playerId", "Adds player to the dishonored enemies list.");
+    SHOW_BEHAVIOR("sh", "princessName: sh", "Show Behavior - Princess will state the name of her current behavior."),
+    LIST__COMMANDS("li", "princessName: li", "List Commands - Displays this list of commands."),
+    IGNORE_TARGET("ig", "princessName: ig: unitId", "Ignore Target - Will not fire on the entity with this ID."),
+    SHOW_DISHONORED("di", "princessName: di", "Show Dishonored - Show the players on the dishonored enemies list."),
+    CLEAR_IGNORED_TARGETS("cl", "princessName: cl", "Clear Ignored Target - Clears the list of ignored targets."),
+    BLOOD_FEUD("bf", "princessName: bf: playerId", "Blood Feud - Adds player to the dishonored enemies list.");
     private final String abbreviation;
     private final String syntax;
     private final String description;

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2896,6 +2896,10 @@ public class Princess extends BotClient {
         if (StringUtility.isNullOrBlank(ticks)) {
             return 0;
         }
+        if (StringUtil.isNumeric(ticks)) {
+            return Integer.parseInt(ticks);
+        }
+
         for (final char tick : ticks.toCharArray()) {
             if (PLUS == tick) {
                 adjustment++;

--- a/megamek/unittests/megamek/client/bot/ChatProcessorTest.java
+++ b/megamek/unittests/megamek/client/bot/ChatProcessorTest.java
@@ -285,7 +285,7 @@ class ChatProcessorTest {
                 // Test the 'caution' command with invalid arguments.
                 mockChatEvent = mock(GamePlayerChatEvent.class);
                 chatMessage = mockHumanPlayerDave.getName() + ": " + mockBotPlayerVGer.getName() + ": "
-                                + ChatCommands.CAUTION.getAbbreviation() + " : +4";
+                                + ChatCommands.CAUTION.getAbbreviation() + " : +";
                 when(mockChatEvent.getMessage()).thenReturn(chatMessage);
                 when(mockChatEvent.getPlayer()).thenReturn(mockHumanPlayerDave);
                 mockPrincess = spy(new Princess(mockBotPlayerVGer.getName(), "test", 1));
@@ -327,7 +327,7 @@ class ChatProcessorTest {
                 // Test the 'avoid' command with invalid arguments.
                 mockChatEvent = mock(GamePlayerChatEvent.class);
                 chatMessage = mockHumanPlayerDave.getName() + ": " + mockBotPlayerVGer.getName() + ": "
-                                + ChatCommands.AVOID.getAbbreviation() + " : +5";
+                                + ChatCommands.AVOID.getAbbreviation() + " : 6";
                 when(mockChatEvent.getMessage()).thenReturn(chatMessage);
                 when(mockChatEvent.getPlayer()).thenReturn(mockHumanPlayerDave);
                 mockPrincess = spy(new Princess(mockBotPlayerVGer.getName(), "test", 1));
@@ -411,7 +411,7 @@ class ChatProcessorTest {
                 // Test the 'herding' command with invalid arguments.
                 mockChatEvent = mock(GamePlayerChatEvent.class);
                 chatMessage = mockHumanPlayerDave.getName() + ": " + mockBotPlayerVGer.getName() + ": "
-                                + ChatCommands.HERDING.getAbbreviation() + " : -4";
+                                + ChatCommands.HERDING.getAbbreviation() + " : -a";
                 when(mockChatEvent.getMessage()).thenReturn(chatMessage);
                 when(mockChatEvent.getPlayer()).thenReturn(mockHumanPlayerDave);
                 mockPrincess = spy(new Princess(mockBotPlayerVGer.getName(), "test", 1));
@@ -453,7 +453,7 @@ class ChatProcessorTest {
                 // Test the 'brave' command with invalid arguments.
                 mockChatEvent = mock(GamePlayerChatEvent.class);
                 chatMessage = mockHumanPlayerDave.getName() + ": " + mockBotPlayerVGer.getName() + ": "
-                                + ChatCommands.BRAVERY.getAbbreviation() + " : -2";
+                                + ChatCommands.BRAVERY.getAbbreviation() + " : -p";
                 when(mockChatEvent.getMessage()).thenReturn(chatMessage);
                 when(mockChatEvent.getPlayer()).thenReturn(mockHumanPlayerDave);
                 mockPrincess = spy(new Princess(mockBotPlayerVGer.getName(), "test", 1));

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -89,10 +89,16 @@ class PrincessTest {
         assertEquals(-2, mockPrincess.calculateAdjustment("--"));
 
         // Test an adjustment with some bad characters.
-        assertEquals(1, mockPrincess.calculateAdjustment("+4"));
+        assertEquals(1, mockPrincess.calculateAdjustment("+p"));
 
-        // Test an adjustment with nothing but bad characters.
-        assertEquals(0, mockPrincess.calculateAdjustment("5"));
+        // Test an adjustment with a number should set the value to the number.
+        assertEquals(5, mockPrincess.calculateAdjustment("5"));
+
+        // Test an adjustment with a number should set the value to the number.
+        assertEquals(-5, mockPrincess.calculateAdjustment("-5"));
+
+        // Test an adjustment with a number should set the value to the number.
+        assertEquals(22, mockPrincess.calculateAdjustment("+22"));
 
         // Test an empty ticks argument.
         assertEquals(0, mockPrincess.calculateAdjustment(""));


### PR DESCRIPTION
The chat commands syntax and how they were used in the chat were wrong and did not align with how they actually work.

This not only fix that, as it also fix an error that I commited where I mistakenly believed that you could set the bot behavior using discrete values, this fix also allows that.