### PR TITLE
Issue #6537: Improved name search for diacritics

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -24,6 +24,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.WindowEvent;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -676,6 +677,8 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
             String text = textFilter.getText().toLowerCase();
             String[] tokens = text.split(" ");
             String searchText = unit.getName().toLowerCase() + "###" + unit.getModel().toLowerCase();
+            // search in both the actual name and a stripped version so "Götterdämmerung" can be found with both "gott" and "gött"
+            searchText = searchText + "###" + stripAccents(searchText);
             for (String token : tokens) {
                 if (!searchText.contains(token)) {
                     return false;
@@ -683,6 +686,14 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
             }
         }
         return true;
+    }
+
+    public static String stripAccents(String input) {
+        if (input == null) {
+            return null;
+        }
+        String normalized = Normalizer.normalize(input, Normalizer.Form.NFD);
+        return normalized.replaceAll("\\p{M}", "");
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -674,11 +674,9 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
     protected boolean matchesTextFilter(MekSummary unit) {
         if (!textFilter.getText().isBlank()) {
-            String text = textFilter.getText().toLowerCase();
+            String text = stripAccents(textFilter.getText().toLowerCase());
             String[] tokens = text.split(" ");
-            String searchText = unit.getName().toLowerCase() + "###" + unit.getModel().toLowerCase();
-            // search in both the actual name and a stripped version so "Götterdämmerung" can be found with both "gott" and "gött"
-            searchText = searchText + "###" + stripAccents(searchText);
+            String searchText = stripAccents(unit.getName().toLowerCase() + "###" + unit.getModel().toLowerCase());
             for (String token : tokens) {
                 if (!searchText.contains(token)) {
                     return false;


### PR DESCRIPTION
Fixes #6537 
In the unit selector, allows base latin characters to find diacritics. Both "Gött" and "Gott" will find the "Götterdämmerung", "Gun" will find the "Gún" and "Arana" the "Aran~a" (cant even find how to type that)