### PR TITLE
Issue 2457: Aero units on ground maps should use TO:AR visual range tables

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -5210,7 +5210,7 @@ public class Compute {
         // the flightline against ground targets
         // TO:AR Errata forum post clarifies that ground
         // mapsheet aero use ground sensor table
-        if (game.getBoard().onGround() && (te != null && ae.isAirborne() && !te.isAirborne()) ) {
+        if (!game.getBoard().onGround() && (te != null && ae.isAirborne() && !te.isAirborne()) ) {
             // Can't see anything if above Alt 8.
             if (ae.getAltitude() > 8) {
                 range = 0;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -5208,8 +5208,9 @@ public class Compute {
 
         // If we're an airborne aero, sensor range is limited to within a few hexes of
         // the flightline against ground targets
-        // TO Dec 2017 Errata p17
-        if (te != null && ae.isAirborne() && !te.isAirborne()) {
+        // TO:AR Errata forum post clarifies that ground
+        // mapsheet aero use ground sensor table
+        if (game.getBoard().onGround() && (te != null && ae.isAirborne() && !te.isAirborne()) ) {
             // Can't see anything if above Alt 8.
             if (ae.getAltitude() > 8) {
                 range = 0;

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4404,11 +4404,11 @@ public class Compute {
      *
      * @param game   The current {@link Game}
      * @param los
-     * @param ae
+     * @param attackingEntity
      * @param target
      * @return
      */
-    public static boolean inVisualRange(Game game, LosEffects los, Entity ae,
+    public static boolean inVisualRange(Game game, LosEffects los, Entity attackingEntity,
             Targetable target) {
         // Use firing solution if Advanced Sensors is on
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)
@@ -4432,56 +4432,63 @@ public class Compute {
         }
 
         // if either does not have a position then return false
-        if ((ae.getPosition() == null) || (target.getPosition() == null)) {
+        if ((attackingEntity.getPosition() == null) || (target.getPosition() == null)) {
             return false;
         }
 
         // check visual range based on planetary conditions
         if (los == null) {
-            los = LosEffects.calculateLOS(game, ae, target);
+            los = LosEffects.calculateLOS(game, attackingEntity, target);
         }
-        int visualRange = getVisualRange(game, ae, los, teIlluminated);
+        int visualRange = getVisualRange(game, attackingEntity, los, teIlluminated);
 
         // Check for factors that only apply to an entity target
         Coords targetPos = target.getPosition();
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
-            Entity te = (Entity) target;
+            Entity targetedEntity = (Entity) target;
 
             // check for camo and null sig on the target
-            if (te.isVoidSigActive()) {
+            if (targetedEntity.isVoidSigActive()) {
                 visualRange = visualRange / 4;
-            } else if (te.hasWorkingMisc(MiscType.F_VISUAL_CAMO, -1)) {
+            } else if (targetedEntity.hasWorkingMisc(MiscType.F_VISUAL_CAMO, -1)) {
                 visualRange = visualRange / 2;
-            } else if (te.isChameleonShieldActive()) {
+            } else if (targetedEntity.isChameleonShieldActive()) {
                 visualRange = visualRange / 2;
-            } else if (te.isConventionalInfantry() && ((Infantry) te).hasSneakCamo()) {
+            } else if (targetedEntity.isConventionalInfantry() && ((Infantry) targetedEntity).hasSneakCamo()) {
                 visualRange = visualRange / 2;
             }
 
             // Ground targets pick the closest path to Aeros (TW pg 107)
-            if ((te.isAero()) && isGroundToAir(ae, target)) {
-                targetPos = Compute.getClosestFlightPath(ae.getId(),
-                        ae.getPosition(), te);
+            if ((targetedEntity.isAero()) && isGroundToAir(attackingEntity, target)) {
+                targetPos = Compute.getClosestFlightPath(attackingEntity.getId(),
+                        attackingEntity.getPosition(), targetedEntity);
             }
-            // Airborne aeros can only see ground targets they overfly, and only at Alt <=8
-            if (isAirToGround(ae, target)) {
-                if (ae.getAltitude() > 8) {
-                    return false;
-                }
-                if (ae.passedOver(target)) {
-                    return true;
-                } else {
-                    return false;
+
+            // Airborne units targeting ground have special rules
+            if (isAirToGround(attackingEntity, target)) {
+                // In Low Altitude, Airborne aeros can only see ground targets
+                // they overfly, and only at Alt <=8. It should also spot units
+                // next to this; Low-atmo board with ground units isn't implemented
+                if (game.getBoard().getType() == Board.T_ATMOSPHERE) {
+                    if (attackingEntity.getAltitude() > 8) {
+                        return false;
+                    }
+                    if (attackingEntity.passedOver(target)) {
+                        return true;
+                    } else {
+                        return false;
+                    }
                 }
             }
         }
 
+        // Undoes any negative visual ranges
         visualRange = Math.max(visualRange, 1);
         int distance;
         // Ground distance
-        distance = ae.getPosition().distance(targetPos);
+        distance = attackingEntity.getPosition().distance(targetPos);
         // Need to track difference in altitude, not just add altitude to the range
-        distance += Math.abs(2 * target.getAltitude() - 2 * ae.getAltitude());
+        distance += Math.abs(2 * target.getAltitude() - 2 * attackingEntity.getAltitude());
         return distance <= visualRange;
 
     }

--- a/megamek/unittests/megamek/common/ComputeSensorRangeTest.java
+++ b/megamek/unittests/megamek/common/ComputeSensorRangeTest.java
@@ -1,0 +1,938 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
+package megamek.common;
+
+import megamek.common.options.GameOptions;
+import megamek.common.planetaryconditions.PlanetaryConditions;
+import megamek.common.planetaryconditions.Weather;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Suite of tests for testing {@link Compute#getSensorRangeByBracket(Game, Entity, Targetable, LosEffects)}.
+ * This largely corresponds to TO:AR pg. 190, "Sensor Range Tables"
+ */
+public class ComputeSensorRangeTest {
+
+    // Start Field sources
+    static List<Integer> activeProbeSensorTypes = Arrays.asList(Sensor.TYPE_BAP, Sensor.TYPE_BLOODHOUND, Sensor.TYPE_CLAN_AP, Sensor.TYPE_EW_EQUIPMENT, Sensor.TYPE_WATCHDOG, Sensor.TYPE_LIGHT_AP, Sensor.TYPE_NOVA);
+    static List<Integer> radarSensorTypes = Arrays.asList(Sensor.TYPE_MEK_RADAR, Sensor.TYPE_VEE_RADAR);
+    static List<Integer> seismicSensorTypes = Arrays.asList(Sensor.TYPE_MEK_SEISMIC, Sensor.TYPE_VEE_SEISMIC);
+    static List<Integer> irSensorTypes = Arrays.asList(Sensor.TYPE_MEK_IR, Sensor.TYPE_VEE_IR);
+    static List<Integer> magscanSensorTypes = Arrays.asList(Sensor.TYPE_MEK_MAGSCAN, Sensor.TYPE_VEE_MAGSCAN);
+    //  End Field Sources
+
+    // Start tests for Compute.getSensorRangeByBracket(Game, Entity, Targetable, LosEffects)
+
+    @ParameterizedTest
+    @FieldSource(value = "radarSensorTypes")
+    void testGetRadarSensorRangeByBracket(int sensorType) {
+
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock weather
+        Weather mockWeather = mock(Weather.class);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = mock(PlanetaryConditions.class); //new PlanetaryConditions();
+        when(mockPlanetaryConditions.getWeather()).thenReturn(mockWeather);
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+        Hex mockTargetHex = mock(Hex.class);
+
+        // Mock Sensor
+        Sensor activeSensor = new Sensor(sensorType);
+
+        // Expected Sensor Range - Normal Conditions, should be full range
+        int expectedValue = activeSensor.getRangeByBracket();
+
+        Entity mockAttackingEntity = mock(Entity.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.getActiveSensor()).thenReturn(activeSensor);
+
+        // Let's put the enemy at our max range
+        Entity mockTarget = mock(Entity.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, expectedValue));
+
+        when(mockBoard.getHex(mockTarget.getPosition())).thenReturn(mockTargetHex);
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a hill in the way. This should block Radar
+        when(mockLos.isBlockedByHill()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's get rid of the hill. Let's put a building in the way instead. This should block radar.
+        when(mockLos.isBlockedByHill()).thenReturn(false);
+        when(mockLos.getHardBuildings()).thenReturn(1);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a different kind of building in the way. This should still block radar.
+        when(mockLos.getHardBuildings()).thenReturn(0);
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the building and test planetary conditions. EMI should reduce the range by 4.
+        when(mockLos.getSoftBuildings()).thenReturn(0);
+        when(mockPlanetaryConditions.isEMI()).thenReturn(true);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's add a lightening storm (-1 range). This should stack with EMI.
+        when(mockWeather.isLightningStorm()).thenReturn(true);
+        assertEquals(Math.max(0, expectedValue - 5), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the EMI and test lightening on its own.
+        when(mockPlanetaryConditions.isEMI()).thenReturn(false);
+        assertEquals(Math.max(0, expectedValue - 1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the lightening and test forest hexes.
+        when(mockWeather.isLightningStorm()).thenReturn(false);
+        when(mockLos.getLightWoods()).thenReturn(3); // Should have no effect
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Heavy Woods/Jungle should remove 1 hex per bracket per hex
+        when(mockLos.getHeavyWoods()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(2);
+        assertEquals(Math.max(0, expectedValue - 2), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Ultraheavy Woods/Jungle should remove 2 hex per bracket per hex
+        when(mockLos.getUltraWoods()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(2);
+        assertEquals(Math.max(0, expectedValue - 6), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(0);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getLightWoods()).thenReturn(0);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(0);
+
+        // Water time - LOS blocked by water only works for sensors if the sensor is magscan
+        // or the attacking entity is a naval vessel.
+        when(mockLos.isBlockedByWater()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // If the attacker is a naval vessel it should be able to see:
+        when(mockAttackingEntity.getMovementMode()).thenReturn(EntityMovementMode.NAVAL);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.isBlockedByWater()).thenReturn(false);
+        when(mockAttackingEntity.getMovementMode()).thenReturn(null);
+
+        // Some sensors are effected by the target or tile's heat
+        mockTarget.heat = 15;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.heat = 0;
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(false);
+
+        // Some sensors are effected by the target's weight
+        when(mockTarget.getWeight()).thenReturn(19.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(20.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(79.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(80.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(100.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(101.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(1000.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(1000.1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(0.0);
+
+        // Industrial terrain blocks some sensors
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(false);
+
+        // Moving effects some sensors detection
+        mockTarget.mpUsed = 0;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 1;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getElevation()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 0;
+        when(mockTarget.getElevation()).thenReturn(0);
+    }
+
+    @ParameterizedTest
+    @FieldSource(value = "irSensorTypes")
+    void testGetIRSensorRangeByBracket(int sensorType) {
+
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock weather
+        Weather mockWeather = mock(Weather.class);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = mock(PlanetaryConditions.class); //new PlanetaryConditions();
+        when(mockPlanetaryConditions.getWeather()).thenReturn(mockWeather);
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+        Hex mockTargetHex = mock(Hex.class);
+
+        // Mock Sensor
+        Sensor activeSensor = new Sensor(sensorType);
+
+        // Expected Sensor Range - Normal Conditions, should be full range
+        int expectedValue = activeSensor.getRangeByBracket();
+
+        Entity mockAttackingEntity = mock(Entity.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.getActiveSensor()).thenReturn(activeSensor);
+
+        // Let's put the enemy at our max range
+        Entity mockTarget = mock(Entity.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, expectedValue));
+
+        when(mockBoard.getHex(mockTarget.getPosition())).thenReturn(mockTargetHex);
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a hill in the way. This should block Radar
+        when(mockLos.isBlockedByHill()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's get rid of the hill. Let's put a building in the way instead. This reduces the range of many sensors.
+        when(mockLos.isBlockedByHill()).thenReturn(false);
+        when(mockLos.getHardBuildings()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 2), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 3), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHardBuildings()).thenReturn(0);
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getSoftBuildings()).thenReturn(2);
+        assertEquals(Math.max(0, expectedValue - 2), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the building and test planetary conditions. EMI should reduce the range by 4.
+        when(mockLos.getSoftBuildings()).thenReturn(0);
+        when(mockPlanetaryConditions.isEMI()).thenReturn(true);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's add a lightening storm (-1 range). This should stack with EMI.
+        when(mockWeather.isLightningStorm()).thenReturn(true);
+        assertEquals(Math.max(0, expectedValue - 5), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the EMI and test lightening on its own.
+        when(mockPlanetaryConditions.isEMI()).thenReturn(false);
+        assertEquals(Math.max(0, expectedValue - 1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the lightening and test forest hexes.
+        when(mockWeather.isLightningStorm()).thenReturn(false);
+        when(mockLos.getLightWoods()).thenReturn(3); // Should have no effect
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Heavy Woods/Jungle should remove 1 hex per bracket per hex
+        when(mockLos.getHeavyWoods()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(2);
+        assertEquals(Math.max(0, expectedValue - 2), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Ultraheavy Woods/Jungle should remove 2 hex per bracket per hex
+        when(mockLos.getUltraWoods()).thenReturn(1);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(2);
+        assertEquals(Math.max(0, expectedValue - 6), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(0);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getLightWoods()).thenReturn(0);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(0);
+
+        // Water time - LOS blocked by water only works for sensors if the sensor is magscan
+        // or the attacking entity is a naval vessel.
+        when(mockLos.isBlockedByWater()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // If the attacker is a naval vessel it should be able to see:
+        when(mockAttackingEntity.getMovementMode()).thenReturn(EntityMovementMode.NAVAL);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.isBlockedByWater()).thenReturn(false);
+        when(mockAttackingEntity.getMovementMode()).thenReturn(null);
+
+        // Some sensors are effected by the target or tile's heat
+        mockTarget.heat = 15;
+        assertEquals(expectedValue+3, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(true);
+        assertEquals(expectedValue+4, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.heat = 0;
+
+        assertEquals(expectedValue+1, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(false);
+
+        // Some sensors are effected by the target's weight
+        when(mockTarget.getWeight()).thenReturn(19.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(20.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(79.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(80.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(100.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(101.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(1000.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(1000.1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(0.0);
+
+        // Industrial terrain blocks some sensors
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(false);
+
+        // Moving effects some sensors detection
+        mockTarget.mpUsed = 0;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 1;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getElevation()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 0;
+        when(mockTarget.getElevation()).thenReturn(0);
+    }
+
+    @ParameterizedTest
+    @FieldSource(value = "magscanSensorTypes")
+    void testGetMagscanSensorRangeByBracket(int sensorType) {
+
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock weather
+        Weather mockWeather = mock(Weather.class);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = mock(PlanetaryConditions.class); //new PlanetaryConditions();
+        when(mockPlanetaryConditions.getWeather()).thenReturn(mockWeather);
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+        Hex mockTargetHex = mock(Hex.class);
+
+        // Mock Sensor
+        Sensor activeSensor = new Sensor(sensorType);
+
+        // Expected Sensor Range - Normal Conditions, should be full range
+        int expectedValue = activeSensor.getRangeByBracket();
+
+        Entity mockAttackingEntity = mock(Entity.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.getActiveSensor()).thenReturn(activeSensor);
+
+        // Let's put the enemy at our max range
+        Entity mockTarget = mock(Entity.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, expectedValue));
+        when(mockTarget.getWeight()).thenReturn(50.0); //Magscan needs target to have weight
+
+
+        when(mockBoard.getHex(mockTarget.getPosition())).thenReturn(mockTargetHex);
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a hill in the way.
+        when(mockLos.isBlockedByHill()).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's get rid of the hill. Let's put a building in the way instead. .
+        when(mockLos.isBlockedByHill()).thenReturn(false);
+        when(mockLos.getHardBuildings()).thenReturn(1);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a different kind of building in the way. This should still block radar.
+        when(mockLos.getHardBuildings()).thenReturn(0);
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the building and test planetary conditions. EMI should reduce the range by 4.
+        when(mockLos.getSoftBuildings()).thenReturn(0);
+        when(mockPlanetaryConditions.isEMI()).thenReturn(true);
+        assertEquals(Math.max(0, expectedValue - 4), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's add a lightening storm (-1 range). This should stack with EMI.
+        when(mockWeather.isLightningStorm()).thenReturn(true);
+        assertEquals(Math.max(0, expectedValue - 5), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the EMI and test lightening on its own.
+        when(mockPlanetaryConditions.isEMI()).thenReturn(false);
+        assertEquals(Math.max(0, expectedValue - 1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the lightening and test forest hexes.
+        when(mockWeather.isLightningStorm()).thenReturn(false);
+        when(mockLos.getLightWoods()).thenReturn(3); // Should have no effect
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Heavy Woods/Jungle
+        when(mockLos.getHeavyWoods()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Ultraheavy Woods/Jungle
+        when(mockLos.getUltraWoods()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getLightWoods()).thenReturn(0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(0);
+
+        // Water time - LOS blocked by water only works for sensors if the sensor is magscan
+        // or the attacking entity is a naval vessel.
+        when(mockLos.isBlockedByWater()).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // If the attacker is a naval vessel it should be able to see:
+        when(mockAttackingEntity.getMovementMode()).thenReturn(EntityMovementMode.NAVAL);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.isBlockedByWater()).thenReturn(false);
+        when(mockAttackingEntity.getMovementMode()).thenReturn(null);
+
+        // Some sensors are effected by the target or tile's heat
+        mockTarget.heat = 15;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.heat = 0;
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(false);
+
+        // Some sensors are effected by the target's weight
+        when(mockTarget.getWeight()).thenReturn(19.9);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(20.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(79.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(80.0);
+        assertEquals(expectedValue+1, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(100.0);
+        assertEquals(expectedValue+1, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(101.0);
+        assertEquals(expectedValue+2, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(1000.0);
+        assertEquals(expectedValue+2, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(1000.1);
+        assertEquals(expectedValue+3, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(50.0);
+
+        // Industrial terrain blocks some sensors
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(false);
+
+        // Moving effects some sensors detection
+        mockTarget.mpUsed = 0;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 1;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getElevation()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 0;
+        when(mockTarget.getElevation()).thenReturn(0);
+    }
+
+    @ParameterizedTest
+    @FieldSource(value = "seismicSensorTypes")
+    void testGetSeismicSensorRangeByBracket(int sensorType) {
+
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock weather
+        Weather mockWeather = mock(Weather.class);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = mock(PlanetaryConditions.class); //new PlanetaryConditions();
+        when(mockPlanetaryConditions.getWeather()).thenReturn(mockWeather);
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+        Hex mockTargetHex = mock(Hex.class);
+
+        // Mock Sensor
+        Sensor activeSensor = new Sensor(sensorType);
+
+        // Expected Sensor Range - Normal Conditions, should be full range
+        int expectedValue = activeSensor.getRangeByBracket();
+
+        Entity mockAttackingEntity = mock(Entity.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.getActiveSensor()).thenReturn(activeSensor);
+
+        // Let's put the enemy at our max range
+        Entity mockTarget = mock(Entity.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, expectedValue));
+        mockTarget.mpUsed = 1;
+
+        when(mockBoard.getHex(mockTarget.getPosition())).thenReturn(mockTargetHex);
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a hill in the way. This should block Radar
+        when(mockLos.isBlockedByHill()).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's get rid of the hill. Let's put a building in the way instead. This reduces the range of many sensors.
+        when(mockLos.isBlockedByHill()).thenReturn(false);
+        when(mockLos.getHardBuildings()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHardBuildings()).thenReturn(0);
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getSoftBuildings()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the building and test planetary conditions. EMI should reduce the range by 4.
+        when(mockLos.getSoftBuildings()).thenReturn(0);
+        when(mockPlanetaryConditions.isEMI()).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's add a lightening storm (-1 range). This should stack with EMI.
+        when(mockWeather.isLightningStorm()).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the EMI and test lightening on its own.
+        when(mockPlanetaryConditions.isEMI()).thenReturn(false);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the lightening and test forest hexes.
+        when(mockWeather.isLightningStorm()).thenReturn(false);
+        when(mockLos.getLightWoods()).thenReturn(3); // Should have no effect
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Heavy Woods/Jungle should remove 1 hex per bracket per hex
+        when(mockLos.getHeavyWoods()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Ultraheavy Woods/Jungle should remove 2 hex per bracket per hex
+        when(mockLos.getUltraWoods()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getLightWoods()).thenReturn(0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(0);
+
+        // Water time - LOS blocked by water only works for sensors if the sensor is magscan
+        // or the attacking entity is a naval vessel.
+        when(mockLos.isBlockedByWater()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // If the attacker is a naval vessel it should be able to see:
+        when(mockAttackingEntity.getMovementMode()).thenReturn(EntityMovementMode.NAVAL);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.isBlockedByWater()).thenReturn(false);
+        when(mockAttackingEntity.getMovementMode()).thenReturn(null);
+
+        // Some sensors are effected by the target or tile's heat
+        mockTarget.heat = 15;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.heat = 0;
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(false);
+
+        // Some sensors are effected by the target's weight
+        when(mockTarget.getWeight()).thenReturn(19.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(20.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(79.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(80.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(100.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(101.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(1000.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(1000.1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(0.0);
+
+        // Industrial terrain blocks some sensors
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(false);
+
+        // Moving effects some sensors detection
+        mockTarget.mpUsed = 0;
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 1;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getElevation()).thenReturn(1);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 1;
+        when(mockTarget.getElevation()).thenReturn(0);
+    }
+
+    @ParameterizedTest
+    @FieldSource(value = "activeProbeSensorTypes")
+    void testGetActiveProbeSensorRangeByBracket(int sensorType) {
+
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock weather
+        Weather mockWeather = mock(Weather.class);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = mock(PlanetaryConditions.class); //new PlanetaryConditions();
+        when(mockPlanetaryConditions.getWeather()).thenReturn(mockWeather);
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+        Hex mockTargetHex = mock(Hex.class);
+
+        // Mock Sensor
+        Sensor activeSensor = new Sensor(sensorType);
+
+        // Expected Sensor Range - Normal Conditions, should be full range
+        int expectedValue = activeSensor.getRangeByBracket();
+
+        Entity mockAttackingEntity = mock(Entity.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.getActiveSensor()).thenReturn(activeSensor);
+        when(mockAttackingEntity.hasBAP(anyBoolean())).thenReturn(true);
+
+        // Let's put the enemy at our max range
+        Entity mockTarget = mock(Entity.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, expectedValue));
+
+
+        when(mockBoard.getHex(mockTarget.getPosition())).thenReturn(mockTargetHex);
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a hill in the way.
+        when(mockLos.isBlockedByHill()).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's get rid of the hill. Let's put a building in the way instead. .
+        when(mockLos.isBlockedByHill()).thenReturn(false);
+        when(mockLos.getHardBuildings()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's put a different kind of building in the way. This should still block radar.
+        when(mockLos.getHardBuildings()).thenReturn(0);
+        when(mockLos.getSoftBuildings()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the building and test planetary conditions. EMI should reduce the range by 4.
+        when(mockLos.getSoftBuildings()).thenReturn(0);
+        when(mockPlanetaryConditions.isEMI()).thenReturn(true);
+        when(mockAttackingEntity.hasBAP(anyBoolean())).thenReturn(false); // BAPs are disabled under EMI
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's add a lightening storm (-1 range). This should stack with EMI.
+        when(mockWeather.isLightningStorm()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the EMI and test lightening on its own.
+        when(mockAttackingEntity.hasBAP(anyBoolean())).thenReturn(true); // BAPs are disabled under EMI
+        when(mockPlanetaryConditions.isEMI()).thenReturn(false);
+
+        assertEquals(Math.max(0, expectedValue-1), Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Let's remove the lightening and test forest hexes.
+        when(mockWeather.isLightningStorm()).thenReturn(false);
+        when(mockLos.getLightWoods()).thenReturn(3); // Should have no effect
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Heavy Woods/Jungle
+        when(mockLos.getHeavyWoods()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // Ultraheavy Woods/Jungle
+        when(mockLos.getUltraWoods()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(2);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getHeavyWoods()).thenReturn(0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getLightWoods()).thenReturn(0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.getUltraWoods()).thenReturn(0);
+
+        // Water time - LOS blocked by water only works for sensors if the sensor is magscan
+        // or the attacking entity is a naval vessel.
+        when(mockLos.isBlockedByWater()).thenReturn(true);
+        assertEquals(0, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        // If the attacker is a naval vessel it should be able to see:
+        when(mockAttackingEntity.getMovementMode()).thenReturn(EntityMovementMode.NAVAL);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockLos.isBlockedByWater()).thenReturn(false);
+        when(mockAttackingEntity.getMovementMode()).thenReturn(null);
+
+        // Some sensors are effected by the target or tile's heat
+        mockTarget.heat = 15;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.heat = 0;
+
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.FIRE)).thenReturn(false);
+
+        // Some sensors are effected by the target's weight
+        when(mockTarget.getWeight()).thenReturn(19.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(20.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(79.9);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(80.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(100.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(101.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(1000.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+        when(mockTarget.getWeight()).thenReturn(1001.0);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getWeight()).thenReturn(50.0);
+
+        // Industrial terrain blocks some sensors
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(true);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTargetHex.containsTerrain(Terrains.INDUSTRIAL)).thenReturn(false);
+
+        // Moving effects some sensors detection
+        mockTarget.mpUsed = 0;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 1;
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        when(mockTarget.getElevation()).thenReturn(1);
+        assertEquals(expectedValue, Compute.getSensorRangeByBracket(mockGame, mockAttackingEntity, mockTarget, mockLos));
+
+        mockTarget.mpUsed = 0;
+        when(mockTarget.getElevation()).thenReturn(0);
+    }
+
+
+    // End tests for Compute.getSensorRangeByBracket(Game, Entity, Targetable, LosEffects)
+}

--- a/megamek/unittests/megamek/common/ComputeVisualRangeTest.java
+++ b/megamek/unittests/megamek/common/ComputeVisualRangeTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
+package megamek.common;
+
+import megamek.common.options.GameOptions;
+import megamek.common.planetaryconditions.PlanetaryConditions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Vector;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ComputeVisualRangeTest {
+
+    /**
+     * Testing under normal planetary conditions.
+     */
+    @Test
+    void testVisualRange() {
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = new PlanetaryConditions();
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getFlares()).thenReturn(new Vector<>());
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+
+        Tank mockAttackingEntity = mock(Tank.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+
+        Tank mockTarget = mock(Tank.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 7));
+        when(mockTarget.isIlluminated()).thenReturn(true);
+
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Move our target too far away
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 61));
+        assertFalse(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Move our target just close enough
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 60));
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+    }
+
+
+    /**
+     * Testing under normal planetary conditions, air to ground
+     */
+    @Test
+    void testVisualRangeAirToGround() {
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = new PlanetaryConditions();
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getFlares()).thenReturn(new Vector<>());
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+
+        Entity mockAttackingEntity = mock(Aero.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.getAltitude()).thenReturn(5);
+        when(mockAttackingEntity.isAirborne()).thenReturn(true);
+        when(mockAttackingEntity.isAero()).thenReturn(true);
+
+        Entity mockTarget = mock(Tank.class);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 7));
+        when(mockTarget.isIlluminated()).thenReturn(true);
+        when(mockTarget.isAirborne()).thenReturn(false);
+
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Move our target too far away
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 120));
+        assertFalse(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Move our target just close enough
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 110));
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Let's change our altitude - if we go altitude 10 we can't see any ground units
+        when(mockAttackingEntity.getAltitude()).thenReturn(10);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 10));
+        assertFalse(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Let's get low - if we go to NOE we should use "ground" distance
+        when(mockAttackingEntity.getAltitude()).thenReturn(1);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 90));
+        assertFalse(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // But if we bring the enemy a little closer, we'll be able to see them
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 58));
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+    }
+
+
+    /**
+     * Testing under normal planetary conditions, ground to air
+     */
+    @Test
+    void testVisualRangeGroundToAir() {
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.inSpace()).thenReturn(false);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+        // Mock Planetary Conditions
+        PlanetaryConditions mockPlanetaryConditions = new PlanetaryConditions();
+
+
+        Game mockGame = mock(Game.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+
+        LosEffects mockLos = mock(LosEffects.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getFlares()).thenReturn(new Vector<>());
+        when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+
+        Tank mockAttackingEntity = mock(Tank.class);
+        when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+        when(mockAttackingEntity.isAirborne()).thenReturn(false);
+
+
+        Aero mockTarget = mock(Aero.class);
+        when(mockTarget.getAltitude()).thenReturn(5);
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 7));
+        when(mockTarget.isIlluminated()).thenReturn(true);
+        when(mockTarget.isAirborne()).thenReturn(true);
+        when(mockTarget.isAero()).thenReturn(true);
+        when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 7))));
+
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Move our target too far away
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 60));
+        when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 60))));
+        assertFalse(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+        // Move our target just close enough
+        when(mockTarget.getPosition()).thenReturn(new Coords(0, 50));
+        when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 50))));
+        assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
+
+    }
+}


### PR DESCRIPTION
Takes a crack at fixing #2457. 

Includes unit tests for the LOS changes & for sensor ranges.
I'll expand the unit tests if this isn't the end of #2457.