### PR TITLE
MML #1487: unit selector redundant scrollpanes

### DIFF
--- a/megamek/src/megamek/client/ui/swing/MekViewPanel.java
+++ b/megamek/src/megamek/client/ui/swing/MekViewPanel.java
@@ -62,15 +62,17 @@ public class MekViewPanel extends JPanel {
     public static final int DEFAULT_HEIGHT = 600;
 
     public MekViewPanel() {
-        this(DEFAULT_WIDTH, DEFAULT_HEIGHT, true);
+        this(-1, -1, true);
     }
 
     public MekViewPanel(int width, int height, boolean noBorder) {
         Report.setupStylesheet(txtMek);
         txtMek.setEditable(false);
         txtMek.setBorder(new EmptyBorder(5, 10, 0, 0));
-        txtMek.setMinimumSize(new Dimension(width, height));
-        txtMek.setPreferredSize(new Dimension(width, height));
+        if (width != -1) {
+            txtMek.setMinimumSize(new Dimension(width, height));
+            txtMek.setPreferredSize(new Dimension(width, height));
+        }
         txtMek.addHyperlinkListener(e -> {
             if (HyperlinkEvent.EventType.ACTIVATED == e.getEventType()) {
                 UIUtil.browse(e.getURL().toString(), this);
@@ -85,13 +87,17 @@ public class MekViewPanel extends JPanel {
         scrMek.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
 
         var textPanel = new JPanel(new GridLayout(1, 1));
-        textPanel.setMinimumSize(new Dimension(width, height));
-        textPanel.setPreferredSize(new Dimension(width, height));
+        if (width != -1) {
+            textPanel.setMinimumSize(new Dimension(width, height));
+            textPanel.setPreferredSize(new Dimension(width, height));
+        }
         textPanel.add(scrMek);
 
         var fluffPanel = new FixedXPanel();
-        fluffPanel.setMinimumSize(new Dimension(width, height));
-        fluffPanel.setPreferredSize(new Dimension(width, height));
+        if (width != -1) {
+            fluffPanel.setMinimumSize(new Dimension(width, height));
+            fluffPanel.setPreferredSize(new Dimension(width, height));
+        }
         fluffPanel.add(lblMek);
 
         JPanel p = new JPanel();
@@ -99,9 +105,8 @@ public class MekViewPanel extends JPanel {
         p.add(textPanel);
         p.add(fluffPanel);
         p.add(Box.createHorizontalGlue());
-        JScrollPane sp = new JScrollPane(p);
         setLayout(new BorderLayout());
-        add(sp);
+        add(p);
         addMouseWheelListener(wheelForwarder);
     }
 

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -106,7 +106,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     protected Map<Integer, Integer> techLevelListToIndex = new HashMap<>();
     protected JComboBox<String> comboUnitType = new JComboBox<>();
     protected JComboBox<String> comboWeight = new JComboBox<>();
-    private JScrollPane techLevelScroll;
     private JPanel panelFilterButtons;
     protected JLabel labelImage = new JLabel(""); // inline to avoid potential null pointer issues
     protected JTable tableUnits;
@@ -213,7 +212,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         // region Unit Preview Pane
         panePreview = new EntityViewPane(frame, null);
         panePreview.setMinimumSize(new Dimension(0, 0));
-        panePreview.setPreferredSize(new Dimension(0, 0));
         // endregion Unit Preview Pane
 
         // region Selection Panel
@@ -258,15 +256,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         scrollTableUnits = new JScrollPane(tableUnits);
         scrollTableUnits.setName("scrollTableUnits");
 
-        gridBagConstraints.insets = new Insets(5, 0, 0, 0);
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 2;
-        gridBagConstraints.fill = GridBagConstraints.BOTH;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        gridBagConstraints.weightx = 1.0;
-        gridBagConstraints.weighty = 1.0;
-        selectionPanel.add(scrollTableUnits, gridBagConstraints);
-
         panelFilterButtons = new JPanel(new GridBagLayout());
 
         JLabel labelType = new JLabel(Messages.getString("MekSelectorDialog.m_labelType"));
@@ -277,10 +266,11 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         panelFilterButtons.add(labelType, gridBagConstraintsWest);
 
         listTechLevel.setToolTipText(Messages.getString("MekSelectorDialog.m_labelType.ToolTip"));
-        techLevelScroll = new JScrollPane(listTechLevel);
+        listTechLevel.setLayoutOrientation(JList.VERTICAL_WRAP);
+        listTechLevel.setVisibleRowCount(3);
         gridBagConstraintsWest.gridx = 1;
         gridBagConstraintsWest.gridy = 2;
-        panelFilterButtons.add(techLevelScroll, gridBagConstraintsWest);
+        panelFilterButtons.add(listTechLevel, gridBagConstraintsWest);
 
         JLabel labelWeight = new JLabel(Messages.getString("MekSelectorDialog.m_labelWeightClass"));
         labelWeight.setName("labelWeight");
@@ -437,15 +427,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         gridBagConstraints.weighty = 1.0;
         panelFilterButtons.add(labelImage, gridBagConstraints);
 
-        gridBagConstraints = new GridBagConstraints();
-        gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 0;
-        gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
-        gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        gridBagConstraints.weightx = 0.0;
-        gridBagConstraints.insets = new Insets(10, 10, 5, 0);
-        selectionPanel.add(panelFilterButtons, gridBagConstraints);
-
         JPanel panelSearchButtons = new JPanel(new GridBagLayout());
 
         buttonAdvancedSearch = new JButton(Messages.getString("MekSelectorDialog.AdvSearch"));
@@ -476,22 +457,24 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = 0;
-        gridBagConstraints.gridy = 1;
         gridBagConstraints.fill = GridBagConstraints.HORIZONTAL;
         gridBagConstraints.anchor = GridBagConstraints.NORTHWEST;
-        gridBagConstraints.weightx = 0.0;
+        gridBagConstraints.insets = new Insets(10, 10, 5, 0);
+        selectionPanel.add(panelFilterButtons, gridBagConstraints);
+
         gridBagConstraints.insets = new Insets(10, 10, 10, 0);
         selectionPanel.add(panelSearchButtons, gridBagConstraints);
-        // endregion Selection Panel
 
-        JScrollPane selectionScrollPane = new JScrollPane(selectionPanel);
-        JScrollPane previewScrollPane = new JScrollPane(panePreview);
+        gridBagConstraints.insets = new Insets(5, 0, 0, 0);
+        gridBagConstraints.fill = GridBagConstraints.BOTH;
+        gridBagConstraints.weightx = 1;
+        gridBagConstraints.weighty = 1;
+        selectionPanel.add(scrollTableUnits, gridBagConstraints);
 
         JPanel panelButtons = createButtonsPanel();
 
         splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, true,
-                selectionScrollPane, previewScrollPane);
-        splitPane.setResizeWeight(0);
+            selectionPanel, panePreview);
         gridBagConstraints = new GridBagConstraints();
         gridBagConstraints.gridx = gridBagConstraints.gridy = 0;
         gridBagConstraints.fill = GridBagConstraints.BOTH;


### PR DESCRIPTION
I think this fixes MegaMek/megameklab#1487
- removes a few redundant scrollpanes from the unit selector and unit preview. The left side of the unit selector no longer gets a scrollpane outside the unit table; it doesn't require much space as the unit table is flexible. The unit preview no longer gets dual scrollpanes
- the tech level list (called "Group") was misbehaving by becoming pixel-sized when the unit selector was made smaller than some unreasonable threshold so I removed the scrollpane on it and made it multi-column instead, see screenshot
- also, some setXXXSize methods are now only called when a specific size is given. This is used in MHQ in the personnel market so I kept it; but these methods should be avoided when possible, overriding getPreferredSize instead. 

![image](https://github.com/user-attachments/assets/72113f13-2637-4828-a14b-b5c813d8c8c4)
