### PR TITLE
Fix 5870: princess engaging targets outside visual range in heavy fog

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -163,6 +163,7 @@ public class FireControl {
     static final TargetRollModifier TH_SWARM_STOPPED = new TargetRollModifier(TargetRoll.AUTOMATIC_SUCCESS,
             "stops swarming");
     static final TargetRollModifier TH_OUT_OF_RANGE = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "out of range");
+    static final TargetRollModifier TH_OUT_OF_VISUAL = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "out of visual targeting range");
     static final TargetRollModifier TH_SHORT_RANGE = new TargetRollModifier(0, "Short Range");
     static final TargetRollModifier TH_MEDIUM_RANGE = new TargetRollModifier(2, "Medium Range");
     static final TargetRollModifier TH_LONG_RANGE = new TargetRollModifier(4, "Long Range");
@@ -303,6 +304,11 @@ public class FireControl {
         final int maxRange = owner.getMaxWeaponRange(shooter, target.isAirborne());
         if (distance > maxRange) {
             return new ToHitData(TH_RNG_TOO_FAR);
+        }
+
+        final int maxVisRange = game.getPlanetaryConditions().getVisualRange(shooter, shooter.isUsingSearchlight());
+        if (distance > maxVisRange) {
+            return new ToHitData(TH_OUT_OF_VISUAL);
         }
 
         final ToHitData toHitData = new ToHitData();

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1380,7 +1380,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // c3 units can fire if any other unit in their network is in
                 // visual or sensor range
                 for (Entity en : game.getEntitiesVector()) {
-                    if (!en.isEnemyOf(ae) && en.onSameC3NetworkAs(ae) && Compute.canSee(game, en, target)) {
+                    // We got here because ae can't see the target, so we need a C3 buddy that _can_
+                    // or there's no shot.
+                    if (!en.isEnemyOf(ae) && en.onSameC3NetworkAs(ae) && Compute.canSee(game, en, target, false, null, null)) {
                         networkSee = true;
                         break;
                     }

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -51,6 +51,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import megamek.common.planetaryconditions.Atmosphere;
+import megamek.common.planetaryconditions.PlanetaryConditions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -233,6 +235,11 @@ class FireControlTest {
         mockGame = mock(Game.class);
         when(mockGame.getOptions()).thenReturn(mockGameOptions);
         when(mockGame.getBoard()).thenReturn(mockBoard);
+
+        // Base planetary conditions
+        PlanetaryConditions planetaryConditions = new PlanetaryConditions();
+        planetaryConditions.setAtmosphere(Atmosphere.STANDARD);
+        when(mockGame.getPlanetaryConditions()).thenReturn(planetaryConditions);
 
         mockTarget = mock(BipedMek.class);
         when(mockTarget.getDisplayName()).thenReturn("mock target");


### PR DESCRIPTION
Please see #5870 for analysis of the root cause.

This fix lets Princess use knowledge of the current visual range when guessing at attack effectiveness for movement planning.

It also removes the ability for C3-equipped units to completely bypass LOS restrictions as long as one C3 network member has a target within their sensor ranges.
Based on forum posts and TacOps, it looks like at least one member of the network needs to have _visual_ LOS, including any Planetary Conditions that restrict visual range, for the network to provide targeting capabilities to its members.  Otherwise it's just sharing the already-detected sensor pings.

Testing:
- Tested scenario from the linked issue repeatedly, with and without fixes.
- Ran all 3 projects' unit tests.
- Updated FireControlTest to provide the necessary planetary environment data that Princess now checks.

Close #5870 