### PR TITLE
Issue 6511: Prevent cast class exception when switching Princess's ammo.

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2881,8 +2881,14 @@ public class FireControl {
                 continue;
             }
 
-            // If everything looks okay, replace the old WAA with the updated copy
-            info.setAction(cloneWAA);
+            /* If everything looks okay, update the action with the new values
+            *  Don't replace the old action with the clone - the clone doesn't
+            *  consider that the waa might have been a subclass of WeaponAttackAction
+            *  - like ArtilleryAttackAction. So instead update the changed values: */
+            info.getAction().setAmmoId(cloneWAA.getAmmoId());
+            info.getAction().setAmmoMunitionType(cloneWAA.getAmmoMunitionType());
+            info.getAction().setAmmoCarrier(cloneWAA.getAmmoCarrier());
+
             owner.sendAmmoChange(info.getShooter().getId(), shooter.getEquipmentNum(currentWeapon),
                     shooter.getEquipmentNum(mountedAmmo), mountedAmmo.getSwitchedReason());
         }


### PR DESCRIPTION
Fixes #6511 

There is a subclass of `WeaponAttackAction`, `ArtilleryAttackAction`. In `FireControl::loadAmmo` the action's `WeaponAttackAction` is cloned and then replaced. However, it doesn't consider if the original weapon attack action was a subclass. 

To prevent this, I opted to update the vales of the original weapon attack action to be the updated values from the cloned action. 