### PR TITLE
Allow units with unlinked weapon enhancements to load as invalid instead of failing to load

### DIFF
--- a/megamek/src/megamek/common/MekFileParser.java
+++ b/megamek/src/megamek/common/MekFileParser.java
@@ -316,7 +316,7 @@ public class MekFileParser {
                     }
                 }
                 if (m.getLinked() == null) {
-                    throw new EntityLoadingException("Unable to match " + m.getName() + " to laser for "
+                    logger.error("Unable to match " + m.getName() + " to laser for "
                             + ent.getShortName());
                 }
             } else if ((m.getType().hasFlag(MiscType.F_DETACHABLE_WEAPON_PACK))) {
@@ -378,7 +378,7 @@ public class MekFileParser {
 
                 if (m.getLinked() == null) {
                     // huh. this shouldn't happen
-                    throw new EntityLoadingException("Unable to match Artemis to launcher for " + ent.getShortName());
+                    logger.error("Unable to match Artemis to launcher for " + ent.getShortName());
                 }
             } else if ((m.getType().hasFlag(MiscType.F_STEALTH) || m.getType().hasFlag(MiscType.F_VOIDSIG))
                     && (ent instanceof Mek)) {
@@ -395,7 +395,7 @@ public class MekFileParser {
                 if (m.getLinked() == null) {
                     // This mek has stealth armor but no ECM. Probably
                     // an improperly created custom.
-                    throw new EntityLoadingException(
+                    logger.error(
                             "Unable to find an ECM Suite for " + ent.getShortName()
                                     + ".  Meks with Stealth Armor or Void-Signature-System must also be equipped with an ECM Suite.");
                 }
@@ -461,7 +461,7 @@ public class MekFileParser {
 
                 if (m.getLinked() == null) {
                     // huh. this shouldn't happen
-                    throw new EntityLoadingException(
+                    logger.error(
                             "Unable to match Apollo to launcher for " + ent.getShortName());
                 }
             } // End link-Apollo
@@ -512,8 +512,8 @@ public class MekFileParser {
                         || ((Mek) ent).hasTSM(true)
                         || (!ent.getMPBoosters().isNone() && !ent.hasWorkingMisc(
                                 MiscType.F_MASC, MiscType.S_SUPERCHARGER))) {
-                    throw new EntityLoadingException(
-                            "Unable to load AES due to incompatible systems for " + ent.getShortName());
+                    logger.error(
+                            "Loading AES with incompatible systems for " + ent.getShortName());
                 }
 
                 if ((m.getLocation() != Mek.LOC_LARM)
@@ -632,11 +632,10 @@ public class MekFileParser {
                         }
                     }
                 }
-
-                // huh. this shouldn't happen
-                Objects.requireNonNull(m.getLinked(),
-                        "No available PPC to match Capacitor for " + ent.getShortName() + "!");
-
+                if (m.getLinked() == null) {
+                    // huh. this shouldn't happen
+                    logger.error("No available PPC to match Capacitor for " + ent.getShortName() + "!");
+                }
             }
         } // Check the next piece of equipment.
 

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1491,7 +1491,9 @@ public abstract class TestEntity implements TestEntityOption {
                 artemisP++;
             } else if (m.getType().hasFlag(MiscType.F_APOLLO)) {
                 apollo++;
-            } else if (m.getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
+            }
+
+            if (m.getType().hasFlag(MiscType.F_PPC_CAPACITOR)) {
                 if (m.getLinked() == null) {
                     buff
                         .append(m.getType().getName())


### PR DESCRIPTION
Some configurations of mech equipment previously threw an exception on load, preventing them from being loaded entirely.

A mek with a PPC capacitor but no PPC would throw an exception despite the fact that although the unit violates the construction rules, it does not actually cause any problems for the normal operation of the program.

This PR allows units with unlinked Capacitors, Insulators, Pulse Modules, Artemis, or Apollo to be loaded successfully, though they are still considered invalid and so the user is unlikely to accidentally try to use them in a game.

Also covered are meks with AES and a supercharger/masc.

This makes it so that a user can close MegaMekLab with an in-progress design and then continue working on that design when they re-open it later, instead of that unit file permanently being unloadable.