### PR TITLE
Change keys List from ArrayList to thread-safe Vector

### DIFF
--- a/megamek/src/megamek/common/battlevalue/BVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BVCalculator.java
@@ -22,12 +22,7 @@ import static megamek.client.ui.swing.calculationReport.CalculationReport.format
 import static megamek.common.AmmoType.T_AMS;
 import static megamek.common.AmmoType.T_APDS;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Predicate;
 
 import megamek.client.ui.swing.calculationReport.CalculationReport;
@@ -61,7 +56,7 @@ public abstract class BVCalculator {
     protected boolean ignoreC3;
     protected boolean ignoreSkill;
     protected Map<String, Double> ammoMap = new HashMap<>();
-    protected List<String> keys = new ArrayList<>();
+    protected List<String> keys = new Vector<>();
     protected Map<String, String> names = new HashMap<>();
     protected Map<String, Double> weaponsForExcessiveAmmo = new HashMap<>();
     protected int runMP;


### PR DESCRIPTION
This change was requested by @Scoppio, to fix BV calculation issues caused by ArrayLists not being thread-safe.
This change converts the ArrayList in BVCalculator.java to a thread-safe Vector, preventing various bugs in multi-threaded usage such as ACAR sims.

Testing:
- Ran several ACAR simulations
- Ran all 3 projects' unit tests