### PR TITLE
Fix 5590: princess firing on 13s due to intervening trees, etc.

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2844,6 +2844,10 @@ public class FireControl {
             final AmmoMounted suggestedAmmo = info.getAmmo();
             final AmmoMounted mountedAmmo = getPreferredAmmo(shooter, info.getTarget(), currentWeapon, suggestedAmmo);
 
+            if (mountedAmmo == null) {
+                continue;
+            }
+
             // If the selected ammo would cause the shot to miss, skip loading it.
             final WeaponAttackAction cloneWAA = new WeaponAttackAction(info.getAction());
             cloneWAA.setAmmoId(shooter.getEquipmentNum(mountedAmmo));
@@ -2858,15 +2862,14 @@ public class FireControl {
 
             // if we found preferred ammo but can't apply it to the weapon, log it and
             // continue.
-            if ((null != mountedAmmo) && !shooter.loadWeapon(currentWeapon, mountedAmmo)) {
+            if (!shooter.loadWeapon(currentWeapon, mountedAmmo)) {
                 logger.warn(shooter.getDisplayName() + " tried to load "
                         + currentWeapon.getName() + " with ammo " +
                         mountedAmmo.getDesc() + " but failed somehow.");
                 continue;
                 // if we didn't find preferred ammo after all, continue
-            } else if (mountedAmmo == null) {
-                continue;
             }
+
             // If everything looks okay, replace the old WAA with the updated copy
             info.setAction(cloneWAA);
             owner.sendAmmoChange(info.getShooter().getId(), shooter.getEquipmentNum(currentWeapon),

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -354,8 +354,12 @@ public class FireControl {
         }
 
         // terrain modifiers, since "compute" won't let me do these remotely
+        LosEffects los = LosEffects.calculateLOS(game, shooter, target);
+
+        // We want to check the target hex _and_ the intervening hexes for woods, smoke, etc.
         final Hex targetHex = game.getBoard().getHex(targetState.getPosition());
-        int woodsLevel = targetHex.terrainLevel(Terrains.WOODS);
+        int woodsLevel = targetHex.terrainLevel(Terrains.WOODS) +
+            ((los.thruWoods()) ? los.getLightWoods() + los.getHeavyWoods() + los.getUltraWoods() : 0);
         if (targetHex.terrainLevel(Terrains.JUNGLE) > woodsLevel) {
             woodsLevel = targetHex.terrainLevel(Terrains.JUNGLE);
         }
@@ -363,7 +367,9 @@ public class FireControl {
             toHitData.addModifier(woodsLevel, TH_WOODS);
         }
 
-        final int smokeLevel = targetHex.terrainLevel(Terrains.SMOKE);
+        // final int smokeLevel = targetHex.terrainLevel(Terrains.SMOKE);
+        final int smokeLevel = targetHex.terrainLevel(Terrains.SMOKE) +
+            los.getLightSmoke() + los.getHeavySmoke();
         if (1 <= smokeLevel) {
             // Smoke level doesn't necessarily correspond to the to-hit modifier
             // even levels are light smoke, odd are heavy smoke
@@ -2837,6 +2843,19 @@ public class FireControl {
 
             final AmmoMounted suggestedAmmo = info.getAmmo();
             final AmmoMounted mountedAmmo = getPreferredAmmo(shooter, info.getTarget(), currentWeapon, suggestedAmmo);
+
+            // If the selected ammo would cause the shot to miss, skip loading it.
+            final WeaponAttackAction cloneWAA = new WeaponAttackAction(info.getAction());
+            cloneWAA.setAmmoId(shooter.getEquipmentNum(mountedAmmo));
+            cloneWAA.setAmmoMunitionType(((AmmoType) mountedAmmo.getType()).getMunitionType());
+            cloneWAA.setAmmoCarrier(mountedAmmo.getEntity().getId());
+            if (cloneWAA.toHit(owner.getGame(), owner.getPrecognition().getECMInfo()).cannotSucceed()) {
+                logger.warn(shooter.getDisplayName() + " tried to load "
+                    + currentWeapon.getName() + " with ammo " +
+                    mountedAmmo.getDesc() + " but this would have caused it to miss; skipping.");
+                continue;
+            }
+
             // if we found preferred ammo but can't apply it to the weapon, log it and
             // continue.
             if ((null != mountedAmmo) && !shooter.loadWeapon(currentWeapon, mountedAmmo)) {
@@ -2848,11 +2867,8 @@ public class FireControl {
             } else if (mountedAmmo == null) {
                 continue;
             }
-            final WeaponAttackAction action = info.getAction();
-            action.setAmmoId(shooter.getEquipmentNum(mountedAmmo));
-            action.setAmmoMunitionType(((AmmoType) mountedAmmo.getType()).getMunitionType());
-            action.setAmmoCarrier(mountedAmmo.getEntity().getId());
-            info.setAction(action);
+            // If everything looks okay, replace the old WAA with the updated copy
+            info.setAction(cloneWAA);
             owner.sendAmmoChange(info.getShooter().getId(), shooter.getEquipmentNum(currentWeapon),
                     shooter.getEquipmentNum(mountedAmmo), mountedAmmo.getSwitchedReason());
         }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2849,7 +2849,7 @@ public class FireControl {
             cloneWAA.setAmmoId(shooter.getEquipmentNum(mountedAmmo));
             cloneWAA.setAmmoMunitionType(((AmmoType) mountedAmmo.getType()).getMunitionType());
             cloneWAA.setAmmoCarrier(mountedAmmo.getEntity().getId());
-            if (cloneWAA.toHit(owner.getGame(), owner.getPrecognition().getECMInfo()).cannotSucceed()) {
+            if (cloneWAA.toHit(owner.getGame(), owner.getPrecognition().getECMInfo()).getValue() > 12) {
                 logger.warn(shooter.getDisplayName() + " tried to load "
                     + currentWeapon.getName() + " with ammo " +
                     mountedAmmo.getDesc() + " but this would have caused it to miss; skipping.");

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -445,10 +445,8 @@ public class WeaponFireInfo {
                     boolean blockedByWoods = (
                         weapon.getType().getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE
                     );
-                    blockedByWoods |= (preferredAmmo != null &&
-                        preferredAmmo.getType().getMunitionType().contains(
-                            AmmoType.Munitions.M_CLUSTER
-                        )
+                    blockedByWoods |= preferredAmmo.getType().getMunitionType().contains(
+                        AmmoType.Munitions.M_CLUSTER
                     );
                     if (blockedByWoods) {
                         return 0D;

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -429,6 +429,32 @@ public class WeaponFireInfo {
             ) {
                 return 0D;
             }
+
+            // Handle woods blocking cluster shots
+            if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER)) {
+                // SRMs, LB-X, Flak AC, AC-2 derivatives,
+                // and Silver Bullet Gauss are among the weapons
+                // that lose all effectiveness if this rule is
+                // on and the target is in woods/jungle.
+                if (
+                    game.getBoard().contains(target.getPosition())
+                    && game.getBoard().getHex(target.getPosition()).containsAnyTerrainOf(
+                        Terrains.WOODS, Terrains.JUNGLE
+                    )
+                ) {
+                    boolean blockedByWoods = (
+                        weapon.getType().getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE
+                    );
+                    blockedByWoods |= (preferredAmmo != null &&
+                        preferredAmmo.getType().getMunitionType().contains(
+                            AmmoType.Munitions.M_CLUSTER
+                        )
+                    );
+                    if (blockedByWoods) {
+                        return 0D;
+                    }
+                }
+            }
         }
 
         // bay weapons require special consideration, by looping through all weapons and

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -13,12 +13,7 @@
  */
 package megamek.common.actions;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 
 import megamek.MMConstants;
 import megamek.client.Client;
@@ -142,6 +137,40 @@ public class WeaponAttackAction extends AbstractAttackAction {
         this.weaponId = weaponId;
         this.bombPayloads.put("internal", new int[BombType.B_NUM]);
         this.bombPayloads.put("external", new int[BombType.B_NUM]);
+    }
+
+    // Copy constructor, hopefully with enough info to generate same to-hit data.
+    public WeaponAttackAction(final WeaponAttackAction other) {
+        super(other.getEntityId(), other.getTargetId(), other.getWeaponId());
+
+        aimedLocation = other.aimedLocation;
+        aimMode = other.aimMode;
+        ammoCarrier = other.ammoCarrier;
+        ammoId = other.ammoId;
+        ammoMunitionType = other.ammoMunitionType;
+        isHomingShot = other.isHomingShot;
+        isPointblankShot = other.isPointblankShot;
+        isStrafing = other.isStrafing;
+        isStrafingFirstShot = other.isStrafingFirstShot;
+        launchVelocity = other.launchVelocity;
+        nemesisConfused = other.nemesisConfused;
+        oldTargetId = other.oldTargetId;
+        oldTargetType = other.oldTargetType;
+        originalTargetId = other.originalTargetId;
+        originalTargetType = other.originalTargetType;
+        otherAttackInfo = other.otherAttackInfo;
+        swarmingMissiles = other.swarmingMissiles;
+        swarmMissiles = other.swarmMissiles;
+        weaponId = other.weaponId;
+        this.bombPayloads.put("internal", Arrays.copyOf(other.bombPayloads.get("internal"), BombType.B_NUM));
+        this.bombPayloads.put("external", Arrays.copyOf(other.bombPayloads.get("external"), BombType.B_NUM));
+
+        /**
+         * allECMInfo comes from owner's precognition,
+         * false evenIfAlreadyFired should be false,
+         * ammoId,
+         * ammoCarrier
+         */
     }
 
     public int getWeaponId() {

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -141,7 +141,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
     // Copy constructor, hopefully with enough info to generate same to-hit data.
     public WeaponAttackAction(final WeaponAttackAction other) {
-        super(other.getEntityId(), other.getTargetId(), other.getWeaponId());
+        this(other.getEntityId(), other.getTargetType(), other.getTargetId(), other.getWeaponId());
 
         aimedLocation = other.aimedLocation;
         aimMode = other.aimMode;
@@ -164,13 +164,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
         weaponId = other.weaponId;
         this.bombPayloads.put("internal", Arrays.copyOf(other.bombPayloads.get("internal"), BombType.B_NUM));
         this.bombPayloads.put("external", Arrays.copyOf(other.bombPayloads.get("external"), BombType.B_NUM));
-
-        /**
-         * allECMInfo comes from owner's precognition,
-         * false evenIfAlreadyFired should be false,
-         * ammoId,
-         * ammoCarrier
-         */
     }
 
     public int getWeaponId() {


### PR DESCRIPTION
This patch adds a few bits of extra knowledge to Princess in order to avoid her wasting shots where she shouldn't.

The key issues it fixes are: 
- Princess doesn't know about intervening woods and smoke;
- Princess will switch to ammo that makes her miss;
- Princess pumps cluster rounds into trees with TacOps woods cover enabled.

In more detail:
1. The fast attack "guessing" code used by the FireControl.java class previously only checked if a given hex was _in_ woods, jungle, or smoke for determining its defensive properties (for enemies _or_ allies).  This would often put Princess in a position that was defensively good but not optimal, or offensively useless because it actually had no LOS to a target that Princess thought she could just see.
The fix here was to add a single light-weight LOS modifier check _prior_ to the more in-depth calculations to get better LOS data but allow a fast exit if LOS is blocked.
Princess should now have a better idea of LOS mods from trees and smoke when predicting all units' turns.
2. Princess will switch to ammo that makes her miss because we do a last-chance "ammo efficacy" check after all attacks have been declared, due to the way we assess attacks and where the legacy code lives.
This means that, e.g., an LB-10X shot might be switched from cluster to solid in attempt to bypass special armor, but in doing so the shot goes from a 12 to hit up to a 13 due to the Cluster bonus being lost.
The fix is to clone the existing WeaponAttackAction, give it the suggested new ammo, _confirm_ that it does not have a higher to-hit number, and only then load the new WAA into the queue of attacks to be sent to the server.
3. Princess has no knowledge currently of the TacOps cover rules that allow trees to absorb low-damage shots completely.
The fix is to add a new section in the WeaponFireInfo class (responsible for assessing potential attack effectiveness) to mark such attacks as dealing zero damage if the rule is enabled.  This is a fast but not comprehensive check, and may need updating for full coverage in the future.

Note: 
It appears that there is still the possibility for Princess to be forced to take impossible shots, when ammo usage during the Attack Phase causes one ammo bin to go bingo and the replacement ammo has different to-hit characteristics.
The chief offender is IS LRM Dead-Fire, where switching from D-F rounds to normal rounds at range 1 adds a +5 penalty for minimum range.
Unfortunately I don't see a way to fix this without adding a lot of extra ammo bin checks prior to attacks.

Testing:
- Ran many bot-on-bot matches with tons of smoke and trees.
- Ran all 3 projects' unit tests.

Close #5590 