### PR TITLE
Interim fix for Princess bombing airborne units

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1978,6 +1978,13 @@ public class FireControl {
         BombMounted exampleBomb = null;
 
         // things that cause us to avoid calculating a bomb plan:
+        // Target is flying unit
+        if (target.getTargetType() == Targetable.TYPE_ENTITY) {
+            if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
+                return diveBombPlan;
+            }
+        }
+
         // not having any bombs (in the first place)
         final Iterator<WeaponMounted> weaponIter = shooter.getWeapons();
         if (null == weaponIter) {


### PR DESCRIPTION
This is part 1 and fixes the immediate problem of Princess bombing flying units.

The real fix is much more complex, as:
A) some VTOL units can be bombed / hit with artillery blasts, depending on the underlying terrain type and level of flight,
B) most of the AE blast handling code is insufficient or outdated and needs rewriting,
C) the way we account for AE blast damage in path utility calculations actually _increases_ the likelihood that Princess will massively overkill a single target with bombs.

so that ongoing work will be submitted at a later date.

Close #6146 