### PR TITLE
Update MASH equipment to use size values

### DIFF
--- a/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (2801).blk
+++ b/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (2801).blk
@@ -123,7 +123,7 @@ Medium Laser
 </Aft Equipment>
 
 <Hull Equipment>
-MASH Core Component
+MASH Equipment:SIZE:1
 </Hull Equipment>
 
 <structural_integrity>

--- a/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (3035)Dove.blk
+++ b/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (3035)Dove.blk
@@ -122,16 +122,7 @@ Medium Laser
 </Aft Equipment>
 
 <Hull Equipment>
-MASH Core Component
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
+MASH Equipment:SIZE:10
 </Hull Equipment>
 
 <structural_integrity>

--- a/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (3054).blk
+++ b/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (3054).blk
@@ -124,7 +124,7 @@ Medium Laser
 </Aft Equipment>
 
 <Hull Equipment>
-MASH Core Component
+MASH Equipment:SIZE:1
 </Hull Equipment>
 
 <structural_integrity>

--- a/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (3079).blk
+++ b/megamek/data/mekfiles/dropships/TRO3057R/IS/Condor (3079).blk
@@ -119,7 +119,7 @@ ISERMediumLaser
 </Aft Equipment>
 
 <Hull Equipment>
-MASH Core Component
+MASH Equipment:SIZE:1
 </Hull Equipment>
 
 <structural_integrity>

--- a/megamek/data/mekfiles/dropships/TRO3057R/IS/Seeker (2815M).blk
+++ b/megamek/data/mekfiles/dropships/TRO3057R/IS/Seeker (2815M).blk
@@ -115,7 +115,7 @@ Medium Laser
 </Aft Equipment>
 
 <Hull Equipment>
-MASH Core Component
+MASH Equipment:SIZE:1
 </Hull Equipment>
 
 <structural_integrity>

--- a/megamek/data/mekfiles/dropships/TRO3057R/IS/Seeker (3054).blk
+++ b/megamek/data/mekfiles/dropships/TRO3057R/IS/Seeker (3054).blk
@@ -118,7 +118,7 @@ Medium Laser
 </Aft Equipment>
 
 <Hull Equipment>
-MASH Core Component
+MASH Equipment:SIZE:1
 </Hull Equipment>
 
 <structural_integrity>

--- a/megamek/data/mekfiles/jumpships/3057R/IS/Magellan Jumpship (2960).blk
+++ b/megamek/data/mekfiles/jumpships/3057R/IS/Magellan Jumpship (2960).blk
@@ -143,7 +143,7 @@ ISAMS Ammo:24
 </Aft Right Side Equipment>
 
 <Hull Equipment>
-MASH Core Component
+MASH Equipment:SIZE:1
 ISMobileHPG
 </Hull Equipment>
 

--- a/megamek/data/mekfiles/vehicles/3039u/MASH Truck (ICE).blk
+++ b/megamek/data/mekfiles/vehicles/3039u/MASH Truck (ICE).blk
@@ -56,11 +56,7 @@ Wheeled
 </armor>
 
 <Body Equipment>
-MASH core component
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
+MASH Equipment:SIZE:5
 </Body Equipment>
 
 <Front Equipment>

--- a/megamek/data/mekfiles/vehicles/3039u/MASH Truck.blk
+++ b/megamek/data/mekfiles/vehicles/3039u/MASH Truck.blk
@@ -57,11 +57,7 @@ Wheeled
 </armor>
 
 <Body Equipment>
-MASH core component
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
-MASH Operation Theater
+MASH Equipment:SIZE:5
 </Body Equipment>
 
 <Front Equipment>

--- a/megamek/data/mekfiles/vehicles/3075/Saxon APC (MASH).blk
+++ b/megamek/data/mekfiles/vehicles/3075/Saxon APC (MASH).blk
@@ -61,8 +61,7 @@ Hover
 </armor>
 
 <Body Equipment>
-MASH core component
-MASH Operation Theater
+MASH Equipment:SIZE:2
 IS Ammo MG - Full
 </Body Equipment>
 

--- a/megamek/data/mekfiles/vehicles/XTRs/Primitives III/Carter MERV.blk
+++ b/megamek/data/mekfiles/vehicles/XTRs/Primitives III/Carter MERV.blk
@@ -64,10 +64,9 @@ cargobay:2.0:1:1
 </armor>
 
 <Body Equipment>
-MASH Operation Theater
+MASH Equipment:SIZE:2
 Paramedic Equipment
 ISOffRoadChassis
-MASH Core Component
 </Body Equipment>
 
 <Front Equipment>

--- a/megamek/data/mekfiles/vehicles/XTRs/RetroTech/White Tip Submarine.blk
+++ b/megamek/data/mekfiles/vehicles/XTRs/RetroTech/White Tip Submarine.blk
@@ -89,7 +89,7 @@ IS Ammo LRTorpedo-10
 IS Ammo LRTorpedo-10
 Communications Equipment (7 ton)
 FieldKitchen
-MASH Core Component
+MASH Equipment:SIZE:1
 </Body Equipment>
 
 <Front Equipment>


### PR DESCRIPTION
The old style core and theater equipment cannot be used and the units used to load incorrectly.