### PR TITLE
MML #1536: Unify armorable equipment tests in MM

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -14456,4 +14456,10 @@ public class AmmoType extends EquipmentType {
         return (ammoOfSameType || mmlAmmoMatch || lbxAmmoMatch || ar10Match) && !caselessMismatch
                 && !staticFeedMismatch;
     }
+
+    @Override
+    public boolean isArmorable() {
+        // Coolant pods are implemented as ammo, but are not ammo bins for rules purposes
+        return getAmmoType() == AmmoType.T_COOLANT_POD;
+    }
 }

--- a/megamek/src/megamek/common/CriticalSlot.java
+++ b/megamek/src/megamek/common/CriticalSlot.java
@@ -13,6 +13,8 @@
  */
 package megamek.common;
 
+import megamek.common.annotations.Nullable;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -256,5 +258,12 @@ public class CriticalSlot implements Serializable {
         if (!repairable)
             state.add("Not repairable");
         return typeString + " { " + String.join(", ", state) + " }";
+    }
+
+    /**
+     * @return True if this crit slot is eligible for being an armored component, TO:AUE p.95
+     */
+    public boolean isArmorable() {
+        return ((getType() == CriticalSlot.TYPE_SYSTEM) || ((getMount() != null) && getMount().getType().isArmorable()));
     }
 }

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -1771,4 +1771,11 @@ public class EquipmentType implements ITechnology {
 
         return result;
     }
+
+    /**
+     * @return True if this equipment type is eligible for being an armored component, TO:AUE p.95
+     */
+    public boolean isArmorable() {
+        return isHittable();
+    }
 }

--- a/megamek/src/megamek/common/Mounted.java
+++ b/megamek/src/megamek/common/Mounted.java
@@ -1378,22 +1378,19 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
         linked = null;
     }
 
+    /**
+     * Sets the Mounted to be an armored component, TO:AUE p.95. This method checks if the EquipmentType allows armoring at all and sets
+     * the armored status to false if it doesn't.
+     *
+     * @param armored The armored status to be set
+     */
     public void setArmored(boolean armored) {
-        // Ammobins cannot be armored.
-        if ((getType() instanceof AmmoType)
-                && (((AmmoType) getType()).getAmmoType() != AmmoType.T_COOLANT_POD)) {
-            armoredComponent = false;
-        } else if ((getType() instanceof MiscType)
-                && (getType().hasFlag(MiscType.F_SPIKES)
-                        || getType().hasFlag(MiscType.F_REACTIVE)
-                        || getType().hasFlag(MiscType.F_MODULAR_ARMOR) || ((MiscType) getType())
-                                .isShield())) {
-            armoredComponent = false;
-        } else {
-            armoredComponent = armored;
-        }
+        armoredComponent = getType().isArmorable() && armored;
     }
 
+    /**
+     * @return True if this Mounted is an armored component, TO:AUE p.95
+     */
     public boolean isArmored() {
         return armoredComponent;
     }


### PR DESCRIPTION
This moves tests for armorable components (TO:AUE p95) from MML to MM to unify them. This PR is required for MegaMek/megameklab#1726