### PR TITLE
Cap splashscreen button width

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -261,6 +261,11 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         // the button width "look" reasonable.
         int maximumWidth = (int) (0.9 * scaledMonitorSize.width) - splash.getPreferredSize().width;
 
+        //no more than 50% of image width
+        if (maximumWidth > (int) (0.5 * splash.getPreferredSize().width)) {
+            maximumWidth = (int) (0.5 * splash.getPreferredSize().width);
+        }
+
         Dimension minButtonDim = new Dimension((int) (maximumWidth / 1.618), 25);
         if (textDim.getWidth() > minButtonDim.getWidth()) {
             minButtonDim = textDim;


### PR DESCRIPTION
On ultrawide monitors and some multi-monitor setups that respond poorly to our monitor-width detection, the startup splash could be extremely wide or spill onto other monitors. 

MM, MML, and MHQ all draw their startup splash in essentially the same way, but MML had a few lines that solved this problem that were missing from MM and MHQ, that I just copied over, see here:

https://github.com/MegaMek/megameklab/blob/76fec6f90878379bdf417ab14250961f5259e875/megameklab/src/megameklab/ui/StartupGUI.java#L156