### PR TITLE
Fixes #6451 - Bot command display hotkey text and description missing in key bind menu

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2015,6 +2015,8 @@ KeyBinds.cmdNames.pause=Pause the Game
 KeyBinds.cmdDesc.pause=Pauses the game. Works only when only Princess players with active units remain.
 KeyBinds.cmdNames.unpause=Unpause the Game
 KeyBinds.cmdDesc.unpause=Unpauses the game
+KeyBinds.cmdNames.toggleBotCommandsDisplay=Show Bot Commands
+KeyBinds.cmdDesc.toggleBotCommandsDisplay=Show the Bot Command window to give in-game strategic commands to Princess.
 
 #Key Bindings Overlay
 KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)

--- a/megamek/mmconf/defaultKeyBinds.xml
+++ b/megamek/mmconf/defaultKeyBinds.xml
@@ -505,4 +505,11 @@
         <isRepeatable>false</isRepeatable>
     </KeyBind>
 
+    <KeyBind>
+        <command>toggleBotCommandsDisplay</command> <!-- Ctrl+Shift-G -->
+        <keyCode>71</keyCode>
+        <modifier>192</modifier>
+        <isRepeatable>false</isRepeatable>
+    </KeyBind>
+
 </KeyBindings>


### PR DESCRIPTION
Added name and description for the Ctrl+Shift+G shortcut menu which brings up the new Bot Command Display.  Also added the default configuration so that is gets restored to Ctrl+Shift+G when doing a key bind 'restore to default'.

Fixes #6451 - Missing key bind text and description for Bot Command Display shortcut.

![image](https://github.com/user-attachments/assets/a6dd9f99-f693-4cd5-a684-abd0e1112c47)
