### PR TITLE
feat: added sensor range on minimap, added facing arrow on minimap

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1311,6 +1311,8 @@ CommonSettingsDialog.main=Main
 CommonSettingsDialog.audio=Audio
 CommonSettingsDialog.miniMap=Mini Map
 CommonSettingsDialog.mmSymbol=Use StratOps unit symbols in the Minimap
+CommonSettingsDialog.drawFacingArrowsOnMiniMap=Draw unit facing arrows on the minimap
+CommonSettingsDialog.drawSensorRangeOnMiniMap=Draw unit's active sensor range on the minimap
 CommonSettingsDialog.mouseWheelZoom=Mouse wheel zooms map.
 CommonSettingsDialog.mouseWheelZoomFlip=Flip mouse wheel zoom direction.
 CommonSettingsDialog.moveDefaultClimbMode.tooltip=Sets the default climb mode. false = Go Thru, true = Climb Up
@@ -2445,7 +2447,8 @@ Minimap.menu.ShowHeightTotal=Total T
 Minimap.menu.ShowSymbols=Show Symbols
 Minimap.menu.ShowSymbolsNoSymbols=No Symbols N
 Minimap.menu.ShowSymbolsSymbols=Symbols S
-
+Minimap.menu.ToggleShowSensorRange=Toggle Sensors
+Minimap.menu.ToggleDrawFacingArrows=Toggle Facing Arrows
 
 #Mini round report display
 MiniReportDisplay.Damage=Damage

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -244,6 +244,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private final JCheckBox aOHexShadows = new JCheckBox(Messages.getString("CommonSettingsDialog.aOHexSHadows"));
     private final JCheckBox floatingIso = new JCheckBox(Messages.getString("CommonSettingsDialog.floatingIso"));
     private final JCheckBox mmSymbol = new JCheckBox(Messages.getString("CommonSettingsDialog.mmSymbol"));
+    private final JCheckBox drawFacingArrowsOnMiniMap = new JCheckBox(Messages.getString("CommonSettingsDialog.drawFacingArrowsOnMiniMap"));
+    private final JCheckBox drawSensorRangeOnMiniMap = new JCheckBox(Messages.getString("CommonSettingsDialog.drawSensorRangeOnMiniMap"));
     private final JCheckBox entityOwnerColor = new JCheckBox(
             Messages.getString("CommonSettingsDialog.entityOwnerColor"));
     private final JCheckBox teamColoring = new JCheckBox(Messages.getString("CommonSettingsDialog.teamColoring"));
@@ -502,6 +504,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private boolean savedLevelhighlight;
     private boolean savedFloatingIso;
     private boolean savedMmSymbol;
+    private boolean savedDrawFacingArrowsOnMiniMap;
+    private boolean savedDrawSensorRangeOnMiniMap;
     private boolean savedTeamColoring;
     private boolean savedDockOnLeft;
     private boolean savedDockMultipleOnYAxis;
@@ -1659,6 +1663,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         comps.add(checkboxEntry(gameSummaryMM,
                 Messages.getString("CommonSettingsDialog.gameSummaryMM.tooltip",
                         Configuration.gameSummaryImagesMMDir())));
+        comps.add(checkboxEntry(drawFacingArrowsOnMiniMap, null));
+        comps.add(checkboxEntry(drawSensorRangeOnMiniMap, null));
         return createSettingsPanel(comps);
     }
 
@@ -2049,6 +2055,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             aOHexShadows.setSelected(GUIP.getAOHexShadows());
             floatingIso.setSelected(GUIP.getFloatingIso());
             mmSymbol.setSelected(GUIP.getMmSymbol());
+            drawFacingArrowsOnMiniMap.setSelected(GUIP.getDrawFacingArrowsOnMiniMap());
+            drawSensorRangeOnMiniMap.setSelected(GUIP.getDrawSensorRangeOnMiniMap());
             levelhighlight.setSelected(GUIP.getLevelHighlight());
             shadowMap.setSelected(GUIP.getShadowMap());
             hexInclines.setSelected(GUIP.getHexInclines());
