### PR TITLE
Fix 6434 and 3890: pilot rolls reported before all attacks

### DIFF
--- a/megamek/src/megamek/server/commands/FirestarterCommand.java
+++ b/megamek/src/megamek/server/commands/FirestarterCommand.java
@@ -21,7 +21,6 @@ import megamek.server.commands.arguments.*;
 import megamek.server.totalwarfare.TWGameManager;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -73,7 +72,7 @@ public class FirestarterCommand extends GamemasterServerCommand {
         try {
             Hex hex = gameManager.getGame().getBoard().getHex(coords);
             Objects.requireNonNull(hex, "Hex not found.");
-            gameManager.ignite(coords, fireType, gameManager.getvPhaseReport());
+            gameManager.ignite(coords, fireType, gameManager.getMainPhaseReport());
         } catch (Exception e) {
             throw new IllegalArgumentException("Failed to ignite hex: " + e.getMessage());
         }

--- a/megamek/src/megamek/server/commands/FirestormCommand.java
+++ b/megamek/src/megamek/server/commands/FirestormCommand.java
@@ -102,6 +102,6 @@ public class FirestormCommand extends GamemasterServerCommand {
             // they should not happen, but I don't want to crash the command
             return;
         }
-        gameManager.ignite(coords, fireType, gameManager.getvPhaseReport());
+        gameManager.ignite(coords, fireType, gameManager.getMainPhaseReport());
     }
 }

