### PR TITLE
Force generator update - individual equipment availability values

### DIFF
--- a/megamek/docs/RAT and Force Generator Stuff/rat-generator.txt
+++ b/megamek/docs/RAT and Force Generator Stuff/rat-generator.txt
@@ -172,7 +172,12 @@ This is required to distinguish between different unit types that have the same 
 
 'omni' attribute: can be either 'Clan' or 'IS'. For non-omnis it is absent. Needed to distinguish between omni and fixed-configuration variants, since omnis taken as salvage/isorla use the operating faction to determine which configuration is used. Clan and IS must be stated to distinguish between the Clan Battle Cobra and the ComStar copy.
 
-'availability' node: a comma-separated list of availability codes for the current year. The format is FKEY:AV[+|-][:YEAR], in which FKEY is the faction key, AV is the rating from 1-10, + or - (optional) adjusts av based on rating, and :YEAR optionally provides an introduction year for the faction. If given, the designated unit will not appear in the year range before the one given. This is used frequently for the reformation of the Free Worlds League. Units that were in use by one or more of the former Free Worlds states but not available to the former FWL independents have FWL:(av rating):3139 in 3135.xml, which prevents them from showing up for FWL during 3135-3138. A value of zero is a special case which indicates unavailable even if available to a parent faction. Sometimes a unit may be available to all IS factions except X, for example, and it is easier to add "IS:6,X:0" than to list all IS factions.
+'availability' node: a comma-separated list of availability codes for the current year. The format is FKEY[!RATING]:AV[+|-][:YEAR], in which
+    FKEY is the faction key
+	!RATING is the optional specific equipment rating, typically A through F but depends on faction and factions.xml.  Multiples may be used e.g. FS!A:8!B:7!C:2.  Any rating not provided is considered to be 0 (unavailable).  Not compatible with +/- adjustment or :YEAR modifiers.
+	AV is the rating from 1-10, + or - (optional) adjusts av based on rating
+	:YEAR optionally provides an introduction year for the faction. If given, the designated unit will not appear in the year range before the one given. This is used frequently for the reformation of the Free Worlds League. Units that were in use by one or more of the former Free Worlds states but not available to the former FWL independents have FWL:(av rating):3139 in 3131.xml, which prevents them from showing up for FWL during 3135-3138.
+	A value of zero is a special case which indicates unavailable even if available to a parent faction. Sometimes a unit may be available to all IS factions except X, for example, and it is easier to add "IS:6,X:0" than to list all IS factions.
 
 'model' node: There is one model node for each variant in use during the year range.
 

