### PR TITLE
MML #1721: legacy infantry blk files

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKInfantryFile.java
+++ b/megamek/src/megamek/common/loaders/BLKInfantryFile.java
@@ -71,7 +71,8 @@ public class BLKInfantryFile extends BLKFile implements IMekLoader {
         }
 
         // get primary and secondary weapons
-        if (dataFile.exists("secondn")) {
+        // the check for "secondary" is for legacy infantry files that have a <secondn> block but no actual secondary weapon
+        if (dataFile.exists("secondn") && dataFile.exists("Secondary")) {
             infantry.setSecondaryWeaponsPerSquad(dataFile.getDataAsInt("secondn")[0]);
         }
 


### PR DESCRIPTION
Fixes MegaMek/megameklab#1721
This allows loading legacy infantry files that have a "secondn" entry but no "secondary" (a number of secondary weapons but no weapon type for it). It appears that as recently as 49.16 such files could be produced with MML. In any case, this file check/file correction doesnt hurt.