--- a/megamek/src/megamek/server/commands/FixElevationCommand.java
+++ b/megamek/src/megamek/server/commands/FixElevationCommand.java
@@ -43,7 +43,7 @@ public class FixElevationCommand extends ServerCommand {
             if (entity.fixElevation()) {
                 Building bldg = gameManager.getGame().getBoard().getBuildingAt(entity.getPosition());
                 if (bldg != null) {
-                    gameManager.checkForCollapse(bldg, gameManager.getGame().getPositionMap(), entity.getPosition(), true, gameManager.getvPhaseReport());
+                    gameManager.checkForCollapse(bldg, gameManager.getGame().getPositionMap(), entity.getPosition(), true, gameManager.getMainPhaseReport());
                 }
                 server.sendServerChat(entity.getDisplayName()
                         + " elevation fixed, see megamek.log for details & report a bug if you know how this happened");

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -667,7 +667,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
 
             // Mechanical jump boosters fall damage
             if (md.shouldMechanicalJumpCauseFallDamage()) {
-                gameManager.getvPhaseReport().addAll(gameManager.doEntityFallsInto(entity,
+                gameManager.getMainPhaseReport().addAll(gameManager.doEntityFallsInto(entity,
                         entity.getElevation(), md.getJumpPathHighestPoint(),
                         curPos, entity.getBasePilotingRoll(overallMoveType),
                         false, entity.getJumpMP()));
@@ -750,13 +750,13 @@ class MovePathHandler extends AbstractTWRuleHandler {
             Building bldg = getGame().getBoard().getBuildingAt(curPos);
             if (bldg != null) {
                 gameManager.checkForCollapse(bldg, getGame().getPositionMap(), curPos, true,
-                        gameManager.getvPhaseReport());
+                        gameManager.getMainPhaseReport());
             }
 
             // Don't interact with terrain when jumping onto a building or a bridge
             if (entity.getElevation() == 0) {
                 ServerHelper.checkAndApplyMagmaCrust(curHex, entity.getElevation(), entity, curPos, true,
-                        gameManager.getvPhaseReport(), gameManager);
+                        gameManager.getMainPhaseReport(), gameManager);
                 ServerHelper.checkEnteringMagma(curHex, entity.getElevation(), entity, gameManager);
 
                 // jumped into swamp? maybe stuck!
@@ -879,10 +879,10 @@ class MovePathHandler extends AbstractTWRuleHandler {
                 r = new Report(2126);
                 r.subject = entity.getId();
                 r.addDesc(entity);
-                gameManager.getvPhaseReport().add(r);
-                gameManager.getvPhaseReport().addAll(gameManager.vehicleMotiveDamage((Tank) entity, modifier,
+                gameManager.getMainPhaseReport().add(r);
+                gameManager.getMainPhaseReport().addAll(gameManager.vehicleMotiveDamage((Tank) entity, modifier,
                         false, -1, true));
-                Report.addNewline(gameManager.getvPhaseReport());
+                Report.addNewline(gameManager.getMainPhaseReport());
             }
 
         } // End entity-is-jumping
@@ -973,7 +973,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
             gameManager.send(gameManager.getPacketHelper().createTurnListPacket());
 
             // let everyone know about what just happened
-            if (gameManager.getvPhaseReport().size() > 1) {
+            if (gameManager.getMainPhaseReport().size() > 1) {
                 gameManager.send(entity.getOwner().getId(), gameManager.createSpecialReportPacket());
             }
         } else {
@@ -987,7 +987,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                         addReport(gameManager.landAirMek((LandAirMek) entity, entity.getPosition(), elevation,
                                 entity.delta_distance));
                     } else if (entity.hasETypeFlag(Entity.ETYPE_PROTOMEK)) {
-                        gameManager.getvPhaseReport()
+                        gameManager.getMainPhaseReport()
                                 .addAll(gameManager.landGliderPM((ProtoMek) entity, entity.getPosition(),
                                         elevation, entity.delta_distance));
                     } else {
@@ -1067,7 +1067,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                 if (entity.isAirborneVTOLorWIGE()) {
                     addReport(r);
                     gameManager.crashAirMek(entity, new PilotingRollData(entity.getId(), TargetRoll.AUTOMATIC_FAIL,
-                            "side torso destroyed"), gameManager.getvPhaseReport());
+                            "side torso destroyed"), gameManager.getMainPhaseReport());
                 } else if (entity.isAirborne() && entity.isAero()) {
                     addReport(r);
                     addReport(gameManager.processCrash(entity, ((IAero) entity).getCurrentVelocity(),
@@ -1292,7 +1292,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                             r.addDesc(entity);
                             r.subject = entity.getId();
                             r.add(e.getPosition().getBoardNum());
-                            gameManager.getvPhaseReport().addElement(r);
+                            gameManager.getMainPhaseReport().addElement(r);
                             continueTurnFromPBS = true;
 
                             curFacing = entity.getFacing();
@@ -2254,7 +2254,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
             // of basement it has
             if (isOnGround && curHex.containsTerrain(Terrains.BUILDING)) {
                 Building bldg = getGame().getBoard().getBuildingAt(curPos);
-                if (bldg.rollBasement(curPos, getGame().getBoard(), gameManager.getvPhaseReport())) {
+                if (bldg.rollBasement(curPos, getGame().getBoard(), gameManager.getMainPhaseReport())) {
                     gameManager.sendChangedHex(curPos);
                     Vector<Building> buildings = new Vector<>();
                     buildings.add(bldg);
@@ -2512,7 +2512,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
             if (stepMoveType != EntityMovementType.MOVE_JUMP) {
                 if (!curPos.equals(lastPos)) {
                     ServerHelper.checkAndApplyMagmaCrust(curHex, step.getElevation(), entity, curPos, false,
-                            gameManager.getvPhaseReport(), gameManager);
+                            gameManager.getMainPhaseReport(), gameManager);
                     ServerHelper.checkEnteringMagma(curHex, step.getElevation(), entity, gameManager);
                 }
             }
@@ -2644,9 +2644,9 @@ class MovePathHandler extends AbstractTWRuleHandler {
             // every time we enter a new hex
             if (getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BAP)
                     && !lastPos.equals(curPos)) {
-                if (ServerHelper.detectMinefields(getGame(), entity, curPos, gameManager.getvPhaseReport(), gameManager)
+                if (ServerHelper.detectMinefields(getGame(), entity, curPos, gameManager.getMainPhaseReport(), gameManager)
                         ||
-                        ServerHelper.detectHiddenUnits(getGame(), entity, curPos, gameManager.getvPhaseReport(),
+                        ServerHelper.detectHiddenUnits(getGame(), entity, curPos, gameManager.getMainPhaseReport(),
                                 gameManager)) {
                     detectedHiddenHazard = true;
 
@@ -2665,7 +2665,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                 boolean boom = false;
                 if (isOnGround) {
                     boom = gameManager.checkVibrabombs(entity, curPos, false, lastPos, curPos,
-                            gameManager.getvPhaseReport());
+                            gameManager.getMainPhaseReport());
                 }
                 if (getGame().containsMinefield(curPos)) {
                     // set the new position temporarily, because
@@ -2673,7 +2673,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     // when moving from clear into mined woods
                     entity.setPosition(curPos);
                     if (gameManager.enterMinefield(entity, curPos, step.getElevation(),
-                            isOnGround, gameManager.getvPhaseReport())) {
+                            isOnGround, gameManager.getMainPhaseReport())) {
                         // resolve any piloting rolls from damage unless unit
                         // was jumping
                         if (stepMoveType != EntityMovementType.MOVE_JUMP) {
@@ -3399,14 +3399,14 @@ class MovePathHandler extends AbstractTWRuleHandler {
                 r.subject = entity.getId();
                 r.addDesc(entity);
                 r.add(bldg.getName());
-                gameManager.getvPhaseReport().add(r);
+                gameManager.getMainPhaseReport().add(r);
 
                 final int cf = bldg.getCurrentCF(pos);
                 final int numFloors = Math.max(0, hex.terrainLevel(Terrains.BLDG_ELEV));
-                gameManager.getvPhaseReport().addAll(gameManager.damageBuilding(bldg, 150, " is crushed for ", pos));
+                gameManager.getMainPhaseReport().addAll(gameManager.damageBuilding(bldg, 150, " is crushed for ", pos));
                 int damage = (int) Math.round((cf / 10.0) * numFloors);
                 HitData hit = entity.rollHitLocation(ToHitData.HIT_NORMAL, ToHitData.SIDE_FRONT);
-                gameManager.getvPhaseReport().addAll(gameManager.damageEntity(entity, hit, damage));
+                gameManager.getMainPhaseReport().addAll(gameManager.damageEntity(entity, hit, damage));
             }
 
             // Track this step's location.

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -17925,7 +17925,7 @@ public class TWGameManager extends AbstractGameManager {
                                 && (!game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                         || (game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                                 && lam.isCondEjectCTDest()))) {
-                            addReport(ejectEntity(en, true, false));
+                            vDesc.addAll(ejectEntity(en, true, false));
                         }
                     } else {
                         // Aeros eject if the SI Destroyed switch is on
@@ -17934,7 +17934,7 @@ public class TWGameManager extends AbstractGameManager {
                                 && (!game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                         || (game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                                 && aero.isCondEjectSIDest()))) {
-                            addReport(ejectEntity(en, true, false));
+                            vDesc.addAll(ejectEntity(en, true, false));
                         }
                     }
                     vDesc.addAll(destroyEntity((Entity) ship, "fatal damage threshold"));
@@ -18600,7 +18600,7 @@ public class TWGameManager extends AbstractGameManager {
                                 && (!game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                         || (game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                                 && lam.isCondEjectCTDest()))) {
-                            addReport(ejectEntity(te, true, false));
+                            vDesc.addAll(ejectEntity(te, true, false));
                         }
                     } else {
                         // Aeros eject if the SI Destroyed switch is on
@@ -18609,7 +18609,7 @@ public class TWGameManager extends AbstractGameManager {
                                 && (!game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                         || (game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION)
                                                 && aero.isCondEjectSIDest()))) {
-                            addReport(ejectEntity(te, true, false));
+                            vDesc.addAll(ejectEntity(te, true, false));
                         }
                     }
                     vDesc.addAll(destroyEntity(te, "Structural Integrity Collapse"));

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -88,10 +88,10 @@ public class TWGameManager extends AbstractGameManager {
 
     private Game game = new Game();
 
-    private Vector<Report> vPhaseReport = new Vector<>();
+    private Vector<Report> mainPhaseReport = new Vector<>();
 
-    public Vector<Report> getvPhaseReport() {
-        return vPhaseReport;
+    public Vector<Report> getMainPhaseReport() {
+        return mainPhaseReport;
     }
 
     // Track buildings that are affected by an entity's movement.
@@ -1709,8 +1709,8 @@ public class TWGameManager extends AbstractGameManager {
             }
         }
 
-        vPhaseReport.addAll(teamReport);
-        vPhaseReport.addAll(playerReport);
+        mainPhaseReport.addAll(teamReport);
+        mainPhaseReport.addAll(playerReport);
     }
 
     private List<Report> bvReport(String name, int playerID, BVCountHelper bvc, boolean checkBlind) {
@@ -1845,7 +1845,7 @@ public class TWGameManager extends AbstractGameManager {
         r.add("<pre>");
         reports.add(r);
 
-        vPhaseReport.addAll(reports);
+        mainPhaseReport.addAll(reports);
     }
 
     @Override
@@ -2988,7 +2988,7 @@ public class TWGameManager extends AbstractGameManager {
         }
         Building bldg = game.getBoard().getBuildingAt(centralPos);
         if (null != bldg) {
-            collapseBuilding(bldg, positionMap, centralPos, vPhaseReport);
+            collapseBuilding(bldg, positionMap, centralPos, mainPhaseReport);
         }
         for (int i = 0; i < 6; i++) {
             Coords pos = centralPos.translated(i);
@@ -3000,7 +3000,7 @@ public class TWGameManager extends AbstractGameManager {
             }
             bldg = game.getBoard().getBuildingAt(pos);
             if (null != bldg) {
-                collapseBuilding(bldg, positionMap, pos, vPhaseReport);
+                collapseBuilding(bldg, positionMap, pos, mainPhaseReport);
             }
         }
 
@@ -3015,7 +3015,7 @@ public class TWGameManager extends AbstractGameManager {
                 }
 
                 alreadyHit = artilleryDamageHex(pos, centralPos, damageDice, null, killer.getId(),
-                        killer, null, false, 0, vPhaseReport, false,
+                        killer, null, false, 0, mainPhaseReport, false,
                         alreadyHit, true);
             }
         }
@@ -4557,7 +4557,7 @@ public class TWGameManager extends AbstractGameManager {
                 // and add it to the list of affected buildings.
                 if (bldg.getCurrentCF(nextPos) > 0) {
                     stopTheSkid = true;
-                    if (bldg.rollBasement(nextPos, game.getBoard(), vPhaseReport)) {
+                    if (bldg.rollBasement(nextPos, game.getBoard(), mainPhaseReport)) {
                         sendChangedHex(nextPos);
                         Vector<Building> buildings = new Vector<>();
                         buildings.add(bldg);
@@ -4566,7 +4566,7 @@ public class TWGameManager extends AbstractGameManager {
                     addAffectedBldg(bldg, checkBuildingCollapseWhileMoving(bldg, entity, nextPos));
                 } else {
                     // otherwise it collapses immediately on our head
-                    checkForCollapse(bldg, game.getPositionMap(), nextPos, true, vPhaseReport);
+                    checkForCollapse(bldg, game.getPositionMap(), nextPos, true, mainPhaseReport);
                 }
             } // End handle-building.
 
@@ -4584,7 +4584,7 @@ public class TWGameManager extends AbstractGameManager {
             // Check for collapse of any building the entity might be on
             Building roof = game.getBoard().getBuildingAt(nextPos);
             if (roof != null) {
-                if (checkForCollapse(roof, game.getPositionMap(), nextPos, true, vPhaseReport)) {
+                if (checkForCollapse(roof, game.getPositionMap(), nextPos, true, mainPhaseReport)) {
                     break; // stop skidding if the building collapsed
                 }
             }
@@ -4637,7 +4637,7 @@ public class TWGameManager extends AbstractGameManager {
             // note that this must sequentially occur before the next 'entering liquid
             // magma' check
             // otherwise, magma crust won't have a chance to break
-            ServerHelper.checkAndApplyMagmaCrust(nextHex, nextElevation, entity, curPos, false, vPhaseReport, this);
+            ServerHelper.checkAndApplyMagmaCrust(nextHex, nextElevation, entity, curPos, false, mainPhaseReport, this);
             ServerHelper.checkEnteringMagma(nextHex, nextElevation, entity, this);
 
             // is the next hex a swamp?
@@ -5350,7 +5350,7 @@ public class TWGameManager extends AbstractGameManager {
                 // ack! automatic death! Tanks
                 // suffer an ammo/power plant hit.
                 // TODO : a Mek suffers a Head Blown Off crit.
-                vPhaseReport.addAll(destroyEntity(entity,
+                mainPhaseReport.addAll(destroyEntity(entity,
                         "impossible displacement", entity instanceof Mek,
                         entity instanceof Mek));
             }
@@ -8282,7 +8282,7 @@ public class TWGameManager extends AbstractGameManager {
      * @return true if check succeeds, false otherwise.
      */
     boolean doSkillCheckInPlace(Entity entity, PilotingRollData roll) {
-        return doSkillCheckInPlace(entity, roll, vPhaseReport);
+        return doSkillCheckInPlace(entity, roll, mainPhaseReport);
     }
 
     /**
@@ -8386,7 +8386,7 @@ public class TWGameManager extends AbstractGameManager {
             r.choose(false);
             addReport(r);
             // failed a PSR, possibly check for engine stalling
-            entity.doCheckEngineStallRoll(vPhaseReport);
+            entity.doCheckEngineStallRoll(mainPhaseReport);
             return false;
         }
         // Dislodged swarmers don't get turns.
@@ -8478,7 +8478,7 @@ public class TWGameManager extends AbstractGameManager {
                 entity.setPosition(fallsInPlace ? src : dest);
             }
             // failed a PSR, possibly check for engine stalling
-            entity.doCheckEngineStallRoll(vPhaseReport);
+            entity.doCheckEngineStallRoll(mainPhaseReport);
             return roll.getValue() - diceRoll.getIntValue();
         }
         r.choose(true);
@@ -9363,7 +9363,7 @@ public class TWGameManager extends AbstractGameManager {
         // of basement it has
         Building bldg = game.getBoard().getBuildingAt(entity.getPosition());
         if ((bldg != null)) {
-            if (bldg.rollBasement(entity.getPosition(), game.getBoard(), vPhaseReport)) {
+            if (bldg.rollBasement(entity.getPosition(), game.getBoard(), mainPhaseReport)) {
                 sendChangedHex(entity.getPosition());
                 Vector<Building> buildings = new Vector<>();
                 buildings.add(bldg);
@@ -10283,7 +10283,7 @@ public class TWGameManager extends AbstractGameManager {
 
         // See if any unit with a probe, detects any hidden units
         for (Entity detector : game.getEntitiesVector()) {
-            ServerHelper.detectHiddenUnits(game, detector, detector.getPosition(), vPhaseReport, this);
+            ServerHelper.detectHiddenUnits(game, detector, detector.getPosition(), mainPhaseReport, this);
         }
     }
 
@@ -10555,7 +10555,7 @@ public class TWGameManager extends AbstractGameManager {
         r.add(pos.getBoardNum(), true);
         addReport(r);
 
-        if (clearMinefield(mf, ent, clear, boom, vPhaseReport)) {
+        if (clearMinefield(mf, ent, clear, boom, mainPhaseReport)) {
             removeMinefield(mf);
         }
         // some mines might have blown up
@@ -12245,7 +12245,7 @@ public class TWGameManager extends AbstractGameManager {
                 String rollCalc2 = rollValue2 + " [" + diceRoll2.getIntValue() + " - 2]";
                 r.addDataWithTooltip(rollCalc2, diceRoll2.getReport());
                 r.newlines = 0;
-                vPhaseReport.add(r);
+                mainPhaseReport.add(r);
 
                 if (te instanceof BattleArmor) {
                     r = new Report(3706);
@@ -12254,8 +12254,8 @@ public class TWGameManager extends AbstractGameManager {
                     // TODO : fix for salvage purposes
                     HitData targetTrooper = te.rollHitLocation(ToHitData.HIT_NORMAL, ToHitData.SIDE_FRONT);
                     r.add(te.getLocationAbbr(targetTrooper));
-                    vPhaseReport.add(r);
-                    vPhaseReport.addAll(criticalEntity(ae, targetTrooper.getLocation(),
+                    mainPhaseReport.add(r);
+                    mainPhaseReport.addAll(criticalEntity(ae, targetTrooper.getLocation(),
                             targetTrooper.isRear(), 0, false, false, 0));
                 } else if (te instanceof Mek) {
                     if (((Mek) te).isIndustrial()) {
@@ -12277,14 +12277,14 @@ public class TWGameManager extends AbstractGameManager {
                             r = new Report(3705);
                             r.addDesc(te);
                             r.add(3);
-                            vPhaseReport.add(r);
+                            mainPhaseReport.add(r);
                             te.taserShutdown(3, false);
                         } else {
                             r = new Report(3710);
                             r.addDesc(te);
                             r.add(2);
                             r.add(3);
-                            vPhaseReport.add(r);
+                            mainPhaseReport.add(r);
                             te.setTaserInterference(2, 3, true);
                         }
                     }
@@ -12294,14 +12294,14 @@ public class TWGameManager extends AbstractGameManager {
                         r = new Report(3705);
                         r.addDesc(te);
                         r.add(4);
-                        vPhaseReport.add(r);
+                        mainPhaseReport.add(r);
                         te.taserShutdown(4, false);
                     } else {
                         r = new Report(3710);
                         r.addDesc(te);
                         r.add(2);
                         r.add(4);
-                        vPhaseReport.add(r);
+                        mainPhaseReport.add(r);
                         te.setTaserInterference(2, 4, false);
                     }
                 }
@@ -14098,14 +14098,14 @@ public class TWGameManager extends AbstractGameManager {
             r = new Report(3362);
             r.newlines = 1;
             r.subject = te.getId();
-            vPhaseReport.add(r);
+            mainPhaseReport.add(r);
 
             // If the target's point defenses overheated, report that
             if (taa.getPDOverheated()) {
                 r = new Report(3361);
                 r.newlines = 1;
                 r.subject = te.getId();
-                vPhaseReport.add(r);
+                mainPhaseReport.add(r);
             }
 
             // Damage the missile
@@ -14916,7 +14916,7 @@ public class TWGameManager extends AbstractGameManager {
                     // target gets displaced
                     targetDest = Compute.getValidDisplacement(game,
                             violation.getId(), dest, direction);
-                    vPhaseReport.addAll(doEntityDisplacement(violation, dest,
+                    mainPhaseReport.addAll(doEntityDisplacement(violation, dest,
                             targetDest, new PilotingRollData(violation.getId(),
                                     0, "domino effect")));
                     // Update the violating entity's position on the client.
@@ -15231,7 +15231,7 @@ public class TWGameManager extends AbstractGameManager {
 
             // put in ASF heat build-up first because there are few differences
             if (entity instanceof Aero && !(entity instanceof ConvFighter)) {
-                ServerHelper.resolveAeroHeat(game, entity, vPhaseReport, rhsReports, radicalHSBonus, hotDogMod, this);
+                ServerHelper.resolveAeroHeat(game, entity, mainPhaseReport, rhsReports, radicalHSBonus, hotDogMod, this);
                 continue;
             }
 
@@ -15334,7 +15334,7 @@ public class TWGameManager extends AbstractGameManager {
             // If a Mek is in extreme Temperatures, add or subtract one
             // heat per 10 degrees (or fraction of 10 degrees) above or
             // below 50 or -30 degrees Celsius
-            ServerHelper.adjustHeatExtremeTemp(game, entity, vPhaseReport);
+            ServerHelper.adjustHeatExtremeTemp(game, entity, mainPhaseReport);
 
             // Add +5 Heat if the hex you're in is on fire
             // and was on fire for the full round.
@@ -15490,8 +15490,8 @@ public class TWGameManager extends AbstractGameManager {
             r.add(r.bold(r.fgColor(color, String.valueOf(entity.heat))));
             addReport(r);
             entity.heatBuildup = 0;
-            vPhaseReport.addAll(rhsReports);
-            vPhaseReport.addAll(heatEffectsReports);
+            mainPhaseReport.addAll(rhsReports);
+            mainPhaseReport.addAll(heatEffectsReports);
 
             // Does the unit have inferno ammo?
             if (entity.hasInfernoAmmo()) {
@@ -15936,7 +15936,7 @@ public class TWGameManager extends AbstractGameManager {
             }
         }
 
-        if (vPhaseReport.size() == 1) {
+        if (mainPhaseReport.size() == 1) {
             // I guess nothing happened...
             addReport(new Report(1205, Report.PUBLIC));
         }
@@ -16178,7 +16178,7 @@ public class TWGameManager extends AbstractGameManager {
             // phew!
             r.choose(true);
             addReport(r);
-            Report.addNewline(vPhaseReport);
+            Report.addNewline(mainPhaseReport);
         } else {
             // eek
             r.choose(false);
@@ -16191,7 +16191,7 @@ public class TWGameManager extends AbstractGameManager {
 
                 Building building = getGame().getBoard().getBuildingAt(entity.getPosition());
 
-                Report.addNewline(vPhaseReport);
+                Report.addNewline(mainPhaseReport);
                 addReport(criticalGunEmplacement(gun, building, entity.getPosition()));
                 // Taharqa: TacOps rules, protos and vees no longer die instantly
                 // (hurray!)
@@ -16201,7 +16201,7 @@ public class TWGameManager extends AbstractGameManager {
                     bonus = 0;
                 }
                 // roll a critical hit
-                Report.addNewline(vPhaseReport);
+                Report.addNewline(mainPhaseReport);
                 addReport(criticalTank((Tank) entity, Tank.LOC_FRONT, bonus, 0, true));
             } else if (entity instanceof ProtoMek) {
                 // this code is taken from inferno hits
@@ -16233,13 +16233,13 @@ public class TWGameManager extends AbstractGameManager {
                     }
                     if (entity.getTransferLocation(hit).getLocation() == Entity.LOC_DESTROYED) {
                         addReport(destroyEntity(entity, "flaming death", false, true));
-                        Report.addNewline(vPhaseReport);
+                        Report.addNewline(mainPhaseReport);
                     }
                 }
             } else {
                 // sucks to be you
                 addReport(destroyEntity(entity, "fire", false, false));
-                Report.addNewline(vPhaseReport);
+                Report.addNewline(mainPhaseReport);
             }
         }
     }
@@ -16589,7 +16589,7 @@ public class TWGameManager extends AbstractGameManager {
                 } else {
                     r.choose(false);
                 }
-                vPhaseReport.add(r);
+                mainPhaseReport.add(r);
             }
         }
     }
@@ -16674,7 +16674,7 @@ public class TWGameManager extends AbstractGameManager {
     private void checkForIndustrialUnstall() {
         for (Iterator<Entity> i = game.getEntities(); i.hasNext();) {
             final Entity entity = i.next();
-            entity.checkUnstall(vPhaseReport);
+            entity.checkUnstall(mainPhaseReport);
         }
     }
 
@@ -16692,7 +16692,7 @@ public class TWGameManager extends AbstractGameManager {
                     r.addDesc(mek);
                     r.subject = mek.getId();
                     r.newlines = 0;
-                    vPhaseReport.add(r);
+                    mainPhaseReport.add(r);
                     // for being hit by a physical weapon
                     if (mek.getLevelsFallen() == 0) {
                         r = new Report(5531);
@@ -16703,9 +16703,9 @@ public class TWGameManager extends AbstractGameManager {
                         r.subject = mek.getId();
                         r.add(mek.getLevelsFallen());
                     }
-                    vPhaseReport.add(r);
+                    mainPhaseReport.add(r);
                     HitData newHit = mek.rollHitLocation(ToHitData.HIT_NORMAL, ToHitData.SIDE_FRONT);
-                    vPhaseReport.addAll(criticalEntity(mek,
+                    mainPhaseReport.addAll(criticalEntity(mek,
                             newHit.getLocation(), newHit.isRear(),
                             mek.getLevelsFallen(), 0));
                 }
@@ -19538,10 +19538,10 @@ public class TWGameManager extends AbstractGameManager {
                                         if (transport != null) {
                                             c = transport.getPosition();
                                         }
-                                        vPhaseReport.addAll(deliverInfernoMissiles(te, te, infernos));
+                                        mainPhaseReport.addAll(deliverInfernoMissiles(te, te, infernos));
                                     }
                                     if (c != null) {
-                                        vPhaseReport.addAll(deliverInfernoMissiles(te,
+                                        mainPhaseReport.addAll(deliverInfernoMissiles(te,
                                                 new HexTarget(c, Targetable.TYPE_HEX_ARTILLERY),
                                                 infernos));
                                     }
@@ -20567,8 +20567,8 @@ public class TWGameManager extends AbstractGameManager {
             .newLines(0)
             .add(Messages.getString("OrbitalBombardment.source"))
             .add(orbitalBombardment.getCoords().getBoardNum());
-        getvPhaseReport().addElement(r);
-        Report.addNewline(getvPhaseReport());
+        getMainPhaseReport().addElement(r);
+        Report.addNewline(getMainPhaseReport());
 
         drawOrbitalBombardmentIncomingOnBoard(orbitalBombardment);
         scheduledOrbitalBombardment.add(orbitalBombardment);
@@ -20658,11 +20658,11 @@ public class TWGameManager extends AbstractGameManager {
             drawNukeHitOnBoard(nuke);
             if (nuke.length == 3) {
                 doNuclearExplosion(new Coords(nuke[0] - 1, nuke[1] - 1), nuke[2],
-                        vPhaseReport);
+                    mainPhaseReport);
             }
             if (nuke.length == 6) {
                 doNuclearExplosion(new Coords(nuke[0] - 1, nuke[1] - 1), nuke[2], nuke[3],
-                        nuke[4], nuke[5], vPhaseReport);
+                        nuke[4], nuke[5], mainPhaseReport);
             }
         }
         scheduledNukes.clear();
@@ -20679,7 +20679,7 @@ public class TWGameManager extends AbstractGameManager {
         var r = new Report(1303, Report.PUBLIC);
         r.indent();
         r.newlines = 2;
-        getvPhaseReport().add(r);
+        getMainPhaseReport().add(r);
 
         scheduledOrbitalBombardment
             .forEach(ob ->  doOrbitalBombardment(new Coords(ob.getX(), ob.getY()), ob.getDamage(), ob.getRadius()));
@@ -20690,7 +20690,7 @@ public class TWGameManager extends AbstractGameManager {
         r = new Report(1301, Report.PUBLIC);
         r.indent();
         r.newlines = 2;
-        getvPhaseReport().add(r);
+        getMainPhaseReport().add(r);
     }
 
     public void drawNukeHitOnBoard(int[] nukeArgs) {
@@ -20779,7 +20779,7 @@ public class TWGameManager extends AbstractGameManager {
         Report r = new Report(1300, Report.PUBLIC);
         r.indent();
         r.add(position.getBoardNum(), true);
-        getvPhaseReport().add(r);
+        getMainPhaseReport().add(r);
 
         // Then, do actual blast damage.
         // Use the standard blast function for this.
@@ -20790,7 +20790,7 @@ public class TWGameManager extends AbstractGameManager {
         doExplosion(damage, degradation , false, position, true, tmpV,
             blastedUnitsVec, -1, true);
         Report.indentAll(tmpV, 2);
-        getvPhaseReport().addAll(tmpV);
+        getMainPhaseReport().addAll(tmpV);
     }
 
     /**
@@ -27346,7 +27346,7 @@ public class TWGameManager extends AbstractGameManager {
         // report. This will
         // handle that issue.
         return new Packet(PacketCommand.SENDING_REPORTS,
-                (p == null) || !doBlind() ? vPhaseReport : filterReportVector(vPhaseReport, p));
+                (p == null) || !doBlind() ? mainPhaseReport : filterReportVector(mainPhaseReport, p));
     }
 
     /**
@@ -27354,7 +27354,7 @@ public class TWGameManager extends AbstractGameManager {
      * sent during a phase that is not a report phase.
      */
     public Packet createSpecialReportPacket() {
-        return new Packet(PacketCommand.SENDING_REPORTS_SPECIAL, vPhaseReport.clone());
+        return new Packet(PacketCommand.SENDING_REPORTS_SPECIAL, mainPhaseReport.clone());
     }
 
     /**
@@ -27363,7 +27363,7 @@ public class TWGameManager extends AbstractGameManager {
      */
     private Packet createTacticalGeniusReportPacket(Player p) {
         return new Packet(PacketCommand.SENDING_REPORTS_TACTICAL_GENIUS,
-                (p == null) || !doBlind() ? vPhaseReport.clone() : filterReportVector(vPhaseReport, p));
+                (p == null) || !doBlind() ? mainPhaseReport.clone() : filterReportVector(mainPhaseReport, p));
     }
 
     /**
@@ -27626,7 +27626,7 @@ public class TWGameManager extends AbstractGameManager {
         if (mailer != null) {
             for (var player : mailer.getEmailablePlayers(game)) {
                 try {
-                    var reports = filterReportVector(vPhaseReport, player);
+                    var reports = filterReportVector(mainPhaseReport, player);
                     var message = mailer.newReportMessage(game, reports, player);
                     mailer.send(message);
                 } catch (Exception ex) {
@@ -27973,7 +27973,7 @@ public class TWGameManager extends AbstractGameManager {
         Hashtable<Coords, Vector<Entity>> positionMap = game.getPositionMap();
 
         // Check for collapse of this building due to overloading, and return.
-        boolean rv = checkForCollapse(bldg, positionMap, curPos, true, vPhaseReport);
+        boolean rv = checkForCollapse(bldg, positionMap, curPos, true, mainPhaseReport);
 
         // If the entity was not displaced and didn't fall, move it back where it was
         if (curPos.equals(entity.getPosition()) && !entity.isProne()) {
@@ -28652,7 +28652,7 @@ public class TWGameManager extends AbstractGameManager {
                     Report r = new Report(6460, Report.PUBLIC);
                     r.add(bldg.getName());
                     addReport(r);
-                    collapseBuilding(bldg, positionMap, coords, vPhaseReport);
+                    collapseBuilding(bldg, positionMap, coords, mainPhaseReport);
                 }
             }
         }
@@ -28666,7 +28666,7 @@ public class TWGameManager extends AbstractGameManager {
                 Vector<Coords> coordsToRemove = new Vector<>();
                 for (Coords coords : updateCoords) {
                     if (checkForCollapse(bldg, positionMap, coords, false,
-                            vPhaseReport)) {
+                        mainPhaseReport)) {
                         coordsToRemove.add(coords);
                     }
                 }
@@ -28992,7 +28992,7 @@ public class TWGameManager extends AbstractGameManager {
                             -1, false);
                     Report.indentAll(vRep, 2);
                     vDesc.addAll(vRep);
-                    return vPhaseReport;
+                    return mainPhaseReport;
                 }
                 if (bldg.getType() == BuildingType.WALL) {
                     r = new Report(3442);
@@ -30922,7 +30922,7 @@ public class TWGameManager extends AbstractGameManager {
      * Master report queue vPhaseReport.
      */
     public void addReport(Vector<Report> reports) {
-        vPhaseReport.addAll(reports);
+        mainPhaseReport.addAll(reports);
     }
 
     /**
@@ -30933,7 +30933,7 @@ public class TWGameManager extends AbstractGameManager {
     public void addReport(Vector<Report> reports, int indents) {
         for (Report r : reports) {
             r.indent(indents);
-            vPhaseReport.add(r);
+            mainPhaseReport.add(r);
         }
     }
 
@@ -30942,14 +30942,14 @@ public class TWGameManager extends AbstractGameManager {
      * vPhaseReport queue
      */
     public void addReport(ReportEntry report) {
-        vPhaseReport.addElement((Report) report);
+        mainPhaseReport.addElement((Report) report);
     }
 
     /**
      * New Round has started clear everyone's report queue
      */
     void clearReports() {
-        vPhaseReport.removeAllElements();
+        mainPhaseReport.removeAllElements();
     }
 
     /**
@@ -30957,7 +30957,7 @@ public class TWGameManager extends AbstractGameManager {
      * added to all of the players filters
      */
     void addNewLines() {
-        Report.addNewline(vPhaseReport);
+        Report.addNewline(mainPhaseReport);
     }
 
     /**
@@ -31099,7 +31099,7 @@ public class TWGameManager extends AbstractGameManager {
                     // ack! automatic death! Tanks
                     // suffer an ammo/power plant hit.
                     // TODO : a Mek suffers a Head Blown Off crit.
-                    vPhaseReport.addAll(destroyEntity(entity, "impossible displacement",
+                    mainPhaseReport.addAll(destroyEntity(entity, "impossible displacement",
                             entity instanceof Mek, entity instanceof Mek));
                 }
             }
@@ -31849,7 +31849,7 @@ public class TWGameManager extends AbstractGameManager {
                 }
             }
         }
-        Report.addNewline(vPhaseReport);
+        Report.addNewline(mainPhaseReport);
         return vFullReport;
     }
 

--- a/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
@@ -141,14 +141,11 @@ class TWPhaseEndManager {
                 gameManager.applyBuildingDamage();
                 gameManager.checkForPSRFromDamage();
                 gameManager.cleanupDestroyedNarcPods();
-//                gameManager.addReport(gameManager.resolvePilotingRolls());
-                Vector<Report> pilotingRollsFromDamage = gameManager.resolvePilotingRolls();
+                gameManager.addReport(gameManager.resolvePilotingRolls());
                 gameManager.checkForFlawedCooling();
                 // check phase report
-                if (gameManager.getvPhaseReport().size() + pilotingRollsFromDamage.size() > 1) {
+                if (gameManager.getvPhaseReport().size() > 1) {
                     gameManager.getGame().addReports(gameManager.getvPhaseReport());
-                    gameManager.addReport(pilotingRollsFromDamage);
-                    gameManager.getGame().addReports(pilotingRollsFromDamage);
                     gameManager.changePhase(GamePhase.FIRING_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label

--- a/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
@@ -141,12 +141,13 @@ class TWPhaseEndManager {
                 gameManager.applyBuildingDamage();
                 gameManager.checkForPSRFromDamage();
                 gameManager.cleanupDestroyedNarcPods();
-                gameManager.addReport(gameManager.resolvePilotingRolls());
+//                gameManager.addReport(gameManager.resolvePilotingRolls());
                 Vector<Report> pilotingRollsFromDamage = gameManager.resolvePilotingRolls();
                 gameManager.checkForFlawedCooling();
                 // check phase report
                 if (gameManager.getvPhaseReport().size() + pilotingRollsFromDamage.size() > 1) {
                     gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.addReport(pilotingRollsFromDamage);
                     gameManager.getGame().addReports(pilotingRollsFromDamage);
                     gameManager.changePhase(GamePhase.FIRING_REPORT);
                 } else {

--- a/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
@@ -25,8 +25,6 @@ import megamek.common.enums.GamePhase;
 import megamek.common.event.GameVictoryEvent;
 import megamek.server.ServerHelper;
 
-import java.util.Vector;
-
 class TWPhaseEndManager {
 
     private final TWGameManager gameManager;
@@ -38,17 +36,17 @@ class TWPhaseEndManager {
     void managePhase() {
         switch (gameManager.getGame().getPhase()) {
             case LOUNGE:
-                gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                 gameManager.changePhase(GamePhase.EXCHANGE);
                 break;
             case EXCHANGE:
             case STARTING_SCENARIO:
-                gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                 gameManager.changePhase(GamePhase.SET_ARTILLERY_AUTOHIT_HEXES);
                 break;
             case SET_ARTILLERY_AUTOHIT_HEXES:
                 gameManager.sendSpecialHexDisplayPackets();
-                gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                 boolean hasMinesToDeploy = gameManager.getGame().getPlayersList().stream().anyMatch(Player::hasMinefields);
                 if (hasMinesToDeploy) {
                     gameManager.changePhase(GamePhase.DEPLOY_MINEFIELDS);
@@ -71,7 +69,7 @@ class TWPhaseEndManager {
             case INITIATIVE:
                 gameManager.resolveWhatPlayersCanSeeWhatUnits();
                 gameManager.detectSpacecraft();
-                gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                 gameManager.changePhase(GamePhase.INITIATIVE_REPORT);
                 break;
             case INITIATIVE_REPORT:
@@ -92,7 +90,7 @@ class TWPhaseEndManager {
                 break;
             case MOVEMENT:
                 gameManager.detectHiddenUnits();
-                ServerHelper.detectMinefields(gameManager.getGame(), gameManager.getvPhaseReport(), gameManager);
+                ServerHelper.detectMinefields(gameManager.getGame(), gameManager.getMainPhaseReport(), gameManager);
                 gameManager.updateSpacecraftDetection();
                 gameManager.detectSpacecraft();
                 gameManager.resolveWhatPlayersCanSeeWhatUnits();
@@ -108,13 +106,13 @@ class TWPhaseEndManager {
                 gameManager.checkForFlawedCooling();
                 gameManager.resolveCallSupport();
                 // check phase report
-                if (gameManager.getvPhaseReport().size() > 1) {
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                if (gameManager.getMainPhaseReport().size() > 1) {
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.MOVEMENT_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label
                     gameManager.addReport(new Report(1205, Report.PUBLIC));
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.sendReport();
                     gameManager.changePhase(GamePhase.OFFBOARD);
                 }
@@ -144,14 +142,14 @@ class TWPhaseEndManager {
                 gameManager.addReport(gameManager.resolvePilotingRolls());
                 gameManager.checkForFlawedCooling();
                 // check phase report
-                if (gameManager.getvPhaseReport().size() > 1) {
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                if (gameManager.getMainPhaseReport().size() > 1) {
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.FIRING_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label
                     gameManager.addReport(new Report(1205, Report.PUBLIC));
                     gameManager.sendReport();
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.PHYSICAL);
                 }
                 gameManager.sendGroundObjectUpdate();
@@ -172,13 +170,13 @@ class TWPhaseEndManager {
                 gameManager.checkForFlawedCooling();
                 gameManager.checkForChainWhipGrappleChecks();
                 // check phase report
-                if (gameManager.getvPhaseReport().size() > 1) {
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                if (gameManager.getMainPhaseReport().size() > 1) {
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.PHYSICAL_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label
                     gameManager.addReport(new Report(1205, Report.PUBLIC));
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.sendReport();
                     gameManager.changePhase(GamePhase.END);
                 }
@@ -188,18 +186,18 @@ class TWPhaseEndManager {
                 gameManager.changePhase(GamePhase.END);
                 break;
             case TARGETING:
-                gameManager.getvPhaseReport().addElement(new Report(1035, Report.PUBLIC));
+                gameManager.getMainPhaseReport().addElement(new Report(1035, Report.PUBLIC));
                 gameManager.resolveAllButWeaponAttacks();
                 gameManager.resolveOnlyWeaponAttacks();
                 gameManager.handleAttacks();
                 // check reports
-                if (gameManager.getvPhaseReport().size() > 1) {
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                if (gameManager.getMainPhaseReport().size() > 1) {
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.TARGETING_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label
-                    gameManager.getvPhaseReport().addElement(new Report(1205, Report.PUBLIC));
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getMainPhaseReport().addElement(new Report(1205, Report.PUBLIC));
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.sendReport();
                     gameManager.changePhase(GamePhase.PREMOVEMENT);
                 }
@@ -228,13 +226,13 @@ class TWPhaseEndManager {
                 gameManager.sendTagInfoUpdates();
 
                 // check reports
-                if (gameManager.getvPhaseReport().size() > 1) {
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                if (gameManager.getMainPhaseReport().size() > 1) {
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.OFFBOARD_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label
                     gameManager.addReport(new Report(1205, Report.PUBLIC));
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.sendReport();
                     gameManager.changePhase(GamePhase.PREFIRING);
                 }
@@ -253,15 +251,15 @@ class TWPhaseEndManager {
                 boolean victory = gameManager.victory(); // note this may add reports
                 // check phase report
                 // HACK: hardcoded message ID check
-                if ((gameManager.getvPhaseReport().size() > 3) || ((gameManager.getvPhaseReport().size() > 1)
-                        && (gameManager.getvPhaseReport().elementAt(1).messageId != 1205))) {
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                if ((gameManager.getMainPhaseReport().size() > 3) || ((gameManager.getMainPhaseReport().size() > 1)
+                        && (gameManager.getMainPhaseReport().elementAt(1).messageId != 1205))) {
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.changePhase(GamePhase.END_REPORT);
                 } else {
                     // just the heat and end headers, so we'll add
                     // the <nothing> label
                     gameManager.addReport(new Report(1205, Report.PUBLIC));
-                    gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                     gameManager.sendReport();
                     if (victory) {
                         gameManager.changePhase(GamePhase.VICTORY);

--- a/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
@@ -25,6 +25,8 @@ import megamek.common.enums.GamePhase;
 import megamek.common.event.GameVictoryEvent;
 import megamek.server.ServerHelper;
 
+import java.util.Vector;
+
 class TWPhaseEndManager {
 
     private final TWGameManager gameManager;
@@ -140,10 +142,12 @@ class TWPhaseEndManager {
                 gameManager.checkForPSRFromDamage();
                 gameManager.cleanupDestroyedNarcPods();
                 gameManager.addReport(gameManager.resolvePilotingRolls());
+                Vector<Report> pilotingRollsFromDamage = gameManager.resolvePilotingRolls();
                 gameManager.checkForFlawedCooling();
                 // check phase report
-                if (gameManager.getvPhaseReport().size() > 1) {
+                if (gameManager.getvPhaseReport().size() + pilotingRollsFromDamage.size() > 1) {
                     gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                    gameManager.getGame().addReports(pilotingRollsFromDamage);
                     gameManager.changePhase(GamePhase.FIRING_REPORT);
                 } else {
                     // just the header, so we'll add the <nothing> label

--- a/megamek/src/megamek/server/totalwarfare/TWPhasePreparationManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhasePreparationManager.java
@@ -33,7 +33,6 @@ import megamek.common.Player;
 import megamek.common.Report;
 import megamek.common.enums.GamePhase;
 import megamek.common.options.OptionsConstants;
-import megamek.common.planetaryconditions.PlanetaryConditions;
 import megamek.common.util.EmailService;
 import megamek.logging.MMLogger;
 import megamek.server.DynamicTerrainProcessor;
@@ -212,7 +211,7 @@ public class TWPhasePreparationManager {
                 // Thanks! Ralgith - 2018/03/15
                 gameManager.clearHexUpdateSet();
                 for (DynamicTerrainProcessor tp : gameManager.getTerrainProcessors()) {
-                    tp.doEndPhaseChanges(gameManager.getvPhaseReport());
+                    tp.doEndPhaseChanges(gameManager.getMainPhaseReport());
                 }
                 gameManager.sendChangedHexes();
 
@@ -240,7 +239,7 @@ public class TWPhasePreparationManager {
                 gameManager.clearReports();
                 gameManager.send(gameManager.createAllReportsPacket());
                 gameManager.prepareVictoryReport();
-                gameManager.getGame().addReports(gameManager.getvPhaseReport());
+                gameManager.getGame().addReports(gameManager.getMainPhaseReport());
                 // Before we send the full entities packet we need to loop
                 // through the fighters in squadrons and damage them.
                 for (Entity entity : gameManager.getGame().getEntitiesVector()) {
@@ -290,7 +289,7 @@ public class TWPhasePreparationManager {
                     for (var player : mailer.getEmailablePlayers(gameManager.getGame())) {
                         try {
                             var message = mailer.newReportMessage(
-                                    gameManager.getGame(), gameManager.getvPhaseReport(), player);
+                                    gameManager.getGame(), gameManager.getMainPhaseReport(), player);
                             mailer.send(message);
                         } catch (Exception ex) {
                             logger.error("Error sending email" + ex);

--- a/megamek/unittests/megamek/server/victory/GameManagerTest.java
+++ b/megamek/unittests/megamek/server/victory/GameManagerTest.java
@@ -140,7 +140,7 @@ class GameManagerTest {
         gameManager.setGame(testGame);
         gameManager.victory();
 
-        assertSame(1, gameManager.getvPhaseReport().size());
+        assertSame(1, gameManager.getMainPhaseReport().size());
 
         // Second test server tests with both a team != TEAM_NONE and a player !=
         // PLAYER_NONE
@@ -152,6 +152,6 @@ class GameManagerTest {
         gameManager2.setGame(testGame);
         gameManager2.victory();
 
-        assertSame(2, gameManager2.getvPhaseReport().size());
+        assertSame(2, gameManager2.getMainPhaseReport().size());
     }
 }


### PR DESCRIPTION
This set of fixes cleans up some of what appear to mistakes in how certain critical effects and PSR results are reported.

The issue is that a number of functions within TWGameManager.java used to write directly to vPhaseReport (the class member, not the various _identically named local Vector instances_, thanks for that) or use the `addReport()` function to the same effect, while most of the rest of the code has been updated to pass a per-Phase Vector of reports around, or compose one from the results of calling all the various handling functions.

This fix should clear up two specific instances of Pilot Skill checks appearing in the phase report log _prior_ to the attacks that actually caused them.

NOTE: there are likely many more such functions within TWGameManager.java that need to be examined, and possibly updated:

- Any function that can be called within the Movement Phase _and_ the Attack Handling Phase; that
- returns a non-Vector result, and/or
- calls addReport or vPhaseReport.addAll() on the class member itself.

Unfortunately, there are some 700+ such locations to check within the class.

Prior behaviour:
![Image](https://github.com/user-attachments/assets/54887045-d6b6-478a-a2a6-e8b236bf4bba)
![Image](https://github.com/user-attachments/assets/7e6e1bdf-f560-4d4a-8e77-a84caeac1d1c)

Updated behaviour:
<img width="975" alt="Screenshot_20250125_223526" src="https://github.com/user-attachments/assets/25f5bbe9-3d64-485d-8c7c-3ae438a6839f" />


Testing:
- Ran version of repro reported in #6434 
- Ran all 3 projects' unit tests

Close #3890 #6434 