### PR TITLE
Issue 6524: Prevent weapon-malfunction-crits from being unjammed via Unjam RAC (movement phase) & prevent NPE if unit unjams rapid-fire weapon and flees

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -2847,6 +2847,17 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public boolean canUnjamRAC() {
         for (WeaponMounted mounted : getTotalWeaponList()) {
+
+            // Tanks can suffer a "weapon malfunction" critical. The weapon is marked
+            // as jammed but it should not be unjammed in the movement phase, it should
+            // be unjammed in the firing phase - that is, if this weapon is jammed from
+            // a weapon malfunction critical, we shouldn't unjam it using this method.
+            if (isVehicle() && this instanceof Tank tank) {
+                if (tank.getJammedWeapons().contains(mounted)) {
+                    continue;
+                }
+            }
+
             int ammotype = mounted.getType().getAmmoType();
             if ((ammotype == AmmoType.T_AC_ROTARY)
                     && mounted.isJammed() && !mounted.isDestroyed()) {

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -2241,14 +2241,25 @@ public class Tank extends Entity {
         return (m_bTurretJammed || m_bDualTurretJammed) && getStunnedTurns() <= 0;
     }
 
+    /**
+     * Adds the provided weapon as a weapon that is jammed via the vehicle "weapon malfunction" critical hit
+     * @param weapon Weapon that suffered a "Weapon Malfunction" crit and should be jammed
+     */
     public void addJammedWeapon(Mounted<?> weapon) {
         jammedWeapons.add(weapon);
     }
 
+    /**
+     * All weapons that a vehicle could use "unjam weapon" for
+     * @return all weapons that are jammed via the vehicle "weapon malfunction" critical hit
+     */
     public ArrayList<Mounted<?>> getJammedWeapons() {
         return jammedWeapons;
     }
 
+    /**
+     * Resets the list of weapons a vehicle has jammed via "weapon malfunction" crits to empty
+     */
     public void resetJammedWeapons() {
         jammedWeapons = new ArrayList<>();
     }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -10817,6 +10817,12 @@ public class TWGameManager extends AbstractGameManager {
      * Resolve an Unjam Action object
      */
     private void resolveUnjam(Entity entity) {
+        // Entity will be null if it fled.
+        // If it fled, we don't care about unjamming RAC.
+        if (entity == null) {
+            return;
+        }
+
         Report r;
         final int TN = entity.getCrew().getGunnery() + 3;
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_UNJAM_UAC)) {


### PR DESCRIPTION
Two for one bonus special!

Fixes #6524 

There are two issues at play here:
- An entity is trying to unjam an RAC on the same turn that its fled the map. Once an entity flees, it is null, so the unjam step cannot be properly processed.
  - This is handled by adding a null entity check in resolveUnjam.
  - I suspect a similar bug will occur for other cases in `TWGameManager::resolveAllButWeaponAttacks`. I considered putting the null entity check there, but several of these actions still need to be processed even if the entity has fled, like clearing a minefield or activating an AP pod. I think we should handle these cases as they occur.
  - This only became an issue when we enabled fleeing at the end of movement. Prior to that a unit would never be null before processing its unjam step.
- Tanks were able to unjam "weapon malfunction" crits (TW p. 195) in the movement phases using the "Unjam RAC" which is meant to be used for the RAC or other rapid fire weapons if the setting is enabled.
  - Tank weapons that are jammed because of that are added to a special list that only tanks have. When checking if a weapon can be unjammed in the manner of rapid-fire weapons we first check if the weapon was jammed from a weapon malfunction crit - if it was we can't unjam it using this action.