@@ -2070,7 +2078,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                 }
             }
 
-            minimapTheme.setSelectedItem(CLIENT_PREFERENCES.getMinimapTheme());
+            minimapTheme.setSelectedItem(CLIENT_PREFERENCES.getMinimapTheme().getName());
 
             gameSummaryBV.setSelected(GUIP.getGameSummaryBoardView());
             gameSummaryMM.setSelected(GUIP.getGameSummaryMinimap());
@@ -2139,6 +2147,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             savedLevelhighlight = GUIP.getLevelHighlight();
             savedFloatingIso = GUIP.getFloatingIso();
             savedMmSymbol = GUIP.getMmSymbol();
+            savedDrawFacingArrowsOnMiniMap = GUIP.getDrawFacingArrowsOnMiniMap();
+            savedDrawSensorRangeOnMiniMap = GUIP.getDrawSensorRangeOnMiniMap();
             savedTeamColoring = GUIP.getTeamColoring();
             savedDockOnLeft = GUIP.getDockOnLeft();
             savedDockMultipleOnYAxis = GUIP.getDockMultipleOnYAxis();
@@ -2179,6 +2189,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setLevelHighlight(savedLevelhighlight);
         GUIP.setFloatingIso(savedFloatingIso);
         GUIP.setMmSymbol(savedMmSymbol);
+        GUIP.setDrawSensorRangeOnMiniMap(savedDrawSensorRangeOnMiniMap);
+        GUIP.setDrawFacingArrowsOnMiniMap(savedDrawFacingArrowsOnMiniMap);
         GUIP.setTeamColoring(savedTeamColoring);
         GUIP.setDockOnLeft(savedDockOnLeft);
         GUIP.setDockMultipleOnYAxis(savedDockMultipleOnYAxis);
@@ -2429,7 +2441,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
 
         GUIP.setAttackArrowTransparency((Integer) attackArrowTransparency.getValue());
         GUIP.setECMTransparency((Integer) ecmTransparency.getValue());
