### PR TITLE
fix: fixes html tags showing on tooltips

### DIFF
--- a/megamek/src/megamek/client/ui/swing/util/UIUtil.java
+++ b/megamek/src/megamek/client/ui/swing/util/UIUtil.java
@@ -1113,7 +1113,7 @@ public final class UIUtil {
      * its width and adding HTML tags.
      */
     public static String formatSideTooltip(String text) {
-        return "<P WIDTH=" + scaleForGUI(TOOLTIP_WIDTH) + " style=padding:5>" + text;
+        return "<html><p width=" + scaleForGUI(TOOLTIP_WIDTH) + " style='padding:5'>" + text + "</html>";
     }
 
     /**


### PR DESCRIPTION
## Before

<img width="805" alt="Screenshot 2025-02-02 at 00 08 45" src="https://github.com/user-attachments/assets/68e73cc7-c0fe-4cbc-8b11-ee8b6a101757" />

## After

<img width="460" alt="Screenshot 2025-02-02 at 03 38 03" src="https://github.com/user-attachments/assets/5e7fe9d3-f4c1-4388-82d1-bffbddd8928b" />
