### PR TITLE
Issue 6553: Prevent NPE when opening Map Editor

### DIFF
--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -389,11 +389,13 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
         if (bv != null) {
             bv.addBoardViewListener(boardViewListener);
         }
-        client.addCloseClientListener(() -> {
-            if (gifWriterThread != null && gifWriterThread.isAlive()) {
-                gifWriterThread.stopThread();
-            }
-        });
+        if (client != null) {
+            client.addCloseClientListener(() -> {
+                if (gifWriterThread != null && gifWriterThread.isAlive()) {
+                    gifWriterThread.stopThread();
+                }
+            });
+        }
         GUIP.addPreferenceChangeListener(this);
     }
 


### PR DESCRIPTION
Fixes #6553 

Just a null check for client when opening the minimap.