### PR TITLE
Fix 5429 and 6493 Arrow IV issues

### DIFF
--- a/megamek/i18n/megamek/common/messages.properties
+++ b/megamek/i18n/megamek/common/messages.properties
@@ -610,8 +610,10 @@ BeastSize.monstrous=Monstrous
 ArtilleryMessage.drifted=Artillery drifted here from
 BombMessage.drifted=Bomb drifted here from
 
+### Weapon Handlers
+ArtilleryIndirectHomingHandler.HomingArtyMissChance=Homing shot locked on! (can miss on 3 or less)
 
-
+### ACAR
 acar.invalid_attack=Invalid attack
 acar.invalid_skill=Invalid skill
 acar.skill=Skill

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -366,7 +366,7 @@
 3198=<<span class='miss'><B>misses</B></span> and is rendered ineffective by scatter.
 3199=<data> rounds <span class='success'><B>hit</B></span> the intended hex <data> with <data>.
 3200=<<span class='miss'><B>misses</B></span> and scatters off the board.
-3201=<data> homing rounds arrive at the intended hex.
+3201=<span class='miss'><B>misses</B></span> Terminal guidance failed!  Missed target but hit hex.
 3202=<data> round <<span class='miss'><B>misses</B></span> and scatters to hex <data>.
 3205=<data> (<data>) now on fire for <data> turns.
 3210=<newline>In hex <data>:

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -23,11 +23,13 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.*;
 
+import megamek.client.ui.Messages;
 import megamek.common.*;
 import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.AmmoType.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.GamePhase;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.BombMounted;
 import megamek.common.equipment.WeaponMounted;
