### PR TITLE
feat: quick and simple hazard check for hex

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -831,7 +831,6 @@ public class BasicPathRanker extends PathRanker {
         logMsg.append("\n\tHex ").append(hex.getCoords().toFriendlyString());
 
         Set<Integer> hazards = getHazardTerrainIds(hex);
-
         // No hazards were found, so nothing to worry about.
         if (hazards.isEmpty()) {
             logMsg.append(" has no hazards.");

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -830,30 +830,7 @@ public class BasicPathRanker extends PathRanker {
             StringBuilder logMsg) {
         logMsg.append("\n\tHex ").append(hex.getCoords().toFriendlyString());
 
-        final List<Integer> HAZARDS = new ArrayList<>(Arrays.asList(Terrains.FIRE,
-                Terrains.MAGMA,
-                Terrains.ICE,
-                Terrains.WATER,
-                Terrains.BUILDING,
-                Terrains.BRIDGE,
-                Terrains.BLACK_ICE,
-                Terrains.SNOW,
-                Terrains.SWAMP,
-                Terrains.MUD,
-                Terrains.TUNDRA));
-
-        // Black Ice can appear if the conditions are favorable
-        if (blackIce > 0) {
-            HAZARDS.add(Terrains.PAVEMENT);
-        }
-
-        int[] terrainTypes = hex.getTerrainTypes();
-        Set<Integer> hazards = new HashSet<>();
-        for (int type : terrainTypes) {
-            if (HAZARDS.contains(type)) {
-                hazards.add(type);
-            }
-        }
+        Set<Integer> hazards = getHazardTerrainIds(hex);
 
         // No hazards were found, so nothing to worry about.
         if (hazards.isEmpty()) {
@@ -914,6 +891,35 @@ public class BasicPathRanker extends PathRanker {
                 .append(LOG_DECIMAL.format(hazardValue));
 
         return hazardValue;
+    }
+
+    private static final Set<Integer> HAZARDS = new HashSet<>(Arrays.asList(Terrains.FIRE,
+        Terrains.MAGMA,
+        Terrains.ICE,
+        Terrains.WATER,
+        Terrains.BUILDING,
+        Terrains.BRIDGE,
+        Terrains.BLACK_ICE,
+        Terrains.SNOW,
+        Terrains.SWAMP,
+        Terrains.MUD,
+        Terrains.TUNDRA));
+    private static final Set<Integer> HAZARDS_WITH_BLACK_ICE = new HashSet<>();
+    static {
+        HAZARDS_WITH_BLACK_ICE.addAll(HAZARDS);
+        HAZARDS_WITH_BLACK_ICE.add(Terrains.PAVEMENT);
+    }
+
+    private Set<Integer> getHazardTerrainIds(Hex hex) {
+        var hazards = hex.getTerrainTypesSet();
+        // Black Ice can appear if the conditions are favorable
+        if (blackIce > 0) {
+            hazards.retainAll(HAZARDS_WITH_BLACK_ICE);
+        } else {
+            hazards.retainAll(HAZARDS);
+        }
+
+        return hazards;
     }
 
     // Building collapse and basements are handled in PathRanker.validatePaths.

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -122,6 +122,13 @@ public class Hex implements Serializable {
     }
 
     /**
+     * @return A HashSet that contains an id for each terrain present in this hex.
+     */
+    public Set<Integer> getTerrainTypesSet() {
+        return new HashSet<>(terrains.keySet());
+    }
+
+    /**
      * Resets the theme to what was specified in the board file.
      */
     public void resetTheme() {

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -36,13 +36,7 @@ import static org.mockito.Mockito.when;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.Vector;
+import java.util.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1340,7 +1334,7 @@ class BasicPathRankerTest {
         when(mockProto.getCrew()).thenReturn(mockCrew);
         when(mockProto.getHeatCapacity()).thenReturn(999);
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
         when(mockHexThree.terrainLevel(Terrains.MAGMA)).thenReturn(1);
         assertEquals(167.0, testRanker.checkPathForHazards(mockPath, mockProto, mockGame), TOLERANCE);
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
@@ -1348,7 +1342,7 @@ class BasicPathRankerTest {
 
         // Test waking a ProtoMek through a fire.
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.FIRE, Terrains.WOODS });
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.WOODS, Terrains.FIRE)));
         assertEquals(50.0, testRanker.checkPathForHazards(mockPath, mockProto, mockGame), TOLERANCE);
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
 
@@ -1358,7 +1352,7 @@ class BasicPathRankerTest {
         when(mockInfantry.getArmor(anyInt())).thenReturn(0);
         when(mockInfantry.getCrew()).thenReturn(mockCrew);
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.ICE, Terrains.WATER });
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.ICE, Terrains.WATER)));
         when(mockHexThree.depth()).thenReturn(1);
         assertEquals(1000, testRanker.checkPathForHazards(mockPath, mockInfantry, mockGame), TOLERANCE);
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
@@ -1370,13 +1364,13 @@ class BasicPathRankerTest {
         when(mockTank.getArmor(anyInt())).thenReturn(10);
         when(mockTank.getCrew()).thenReturn(mockCrew);
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.BUILDING, Terrains.FIRE });
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.BUILDING, Terrains.FIRE)));
         assertEquals(26.2859, testRanker.checkPathForHazards(mockPath, mockTank, mockGame), TOLERANCE);
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
 
         // Test walking through a building.
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.BUILDING });
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.BUILDING)));
         assertEquals(1.285, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
 
@@ -1385,6 +1379,10 @@ class BasicPathRankerTest {
         when(mockHexTwo.getTerrainTypes()).thenReturn(new int[] { Terrains.ICE, Terrains.WATER });
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.ICE, Terrains.WATER });
         when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.ICE, Terrains.WATER });
