### PR TITLE
Cost and BV of superheavy meks

### DIFF
--- a/megamek/src/megamek/common/BipedMek.java
+++ b/megamek/src/megamek/common/BipedMek.java
@@ -369,36 +369,6 @@ public class BipedMek extends Mek {
     }
 
     @Override
-    protected double getArmActuatorCost() {
-        double cost = 0;
-        int numOfUpperArmActuators = 0;
-        int numOfLowerArmActuators = 0;
-        int numOfHands = 0;
-        if (hasSystem(Mek.ACTUATOR_HAND, Mek.LOC_LARM)) {
-            numOfHands++;
-        }
-        if (hasSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_LARM)) {
-            numOfLowerArmActuators++;
-        }
-        if (hasSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_LARM)) {
-            numOfUpperArmActuators++;
-        }
-        if (hasSystem(Mek.ACTUATOR_HAND, Mek.LOC_RARM)) {
-            numOfHands++;
-        }
-        if (hasSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_RARM)) {
-            numOfLowerArmActuators++;
-        }
-        if (hasSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_RARM)) {
-            numOfUpperArmActuators++;
-        }
-        cost += numOfUpperArmActuators * weight * 100;
-        cost += numOfLowerArmActuators * weight * 50;
-        cost += numOfHands * weight * 80;
-        return cost;
-    }
-
-    @Override
     protected double getLegActuatorCost() {
         return (weight * 150 * 2) + (weight * 80 * 2) + (weight * 120 * 2);
     }

--- a/megamek/src/megamek/common/Mek.java
+++ b/megamek/src/megamek/common/Mek.java
@@ -3265,7 +3265,30 @@ public abstract class Mek extends Entity {
         return getArmActuatorCost() + getLegActuatorCost();
     }
 
-    protected abstract double getArmActuatorCost();
+    protected double getArmActuatorCost() {
+        int numOfUpperArmActuators = 0;
+        int numOfLowerArmActuators = 0;
+        int numOfHands = 0;
+        if (hasSystem(Mek.ACTUATOR_HAND, Mek.LOC_LARM)) {
+            numOfHands++;
+        }
+        if (hasSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_LARM)) {
+            numOfLowerArmActuators++;
+        }
+        if (hasSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_LARM)) {
+            numOfUpperArmActuators++;
+        }
+        if (hasSystem(Mek.ACTUATOR_HAND, Mek.LOC_RARM)) {
+            numOfHands++;
+        }
+        if (hasSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_RARM)) {
+            numOfLowerArmActuators++;
+        }
+        if (hasSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_RARM)) {
+            numOfUpperArmActuators++;
+        }
+        return weight * (numOfUpperArmActuators * 100 + numOfLowerArmActuators * 50 + numOfHands * 80);
+    }
 
     protected abstract double getLegActuatorCost();
 

--- a/megamek/src/megamek/common/TripodMek.java
+++ b/megamek/src/megamek/common/TripodMek.java
@@ -435,38 +435,8 @@ public class TripodMek extends Mek {
     }
 
     @Override
