### PR TITLE
added check if player was done to validateUpdate

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -1147,8 +1147,8 @@ public class LobbyActions {
     }
 
     /**
-     * Performs standard checks for updates (units must be present, visible and
-     * editable)
+     * Performs standard checks for updates (units must be present, visible,
+     * editable, and player is not done)
      * and returns false if that's not the case. Also shows an error message dialog.
      */
     private boolean validateUpdate(Collection<Entity> entities) {
@@ -1184,8 +1184,6 @@ public class LobbyActions {
         // Gather the necessary sending clients; this list may contain null if some
         // units
         // cannot be affected at all, i.e. are enemies to localplayer and all his bots
-
-     
         List<Client> senders = entities.stream().map(this::correctSender).distinct().collect(toList());
         for (Client sender : senders) {
             if (sender == null) {

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -1163,6 +1163,11 @@ public class LobbyActions {
             LobbyErrors.showCannotViewHidden(frame());
             return false;
         }
+        
+        if (localPlayer().isDone()) {
+            LobbyErrors.showCannotEditWhileDone(frame());
+            return false;
+        }
         return true;
     }
 
@@ -1179,6 +1184,8 @@ public class LobbyActions {
         // Gather the necessary sending clients; this list may contain null if some
         // units
         // cannot be affected at all, i.e. are enemies to localplayer and all his bots
+
+     
         List<Client> senders = entities.stream().map(this::correctSender).distinct().collect(toList());
         for (Client sender : senders) {
             if (sender == null) {

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyErrors.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyErrors.java
@@ -47,6 +47,7 @@ public final class LobbyErrors {
     private static final String FORCE_EMPTY = "Please select only empty forces.";
     private static final String FORCE_ASSIGN_ONLYTEAM = "Can only reassign a force to a teammate when reassigning without units.";
     private static final String FORCE_ATTACH_TOSUB = "Cannot attach a force to its own subforce.";
+    private static final String PLAYER_DONE = "Cannot edit units while your status is Done.";
     private static final String SBF_CONVERSIONERROR = "At least some of the forces you selected cannot be " +
             "converted to SBF Formations. Please select only the topmost forces to be converted, no subforces. " +
             "A converted force must conform to the rules given in Interstellar Operations. Conversion " +
@@ -147,6 +148,10 @@ public final class LobbyErrors {
 
     public static void showSBFConversion(JFrame owner) {
         JOptionPane.showMessageDialog(owner, SBF_CONVERSIONERROR);
+    }
+
+    public static void showCannotEditWhileDone(JFrame owner) {
+        JOptionPane.showMessageDialog(owner, PLAYER_DONE);
     }
 
     private LobbyErrors() { }


### PR DESCRIPTION
fixes #6515 

Added check to validateUpdate to see if localPlayer is done, prevents changes to meks while in done status.  Click "Not Done" to be able to edit units again. Added an error popup to LobbyErrors to go along with it.

![image](https://github.com/user-attachments/assets/5316c1a6-ec58-4189-8972-098e25c8bd7b)