-
+        GUIP.setDrawFacingArrowsOnMiniMap(drawFacingArrowsOnMiniMap.isSelected());
+        GUIP.setDrawSensorRangeOnMiniMap(drawSensorRangeOnMiniMap.isSelected());
         try {
             GUIP.setButtonsPerRow(Integer.parseInt(buttonsPerRow.getText()));
         } catch (Exception ex) {
@@ -2909,6 +2922,10 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             GUIP.setShowDamageLevel(showDamageLevel.isSelected());
         } else if (source.equals(chkHighQualityGraphics)) {
             GUIP.setHighQualityGraphics(chkHighQualityGraphics.isSelected());
+        } else if (source.equals(drawFacingArrowsOnMiniMap)) {
+            GUIP.setDrawFacingArrowsOnMiniMap(drawFacingArrowsOnMiniMap.isSelected());
+        } else if (source.equals(drawSensorRangeOnMiniMap)) {
+            GUIP.setDrawFacingArrowsOnMiniMap(drawSensorRangeOnMiniMap.isSelected());
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -288,6 +288,8 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String MINI_MAP_SYMBOLS_DISPLAY_MODE = "MinimapSymbolsDisplayMode";
     public static final String MINI_MAP_AUTO_DISPLAY_REPORT_PHASE = "MinimapAutoDisplayReportPhase";
     public static final String MINI_MAP_AUTO_DISPLAY_NONREPORT_PHASE = "MinimapAutoDisplayNonReportPhase";
+    public static final String MINI_MAP_SHOW_SENSOR_RANGE = "MinimapShowSensorRange";
+    public static final String MINI_MAP_SHOW_FACING_ARROW = "MinimapShowFacingArrow";
     public static final String FIRE_DISPLAY_TAB_DURING_PHASES = "FireDisplayTabDuringPhases";
     public static final String MOVE_DISPLAY_TAB_DURING_PHASES = "MoveDisplayTabDuringPhases";
     public static final String MINIMUM_SIZE_HEIGHT = "MinimumSizeHeight";
@@ -3434,5 +3436,21 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public File[] getMinimapThemes() {
         // List all .theme files inside the minimap themes folder
         return Configuration.minimapThemesDir().listFiles((dir, name) -> name.endsWith(".theme"));
+    }
+
+    public boolean getDrawFacingArrowsOnMiniMap() {
+        return getBoolean(MINI_MAP_SHOW_SENSOR_RANGE);
+    }
+
+    public boolean getDrawSensorRangeOnMiniMap() {
+        return getBoolean(MINI_MAP_SHOW_FACING_ARROW);
+    }
+
+    public void setDrawFacingArrowsOnMiniMap(boolean state) {
+        store.setValue(MINI_MAP_SHOW_SENSOR_RANGE, state);
+    }
+
+    public void setDrawSensorRangeOnMiniMap(boolean state) {
+        store.setValue(MINI_MAP_SHOW_FACING_ARROW, state);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -975,6 +975,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateFleeButton() {
+        if (ce() == null) {
+            return;
+        }
         boolean hasLastStep = (cmd != null) && (cmd.getLastStep() != null);
         boolean fleeStart = !hasLastStep &&
             ce().canFlee(ce().getPosition());

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -5201,7 +5201,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         return clientgui != null ? clientgui.getDisplayedUnit() : null;
     }
 
-    FovHighlightingAndDarkening getFovHighlighting() {
+    public FovHighlightingAndDarkening getFovHighlighting() {
         return fovHighlightingAndDarkening;
     }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -50,7 +50,7 @@ import megamek.logging.MMLogger;
 /**
  * A helper class for highlighting and darkening hexes.
  */
-class FovHighlightingAndDarkening {
+public class FovHighlightingAndDarkening {
     private static final MMLogger logger = MMLogger.create(FovHighlightingAndDarkening.class);
 
     private final BoardView boardView1;
@@ -265,6 +265,14 @@ class FovHighlightingAndDarkening {
     }
 
     GameListener cacheGameListner;
+
+    /**
+     * Returns the cached all ECM info.
+     * @return the cached all ECM info, nullable
+     */
+    public @Nullable List<ECMInfo> getCachedECMInfo() {
+        return cachedAllECMInfo;
+    }
 
     /**
      * Checks for los effects, preferably from cache, if not getLosEffects

--- a/megamek/src/megamek/client/ui/swing/minimap/BoardviewlessMinimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/BoardviewlessMinimap.java
@@ -430,7 +430,7 @@ public class BoardviewlessMinimap extends JPanel implements OverlayPainter {
                 iconColor = GUIP.getEnemyUnitColor();
             }
         }
-        Color iconColorSemiTransparent = new Color(iconColor.getRed(), iconColor.getGreen(), iconColor.getBlue(), 200);
+        
 
         // Transform for placement and scaling
         var placement = AffineTransform.getTranslateInstance(baseX, baseY);

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -876,9 +876,9 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         int[] xPoints = xPoints(x);
         int[] yPoints = yPoints(x, y);
         g.fillPolygon(xPoints, yPoints, 6);
-//        if (border) {
-//            g.setColor(g.getColor().darker());
-//        }
+        if (border) {
+            g.setColor(g.getColor().darker());
+        }
         g.drawPolygon(xPoints, yPoints, 6);
     }
 

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -876,9 +876,9 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         int[] xPoints = xPoints(x);
         int[] yPoints = yPoints(x, y);
         g.fillPolygon(xPoints, yPoints, 6);
-        if (border) {
-            g.setColor(g.getColor().darker());
-        }
+//        if (border) {
+//            g.setColor(g.getColor().darker());
+//        }
         g.drawPolygon(xPoints, yPoints, 6);
     }
 
@@ -1209,25 +1209,32 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         Stroke saveStroke = g2.getStroke();
 
         g2.setStroke(new BasicStroke(2));
-        Color iconColorSemiTransparent = new Color(iconColor.getRed(), iconColor.getGreen(), iconColor.getBlue(), 180);
+        Color iconColorSemiTransparent = new Color(iconColor.getRed(), iconColor.getGreen(), iconColor.getBlue(), 200);
         g2.setColor(iconColorSemiTransparent);
 
-        int x = entity.getPosition().getX();
-        int y = entity.getPosition().getY();
-
+        var origin = entity.getPosition();
         for (var sensorRange : List.of(minSensorRange, maxSensorRange)) {
             if (sensorRange <= 0) {
                 continue;
             }
 
-            int topLeftX = coordsXToPixel(x-sensorRange);
-            int topLeftY = coordsYtoPixel(y-sensorRange, x-sensorRange);
-            int bottomRightX = coordsXToPixel(x+sensorRange);
-            int bottomRightY = coordsYtoPixel(y+sensorRange, x+sensorRange);
-            int sensorWidth = bottomRightX - topLeftX;
-            int sensorHeight = bottomRightY - topLeftY;
+            int xo;
+            int yo;
+            var sensor = new Path2D.Double();
 
-            g2.drawOval(topLeftX - unitSize - 1, topLeftY - unitSize - 1, sensorWidth + unitSize * 2 + 2, sensorHeight + unitSize * 2 + 2);
+            var internalOrExternal = (sensorRange == minSensorRange) && (maxSensorRange != 0) ? -1 : 1;
+            for (int i = 0; i < 6; i++) {
+                var movingCoord = origin.translated(i, sensorRange + internalOrExternal);
+                xo = coordsXToPixel(movingCoord.getX());
+                yo = coordsYtoPixel(movingCoord.getY(), movingCoord.getX());
+                if (i == 0) {
+                    sensor.moveTo(xo, yo);
+                } else {
+                    sensor.lineTo(xo, yo);
+                }
+            }
+            sensor.closePath();
+            g2.draw(sensor);
         }
         g2.setStroke(saveStroke);
     }

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -20,9 +20,8 @@
  */
 package megamek.client.ui.swing.minimap;
 
-import static megamek.client.ui.swing.minimap.MinimapUnitSymbols.STRAT_BASERECT;
-import static megamek.client.ui.swing.minimap.MinimapUnitSymbols.STRAT_CX;
-import static megamek.client.ui.swing.minimap.MinimapUnitSymbols.STRAT_SYMBOLSIZE;
+import static megamek.client.ui.swing.minimap.MinimapUnitSymbols.*;
+import static megamek.client.ui.swing.minimap.MinimapUnitSymbols.FACING_ARROW;
 import static megamek.common.Terrains.*;
 
 import java.awt.*;
@@ -69,12 +68,12 @@ import megamek.common.actions.EntityAction;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.event.*;
+import megamek.common.options.OptionsConstants;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.ImageUtil;
-import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.logging.MMLogger;
 
 /**
@@ -134,6 +133,8 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     private static final String ACTION_HEIGHT_TOTAL = "HEIGHT_TOTAL";
     private static final String ACTION_SYMBOLS_NO = "SYMBOLS_NO";
     private static final String ACTION_SYMBOLS_SHOW = "SYMBOLS_SHOW";
+    private static final String ACTION_FACING_ARROWS_SHOW = "FACING_ARROWS_SHOW";
+    private static final String ACTION_SENSORS_SHOW = "SENSORS_SHOW";
 
     private static final GUIPreferences GUIP = GUIPreferences.getInstance();
     private static final ClientPreferences CLIENT_PREFERENCES = PreferenceManager.getClientPreferences();
@@ -164,7 +165,8 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     private int zoom = GUIP.getMinimapZoom();
     private int heightDisplayMode = GUIP.getMinimapHeightDisplayMode();
     private int symbolsDisplayMode = GUIP.getMinimapSymbolsDisplayMode();
-
+    private boolean drawSensorRangeOnMiniMap = GUIP.getDrawSensorRangeOnMiniMap();
+    private boolean drawFacingArrowsOnMiniMap = GUIP.getDrawFacingArrowsOnMiniMap();
     private Coords firstLOS;
     private Coords secondLOS;
 
@@ -592,7 +594,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             }
 
             drawDeploymentZone(g);
-
+            // In case the flag SHOW SYMBOLS is set, it will draw the units and other stuff
             if (symbolsDisplayMode == SHOW_SYMBOLS) {
                 if (null != game) {
                     // draw declared fire
@@ -606,6 +608,14 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
                     for (Entity e : game.getEntitiesVector()) {
                         if (e.getPosition() != null) {
                             paintUnit(g, e);
+                        }
+                    }
+
+                    if (drawSensorRangeOnMiniMap) {
+                        for (Entity e : game.getEntitiesVector()) {
+                            if (e.getPosition() != null) {
+                                paintSensor(g, e);
+                            }
                         }
                     }
                 }
@@ -998,8 +1008,8 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     private void paintUnit(Graphics g, Entity entity) {
         int x = entity.getPosition().getX();
         int y = entity.getPosition().getY();
-        int baseX = x * (HEX_SIDE[zoom] + HEX_SIDE_BY_SIN30[zoom]) + leftMargin + HEX_SIDE[zoom];
-        int baseY = (2 * y + 1 + (x % 2)) * HEX_SIDE_BY_COS30[zoom] + topMargin;
+        int baseX = coordsXToPixel(x);
+        int baseY = coordsYtoPixel(y, x);
 
         if (EntityVisibilityUtils.onlyDetectedBySensors(client.getLocalPlayer(), entity)) {
             // This unit is visible only as a sensor Return
@@ -1020,6 +1030,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         Stroke saveStroke = g2.getStroke();
         AffineTransform saveTransform = g2.getTransform();
         boolean stratOpsSymbols = GUIP.getMmSymbol();
+        boolean drawFacingArrows = GUIP.getDrawFacingArrowsOnMiniMap();
 
         // Choose player or team color depending on preferences
         Color iconColor = entity.getOwner().getColour().getColour(false);
@@ -1094,7 +1105,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
                     FontMetrics currentMetrics = getFontMetrics(font);
                     int stringWidth = currentMetrics.stringWidth(s);
                     GlyphVector gv = font.createGlyphVector(fontContext, s);
-                    g2.fill(gv.getOutline((int) STRAT_CX - stringWidth / 2,
+                    g2.fill(gv.getOutline((int) STRAT_CX - (float) stringWidth / 2,
                             (float) STRAT_SYMBOLSIZE.getHeight() / 3.0f));
                 }
             } else if (entity instanceof MekWarrior) {
@@ -1125,6 +1136,19 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             g2.setStroke(new BasicStroke(innerBorderWidth / 2f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
             g2.draw(form);
         }
+        g2.setStroke(new BasicStroke(innerBorderWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
+
+        if (drawFacingArrows) {
+            // draw facing arrow
+            var facing = entity.getFacing();
+            if (facing > -1) {
+                g2.setColor(Color.BLACK);
+                g2.rotate(Math.toRadians(facing * 60));
+                g2.draw(FACING_ARROW);
+                g.setColor(iconColor);
+                g2.fill(FACING_ARROW);
+            }
+        }
 
         g2.setTransform(saveTransform);
 
@@ -1135,11 +1159,85 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             int rad = stratOpsSymbols ? 2 * unitSize - 1 : unitSize + unitSize / 2;
             Color color = GUIP.getUnitSelectedColor();
             g2.setColor(color.darker());
-            g2.setStroke(new BasicStroke(unitSize / 5 + 1));
+            g2.setStroke(new BasicStroke((float) unitSize / 5 + 1));
             g2.drawOval(baseX - rad, baseY - rad, rad * 2, rad * 2);
         }
 
         g2.setStroke(saveStroke);
+    }
+
+
+    /** Draws the symbol for a single entity. Checks visibility in double blind. */
+    private void paintSensor(Graphics g, Entity entity) {
+        if (EntityVisibilityUtils.onlyDetectedBySensors(client.getLocalPlayer(), entity)) {
+            // This unit is visible only as a sensor Return, we dont know the range of its sensor yet
+            return;
+        } else if (!EntityVisibilityUtils.detectedOrHasVisual(client.getLocalPlayer(), game, entity)) {
+            // This unit is not visible, don't draw it
+            return;
+        }
+
+        int maxSensorRange = 0;
+        int minSensorRange = 0;
+
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_SENSORS)) {
+            int bracket = Compute.getSensorRangeBracket(entity, null, null);
+            int range = Compute.getSensorRangeByBracket(game, entity, null, null);
+
+            maxSensorRange = bracket * range;
+            minSensorRange = Math.max((bracket - 1) * range, 0);
+            if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_INCLUSIVE_SENSOR_RANGE)) {
+                minSensorRange = 0;
+            }
+        }
+
+
+        // Choose player or team color depending on preferences
+        Color iconColor = entity.getOwner().getColour().getColour(false);
+        if (GUIP.getTeamColoring() && (client != null)) {
+            boolean isLocalTeam = entity.getOwner().getTeam() == client.getLocalPlayer().getTeam();
+            boolean isLocalPlayer = entity.getOwner().equals(client.getLocalPlayer());
+            if (isLocalPlayer) {
+                iconColor = GUIP.getMyUnitColor();
+            } else if (isLocalTeam) {
+                iconColor = GUIP.getAllyUnitColor();
+            } else {
+                iconColor = GUIP.getEnemyUnitColor();
+            }
+        }
+        Graphics2D g2 = (Graphics2D) g;
+        Stroke saveStroke = g2.getStroke();
+
+        g2.setStroke(new BasicStroke(2));
+        Color iconColorSemiTransparent = new Color(iconColor.getRed(), iconColor.getGreen(), iconColor.getBlue(), 180);
+        g2.setColor(iconColorSemiTransparent);
+
+        int x = entity.getPosition().getX();
+        int y = entity.getPosition().getY();
+
+        for (var sensorRange : List.of(minSensorRange, maxSensorRange)) {
+            if (sensorRange <= 0) {
+                continue;
+            }
+
+            int topLeftX = coordsXToPixel(x-sensorRange);
+            int topLeftY = coordsYtoPixel(y-sensorRange, x-sensorRange);
+            int bottomRightX = coordsXToPixel(x+sensorRange);
+            int bottomRightY = coordsYtoPixel(y+sensorRange, x+sensorRange);
+            int sensorWidth = bottomRightX - topLeftX;
+            int sensorHeight = bottomRightY - topLeftY;
+
+            g2.drawOval(topLeftX - unitSize - 1, topLeftY - unitSize - 1, sensorWidth + unitSize * 2 + 2, sensorHeight + unitSize * 2 + 2);
+        }
+        g2.setStroke(saveStroke);
+    }
+
+    private int coordsYtoPixel(int y, int x) {
+        return (2 * y + 1 + (x % 2)) * HEX_SIDE_BY_COS30[zoom] + topMargin;
+    }
+
+    private int coordsXToPixel(int x) {
+        return x * (HEX_SIDE[zoom] + HEX_SIDE_BY_SIN30[zoom]) + leftMargin + HEX_SIDE[zoom];
     }
 
     /** Draws the road elements previously assembles into the roadHexes list. */
@@ -1428,6 +1526,18 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         }
     }
 
