### PR TITLE
fix: check if it is a narcpod before trying to access getPosition

### DIFF
--- a/megamek/src/megamek/common/GameDatasetLogger.java
+++ b/megamek/src/megamek/common/GameDatasetLogger.java
@@ -176,7 +176,7 @@ public class GameDatasetLogger {
         if (target != null ) {
             targetId = target.getId() + "";
             targetType = target.getClass().getSimpleName();
-            targetCoords = target.getPosition() != null ? target.getPosition().toTSV() : "-1\t-1";
+            targetCoords = !(target instanceof INarcPod) && target.getPosition() != null ? target.getPosition().toTSV() : "-1\t-1";
             if (target instanceof Entity entity) {
                 targetPlayerId = entity.getOwner().getId() + "";
                 targetRole = entity.getRole() == null ? UnitRole.NONE.name() : entity.getRole().name();


### PR DESCRIPTION
Aparently 19 years ago someone had the idea that NarcPod is a "targetable" but it has no "position" and you should not ask its position, and if you do it throws a runtime exception at you. This is... Unexpected and unwelcomed, as it implements a common API for things that can be targeted I imagined that anything that implements this API would... well.. be targetable, narcpods are not, and if you dont first check if it is not a narcpod you cannot safely check the coordinates of an attack action.

So, this PR handles that problem in the dataset logger.