@@ -576,6 +578,57 @@ public class WeaponFireInfo {
     }
 
     /**
+     * For some ToHitData results, add additional modifiers that may impact the actual
+     * probability of hitting with this weapon.
+     * Prime example: Homing artillery, which requires a friendly TAG-equipped unit be able to hit the
+     *                target at the appropriate time.
+     * @param realToHitData
+     * @return
+     */
+    ToHitData postProcessToHit(ToHitData realToHitData) {
+        boolean isHoming = preferredAmmo != null && preferredAmmo.isHomingAmmoInHomingMode();
+        if (isHoming) {
+            String msg = realToHitData.getCumulativePlainDesc();
+            ToHitData thd;
+            if (game.getPhase() != GamePhase.FIRING) {
+                // Check if any spotters can help us out...
+                Entity te = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target : null;
+                Entity spotter = Compute.findTAGSpotter(game, shooter, target, false);
+                if (spotter != null) {
+                    // Chance of getting a TAG spot is, at base, the spotter's gunnery skill
+                    thd = new ToHitData(spotter.getCrew().getGunnery(), msg);
+                    // Likelihood of hitting goes up as speed goes down...
+                    if (null != te) {
+                        thd.append(
+                            Compute.getTargetMovementModifier(
+                                te.getRunMP(),
+                                false,
+                                false,
+                                game));
+                    }
+                    // Replace the 4+ THD with an approximation of our TAG chances.
+                    return thd;
+                } else {
+                    // No chance to TAG means no chance to hit.
+                    return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
+                }
+            } else {
+                // Firing direct Homing shot
+                if (Compute.isTargetTagged(target, game)) {
+                    // If the target is already TAGged, it's just the original check.
+                    return realToHitData;
+                } else {
+                    // No more chances to TAG if we're in the Firing phase, so no chance
+                    // for Homing shot to hit either.
+                    return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
+                }
+            }
+        }
+
+        return realToHitData;
+    }
+
+    /**
      * Generalized computation of hitting with TAG given current guidable muniitions
      * in play
      *
@@ -709,7 +762,7 @@ public class WeaponFireInfo {
         getWeaponAttackAction().setAmmoId(shooter.getEquipmentNum(this.getAmmo()));
 
         if (!guess) {
-            setToHit(calcRealToHit(getWeaponAttackAction()));
+            setToHit(postProcessToHit(calcRealToHit(getWeaponAttackAction())));
         } else if (null != shooterPath) {
             setToHit(calcToHit(shooterPath, assumeUnderFlightPath));
         } else {

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -351,7 +351,7 @@ public class BombType extends AmmoType {
         BombType bomb = new BombType();
 
         bomb.name = "Arrow IV Homing Missile (Air-Launched Version)";
-        bomb.shortName = "Arrow IV Homing (Air-Launch)";
+        bomb.shortName = "Arrow IV Homing Air";
         bomb.setInternalName(BombType.getBombInternalName(BombType.B_HOMING));
         bomb.addLookupName("IS " + BombType.getBombInternalName(BombType.B_HOMING));
         bomb.addLookupName("Clan " + BombType.getBombInternalName(BombType.B_HOMING));
@@ -389,7 +389,7 @@ public class BombType extends AmmoType {
         BombType bomb = new BombType();
 
         bomb.name = "Arrow IV Non-Homing Missile (Air-Launched Version)";
-        bomb.shortName = "Arrow IV (Air-Launched Version)";
+        bomb.shortName = "Arrow IV Air";
         bomb.setInternalName(BombType.getBombInternalName(BombType.B_ARROW));
         bomb.addLookupName("IS " + BombType.getBombInternalName(BombType.B_ARROW));
         bomb.addLookupName("Clan " + BombType.getBombInternalName(BombType.B_ARROW));

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -29,7 +29,7 @@ import java.util.Vector;
 public class ArtilleryAttackAction extends WeaponAttackAction implements Serializable {
     private static final long serialVersionUID = -3893844894076028005L;
     private int turnsTilHit;
-    private Vector<Integer> spotterIds; // IDs of possible spotters, won't know
+    private Vector<Integer> spotterIds = new Vector<>(); // IDs of possible spotters, won't know
     // until it lands.
     protected int playerId;
     private Coords firingCoords;

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -1466,7 +1466,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // Airborne units cannot tag and attack
         // http://bg.battletech.com/forums/index.php?topic=17613.new;topicseen#new
-        if (ae.isAirborne() && ae.usedTag()) {
+        // Rules seem to allow multiple TAG attempts but not TAG + any other attacks
+        if (ae.isAirborne() && !isTAG && ae.usedTag()) {
             return Messages.getString("WeaponAttackAction.AeroCantTAGAndShoot");
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -20,6 +20,7 @@ import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.common.*;
 import megamek.common.enums.AimingMode;
+import megamek.common.enums.GamePhase;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
@@ -5393,21 +5394,26 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if (isHoming) {
             srt.setSpecialResolution(true);
             String msg = Messages.getString("WeaponAttackAction.HomingArty");
-            // Check if any spotters can help us out...
-            if (Compute.findTAGSpotter(game, ae, target, true) != null) {
-                // Likelihood of hitting goes up as speed goes down...
-                ToHitData thd = new ToHitData(4, msg);
-                if (null != te) {
-                    thd.append(
+            if (game.getPhase() != GamePhase.FIRING) {
+                // This check is for bot planning _only_; consider removing to bot hit calc code.
+                // Check if any spotters can help us out...
+                if (Compute.findTAGSpotter(game, ae, target, true) != null) {
+                    // Likelihood of hitting goes up as speed goes down...
+                    ToHitData thd = new ToHitData(4, msg);
+                    if (null != te) {
+                        thd.append(
                             Compute.getTargetMovementModifier(
-                                    te.getRunMP(),
-                                    false,
-                                    false,
-                                    game));
+                                te.getRunMP(),
+                                false,
+                                false,
+                                game));
+                    }
+                    return thd;
+                } else {
+                    return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
                 }
-                return thd;
             } else {
-                return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
+                return new ToHitData(4, msg);
             }
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5388,33 +5388,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
             te = (Entity) target;
         }
 
-        // Homing warheads just need a flat 4 to seek out a successful TAG, but Princess
-        // needs help
-        // judging what a good homing target is.
+        // Homing warheads just need a flat 4 to seek out a successful TAG
         if (isHoming) {
             srt.setSpecialResolution(true);
             String msg = Messages.getString("WeaponAttackAction.HomingArty");
-            if (game.getPhase() != GamePhase.FIRING) {
-                // This check is for bot planning _only_; consider removing to bot hit calc code.
-                // Check if any spotters can help us out...
-                if (Compute.findTAGSpotter(game, ae, target, true) != null) {
-                    // Likelihood of hitting goes up as speed goes down...
-                    ToHitData thd = new ToHitData(4, msg);
-                    if (null != te) {
-                        thd.append(
-                            Compute.getTargetMovementModifier(
-                                te.getRunMP(),
-                                false,
-                                false,
-                                game));
-                    }
-                    return thd;
-                } else {
-                    return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
-                }
-            } else {
-                return new ToHitData(4, msg);
-            }
+            return new ToHitData(4, msg);
         }
 
         // Don't bother adding up modifiers if the target hex has been hit before

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -447,15 +447,14 @@ public class AreaEffectHelper {
             }
         }
 
-        // convention infantry take x2 damage from AE weapons
-        if (entity.isConventionalInfantry()) {
+        // Conventional infantry take x2 in the open and
+        // an additional x2 damage from AE weapons in general but
+        // this is handled in main damageEntity() function now.
+        if (entity.isConventionalInfantry() && isFuelAirBomb) {
+            // if it's fuel-air, we take more damage!
             hits *= 2;
-
-            // if it's fuel-air, we take even more damage!
-            if (isFuelAirBomb) {
-                hits *= 2;
-            }
         }
+
         boolean specialCaseFlechette = false;
 
         // Entity/ammo specific damage modifiers

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -201,6 +201,12 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         int hits = handleAMS(vPhaseReport);
 
         if (bMissed && !missReported) {
+            // Notify player of last-second miss that hits the hex instead
+            r = new Report(3201);
+            r.subject = ae.getId();
+            r.newlines = 0;
+            vPhaseReport.addElement(r);
+
             reportMiss(vPhaseReport);
 
             // Works out fire setting, AMS shots, and whether continuation is
@@ -293,11 +299,6 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
                 if (!bMissed && (entity == entityTarget)) {
                     continue; // don't splash the original target unless it's a miss
                 }
-            //public static void artilleryDamageEntity(
-                //        Entity entity, int damage, Building bldg, int bldgAbsorbs,
-            //            boolean variableDamage, boolean asfFlak, boolean flak, int altitude,
-            //            Coords attackSource, AmmoType ammo, Coords coords, boolean isFuelAirBomb,
-            //            Entity killer, Hex hex, int subjectId, Vector<Report> vPhaseReport, TWGameManager gameManager)
 
                 AreaEffectHelper.artilleryDamageEntity(
                     entity, ratedDamage, bldg, bldgAbsorbs,
@@ -392,7 +393,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             target = newTarget;
             aaa.setTargetId(target.getId());
             aaa.setTargetType(target.getTargetType());
-            toHit = new ToHitData(4,Messages.getString("WeaponAttackAction.HomingArtyMissChance"));
+            toHit = new ToHitData(4,Messages.getString("ArtilleryIndirectHomingHandler.HomingArtyMissChance"));
         } else {
             // The player gets to select the target
             List<Integer> targetIds = new ArrayList<>();
@@ -406,7 +407,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             target = newTarget;
             aaa.setTargetId(target.getId());
             aaa.setTargetType(target.getTargetType());
-            toHit = new ToHitData(4,Messages.getString("WeaponAttackAction.HomingArtyMissChance"));
+            toHit = new ToHitData(4,Messages.getString("ArtilleryIndirectHomingHandler.HomingArtyMissChance"));
         }
     }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -188,7 +188,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         AmmoType ammoType = (AmmoType) ammo.getType();
 
         // copperhead gets 10 damage less than standard
-        if (ammoType.getAmmoType() != AmmoType.T_ARROW_IV || ammoType.getAmmoType() != AmmoType.T_ARROW_IV_BOMB) {
+        if (!(ammoType.getAmmoType() == AmmoType.T_ARROW_IV || ammoType.getAmmoType() == AmmoType.T_ARROW_IV_BOMB)) {
             nDamPerHit -= 10;
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -188,7 +188,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         AmmoType ammoType = (AmmoType) ammo.getType();
 
         // copperhead gets 10 damage less than standard
-        if (ammoType.getAmmoType() != AmmoType.T_ARROW_IV) {
+        if (ammoType.getAmmoType() != AmmoType.T_ARROW_IV || ammoType.getAmmoType() != AmmoType.T_ARROW_IV_BOMB) {
             nDamPerHit -= 10;
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -392,6 +392,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             target = newTarget;
             aaa.setTargetId(target.getId());
             aaa.setTargetType(target.getTargetType());
+            toHit = new ToHitData(4,Messages.getString("WeaponAttackAction.HomingArtyMissChance"));
         } else {
             // The player gets to select the target
             List<Integer> targetIds = new ArrayList<>();
@@ -405,6 +406,7 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             target = newTarget;
             aaa.setTargetId(target.getId());
             aaa.setTargetType(target.getTargetType());
+            toHit = new ToHitData(4,Messages.getString("WeaponAttackAction.HomingArtyMissChance"));
         }
     }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -293,10 +293,17 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
                 if (!bMissed && (entity == entityTarget)) {
                     continue; // don't splash the original target unless it's a miss
                 }
+            //public static void artilleryDamageEntity(
+                //        Entity entity, int damage, Building bldg, int bldgAbsorbs,
+            //            boolean variableDamage, boolean asfFlak, boolean flak, int altitude,
+            //            Coords attackSource, AmmoType ammo, Coords coords, boolean isFuelAirBomb,
+            //            Entity killer, Hex hex, int subjectId, Vector<Report> vPhaseReport, TWGameManager gameManager)
 
-                AreaEffectHelper.artilleryDamageEntity(entity, ratedDamage, bldg, bldgAbsorbs,
-                        targetInBuilding, bldgDamagedOnMiss, missReported, ratedDamage, coords, ammoType,
-                        coords, targetingHex, entityTarget, hex, hexDamage, vPhaseReport, gameManager);
+                AreaEffectHelper.artilleryDamageEntity(
+                    entity, ratedDamage, bldg, bldgAbsorbs,
+                    false, false, false, 0,
+                    coords, ammoType, coords, false,
+                    ae, hex, ae.getId(), vPhaseReport, gameManager);
             }
         }
         Report.addNewline(vPhaseReport);

--- a/megamek/src/megamek/common/weapons/bombs/BombArrowIV.java
+++ b/megamek/src/megamek/common/weapons/bombs/BombArrowIV.java
@@ -26,7 +26,7 @@ public class BombArrowIV extends ArtilleryWeapon {
 
     public BombArrowIV() {
         super();
-        this.name = "Arrow IV Non-Homing Missile (Air-Launched Version)";
+        this.name = "Arrow IV Bomb Mount";
         this.setInternalName(BombType.getBombWeaponName(BombType.B_ARROW));
         this.heat = 0;
         this.rackSize = 20;

--- a/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
@@ -5,10 +5,11 @@ import megamek.common.*;
 import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.enums.GamePhase;
-import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import megamek.logging.MMLogger;
 import megamek.server.Server;
 import megamek.server.totalwarfare.TWGameManager;
 import org.junit.jupiter.api.BeforeAll;
@@ -37,6 +38,7 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
     private Server server;
     private Random random = new Random();
     static WeaponType tagType = (WeaponType) EquipmentType.get("IS TAG");
+    private static final MMLogger logger = MMLogger.create(ArtilleryWeaponIndirectHomingHandlerTest.class);
 
     @BeforeAll
     static void beforeAll() {
@@ -99,6 +101,8 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
         game.addEntity(mockMek);
         mockMek.setOwner(owner);
 
+        mockMek.setDeployed(true);
+
         return mockMek;
     }
 
@@ -122,9 +126,23 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
         mockCrew.setOptions(pOpt);
         mockInfantry.setCrew(mockCrew);
 
+        mockInfantry.setSquadSize(7);
+        mockInfantry.setSquadCount(4);
+        mockInfantry.autoSetInternal();
+        try {
+            mockInfantry.addEquipment(EquipmentType.get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE),
+                Infantry.LOC_INFANTRY);
+            mockInfantry.setPrimaryWeapon((InfantryWeapon) InfantryWeapon
+                .get(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE));
+        } catch (LocationFullException ex) {
+            // do nothing
+        }
+
         mockInfantry.setId(game.getNextEntityId());
         game.addEntity(mockInfantry);
         mockInfantry.setOwner(owner);
+
+        mockInfantry.setDeployed(true);
 
         return mockInfantry;
     }
@@ -153,6 +171,8 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
 
         mockAeroSpaceFighter.setId(game.getNextEntityId());
         game.addEntity(mockAeroSpaceFighter);
+
+        mockAeroSpaceFighter.setDeployed(true);
 
         return mockAeroSpaceFighter;
     }
@@ -220,18 +240,23 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
      * and the homing attack conversion / handling.
      */
     @Test
