### PR TITLE
fix: ranked path fix

### DIFF
--- a/megamek/src/megamek/client/bot/princess/RankedPath.java
+++ b/megamek/src/megamek/client/bot/princess/RankedPath.java
@@ -20,6 +20,8 @@
 package megamek.client.bot.princess;
 
 import megamek.common.MovePath;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.text.DecimalFormat;
 
@@ -72,42 +74,43 @@ public class RankedPath implements Comparable<RankedPath> {
         if (p.rank < rank) {
             return 1;
         }
-        return Integer.compare(path.getHexesMoved(), p.path.getHexesMoved());
+        if (path.getHexesMoved() < p.path.getHexesMoved()) {
+            return -1;
+        }
+        if (p.path.getHexesMoved() < path.getHexesMoved()) {
+            return 1;
+        }
+        if (expectedDamage < p.expectedDamage) {
+            return -1;
+        }
+        if (p.expectedDamage < expectedDamage) {
+            return 1;
+        }
+        return hashCode() > 0 ? 1 : -1;
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+    public boolean equals(Object object) {
+        if (this == object) return true;
 
-        RankedPath that = (RankedPath) o;
+        if (!(object instanceof RankedPath that)) return false;
 
-        if (Double.compare(that.rank, rank) != 0) {
-            return false;
-        }
-        if (!path.equals(that.path)) {
-            return false;
-        }
-        if (reason != null ? !reason.equals(that.reason) : that.reason != null) {
-            return false;
-        }
-
-        return true;
+        return new EqualsBuilder()
+            .append(getRank(), that.getRank())
+            .append(getExpectedDamage(), that.getExpectedDamage())
+            .append(getPath(), that.getPath())
+            .append(getReason(), that.getReason())
+            .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result;
-        long temp;
-        result = path.hashCode();
-        temp = Double.doubleToLongBits(rank);
-        result = 31 * result + (int) (temp ^ (temp >>> 32));
-        result = 31 * result + (reason != null ? reason.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder(17, 37)
+            .append(getPath())
+            .append(getRank())
+            .append(getReason())
+            .append(getExpectedDamage())
+            .toHashCode();
     }
 
     @Override

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -26,6 +26,8 @@ import megamek.common.pathfinder.DestructionAwareDestinationPathfinder;
 import megamek.common.pathfinder.ShortestPathFinder;
 import megamek.common.preference.PreferenceManager;
 import megamek.logging.MMLogger;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Holds movement path for an entity.
@@ -2053,5 +2055,33 @@ public class MovePath implements Cloneable, Serializable {
         }
 
         return maxMP;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+
+        if (!(object instanceof MovePath movePath)) return false;
+
+        return new EqualsBuilder()
+            .append(entity, movePath.entity)
+            .append(careful, movePath.careful)
+            .append(gravityConcern, movePath.gravityConcern)
+            .append(gravity, movePath.gravity)
+            .append(steps, movePath.steps)
+            .append(containedStepTypes, movePath.containedStepTypes)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+            .append(entity)
+            .append(steps)
+            .append(containedStepTypes)
+            .append(careful)
+            .append(gravityConcern)
+            .append(gravity)
+            .toHashCode();
     }
 }


### PR DESCRIPTION
# The bug
Due to an oversight of my part, I let it pass over me that when adding an object to a treeset, it may replace the object that is already present in the tree if the result of the comparison is equal to 0.
The consequence of this mistake is that if there were two path with the same rank, and same hexes moved, it would then substitute one of the for the other, which would cull the paths during insertion in the rankedPath list, unfortunatelly this does not provide much better performance, so there is no upside to this bug and it has to be addressed.

# This fix
This change makes that no two movepaths will never return 0 in the comparsion. It also implements a hashCode and equals for RankedPath and MovePath.
