### PR TITLE
fix: stop dropShadow from being calculated for force display tree

### DIFF
--- a/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekTreeRenderer.java
+++ b/megamek/src/megamek/client/ui/swing/forceDisplay/ForceDisplayMekTreeRenderer.java
@@ -89,7 +89,7 @@ public class ForceDisplayMekTreeRenderer extends DefaultTreeCellRenderer {
                 setIcon(getToolkit().getImage(UNKNOWN_UNIT), size - 5);
             } else {
                 Camouflage camo = entity.getCamouflageOrElseOwners();
-                Image image = clientGUI.getBoardView().getTilesetManager().loadPreviewImage(entity, camo);
+                Image image = clientGUI.getBoardView().getTilesetManager().loadPreviewImage(entity, camo, false);
                 setIconTextGap(UIUtil.scaleForGUI(10));
                 setIcon(image, size);
             }

--- a/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/EntityImage.java
@@ -162,48 +162,54 @@ public class EntityImage {
     private final boolean isTank;
     private final int unitHeight;
     private final int unitElevation;
+    private final boolean withShadows;
 
     public static EntityImage createIcon(Image base, Camouflage camouflage, Entity entity) {
-        return createIcon(base, null, camouflage, entity, -1, true);
+        return createIcon(base, null, camouflage, entity, -1, true, true);
+    }
+
+    public static EntityImage createIcon(Image base, Camouflage camouflage, Entity entity, boolean withShadows) {
+        return createIcon(base, null, camouflage, entity, -1, true, withShadows);
     }
 
     public static EntityImage createLobbyIcon(Image base, Camouflage camouflage, Entity entity) {
-        return createIcon(base, null, camouflage, entity, -1, true);
+        return createIcon(base, null, camouflage, entity, -1, true, true);
     }
 
     public static EntityImage createIcon(Image base, Image wreck, Camouflage camouflage,
             Entity entity, int secondaryPos) {
-        return createIcon(base, wreck, camouflage, entity, secondaryPos, false);
+        return createIcon(base, wreck, camouflage, entity, secondaryPos, false, true);
     }
 
     public static EntityImage createIcon(Image base, Image wreck, Camouflage camouflage,
-            Entity entity, int secondaryPos, boolean preview) {
+            Entity entity, int secondaryPos, boolean preview, boolean withShadows) {
         if (entity instanceof FighterSquadron) {
-            return new FighterSquadronIcon(base, wreck, camouflage, entity, secondaryPos, preview);
+            return new FighterSquadronIcon(base, wreck, camouflage, entity, secondaryPos, preview, withShadows);
         } else {
-            return new EntityImage(base, wreck, camouflage, entity, secondaryPos, preview);
+            return new EntityImage(base, wreck, camouflage, entity, secondaryPos, preview, withShadows);
         }
     }
 
     public EntityImage(Image base, Camouflage camouflage, Component comp, Entity entity) {
-        this(base, null, camouflage, entity, -1, true);
+        this(base, null, camouflage, entity, -1, true, true);
     }
 
     public EntityImage(Image base, Image wreck, Camouflage camouflage, Component comp,
             Entity entity, int secondaryPos) {
-        this(base, wreck, camouflage, entity, secondaryPos, false);
+        this(base, wreck, camouflage, entity, secondaryPos, false, true);
     }
 
     public EntityImage(Image base, Image wreck, Camouflage camouflage,
-            Entity entity, int secondaryPos, boolean preview) {
-        this(base, wreck, camouflage, null, entity, secondaryPos, preview);
+            Entity entity, int secondaryPos, boolean preview, boolean withShadows) {
+        this(base, wreck, camouflage, null, entity, secondaryPos, preview, withShadows);
     }
 
     public EntityImage(Image base, Image wreck, Camouflage camouflage, Component comp,
-            Entity entity, int secondaryPos, boolean preview) {
+            Entity entity, int secondaryPos, boolean preview, boolean withShadows) {
         this.base = base;
         setCamouflage(camouflage);
         this.wreck = wreck;
+        this.withShadows = withShadows;
         this.dmgLevel = calculateDamageLevel(entity);
         // hack: gun emplacements are pretty beefy but have weight 0
         this.weight = entity instanceof GunEmplacement ? SMOKE_THREE + 1 : entity.getWeight();
@@ -286,7 +292,7 @@ public class EntityImage {
 
             // Generate rotated images for the unit and for a wreck
             fImage = rotateImage(fImage, i);
-            if (GUIP.getShadowMap() && isSingleHex) {
+            if (GUIP.getShadowMap() && isSingleHex && withShadows) {
                 facings[i] = applyDropShadow(fImage);
             } else {
                 facings[i] = fImage;

--- a/megamek/src/megamek/client/ui/swing/tileset/FighterSquadronIcon.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/FighterSquadronIcon.java
@@ -107,8 +107,8 @@ public class FighterSquadronIcon extends EntityImage {
      */
     private final int positionHash;
 
-    public FighterSquadronIcon(Image base, Image wreck, Camouflage camouflage, Entity entity, int secondaryPos, boolean preview) {
-        super(base, wreck, camouflage, entity, secondaryPos, preview);
+    public FighterSquadronIcon(Image base, Image wreck, Camouflage camouflage, Entity entity, int secondaryPos, boolean preview, boolean withShadows) {
+        super(base, wreck, camouflage, entity, secondaryPos, preview, withShadows);
         if (entity instanceof FighterSquadron) {
             squadron = (FighterSquadron) entity;
         } else {

--- a/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/TilesetManager.java
@@ -540,8 +540,15 @@ public class TilesetManager implements IPreferenceChangeListener {
      * Loads a preview image of the unit into the BufferedPanel.
      */
     public Image loadPreviewImage(Entity entity, Camouflage camouflage) {
+        return loadPreviewImage(entity, camouflage, true);
+    }
+
+    /**
+     * Loads a preview image of the unit into the BufferedPanel.
+     */
+    public Image loadPreviewImage(Entity entity, Camouflage camouflage, boolean withShadows) {
         Image base = MMStaticDirectoryManager.getMekTileset().imageFor(entity);
-        EntityImage entityImage = EntityImage.createIcon(base, camouflage, entity);
+        EntityImage entityImage = EntityImage.createIcon(base, camouflage, entity, withShadows);
         entityImage.loadFacings();
         return entityImage.getFacing(entity.getFacing());
     }


### PR DESCRIPTION
fix: stop dropShadow from being calculated for force display tree renderer, reducing time spent alot on rendering