+        when(mockHexTwo.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.ICE, Terrains.WATER)));
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.ICE, Terrains.WATER)));
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.ICE, Terrains.WATER)));
+
         when(mockHexTwo.terrainLevel(Terrains.WATER)).thenReturn(0);
         when(mockHexThree.terrainLevel(Terrains.WATER)).thenReturn(1);
         when(mockFinalHex.terrainLevel(Terrains.WATER)).thenReturn(2);
@@ -1397,9 +1395,9 @@ class BasicPathRankerTest {
         when(mockUnit.getArmor(Mek.LOC_RARM)).thenReturn(0);
         assertEquals(2000, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockUnit.getArmor(Mek.LOC_RARM)).thenReturn(10);
-        when(mockHexTwo.getTerrainTypes()).thenReturn(new int[0]);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[0]);
+        when(mockHexTwo.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
         when(mockHexTwo.terrainLevel(Terrains.WATER)).thenReturn(0);
         when(mockHexThree.terrainLevel(Terrains.WATER)).thenReturn(0);
         when(mockFinalHex.terrainLevel(Terrains.WATER)).thenReturn(0);
@@ -1409,16 +1407,16 @@ class BasicPathRankerTest {
 
         // Test walking over 3 hexes of magma crust.
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexTwo.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
+        when(mockHexTwo.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
         when(mockHexTwo.terrainLevel(Terrains.MAGMA)).thenReturn(1);
         when(mockHexThree.terrainLevel(Terrains.MAGMA)).thenReturn(1);
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(1);
         assertEquals(361.500, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
-        when(mockHexTwo.getTerrainTypes()).thenReturn(new int[0]);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[0]);
+        when(mockHexTwo.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
         when(mockHexTwo.terrainLevel(Terrains.MAGMA)).thenReturn(0);
         when(mockHexThree.terrainLevel(Terrains.MAGMA)).thenReturn(0);
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(0);
@@ -1428,24 +1426,25 @@ class BasicPathRankerTest {
         // number
         when(mockPath.isJumping()).thenReturn(false);
         when(mockFinalStep.isProne()).thenReturn(true);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(2);
         assertEquals(56010.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockFinalStep.isProne()).thenReturn(false);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[0]);
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(0);
 
         // Test walking through 2 hexes of fire.
         when(mockPath.isJumping()).thenReturn(false);
-        when(mockHexTwo.getTerrainTypes()).thenReturn(new int[] { Terrains.WOODS, Terrains.FIRE });
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[] { Terrains.WOODS, Terrains.FIRE });
+        when(mockHexTwo.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.WOODS, Terrains.FIRE)));
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.WOODS, Terrains.FIRE)));
         assertEquals(4.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
-        when(mockHexTwo.getTerrainTypes()).thenReturn(new int[0]);
-        when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
+        when(mockHexTwo.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
+        when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(0)));
 
         // Test jumping.
         when(mockPath.isJumping()).thenReturn(true);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.ICE, Terrains.WATER });