-    void handleArrowIVHomingBombTargetMekNoTAG() throws LocationFullException {
+    void handleArrowIVHomingBombTargetMekWithTAG() throws LocationFullException {
         // Create and load entities
         AeroSpaceFighter attacker = createASF("ATT-10", "Buzzsaw", "Alyce", aPlayer);
         loadBombOnASF(attacker, BombType.B_HOMING);
         Mek tagger = createMek("TAG-3R", "Taggity", "Taggart", aPlayer, 1, 1);
         Mounted<?> tagWeapon = tagger.addEquipment(tagType, Mek.LOC_CT);
         Mek defender = createMek("TGT-1A", "Targeto", "Bob", dPlayer);
+        Infantry crunchies = createInfantry("LittleGreen", "ArmyMen", "Elgato", dPlayer);
 
         // Set positions; critical for WAA
-        attacker.setPosition(new Coords(8,15));
-        tagger.setPosition(new Coords(1,1));
-        defender.setPosition(new Coords(8,1));
+        Coords attackerPosition = new Coords(8,15);
+        Coords taggerPosition = new Coords(1,1);
+        Coords defenderPosition = new Coords(8,1);
+        attacker.setPosition(attackerPosition);
+        tagger.setPosition(taggerPosition);
+        defender.setPosition(defenderPosition);
+        crunchies.setPosition(defenderPosition);
 
         // Create TAG WAA and handler
         WeaponAttackAction tagWAA = makeWAA(tagger, defender, tagWeapon);
@@ -253,18 +278,76 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
 
         // Now handle hit turn!
         game.setPhase(GamePhase.OFFBOARD);
+        // This should not signal any further attacks to be processed
         assertFalse(taggie.handle(game.getPhase(), reports));
-        // This should not
-        assertFalse(artie.handle(game.getPhase(), reports),
-            reports.stream()
-            .map(Report::text)
-            .collect(Collectors.joining(",\n"))
-        );
+        // This should not signal any further attacks to be processed
+        assertFalse(artie.handle(game.getPhase(), reports));
+
+        // Change phase and check that the target was destroyed.
         gameManager.changePhase(GamePhase.FIRING);
         assertTrue(defender.isDestroyed());
+        // Infantry shouldn't be fully destroyed, though!
+        assertFalse(crunchies.isDestroyed());
+
+        // for debugging purposes only.  Use debug mode, place breakpoint above,
+        // evaluate manually
+        reports.stream()
+            .map(Report::text)
+            .collect(Collectors.joining(",\n"));
 
     }
 
+    @Test
+    void handleArrowIVHomingBombTargetMekWithASFTAG() throws LocationFullException {
+        // Create and load entities
+        AeroSpaceFighter attacker = createASF("ATT-10", "Buzzsaw", "Alyce", aPlayer);
+        loadBombOnASF(attacker, BombType.B_HOMING);
+        AeroSpaceFighter tagger = createASF("TAGA-10", "Sky Eye", "MacTaggert", aPlayer);
+        loadBombOnASF(tagger, BombType.B_TAG);
+        Mek defender = createMek("TGT-1A", "Targeto", "Bob", dPlayer);
+
+        // Set positions; critical for WAA
+        Coords attackerPosition = new Coords(8,15);
+        Coords taggerPosition = new Coords(1,1);
+        Coords defenderPosition = new Coords(8,1);
+        attacker.setPosition(attackerPosition);
+        tagger.setPosition(taggerPosition);
+        defender.setPosition(defenderPosition);
+
+        // Create TAG WAA and handler
+        WeaponAttackAction tagWAA = makeWAA(tagger, defender, tagger.getWeapon(0));
+        TAGHandler taggie = new TAGHandler(makeTHD(2), tagWAA, game, gameManager);
+
+        // Create Artillery WAA and handler
+        ArtilleryAttackAction awaa = makeArtilleryWAA(attacker, defender, attacker.getWeapon(0));
+        ArtilleryWeaponIndirectHomingHandler artie = new ArtilleryWeaponIndirectHomingHandler(
+            makeAutoHitHomingTHD(), awaa, game, gameManager);
+
+        // Set game phase and run handler to simulate initial firing
+        game.setPhase(GamePhase.TARGETING);
+        Vector<Report> reports = new Vector<>();
+        assertTrue(artie.handle(game.getPhase(), reports));
+
+        // set phase to offboard to increment TurnsTilHit
+        game.setPhase(GamePhase.OFFBOARD);
+        assertTrue(artie.handle(game.getPhase(), reports));
+
+        // Now handle hit turn!
+        game.setPhase(GamePhase.OFFBOARD);
+        assertFalse(taggie.handle(game.getPhase(), reports));
+        assertFalse(artie.handle(game.getPhase(), reports));
+
+        // Change phase and check that the target was destroyed.
+        gameManager.changePhase(GamePhase.FIRING);
+        assertTrue(defender.isDestroyed());
+
+        // for debugging purposes only.  Use debug mode, place breakpoint above,
+        // evaluate manually
+        reports.stream()
+            .map(Report::text)
+            .collect(Collectors.joining(",\n"));
+
+    }
     @Test
     void convertHomingShotToEntityTarget() {
     }

--- a/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
@@ -349,11 +349,4 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
             .collect(Collectors.joining(",\n"));
 
     }
