### PR TITLE
fixed so correctDupeName() used to change name on initial connection

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -734,7 +734,8 @@ public class Server implements Runnable {
 
         if (!returning) {
             // Check to avoid duplicate names...
-            sendToPending(connId, new Packet(PacketCommand.SERVER_CORRECT_NAME, correctDupeName(name)));
+            name = correctDupeName(name);
+            sendToPending(connId, new Packet(PacketCommand.SERVER_CORRECT_NAME, name));
         }
 
         // right, switch the connection into the "active" bin


### PR DESCRIPTION
fixes #6535

looks like the correctDupeName() wasnt be used when adding players.  Changed it so corrected name is used to setup new players, worked when starting new game and trying to connect with another player of same name