-    protected double getArmActuatorCost() {
-        double cost = 0;
-        int numOfUpperArmActuators = 0;
-        int numOfLowerArmActuators = 0;
-        int numOfHands = 0;
-        if (hasSystem(Mek.ACTUATOR_HAND, Mek.LOC_LARM)) {
-            numOfHands++;
-        }
-        if (hasSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_LARM)) {
-            numOfLowerArmActuators++;
-        }
-        if (hasSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_LARM)) {
-            numOfUpperArmActuators++;
-        }
-        if (hasSystem(Mek.ACTUATOR_HAND, Mek.LOC_RARM)) {
-            numOfHands++;
-        }
-        if (hasSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_RARM)) {
-            numOfLowerArmActuators++;
-        }
-        if (hasSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_RARM)) {
-            numOfUpperArmActuators++;
-        }
-        cost += numOfUpperArmActuators * weight * 100;
-        cost += numOfLowerArmActuators * weight * 50;
-        cost += numOfHands * weight * 80;
-        return cost;
-    }
-
-    @Override
     protected double getLegActuatorCost() {
-        return (weight * 150 * 2) + (weight * 80 * 2) + (weight * 120 * 2);
+        return weight * 3 * (150 + 80 + 120);
     }
 
     /**

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -203,9 +203,9 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
                 toSubtract = 1;
             }
 
-            // For weapons split between locations, subtract per critical slot
+            // For weapons split between locations, subtract per critical slot; on superheavy, consider the reduced slot count
             int criticals;
-            if (mounted.isSplit()) {
+            if (mounted.isSplit() || mek.isSuperHeavy()) {
                 criticals = 0;
                 for (int l = 0; l < entity.locations(); l++) {
                     if (((l == mounted.getLocation()) || (l == mounted.getSecondLocation()))

--- a/megamek/src/megamek/common/cost/MekCostCalculator.java
+++ b/megamek/src/megamek/common/cost/MekCostCalculator.java
@@ -29,56 +29,31 @@ public class MekCostCalculator {
         double[] costs = new double[17 + mek.locations()];
         int i = 0;
 
-        double cockpitCost;
-        switch (mek.getCockpitType()) {
-            case Mek.COCKPIT_TORSO_MOUNTED:
-                cockpitCost = 750000;
-                break;
-            case Mek.COCKPIT_DUAL:
+        double cockpitCost = switch (mek.getCockpitType()) {
+            case Mek.COCKPIT_TORSO_MOUNTED -> 750000;
+            case Mek.COCKPIT_DUAL ->
                 // Solaris VII - The Game World (German) This is not actually canonical as it
                 // has never been repeated in any English language source including Tech Manual
-                cockpitCost = 40000;
-                break;
-            case Mek.COCKPIT_COMMAND_CONSOLE:
+                40000;
+            case Mek.COCKPIT_COMMAND_CONSOLE ->
                 // Command Consoles are listed as a cost of 500,000.
                 // That appears to be in addition to the primary cockpit.
-                cockpitCost = 700000;
-                break;
-            case Mek.COCKPIT_SMALL:
-                cockpitCost = 175000;
-                break;
-            case Mek.COCKPIT_VRRP:
-                cockpitCost = 1250000;
-                break;
-            case Mek.COCKPIT_INDUSTRIAL:
-            case Mek.COCKPIT_PRIMITIVE_INDUSTRIAL:
-                cockpitCost = 100000;
-                break;
-            case Mek.COCKPIT_TRIPOD:
-            case Mek.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL:
-                cockpitCost = 400000;
-                break;
-            case Mek.COCKPIT_TRIPOD_INDUSTRIAL:
-            case Mek.COCKPIT_SUPERHEAVY:
-                cockpitCost = 300000;
-                break;
-            case Mek.COCKPIT_QUADVEE:
-                cockpitCost = 375000;
-                break;
-            case Mek.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE:
+                700000;
+            case Mek.COCKPIT_SMALL -> 175000;
+            case Mek.COCKPIT_VRRP -> 1250000;
+            case Mek.COCKPIT_INDUSTRIAL, Mek.COCKPIT_PRIMITIVE_INDUSTRIAL -> 100000;
+            case Mek.COCKPIT_TRIPOD, Mek.COCKPIT_SUPERHEAVY_TRIPOD_INDUSTRIAL -> 400000;
+            case Mek.COCKPIT_TRIPOD_INDUSTRIAL, Mek.COCKPIT_SUPERHEAVY -> 300000;
+            case Mek.COCKPIT_QUADVEE -> 375000;
+            case Mek.COCKPIT_SUPERHEAVY_COMMAND_CONSOLE ->
                 // The cost is the sum of both superheavy cockpit and command console
-                cockpitCost = 800000;
-                break;
-            case Mek.COCKPIT_SUPERHEAVY_TRIPOD:
-                cockpitCost = 500000;
-                break;
-            case Mek.COCKPIT_SMALL_COMMAND_CONSOLE:
+                800000;
+            case Mek.COCKPIT_SUPERHEAVY_TRIPOD -> 500000;
+            case Mek.COCKPIT_SMALL_COMMAND_CONSOLE ->
                 // The cost is the sum of both small and command console
-                cockpitCost = 675000;
-                break;
-            default:
-                cockpitCost = 200000;
-        }
+                675000;
+            default -> 200000;
+        };
         if (mek.hasEiCockpit()
                 && ((null != mek.getCrew()) && mek.hasAbility(OptionsConstants.UNOFF_EI_IMPLANT))) {
             cockpitCost = 400000;
@@ -87,11 +62,11 @@ public class MekCostCalculator {
         costs[i++] = 50000;// life support
         costs[i++] = mek.getWeight() * 2000;// sensors
         int muscCost = mek.hasSCM() ? 10000 : mek.hasTSM(false) ? 16000 :
-                mek.hasTSM(true) ? 32000 : mek.hasIndustrialTSM() ? 12000 : 2000;
+            mek.hasTSM(true) ? 32000 : mek.hasIndustrialTSM() ? 12000 : mek.isSuperHeavy() ? 12000 : 2000;
         costs[i++] = muscCost * mek.getWeight();// musculature
-        double structureCost = EquipmentType.getStructureCost(mek.getStructureType()) * mek.getWeight();// IS
+        double structureCost = getStructureCost(mek) * mek.getWeight() * (mek.isTripodMek() ? 1.2 : 1);// IS
         costs[i++] = structureCost;
-        costs[i++] = mek.getActuatorCost();// arm and/or leg actuators
+        costs[i++] = mek.getActuatorCost() * (mek.isSuperHeavy() ? 2 : 1);// arm and/or leg actuators
         if (mek.hasEngine()) {
             costs[i++] = (mek.getEngine().getBaseCost() * mek.getEngine().getRating() * mek.getWeight()) / 75.0;
         }
@@ -99,7 +74,7 @@ public class MekCostCalculator {
             costs[i++] = 750000 * (int) Math.ceil((mek.getOriginalWalkMP() * mek.getWeight()) / 100f) * 0.5;
         } else if (mek.getGyroType() == Mek.GYRO_COMPACT) {
             costs[i++] = 400000 * (int) Math.ceil((mek.getOriginalWalkMP() * mek.getWeight()) / 100f) * 1.5;
-        } else if (mek.getGyroType() == Mek.GYRO_HEAVY_DUTY) {
+        } else if ((mek.getGyroType() == Mek.GYRO_HEAVY_DUTY) || (mek.getGyroType() == Mek.GYRO_SUPERHEAVY)) {
             costs[i++] = 500000 * (int) Math.ceil((mek.getOriginalWalkMP() * mek.getWeight()) / 100f) * 2;
         } else if (mek.getGyroType() == Mek.GYRO_STANDARD) {
             costs[i++] = 300000 * (int) Math.ceil((mek.getOriginalWalkMP() * mek.getWeight()) / 100f);
@@ -195,6 +170,29 @@ public class MekCostCalculator {
                 "Conversion Equipment", "Quirk Multiplier", "Omni Multiplier", "Weight Multiplier" };
         CostCalculator.fillInReport(costReport, mek, ignoreAmmo, systemNames, 13, cost, costs);
         return cost;
+    }
+
+    private static int getStructureCost(Mek mek) {
+        if (mek.isSuperHeavy()) {
+            return switch (mek.getStructureType()) {
+                case EquipmentType.T_STRUCTURE_STANDARD -> 4000;
+                case EquipmentType.T_STRUCTURE_INDUSTRIAL -> 3000;
+                case EquipmentType.T_STRUCTURE_ENDO_STEEL -> 16000;
+                case EquipmentType.T_STRUCTURE_COMPOSITE -> 1600;
+                case EquipmentType.T_STRUCTURE_ENDO_COMPOSITE -> 6400;
+                default -> 0;
+            };
+        } else {
+            return switch (mek.getStructureType()) {
+                case EquipmentType.T_STRUCTURE_STANDARD -> 400;
+                case EquipmentType.T_STRUCTURE_INDUSTRIAL -> 300;
+                case EquipmentType.T_STRUCTURE_ENDO_STEEL, EquipmentType.T_STRUCTURE_COMPOSITE -> 1600;
+                case EquipmentType.T_STRUCTURE_ENDO_PROTOTYPE -> 4800;
+                case EquipmentType.T_STRUCTURE_REINFORCED -> 6400;
+                case EquipmentType.T_STRUCTURE_ENDO_COMPOSITE -> 3200;
+                default -> 0;
+            };
+        }
     }
 
 }


### PR DESCRIPTION
fixes MegaMek/megameklab#1523

- incorporate superheavy mek cost rules from IO:AE
- move arm actuator cost code to Mek to remove the duplicate code in BipedMek and TripodMek
- fix Tripods calculating leg actuator cost only for 2 legs
- consider structure costs of tripods
- consider the exact slots on superheavy meks for BV modifiers of explosive weapons (typically fewerthan on normal meks)