### PR TITLE
Allow Arty correctly on DS/SC

### DIFF
--- a/megamek/src/megamek/common/weapons/artillery/ArtilleryWeapon.java
+++ b/megamek/src/megamek/common/weapons/artillery/ArtilleryWeapon.java
@@ -34,7 +34,7 @@ public abstract class ArtilleryWeapon extends AmmoWeapon {
 
     public ArtilleryWeapon() {
         super();
-        flags = flags.or(F_ARTILLERY).or(F_MEK_WEAPON).or(F_TANK_WEAPON);
+        flags = flags.or(F_ARTILLERY).or(F_MEK_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON);
         damage = DAMAGE_ARTILLERY;
         atClass = CLASS_ARTILLERY;
     }

--- a/megamek/src/megamek/common/weapons/artillery/Sniper.java
+++ b/megamek/src/megamek/common/weapons/artillery/Sniper.java
@@ -34,7 +34,6 @@ public class Sniper extends ArtilleryWeapon {
         addLookupName("CLSniper");
         addLookupName("CLSniperArtillery");
         addLookupName("Clan Sniper");
-        flags = flags.or(F_AERO_WEAPON);
         heat = 10;
         rackSize = 20;
         ammoType = AmmoType.T_SNIPER;

--- a/megamek/src/megamek/common/weapons/artillery/Thumper.java
+++ b/megamek/src/megamek/common/weapons/artillery/Thumper.java
@@ -33,7 +33,6 @@ public class Thumper extends ArtilleryWeapon {
         addLookupName("CLThumper");
         addLookupName("CLThumperArtillery");
         addLookupName("Clan Thumper");
-        flags = flags.or(F_AERO_WEAPON);
         heat = 5;
         rackSize = 15;
         ammoType = AmmoType.T_THUMPER;


### PR DESCRIPTION
Fixes MegaMek/megameklab#1692

Code to filter long toms from fighters and all arty from capital craft was already present in AeroUtil, but the aero flag was missing.