-    @Test
-    void convertHomingShotToEntityTarget() {
-    }
-
-    @Test
-    void handleSpecialMiss() {
-    }
 }

--- a/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
@@ -314,10 +314,6 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
         tagger.setPosition(taggerPosition);
         defender.setPosition(defenderPosition);
 
-        // Create TAG WAA and handler
-        WeaponAttackAction tagWAA = makeWAA(tagger, defender, tagger.getWeapon(0));
-        TAGHandler taggie = new TAGHandler(makeTHD(2), tagWAA, game, gameManager);
-
         // Create Artillery WAA and handler
         ArtilleryAttackAction awaa = makeArtilleryWAA(attacker, defender, attacker.getWeapon(0));
         ArtilleryWeaponIndirectHomingHandler artie = new ArtilleryWeaponIndirectHomingHandler(
@@ -334,6 +330,11 @@ class ArtilleryWeaponIndirectHomingHandlerTest {
 
         // Now handle hit turn!
         game.setPhase(GamePhase.OFFBOARD);
+
+        // Create TAG WAA and handler after Artillery shot (as a test)
+        WeaponAttackAction tagWAA = makeWAA(tagger, defender, tagger.getWeapon(0));
+        TAGHandler taggie = new TAGHandler(makeTHD(2), tagWAA, game, gameManager);
+
         assertFalse(taggie.handle(game.getPhase(), reports));
         assertFalse(artie.handle(game.getPhase(), reports));
 

--- a/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandlerTest.java
@@ -1,0 +1,275 @@
+package megamek.common.weapons;
+
+import megamek.client.ui.Messages;
+import megamek.common.*;
+import megamek.common.actions.ArtilleryAttackAction;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.enums.GamePhase;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.PilotOptions;
+import megamek.server.Server;
+import megamek.server.totalwarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Hashtable;
+import java.util.Random;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
+import static megamek.MMConstants.MAX_PORT;
+import static megamek.MMConstants.MIN_PORT;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ArtilleryWeaponIndirectHomingHandlerTest {
+    private Player aPlayer;
+    private Player dPlayer;
+    private TWGameManager gameManager;
+    private Game game;
+    private Server server;
+    private Random random = new Random();
+    static WeaponType tagType = (WeaponType) EquipmentType.get("IS TAG");
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // Players
+        aPlayer = new Player(0, "Attacker");
+        dPlayer = new Player(1, "Defender");
+        gameManager = new TWGameManager();
+
+        game = gameManager.getGame();
+        game.createVictoryConditions();
+        game.addPlayer(aPlayer.getId(), aPlayer);
+        game.addPlayer(dPlayer.getId(), dPlayer);
+
+        // GameOptions
+        GameOptions options = mock(GameOptions.class);
+        when(options.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_AMS)).thenReturn(false);
+        when(options.booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADV_POINTDEF)).thenReturn(false);
+        when(options.stringOption(OptionsConstants.ALLOWED_TECHLEVEL)).thenReturn("Experimental");
+        game.setOptions(options);
+
+        // Board
+        Board mockBoard = mock(Board.class);
+        Hex mockHex = mock(Hex.class);
+        when(mockHex.getLevel()).thenReturn(0);
+        when(mockHex.containsTerrain(anyInt())).thenReturn(false);
+        when(mockBoard.getHex(any(Coords.class))).thenReturn(mockHex);
+        when(mockBoard.getBuildings()).thenReturn(new Vector<Building>().elements());
+        when(mockBoard.getSpecialHexDisplayTable()).thenReturn(new Hashtable<>());
+        game.setBoard(mockBoard);
+
+        server = new Server(null, random.nextInt(MIN_PORT, MAX_PORT), gameManager, false, "", null, true);
+    }
+
+    Mek createMek(String chassis, String model, String crewName, Player owner) {
+        Mek unit = createMek(chassis, model, crewName, owner, 4, 5);
+        return unit;
+    }
+
+    Mek createMek(String chassis, String model, String crewName, Player owner, int gSkill, int pSkill) {
+        // Create a real Mek with some mocked fields
+        Mek mockMek = new BipedMek();
+        mockMek.setGame(game);
+        mockMek.setChassis(chassis);
+        mockMek.setModel(model);
+
+        Crew mockCrew = new Crew(CrewType.SINGLE);
+        mockCrew.setGunnery(gSkill);
+        mockCrew.setPiloting(pSkill);
+        PilotOptions pOpt = new PilotOptions();
+        mockCrew.setName(crewName, 0);
+        mockCrew.setOptions(pOpt);
+        mockMek.setCrew(mockCrew);
+
+        mockMek.setId(game.getNextEntityId());
+        game.addEntity(mockMek);
+        mockMek.setOwner(owner);
+
+        return mockMek;
+    }
+
+    Infantry createInfantry(String chassis, String model, String crewName, Player owner) {
+        Infantry unit = createInfantry(chassis, model, crewName, owner, 5, 8);
+        return unit;
+    }
+
+    Infantry createInfantry(String chassis, String model, String crewName, Player owner, int gSkill, int pSkill) {
+        // Create a real Infantry unit with some mocked fields
+        Infantry mockInfantry = new Infantry();
+        mockInfantry.setGame(game);
+        mockInfantry.setChassis(chassis);
+        mockInfantry.setModel(model);
+
+        Crew mockCrew = new Crew(CrewType.INFANTRY_CREW);
+        mockCrew.setGunnery(gSkill);
+        mockCrew.setPiloting(pSkill);
+        PilotOptions pOpt = new PilotOptions();
+        mockCrew.setName(crewName, 0);
+        mockCrew.setOptions(pOpt);
+        mockInfantry.setCrew(mockCrew);
+
+        mockInfantry.setId(game.getNextEntityId());
+        game.addEntity(mockInfantry);
+        mockInfantry.setOwner(owner);
+
+        return mockInfantry;
+    }
+
+    AeroSpaceFighter createASF(String chassis, String model, String crewName, Player owner) {
+        AeroSpaceFighter unit = createASF(chassis, model, crewName, owner, 3, 4);
+        unit.setOwner(owner);
+        return unit;
+    }
+
+    AeroSpaceFighter createASF(String chassis, String model, String crewName, Player owner, int gSkill, int pSkill) {
+        // Create a real AeroSpaceFighter unit with some mocked fields
+        AeroSpaceFighter mockAeroSpaceFighter = new AeroSpaceFighter();
+        mockAeroSpaceFighter.setGame(game);
+        mockAeroSpaceFighter.setChassis(chassis);
+        mockAeroSpaceFighter.setModel(model);
+
+        Crew mockCrew = new Crew(CrewType.SINGLE);
+        mockCrew.setGunnery(gSkill);
+        mockCrew.setPiloting(pSkill);
+        PilotOptions pOpt = new PilotOptions();
+        mockCrew.setName(crewName, 0);
+        mockCrew.setOptions(pOpt);
+        mockAeroSpaceFighter.setCrew(mockCrew);
+        mockAeroSpaceFighter.setOwner(owner);
+
+        mockAeroSpaceFighter.setId(game.getNextEntityId());
+        game.addEntity(mockAeroSpaceFighter);
+
+        return mockAeroSpaceFighter;
+    }
+
+    ToHitData makeTHD(int skill) {
+        return makeTHD(skill, "Gunnery Skill");
+    }
+
+    ToHitData makeTHD(int skill, String message) {
+        ToHitData thd = new ToHitData();
+        thd.addModifier(skill, message);
+        return thd;
+    }
+
+    ToHitData makeIndirectTHD(int skill) {
+        ToHitData iTHD = makeTHD(skill);
+        iTHD.addModifier(7, Messages.getString("WeaponAttackAction.IndirectArty"));
+        return iTHD;
+    }
+
+    ToHitData makeIndirectHomingTHD() {
+        // Not actually skill, but rather auto-miss cutoff
+        return makeTHD(4, "Homing shot (will miss if TAG misses)");
+    }
+
+    ToHitData makeAutoHitHomingTHD() {
+        // Not actually skill, but rather auto-miss cutoff
+        return makeTHD(2, "Homing shot (will miss if TAG misses)");
+    }
+
+    WeaponAttackAction makeWAA(Entity attacker, Entity defender, Mounted weapon) {
+        return new WeaponAttackAction(
+            attacker.getId(),
+            defender.getId(),
+            attacker.getEquipmentNum(weapon)
+        );
+    }
+
+    ArtilleryAttackAction makeArtilleryWAA(Entity attacker, Entity defender, Mounted weapon) {
+        return new ArtilleryAttackAction(
+            attacker.getId(),
+            defender.getTargetType(),
+            defender.getId(),
+            attacker.getEquipmentNum(weapon),
+            game
+        );
+    }
+
+
+    void loadBombOnASF(Entity bomber, int bombType) {
+        loadBombsOnASF(bomber, bombType, 1);
+    }
+
+    void loadBombsOnASF(Entity bomber, int bombType, int count) {
+        int[] bombsArray = new int[BombType.B_NUM];
+        bombsArray[bombType] = count;
+        ((IBomber) bomber).setExtBombChoices(bombsArray);
+        ((IBomber) bomber).applyBombs();
+    }
+
+    /**
+     * This test actually exists to quickly iterate through artillery handling code,
+     * for debugging purposes.
+     * It iterates through one Homing Arrow IV bomb launch, the subsequent tagging turn,
+     * and the homing attack conversion / handling.
+     */
+    @Test
+    void handleArrowIVHomingBombTargetMekNoTAG() throws LocationFullException {
+        // Create and load entities
+        AeroSpaceFighter attacker = createASF("ATT-10", "Buzzsaw", "Alyce", aPlayer);
+        loadBombOnASF(attacker, BombType.B_HOMING);
+        Mek tagger = createMek("TAG-3R", "Taggity", "Taggart", aPlayer, 1, 1);
+        Mounted<?> tagWeapon = tagger.addEquipment(tagType, Mek.LOC_CT);
+        Mek defender = createMek("TGT-1A", "Targeto", "Bob", dPlayer);
+
+        // Set positions; critical for WAA
+        attacker.setPosition(new Coords(8,15));
+        tagger.setPosition(new Coords(1,1));
+        defender.setPosition(new Coords(8,1));
+
+        // Create TAG WAA and handler
+        WeaponAttackAction tagWAA = makeWAA(tagger, defender, tagWeapon);
+        TAGHandler taggie = new TAGHandler(makeTHD(2), tagWAA, game, gameManager);
+
+        // Create Artillery WAA and handler
+        ArtilleryAttackAction awaa = makeArtilleryWAA(attacker, defender, attacker.getWeapon(0));
+        ArtilleryWeaponIndirectHomingHandler artie = new ArtilleryWeaponIndirectHomingHandler(
+            makeAutoHitHomingTHD(), awaa, game, gameManager);
+
+        // Set game phase and run handler to simulate initial firing
+        game.setPhase(GamePhase.TARGETING);
+        Vector<Report> reports = new Vector<>();
+        assertTrue(artie.handle(game.getPhase(), reports));
+
+        // set phase to offboard to increment TurnsTilHit
+        game.setPhase(GamePhase.OFFBOARD);
+        assertTrue(artie.handle(game.getPhase(), reports));
+
+        // Now handle hit turn!
+        game.setPhase(GamePhase.OFFBOARD);
+        assertFalse(taggie.handle(game.getPhase(), reports));
+        // This should not
+        assertFalse(artie.handle(game.getPhase(), reports),
+            reports.stream()
+            .map(Report::text)
+            .collect(Collectors.joining(",\n"))
+        );
+        gameManager.changePhase(GamePhase.FIRING);
+        assertTrue(defender.isDestroyed());
+
+    }
+
+    @Test
+    void convertHomingShotToEntityTarget() {
+    }
+
+    @Test
+    void handleSpecialMiss() {
+    }
+}


