### PR TITLE
MegaMekLab Issue 1662: Fixed issue with Mek exporting to text

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/mek.ftl
+++ b/megamek/resources/megamek/common/templates/tro/mek.ftl
@@ -29,7 +29,7 @@ ${formatBasicDataRow("Engine", engineName, engineMass)}
 	${qvType} Cruising MP: ${qvCruise}
 	${qvType} Flanking MP: ${qvFlank}
 </#if>
-${formatBasicDataRow(hsType, hsCount, hsMass)}<#if riscKit> w/ RISC Heat Sink Override Kit</#if>
+${formatBasicDataRow(hsType, hsCount, hsMass)}<#if riscKit??> w/ RISC Heat Sink Override Kit</#if>
 ${formatBasicDataRow(gyroType, "", gyroMass)}
 ${formatBasicDataRow(cockpitType, "", cockpitMass)}
 ${formatBasicDataRow("Armor Factor" + armorType, armorFactor, armorMass)}


### PR DESCRIPTION
Fixes MegaMek/MegaMekLab#1662 

`<#if riscKit>` was throwing an error when a null value for riscKit was provided. This lets it work properly if riscKit is null. 

This is handled the same way in `mek.ftlh`, line 39