+
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.ICE, Terrains.WATER)));
         when(mockFinalHex.terrainLevel(Terrains.WATER)).thenReturn(2);
         when(mockFinalHex.depth()).thenReturn(2);
         when(mockUnit.getArmor(eq(Mek.LOC_LLEG))).thenReturn(0);
@@ -1453,15 +1452,17 @@ class BasicPathRankerTest {
         when(mockUnit.getArmor(eq(Mek.LOC_LLEG))).thenReturn(10);
         when(mockFinalHex.terrainLevel(Terrains.WATER)).thenReturn(0);
         when(mockFinalHex.depth()).thenReturn(0);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(1);
         assertEquals(3134.5, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(2);
         assertEquals(6264.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(0);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.WOODS, Terrains.FIRE });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.WOODS, Terrains.FIRE)));
         assertEquals(5.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.WOODS });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.WOODS)));
+
+
         assertEquals(0.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
 
         // Test a movement type that doesn't worry about ground terrain.
@@ -1502,7 +1503,7 @@ class BasicPathRankerTest {
         when(mockUnit.getArmor(eq(Mek.LOC_LLEG))).thenReturn(24);
         when(mockUnit.getArmor(eq(Mek.LOC_RLEG))).thenReturn(24);
         when(mockFinalHex.depth()).thenReturn(0);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.MAGMA });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MAGMA)));
         // Only 50% chance to break through Crust, but must make PSR to avoid getting
         // bogged down.
         when(mockFinalHex.terrainLevel(Terrains.MAGMA)).thenReturn(1);
@@ -1626,7 +1627,7 @@ class BasicPathRankerTest {
         // to total destruction.
         when(mockPath.isJumping()).thenReturn(true);
         when(mockFinalHex.depth()).thenReturn(0);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.SWAMP });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.SWAMP)));
         when(mockFinalHex.terrainLevel(Terrains.SWAMP)).thenReturn(1);
         assertEquals(35.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockFinalHex.terrainLevel(Terrains.SWAMP)).thenReturn(2);
@@ -1706,7 +1707,7 @@ class BasicPathRankerTest {
         // down here. Small hazard to Meks due to PSR malus
         when(mockPath.isJumping()).thenReturn(false);
         when(mockFinalHex.depth()).thenReturn(0);
-        when(mockFinalHex.getTerrainTypes()).thenReturn(new int[] { Terrains.MUD });
+        when(mockFinalHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.MUD)));
         assertEquals(2.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
 
         // Test non-hover vehicle hazard
@@ -1756,7 +1757,7 @@ class BasicPathRankerTest {
         when(mockCrew.getPiloting()).thenReturn(5);
 
         // Test visible black ice hazard value
-        when(mockPenultimateHex.getTerrainTypes()).thenReturn(new int[] { Terrains.BLACK_ICE });
+        when(mockPenultimateHex.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.BLACK_ICE)));
         assertEquals(12.0, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
     }
 


### PR DESCRIPTION
previous code did what "hashset.retainAll" does as standard.
Instead of instantiating one new array every time a hex is checked for hazards, it uses two default sets for hazard terrain types and choses one or the other to retain against the terrain types of the hex.