### PR TITLE
Fix 5590 part 2 stop choosing zero damage attacks completely

### DIFF
--- a/megamek/i18n/megamek/client/bot/messages.properties
+++ b/megamek/i18n/megamek/client/bot/messages.properties
@@ -1,3 +1,6 @@
 BotClient.Hi=Hi, I'm a bot client\!
 BotClient.HowAbout=How about a nice game of chess?
 BotClient.Bye=Dave, this conversation can serve no purpose anymore. Goodbye.
+
+FireControl.LoadAmmo.CauseMiss={} tried to load {} with ammo {} but this would have caused it to miss; skipping.
+FireControl.LoadAmmo.FailureToLoad={} tried to load {} with ammo {} but failed somehow.

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2117,7 +2117,8 @@ public class FireControl {
                         continue;
                     }
                 }
-                if (bestShoot.getProbabilityToHit() > toHitThreshold) {
+                // Attack should have a chance to hit, and expect to do non-zero damage; otherwise skip it
+                if (bestShoot.getProbabilityToHit() > toHitThreshold && bestShoot.getExpectedDamage() > 0.0) {
                     myPlan.add(bestShoot);
                     continue;
                 }
@@ -2844,6 +2845,7 @@ public class FireControl {
             final AmmoMounted suggestedAmmo = info.getAmmo();
             final AmmoMounted mountedAmmo = getPreferredAmmo(shooter, info.getTarget(), currentWeapon, suggestedAmmo);
 
+            // if we didn't find preferred ammo after all, continue
             if (mountedAmmo == null) {
                 continue;
             }
@@ -2854,20 +2856,29 @@ public class FireControl {
             cloneWAA.setAmmoMunitionType(((AmmoType) mountedAmmo.getType()).getMunitionType());
             cloneWAA.setAmmoCarrier(mountedAmmo.getEntity().getId());
             if (cloneWAA.toHit(owner.getGame(), owner.getPrecognition().getECMInfo()).getValue() > 12) {
-                logger.warn(shooter.getDisplayName() + " tried to load "
-                    + currentWeapon.getName() + " with ammo " +
-                    mountedAmmo.getDesc() + " but this would have caused it to miss; skipping.");
+                logger.warn(
+                    Messages.getString(
+                        "FireControl.LoadAmmo.CauseMiss",
+                        shooter.getDisplayName(),
+                        currentWeapon.getName(),
+                        mountedAmmo.getDesc()
+                    )
+                );
                 continue;
             }
 
             // if we found preferred ammo but can't apply it to the weapon, log it and
             // continue.
             if (!shooter.loadWeapon(currentWeapon, mountedAmmo)) {
-                logger.warn(shooter.getDisplayName() + " tried to load "
-                        + currentWeapon.getName() + " with ammo " +
-                        mountedAmmo.getDesc() + " but failed somehow.");
+                logger.warn(
+                    Messages.getString(
+                        "FireControl.LoadAmmo.FailureToLoad",
+                        shooter.getDisplayName(),
+                        currentWeapon.getName(),
+                        mountedAmmo.getDesc()
+                    )
+                );
                 continue;
-                // if we didn't find preferred ammo after all, continue
             }
 
             // If everything looks okay, replace the old WAA with the updated copy

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -432,7 +432,7 @@ public class WeaponFireInfo {
 
             // Handle woods blocking cluster shots
             if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER)) {
-                // SRMs, LB-X, Flak AC, AC-2 derivatives,
+                // SRMs, LB-X, Flak AC, AC-2 derivatives, MGs, smaller LRMs,
                 // and Silver Bullet Gauss are among the weapons
                 // that lose all effectiveness if this rule is
                 // on and the target is in woods/jungle.
@@ -442,12 +442,19 @@ public class WeaponFireInfo {
                         Terrains.WOODS, Terrains.JUNGLE
                     )
                 ) {
+                    int woodsLevel = 2 * Math.max(
+                        game.getBoard().getHex(target.getPosition()).terrainLevel(Terrains.WOODS),
+                        game.getBoard().getHex(target.getPosition()).terrainLevel(Terrains.JUNGLE)
+                    );
                     boolean blockedByWoods = (
                         weapon.getType().getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE
                     );
+                    blockedByWoods |= weapon.getType().getRackSize() <= woodsLevel
+                        || weapon.getType().getDamage() <= woodsLevel;
                     blockedByWoods |= preferredAmmo.getType().getMunitionType().contains(
                         AmmoType.Munitions.M_CLUSTER
                     );
+
                     if (blockedByWoods) {
                         return 0D;
                     }

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -536,6 +536,7 @@ class FireControlTest {
         shooterWeapons.add(mockPPC);
         mockPPCFireInfo = mock(WeaponFireInfo.class);
         when(mockPPCFireInfo.getProbabilityToHit()).thenReturn(0.5);
+        when(mockPPCFireInfo.getExpectedDamage()).thenReturn(5.0);
         doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
                 any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockPPC),
                 isNull(),
@@ -571,6 +572,7 @@ class FireControlTest {
         shooterWeapons.add(mockLRM5);
         mockLRMFireInfo = mock(WeaponFireInfo.class);
         when(mockLRMFireInfo.getProbabilityToHit()).thenReturn(0.6);
+        when(mockLRMFireInfo.getExpectedDamage()).thenReturn(2.0);
         doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
                 any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5),
                 any(AmmoMounted.class),


### PR DESCRIPTION
This is an addendum to the prior 5590 work.  Nice-to-have in 0.50.03 but not critical.

This updates the new logging to use properties to allow i18n support, adds a few lower-damage weapons to those that Princess knows are blocked by trees (when the TacOps Woods Cover rule is on), and now causes Princess to completely drop 0-damage attacks with good to-hit numbers.  Previously these 0-damage attacks might be selected when nothing else presented itself.

Testing:
- Ran several more mock battles
- Ran all 3 projects' unit tests.
- Fixed one unit test.