### PR TITLE
feat: adding option to enable and disable minimap hex borders, and ad…

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1314,6 +1314,7 @@ CommonSettingsDialog.miniMap=Mini Map
 CommonSettingsDialog.mmSymbol=Use StratOps unit symbols in the Minimap
 CommonSettingsDialog.drawFacingArrowsOnMiniMap=Draw unit facing arrows on the minimap
 CommonSettingsDialog.drawSensorRangeOnMiniMap=Draw unit's active sensor range on the minimap
+CommonSettingsDialog.paintBordersOnMiniMap=Draw the hex borders on the minimap
 CommonSettingsDialog.mouseWheelZoom=Mouse wheel zooms map.
 CommonSettingsDialog.mouseWheelZoomFlip=Flip mouse wheel zoom direction.
 CommonSettingsDialog.moveDefaultClimbMode.tooltip=Sets the default climb mode. false = Go Thru, true = Climb Up
@@ -2452,6 +2453,7 @@ Minimap.menu.ShowSymbolsNoSymbols=No Symbols N
 Minimap.menu.ShowSymbolsSymbols=Symbols S
 Minimap.menu.ToggleShowSensorRange=Toggle Sensors
 Minimap.menu.ToggleDrawFacingArrows=Toggle Facing Arrows
+Minimap.menu.ToggleDrawHexBorder=Toggle Draw Hex Border
 
 #Mini round report display
 MiniReportDisplay.Damage=Damage

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -246,6 +246,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private final JCheckBox mmSymbol = new JCheckBox(Messages.getString("CommonSettingsDialog.mmSymbol"));
     private final JCheckBox drawFacingArrowsOnMiniMap = new JCheckBox(Messages.getString("CommonSettingsDialog.drawFacingArrowsOnMiniMap"));
     private final JCheckBox drawSensorRangeOnMiniMap = new JCheckBox(Messages.getString("CommonSettingsDialog.drawSensorRangeOnMiniMap"));
+    private final JCheckBox paintBordersOnMiniMap = new JCheckBox(Messages.getString("CommonSettingsDialog.paintBordersOnMiniMap"));
     private final JCheckBox entityOwnerColor = new JCheckBox(
             Messages.getString("CommonSettingsDialog.entityOwnerColor"));
     private final JCheckBox teamColoring = new JCheckBox(Messages.getString("CommonSettingsDialog.teamColoring"));
@@ -506,6 +507,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
     private boolean savedMmSymbol;
     private boolean savedDrawFacingArrowsOnMiniMap;
     private boolean savedDrawSensorRangeOnMiniMap;
+    private boolean savedPaintBorders;
     private boolean savedTeamColoring;
     private boolean savedDockOnLeft;
     private boolean savedDockMultipleOnYAxis;
@@ -1665,6 +1667,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
                         Configuration.gameSummaryImagesMMDir())));
         comps.add(checkboxEntry(drawFacingArrowsOnMiniMap, null));
         comps.add(checkboxEntry(drawSensorRangeOnMiniMap, null));
+        comps.add(checkboxEntry(paintBordersOnMiniMap, null));
         return createSettingsPanel(comps);
     }
 
@@ -2057,6 +2060,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             mmSymbol.setSelected(GUIP.getMmSymbol());
             drawFacingArrowsOnMiniMap.setSelected(GUIP.getDrawFacingArrowsOnMiniMap());
             drawSensorRangeOnMiniMap.setSelected(GUIP.getDrawSensorRangeOnMiniMap());
+            paintBordersOnMiniMap.setSelected(GUIP.paintBorders());
             levelhighlight.setSelected(GUIP.getLevelHighlight());
             shadowMap.setSelected(GUIP.getShadowMap());
             hexInclines.setSelected(GUIP.getHexInclines());
@@ -2149,6 +2153,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             savedMmSymbol = GUIP.getMmSymbol();
             savedDrawFacingArrowsOnMiniMap = GUIP.getDrawFacingArrowsOnMiniMap();
             savedDrawSensorRangeOnMiniMap = GUIP.getDrawSensorRangeOnMiniMap();
+            savedPaintBorders = GUIP.paintBorders();
             savedTeamColoring = GUIP.getTeamColoring();
             savedDockOnLeft = GUIP.getDockOnLeft();
             savedDockMultipleOnYAxis = GUIP.getDockMultipleOnYAxis();
@@ -2191,6 +2196,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setMmSymbol(savedMmSymbol);
         GUIP.setDrawSensorRangeOnMiniMap(savedDrawSensorRangeOnMiniMap);
         GUIP.setDrawFacingArrowsOnMiniMap(savedDrawFacingArrowsOnMiniMap);
+        GUIP.setPaintBorders(savedPaintBorders);
         GUIP.setTeamColoring(savedTeamColoring);
         GUIP.setDockOnLeft(savedDockOnLeft);
         GUIP.setDockMultipleOnYAxis(savedDockMultipleOnYAxis);
@@ -2443,6 +2449,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
         GUIP.setECMTransparency((Integer) ecmTransparency.getValue());
         GUIP.setDrawFacingArrowsOnMiniMap(drawFacingArrowsOnMiniMap.isSelected());
         GUIP.setDrawSensorRangeOnMiniMap(drawSensorRangeOnMiniMap.isSelected());