### PR DESCRIPTION
Fixes the following Arrow IV / Homing Artillery issues:
- #5429
    - Arrow IV Homing Bomb rounds dealing incorrect damage on hits.
    - Arrow IV Homing Bomb rounds sometimes missing en masse, supposedly due to no TAG hits, despite TAGged units in range.
- #6493 
   - Direct-fire Homing munitions reporting a TMM modifier for target movement.
- Un-reported issues:
   - AE rounds dealing octuple damage to Conventional Infantry units in the open (should be quadruple only).
   - Incorrect target roll reporting for some Homing shots' last-ditch miss roll.
   - Possible NPE when checking for spotters before Vector was initialized.
   - Aerospace units restricted to only firing a single TAG, although the rules allow for firing multiple TAGs at the same target.
   - `ArtilleryWeaponIndirectHomingHandler.java` could produce other incorrect reports when dealing AE damage.

Root causes were:
1. Arrow IV Homing Bomb rounds being treated as Copperhead rounds (-10 to base damage) instead of Arrow IV for damage calculations.
2. A single ToHitData instance was reused when checking for valid TAG hits, and would continue reporting "IMPOSSIBLE" value if _any_ TAGs missed or were out of range of the current Homing round's target.
3. I put a bot-related modifier, meant to provide utility hinting to Princess while building fire plans, into code that is actually called by the UI as well.
4. Several damage-doubling checks were being done in both the AreaEffectHelper and in DamageEntity.  The newer checks in DamageEntity should take precedence.
5. There was no specific report for the case where TAG hits, but the Homing Attack rolls under 4 and only hits the target Hex, not the target Entity.
6. Addition of new calls, probably.
7. Overly restrictive check.
8. `ArtilleryWeaponIndirectHomingHandler.java` was using wrong values to call `AreaEffectHelper.artilleryDamageEntity`, but they happened to line up type-wise so there were no IDE warnings.

I also took the liberty of shrinking the Arrow IV Bomb weapon equipment and bomb ammo names, for clarity.

Testing:
- Ran copious games with Homing artillery of various types, and TAG units both ground and Airborne.
- Ran standard Battle Royale with 80k vs 80k bot armies of mixed units containing various artillery and TAG units.
- Added new unit tests for relevant code.
- Ran all 3 projects' unit tests.

Close #5429 
Close #6493 