### PR TITLE
feat: uses median of the 5 closest enemies for facing mod

### DIFF
--- a/megamek/unittests/megamek/common/CoordsTest.java
+++ b/megamek/unittests/megamek/common/CoordsTest.java
@@ -68,6 +68,23 @@ class CoordsTest {
     }
 
     @Test
+    void testMedian() {
+        var c1 = new Coords(19, 9);
+        var c2 = new Coords(24, 9);
+        var c3 = new Coords(19, 12);
+        var c4 = new Coords(10, 10);
+        var c5 = new Coords(8, 10);
+        var teamBlue = List.of(c1, c2, c3, c4, c5);
+
+        var a1 = new Coords(12, 11);
+
+        var closestEnemy = a1.closestCoords(teamBlue);
+        var medianPosition = Coords.median(teamBlue);
+        assertEquals(c4, closestEnemy);
+        assertEquals(new Coords(18, 9), medianPosition);
+    }
+
+    @Test
     void testDistance() {
         assertEquals(new Coords(13, 6).distance(new Coords(15, 1)), 6);
         assertEquals(new Coords(12, 2).distance(new Coords(9, 2)), 3);


### PR DESCRIPTION
# What it does?

The `Better Facing Mod` uses the median of the 5 closest enemies as the center position to face towards. The number 5 is completely arbitrary, but I think it is a good compromise betwen "sheer numbers" and emergency.

The new algorithm added is very direct:

- It sort enemies for the distance away from the unit.
- Units that have not moved are considered as if they were going to move directly towards the unit.
- The top 5 closest units are chosen.
- The median of the current position of the units is picked up as the target to face towards.
- The final facing is decided also basing upon which side of the entity has more armor left. It is using a very simple calculation which should be further improved in the future to consider things like exposed internals, XL engines, sides containing ammo bins. It is also missing other types of vehicles, as only Meks are considered in this bias for facing left or right side.

The result we can see in this image, im yellow we have the warhammer looking towards the Wraith, its closest enemy. In Green we have the median position of the 5 enemies closest to the Warhammer, with the new algorithm, the Warhammer would be facing towards that point instead.


<img width="1382" alt="Screenshot 2025-02-08 at 22 49 49" src="https://github.com/user-attachments/assets/f5334721-e185-4765-b286-01fed85f2e60" />