+        GUIP.setPaintBorders(paintBordersOnMiniMap.isSelected());
         try {
             GUIP.setButtonsPerRow(Integer.parseInt(buttonsPerRow.getText()));
         } catch (Exception ex) {
@@ -2926,6 +2933,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             GUIP.setDrawFacingArrowsOnMiniMap(drawFacingArrowsOnMiniMap.isSelected());
         } else if (source.equals(drawSensorRangeOnMiniMap)) {
             GUIP.setDrawFacingArrowsOnMiniMap(drawSensorRangeOnMiniMap.isSelected());
+        } else if (source.equals(paintBordersOnMiniMap)) {
+            GUIP.setPaintBorders(paintBordersOnMiniMap.isSelected());
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -290,6 +290,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String MINI_MAP_AUTO_DISPLAY_NONREPORT_PHASE = "MinimapAutoDisplayNonReportPhase";
     public static final String MINI_MAP_SHOW_SENSOR_RANGE = "MinimapShowSensorRange";
     public static final String MINI_MAP_SHOW_FACING_ARROW = "MinimapShowFacingArrow";
+    public static final String MINI_MAP_PAINT_BORDERS = "MinimapPaintBorders";
     public static final String FIRE_DISPLAY_TAB_DURING_PHASES = "FireDisplayTabDuringPhases";
     public static final String MOVE_DISPLAY_TAB_DURING_PHASES = "MoveDisplayTabDuringPhases";
     public static final String MINIMUM_SIZE_HEIGHT = "MinimumSizeHeight";
@@ -683,6 +684,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(MINI_MAP_ENABLED, true);
         store.setDefault(MINI_MAP_AUTO_DISPLAY_REPORT_PHASE, 0);
         store.setDefault(MINI_MAP_AUTO_DISPLAY_NONREPORT_PHASE, 1);
+        store.setDefault(MINI_MAP_SHOW_SENSOR_RANGE, true);
+        store.setDefault(MINI_MAP_SHOW_FACING_ARROW, true);
+        store.setDefault(MINI_MAP_PAINT_BORDERS, true);
+
         store.setDefault(MOVE_DISPLAY_TAB_DURING_PHASES, true);
         store.setDefault(FIRE_DISPLAY_TAB_DURING_PHASES, true);
 
@@ -3452,5 +3457,13 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setDrawSensorRangeOnMiniMap(boolean state) {
         store.setValue(MINI_MAP_SHOW_FACING_ARROW, state);
+    }
+
+    public boolean paintBorders() {
+        return getBoolean(MINI_MAP_PAINT_BORDERS);
+    }
+
+    public void setPaintBorders(boolean state) {
+        store.setValue(MINI_MAP_PAINT_BORDERS, state);
     }
 }

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -167,6 +167,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
     private int symbolsDisplayMode = GUIP.getMinimapSymbolsDisplayMode();
     private boolean drawSensorRangeOnMiniMap = GUIP.getDrawSensorRangeOnMiniMap();
     private boolean drawFacingArrowsOnMiniMap = GUIP.getDrawFacingArrowsOnMiniMap();
+    private boolean paintBorders = GUIP.paintBorders();
     private Coords firstLOS;
     private Coords secondLOS;
 
@@ -561,7 +562,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
                         } else if (h.containsTerrain(SKY)) {
                             paintLowAtmoSkyCoord(gg, j, k);
                         } else {
-                            paintCoord(gg, j, k, zoom > 1);
+                            paintCoord(gg, j, k, paintBorders && zoom > 1);
                         }
                     }
                     addRoadElements(h, j, k);
@@ -1030,7 +1031,6 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         Stroke saveStroke = g2.getStroke();
         AffineTransform saveTransform = g2.getTransform();
         boolean stratOpsSymbols = GUIP.getMmSymbol();
-        boolean drawFacingArrows = GUIP.getDrawFacingArrowsOnMiniMap();
 
         // Choose player or team color depending on preferences
         Color iconColor = entity.getOwner().getColour().getColour(false);
@@ -1138,7 +1138,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         }
         g2.setStroke(new BasicStroke(innerBorderWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
 
-        if (drawFacingArrows) {
+        if (drawFacingArrowsOnMiniMap) {
             // draw facing arrow
             var facing = entity.getFacing();
             if (facing > -1) {
@@ -1545,6 +1545,12 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         initializeMap();
     }
 
+    private void setPaintBordersDisplay(boolean state) {
+        paintBorders = state;
+        GUIP.setPaintBorders(state);
+        initializeMap();
+    }
+
     private void setSymbolsDisplay(int i) {
         symbolsDisplayMode = i;
         GUIP.setMiniMapSymbolsDisplayMode(i);
@@ -1784,6 +1790,13 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             });
             toggleDrawFacing.setSelected(drawFacingArrowsOnMiniMap);
             symbolsMenu.add(toggleDrawFacing);
+
+            JCheckBoxMenuItem togglePaintBorders = new JCheckBoxMenuItem(Messages.getString("Minimap.menu.ToggleDrawHexBorder"));
+            togglePaintBorders.addActionListener(l -> {
+                setPaintBordersDisplay(!paintBorders);
+            });
+            togglePaintBorders.setSelected(drawFacingArrowsOnMiniMap);
+            symbolsMenu.add(togglePaintBorders);
 
             popup.add(symbolsMenu);
             popup.show(me.getComponent(), me.getX(), me.getY());


### PR DESCRIPTION
feat: adding option to enable and disable minimap hex borders, and added missing defaults for facing arrows and sensors, on by default

<img width="254" alt="Screenshot 2025-01-31 at 00 53 54" src="https://github.com/user-attachments/assets/e0d26993-9615-4514-9813-5e66f0624103" />
