### PR TITLE
fix: bounds check for unit editor dialog (MHQ #4985)

### DIFF
--- a/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/UnitEditorDialog.java
@@ -1565,7 +1565,7 @@ public class UnitEditorDialog extends JDialog {
             }
 
             if (current > 0) {
-                for (int i = 0; i < current; i++) {
+                for (int i = 0; i < current && i < checks.size(); i++) {
                     checks.get(i).setSelected(true);
                 }
             }


### PR DESCRIPTION
Fixes MHQ 4985 by bounds checking the array being accessed if the number of crits is somehow higher than the location can support.