+    private void setSensorRangeDisplay(boolean state) {
+        drawSensorRangeOnMiniMap = state;
+        GUIP.setDrawSensorRangeOnMiniMap(state);
+        initializeMap();
+    }
+
+    private void setFacingArrowsDisplay(boolean state) {
+        drawFacingArrowsOnMiniMap = state;
+        GUIP.setDrawFacingArrowsOnMiniMap(state);
+        initializeMap();
+    }
+
     private void setSymbolsDisplay(int i) {
         symbolsDisplayMode = i;
         GUIP.setMiniMapSymbolsDisplayMode(i);
@@ -1590,6 +1700,8 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         }
     };
 
+
+
     MouseListener mouseListener = new MouseAdapter() {
         @Override
         public void mouseClicked(MouseEvent me) {
@@ -1624,31 +1736,49 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             String msg_zoomout = Messages.getString("Minimap.menu.ZoomOut");
             zoomMenu.add(menuItem(msg_zoomout, ACTION_ZOOM_OUT, zoom != MIM_ZOOM, listener, false));
             popup.add(zoomMenu);
+
             String msg_showheight = Messages.getString("Minimap.menu.ShowHeight");
             JMenu heightMenu = new JMenu(msg_showheight);
-            String msg_showheightnone = Messages.getString("Minimap.menu.ShowHeightNone");
-            heightMenu.add(menuItem(msg_showheightnone, ACTION_HEIGHT_NONE, zoom >= MIM_ZOOM_FOR_HEIGHT, listener,
-                    heightDisplayMode == SHOW_NO_HEIGHT));
-            String msg_showheightground = Messages.getString("Minimap.menu.ShowHeightGround");
-            heightMenu.add(menuItem(msg_showheightground, ACTION_HEIGHT_GROUND, zoom >= MIM_ZOOM_FOR_HEIGHT, listener,
-                    heightDisplayMode == SHOW_GROUND_HEIGHT));
-            String msg_showheightbuilding = Messages.getString("Minimap.menu.ShowHeightBuilding");
-            heightMenu.add(menuItem(msg_showheightbuilding, ACTION_HEIGHT_BUILDING, zoom >= MIM_ZOOM_FOR_HEIGHT,
-                    listener, heightDisplayMode == SHOW_BUILDING_HEIGHT));
-            String msg_showheighttotal = Messages.getString("Minimap.menu.ShowHeightTotal");
-            heightMenu.add(menuItem(msg_showheighttotal, ACTION_HEIGHT_TOTAL, zoom >= MIM_ZOOM_FOR_HEIGHT, listener,
-                    heightDisplayMode == SHOW_TOTAL_HEIGHT));
-            popup.add(heightMenu);
-            String msg_showsymbols = Messages.getString("Minimap.menu.ShowSymbols");
-            JMenu symbolsMenu = new JMenu(msg_showsymbols);
-            String msg_showsymbolsnosymbols = Messages.getString("Minimap.menu.ShowSymbolsNoSymbols");
-            symbolsMenu.add(menuItem(msg_showsymbolsnosymbols, ACTION_SYMBOLS_NO, true, listener,
-                    symbolsDisplayMode == SHOW_NO_SYMBOLS));
-            String msg_showsymbolssymbols = Messages.getString("Minimap.menu.ShowSymbolsSymbols");
-            symbolsMenu.add(menuItem(msg_showsymbolssymbols, ACTION_SYMBOLS_SHOW, true, listener,
-                    symbolsDisplayMode == SHOW_SYMBOLS));
-            popup.add(symbolsMenu);
 
+            String msg_showheightnone = Messages.getString("Minimap.menu.ShowHeightNone");
+            heightMenu.add(menuItem(msg_showheightnone, ACTION_HEIGHT_NONE, zoom >= MIM_ZOOM_FOR_HEIGHT, listener, heightDisplayMode == SHOW_NO_HEIGHT));
+
+            String msg_showheightground = Messages.getString("Minimap.menu.ShowHeightGround");
+            heightMenu.add(menuItem(msg_showheightground, ACTION_HEIGHT_GROUND, zoom >= MIM_ZOOM_FOR_HEIGHT, listener, heightDisplayMode == SHOW_GROUND_HEIGHT));
+
+            String msg_showheightbuilding = Messages.getString("Minimap.menu.ShowHeightBuilding");
+            heightMenu.add(menuItem(msg_showheightbuilding, ACTION_HEIGHT_BUILDING, zoom >= MIM_ZOOM_FOR_HEIGHT, listener, heightDisplayMode == SHOW_BUILDING_HEIGHT));
+
+            String msg_showheighttotal = Messages.getString("Minimap.menu.ShowHeightTotal");
+            heightMenu.add(menuItem(msg_showheighttotal, ACTION_HEIGHT_TOTAL, zoom >= MIM_ZOOM_FOR_HEIGHT, listener, heightDisplayMode == SHOW_TOTAL_HEIGHT));
+
+            popup.add(heightMenu);
+
+            String lblShowSymbols = Messages.getString("Minimap.menu.ShowSymbols");
+            JMenu symbolsMenu = new JMenu(lblShowSymbols);
+
+            String lblShowSymbolsNoSymbols = Messages.getString("Minimap.menu.ShowSymbolsNoSymbols");
+            symbolsMenu.add(menuItem(lblShowSymbolsNoSymbols, ACTION_SYMBOLS_NO, true, listener, symbolsDisplayMode == SHOW_NO_SYMBOLS));
+
+            String lblShowSymbolsSymbols = Messages.getString("Minimap.menu.ShowSymbolsSymbols");
+            symbolsMenu.add(menuItem(lblShowSymbolsSymbols, ACTION_SYMBOLS_SHOW, true, listener, symbolsDisplayMode == SHOW_SYMBOLS));;
+
+            JCheckBoxMenuItem toggleDrawSensor = new JCheckBoxMenuItem(Messages.getString("Minimap.menu.ToggleShowSensorRange"));
+            toggleDrawSensor.addActionListener(l -> {
+                setSensorRangeDisplay(!drawSensorRangeOnMiniMap);
+            });
+            toggleDrawSensor.setSelected(drawSensorRangeOnMiniMap);
+            symbolsMenu.add(toggleDrawSensor);
+
+
+            JCheckBoxMenuItem toggleDrawFacing = new JCheckBoxMenuItem(Messages.getString("Minimap.menu.ToggleDrawFacingArrows"));
+            toggleDrawFacing.addActionListener(l -> {
+                setFacingArrowsDisplay(!drawFacingArrowsOnMiniMap);
+            });
+            toggleDrawFacing.setSelected(drawFacingArrowsOnMiniMap);
+            symbolsMenu.add(toggleDrawFacing);
+
+            popup.add(symbolsMenu);
             popup.show(me.getComponent(), me.getX(), me.getY());
         }
 

--- a/megamek/src/megamek/client/ui/swing/minimap/MinimapUnitSymbols.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/MinimapUnitSymbols.java
@@ -49,6 +49,7 @@ public class MinimapUnitSymbols {
     public static final Path2D STRAT_HOVER;
     public static final Path2D STRAT_WHEELED;
     public static final Path2D STRAT_NAVAL;
+    public static final Path2D FACING_ARROW;
     public static final Path2D STD_MEK;
     public static final Path2D STD_TANK;
     public static final Path2D STD_VTOL;
@@ -64,6 +65,13 @@ public class MinimapUnitSymbols {
     private static final double PIHALF = PI / 2;
 
     static {
+        FACING_ARROW = new Path2D.Double();
+        FACING_ARROW.moveTo(0, -130);
+        FACING_ARROW.lineTo(25, -130);
+        FACING_ARROW.lineTo(0, -180);
+        FACING_ARROW.lineTo(-25, -130);
+        FACING_ARROW.closePath();
+
         STD_MEK = new Path2D.Double();
         STD_MEK.moveTo(-25, 45);
         STD_MEK.lineTo(25, 45);

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -361,6 +361,9 @@ public class ClientPreferences extends PreferenceStoreProxy {
     }
 
     public void setMinimapTheme(String theme) {
+        if (theme == null) {
+            return;
+        }
         store.setValue(MINIMAP_THEME, theme);
     }
 


### PR DESCRIPTION
Both options are available on the client options in the minimap tab, they are also accessible through the minimap right click contextual menu.

# Example
<img width="591" alt="Screenshot 2025-01-27 at 01 09 26" src="https://github.com/user-attachments/assets/9cdc4c8c-aa5c-4e1f-8aa2-de26c888008c" />

## Quirks

The external braket is half hex bigger, while the internal bracket is half hex smaller, so an 8-16 sensor is shown around 7.5 - 16.5