--- a/megamek/src/megamek/client/ratgenerator/AbstractUnitRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/AbstractUnitRecord.java
@@ -52,7 +52,13 @@ public class AbstractUnitRecord {
      * @return The adjusted availability rating.
      */
     public int calcAvailability(AvailabilityRating avRating, int equipRating, int ratingLevels, int year) {
-        int retVal = avRating.adjustForRating(equipRating, ratingLevels);
+
+        int retVal;
+        if (!avRating.hasMultipleRatings()) {
+            retVal = avRating.adjustForRating(equipRating, ratingLevels);
+        } else {
+            retVal = avRating.getAvailability(equipRating);
+        }
 
         // Pre-production prototypes are heavily reduced
         if (year == introYear - 1) {

--- a/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
+++ b/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
@@ -15,13 +15,13 @@
 */
 package megamek.client.ratgenerator;
 
-import megamek.codeUtilities.StringUtility;
 import megamek.logging.MMLogger;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 /**
  * Handles availability rating values and calculations for RAT generator.
@@ -319,20 +319,27 @@ public class AvailabilityRating {
     }
 
     public String getFactionCode() {
-        String retVal = faction;
-        if (!StringUtility.isNullOrBlank(ratings)) {
-            retVal += "!" + ratings;
-        }
-        return retVal;
+        return faction;
     }
 
+    /**
+     * Get the string equivalent of the ratings values. Multiple ratings
+     * requires compiling them back into a !RATING:VALUE!RATING:VALUE format
+     * @return string with properly formatted availability values, without
+     * the leading faction code
+     */
     public String getAvailabilityCode() {
-        if (ratingAdjustment == 0) {
-            return Integer.toString(availability);
-        } else if (ratingAdjustment < 0) {
-            return availability + "-";
+        if (!hasMultipleRatings()) {
+            if (ratingAdjustment == 0) {
+                return Integer.toString(availability);
+            } else if (ratingAdjustment < 0) {
+                return availability + "-";
+            } else {
+                return availability + "+";
+            }
         } else {
-            return availability + "+";
+            Collection<String> equipRatings = ratingByLevel.keySet();
+            return equipRatings.stream().map(curLevel -> '!' + curLevel + ':' + ratingByLevel.get(curLevel)).collect(Collectors.joining());
         }
     }
 

--- a/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
+++ b/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
@@ -186,7 +186,7 @@ public class AvailabilityRating {
     /**
      * Returns the availability value, using the provided equipment value if
      * multiple levels are present or the raw value if not
-     * @param equipmentLevel
+     * @param equipmentLevel  name of equipment level, typically one of A/B/C/D/F
      * @return
      */
     public int getAvailability(String equipmentLevel) {
@@ -194,6 +194,21 @@ public class AvailabilityRating {
             return getAvailability();
         } else {
             return ratingByLevel.getOrDefault(equipmentLevel, 0);
+        }
+    }
+
+    /**
+     * Returns the availability value, using the provided equipment level if
+     * multiple levels are present or the raw value if not
+     * @param equipmentLevelIndex index number of equipment level, typically
+     *                            0 (F), 1 (D), 2 (C), 3 (B), 4 (A)
+     * @return
+     */
+    public int getAvailability(int equipmentLevelIndex) {
+        if (!hasMultipleRatings() || equipmentLevelIndex < 0) {
+            return getAvailability();
+        } else {
+            return ratingByNumericLevel.getOrDefault(equipmentLevelIndex, 0);
         }
     }
 

--- a/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
+++ b/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
@@ -138,9 +138,6 @@ public class AvailabilityRating {
         } else {
 
             fields = code.split("!");
-            // FIXME: See if this property can be removed entirely
-//            String[] subfields = fields[0].split("!");
-//            ratings = subfields[1];
             faction = fields[0];
             String[] subfields;
             int avRating;
@@ -184,10 +181,10 @@ public class AvailabilityRating {
     }
 
     /**
-     * Returns the availability value, using the provided equipment value if
+     * Returns the availability value, using the provided equipment rating if
      * multiple levels are present or the raw value if not
      * @param equipmentLevel  name of equipment level, typically one of A/B/C/D/F
-     * @return
+     * @return  availability value for the specified equipment rating string
      */
     public int getAvailability(String equipmentLevel) {
         if (!hasMultipleRatings()) {
@@ -202,7 +199,7 @@ public class AvailabilityRating {
      * multiple levels are present or the raw value if not
      * @param equipmentLevelIndex index number of equipment level, typically
      *                            0 (F), 1 (D), 2 (C), 3 (B), 4 (A)
-     * @return
+     * @return   availability value for the specified equipment rating value
      */
     public int getAvailability(int equipmentLevelIndex) {
         if (!hasMultipleRatings() || equipmentLevelIndex < 0) {
@@ -349,11 +346,11 @@ public class AvailabilityRating {
             return getFactionCode() + ":" + getAvailabilityCode()
                     + ":" + startYear;
         }
-        return getFactionCode() + ":" + getAvailabilityCode();
+        return getFactionCode() + (hasMultipleRatings() ? "" : ":") + getAvailabilityCode();
     }
 
     public AvailabilityRating makeCopy(String newFaction) {
-        return new AvailabilityRating(unitName, era, newFaction + ":" + getAvailabilityCode());
+        return new AvailabilityRating(unitName, era, newFaction + (hasMultipleRatings() ? "" : ":") + getAvailabilityCode());
     }
 
     public double getWeight() {

--- a/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
+++ b/megamek/src/megamek/client/ratgenerator/AvailabilityRating.java
@@ -1,7 +1,7 @@
 /*
 * MegaMek -
 * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
-* Copyright (C) 2018 The MegaMek Team
+* Copyright (C) 2025 The MegaMek Team
 *
 * This program is free software; you can redistribute it and/or modify it under
 * the terms of the GNU General Public License as published by the Free Software
@@ -21,21 +21,16 @@ import megamek.logging.MMLogger;
 /**
  * Handles availability rating values and calculations for RAT generator.
  * Availability is rated on a base-2 logarithmic scale from 0 (non-existent) to
- * 10 (ubiquitous),
- * with 6 being a typical value when the source material does not give an
- * indication of frequency.
+ * 10 (ubiquitous), with 6 being a typical value when the source material does
+ * not give an indication of frequency.
  * The availability rating is actually twice the exponent, which allows more
- * precision
- * while still storing values as integers (so it's really a base-(sqrt(2))
- * scale, but using
- * 2 as the base should theoretically be faster).
+ * precision while still storing values as integers (so it's really a
+ * base-(sqrt(2)) scale, but using 2 as the base should theoretically be faster).
  *
- * These values are stored separately for chassis and models; for example, there
- * is
- * one value to indicate the likelihood that a medium Mek is a Phoenix Hawk and
- * another
- * set of values to indicate the likelihood that a give Phoenix Hawk is a 1D or
- * 1K, etc.
+ * These values are stored separately for chassis and models; there is one
+ * value to indicate the likelihood that a medium Mek is a Phoenix Hawk and
+ * another set of values to indicate the likelihood that a give Phoenix Hawk
+ * is a 1D or 1K, etc.
  *
  * @author Neoancient
  */
@@ -57,22 +52,20 @@ public class AvailabilityRating {
      * @param unit The chassis or model key
      * @param era  The era that this availability code applies to.
      * @param code A string with the format FKEY[!RATING]:AV[+/-][:YEAR]
-     *             FKEY: the faction key
-     *             RATING: if supplied, will limit this record to units with the
+     *             <br>examples: FS:3+, DC!A:8:3051
+     *             <br>FKEY: the faction key
+     *             <br>!RATING: if supplied, will limit this record to units with the
      *             indicated equipment rating
-     *             AV: a value that indicates how common this unit is, from 0
+     *             <br>AV: a value that indicates how common this unit is, from 0
      *             (non-existent) to 10 (ubiquitous)
-     *             +: the indicated av rating applies to the highest equipment
-     *             rating for the faction
-     *             (usually A or Keshik) and decreases for each step the rating is
-     *             reduced.
-     *             -: as +, but applies to the lowest equipment rating (F or PGC)
-     *             and decreases
-     *             as rating increases.
-     *             YEAR: when the unit becomes available to the faction, if later
-     *             than the beginning of the era.
-     *             Any year before this within the era will be treated as having no
-     *             availability.
+     *             <br>+: the indicated av rating applies to the highest equipment
+     *             rating for the faction (usually A or Keshik) and decreases
+     *             for each step the rating is reduced.
+     *             <br>-: as +, but applies to the lowest equipment rating (F or PGC)
+     *             and decreases as rating increases.
+     *             <br>YEAR: when the unit becomes available to the faction, if later
+     *             than the beginning of the era. Any year before this within the era
+     *             will be treated as having no availability.
      */
     public AvailabilityRating(String unit, int era, String code) {
         unitName = unit;

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -1578,7 +1578,7 @@ public class RATGenerator {
                         ar.setRatingByNumericLevel(factions.get(ar.getFaction()));
                     }
 
-                    cr.getIncludedFactions().add(code.split(":")[0]);
+                    cr.getIncludedFactions().add(ar.getFaction());
                     chassisIndex.get(era).get(chassisKey).put(ar.getFactionCode(), ar);
 
                 }
@@ -1631,7 +1631,7 @@ public class RATGenerator {
                         ar.setRatingByNumericLevel(factions.get(ar.getFaction()));
                     }
 
-                    mr.getIncludedFactions().add(code.split(":")[0]);
+                    mr.getIncludedFactions().add(ar.getFaction());
                     modelIndex.get(era).get(mr.getKey()).put(ar.getFactionCode(), ar);
 
                 }

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -1568,10 +1568,19 @@ public class RATGenerator {
             if (wn2.getNodeName().equalsIgnoreCase("availability")) {
                 chassisIndex.get(era).put(chassisKey, new HashMap<>());
                 String[] codes = wn2.getTextContent().trim().split(",");
+                // Create a separate availability rating for each provided faction
                 for (String code : codes) {
+
                     AvailabilityRating ar = new AvailabilityRating(chassisKey, era, code);
+                    // If it provides availability values based on equipment ratings,
+                    // generate index values in addition to letter values
+                    if (ar.hasMultipleRatings()) {
+                        ar.setRatingByNumericLevel(factions.get(ar.getFaction()));
+                    }
+
                     cr.getIncludedFactions().add(code.split(":")[0]);
                     chassisIndex.get(era).get(chassisKey).put(ar.getFactionCode(), ar);
+
                 }
             } else if (wn2.getNodeName().equalsIgnoreCase("model")) {
                 parseModelNode(era, cr, wn2);
@@ -1612,10 +1621,19 @@ public class RATGenerator {
             } else if (wn2.getNodeName().equalsIgnoreCase("availability")) {
                 modelIndex.get(era).put(mr.getKey(), new HashMap<>());
                 String[] codes = wn2.getTextContent().trim().split(",");
+                // Create a separate availability rating for each provided faction
                 for (String code : codes) {
+
                     AvailabilityRating ar = new AvailabilityRating(mr.getKey(), era, code);
+                    // If it provides availability values based on equipment ratings,
+                    // generate index values in addition to letter values
+                    if (ar.hasMultipleRatings()) {
+                        ar.setRatingByNumericLevel(factions.get(ar.getFaction()));
+                    }
+
                     mr.getIncludedFactions().add(code.split(":")[0]);
                     modelIndex.get(era).get(mr.getKey()).put(ar.getFactionCode(), ar);
+
                 }
             }
         }


### PR DESCRIPTION
The method of providing availability values covers most situations but has problems with a couple of edge cases.  When a chassis or model requires high availability but should be limited to one or two equipment levels there is no way of handling this.  For example, a MilitiaMek that is widely available in low-rated garrison forces needs a high availability value but that will spill into other equipment ratings e.g. FS:8- is effectively F 8, D 7, C 6, B 5, and A 4.  Which means it will be showing up in A-rated forces, which is not desired.  Keeping it out of A-rated forces means using a lower than desired availability value.

This fleshes out and extends some original code in reading the availability values.  There is a new formatting option of using "!" to identify specific equipment levels.  For example, FS!F:8!D:5 will make the availability value 8 for F-rated generation, 5 for D-rated, and 0 (not available) for the ones that are not included.

Also updates the TXT documentation to cover the new additional formatting option.