### PR TITLE
Refactor startup to query if the user would like sentry enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ OfficialUnitList.txt
 equipment.txt
 .github/copilot-instructions.md
 *.iml
+sentry.properties

--- a/megamek/src/megamek/MMConstants.java
+++ b/megamek/src/megamek/MMConstants.java
@@ -105,4 +105,16 @@ public final class MMConstants extends SuiteConstants {
     // endregion Magic Numbers That Should Be Enums
 
     public static final String CL_KEY_FILEEXTENTION_BOARD = ".board";
+
+    public static final SentryAttributes SENTRY_ATTRIBUTES = new SentryAttributes() {
+        @Override
+        public String serverName() {
+            return "MegaMekClient";
+        }
+
+        @Override
+        public String dsn() {
+            return "https://b1720cb789ec56df7df9610dfa463c09@sentry.tapenvy.us/8";
+        }
+    };
 }

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -37,6 +37,7 @@ import megamek.server.DedicatedServer;
 import megamek.utilities.GifWriter;
 import megamek.utilities.PrincessFineTuning;
 import megamek.utilities.RATGeneratorEditor;
+import megamek.utilities.StartupUtil;
 
 import javax.swing.*;
 import java.io.*;
@@ -66,39 +67,15 @@ public class MegaMek {
     private static final NumberFormat numberFormatter = NumberFormat.getInstance();
 
     private static final MMLogger logger = MMLogger.create(MegaMek.class);
-    private static final SanityInputFilter sanityInputFilter = new SanityInputFilter();
 
     public static void main(String... args) {
-        ObjectInputFilter.Config.setSerialFilter(sanityInputFilter);
+        StartupUtil.setupEnvironment(logger);
 
-        // Configure Sentry with defaults. Although the client defaults to enabled, the
-        // properties file is used to disable it and additional configuration can be
-        // done inside of the sentry.properties file. The defaults for everything else
-        // is set here.
-        Sentry.init(options -> {
-            options.setEnableExternalConfiguration(true);
-            options.setDsn("https://b1720cb789ec56df7df9610dfa463c09@sentry.tapenvy.us/8");
-            options.setEnvironment("production");
-            options.setTracesSampleRate(0.2);
-            options.setDebug(true);
-            options.setServerName("MegaMekClient");
-            options.setRelease(SuiteConstants.VERSION.toString());
-        });
-
-        ToolTipManager.sharedInstance().setDismissDelay(Integer.MAX_VALUE);
-
-        // First, create a global default exception handler
-        Thread.setDefaultUncaughtExceptionHandler((thread, t) -> {
-            final String name = t.getClass().getName();
-            final String message = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION, name);
-            final String title = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION_TITLE, name);
-            logger.error(t, message, title);
-        });
 
         // Second, let's handle logging
         initializeLogging(MMConstants.PROJECT_NAME);
 
-        // Third, Command Line Arguments and Startup
+        // Command Line Arguments and Startup
         MegaMekCommandLineParser parser = new MegaMekCommandLineParser(args);
 
         // Parse the command line arguments and throw an error if needed.

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -69,7 +69,7 @@ public class MegaMek {
     private static final MMLogger logger = MMLogger.create(MegaMek.class);
 
     public static void main(String... args) {
-        StartupUtil.setupEnvironment(logger);
+        StartupUtil.setupEnvironment(logger, MMConstants.SENTRY_ATTRIBUTES);
 
 
         // Second, let's handle logging

--- a/megamek/src/megamek/SuiteConstants.java
+++ b/megamek/src/megamek/SuiteConstants.java
@@ -67,4 +67,9 @@ public abstract class SuiteConstants {
     public static final String MM_PREFERENCES_FILE = "mmconf/mm.preferences";
     public static final String MML_PREFERENCES_FILE = "mmconf/mml.preferences";
     // endregion File Paths
+
+    public interface SentryAttributes {
+        String serverName();
+        String dsn();
+    }
 }

--- a/megamek/src/megamek/utilities/StartupUtil.java
+++ b/megamek/src/megamek/utilities/StartupUtil.java
@@ -99,7 +99,7 @@ public final class StartupUtil {
             "Would you like to enable Sentry", "Sentry",
             JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
 
-        try (var writer = new FileWriter(propFile)) {
+        try (var writer = new FileWriter(propFile, false)) {
             if (shouldSentry) {
                 writer.write("enabled=true\n");
             } else {
@@ -113,6 +113,7 @@ public final class StartupUtil {
             e.printStackTrace();
             System.exit(1);
         }
+        window.dispose();
 
     }
 

--- a/megamek/src/megamek/utilities/StartupUtil.java
+++ b/megamek/src/megamek/utilities/StartupUtil.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import javax.swing.*;
 import java.io.*;
-import java.nio.file.Files;
 
 /**
  * Common tasks to be performed when any of the suite programs first start.
@@ -34,10 +33,11 @@ public final class StartupUtil {
      * Enable ObjectInputFilter, logging and Sentry, set global exception handler,
      * and other startup tasks to prepare the execution environment.
      * @param topLevelLogger The logger for uncaught exceptions
+     * @param sentryAttributes The parameters for sentry for the specific project being started
      */
-    public static void setupEnvironment(MMLogger topLevelLogger) {
+    public static void setupEnvironment(MMLogger topLevelLogger, SuiteConstants.SentryAttributes sentryAttributes) {
         setOif();
-        setSentry();
+        setSentry(sentryAttributes);
         setTooltips();
         setExceptionHandler(topLevelLogger);
     }
@@ -61,25 +61,24 @@ public final class StartupUtil {
         ObjectInputFilter.Config.setSerialFilter(sanityInputFilter);
     }
 
-    private static void setSentry() {
+    private static void setSentry(SuiteConstants.SentryAttributes sentryAttributes) {
         querySentry();
-        initSentry();
+        initSentry(sentryAttributes);
     }
 
     /**
-     * // Configure Sentry with defaults. Although the client defaults to enabled, the
-     *         // properties file is used to disable it and additional configuration can be
-     *         // done inside the sentry.properties file. The defaults for everything else
-     *         // is set here.
+     * Configure Sentry with defaults.
+     * The properties file is used to disable it and additional configuration can be
+     * done inside the sentry.properties file. The defaults for everything else is set here.
      */
-    private static void initSentry() {
+    private static void initSentry(SuiteConstants.SentryAttributes sentryAttributes) {
         Sentry.init(options -> {
             options.setEnableExternalConfiguration(true);
-            options.setDsn("https://b1720cb789ec56df7df9610dfa463c09@sentry.tapenvy.us/8");
+            options.setDsn(sentryAttributes.dsn());
             options.setEnvironment("production");
             options.setTracesSampleRate(0.2);
             options.setDebug(true);
-            options.setServerName("MegaMekClient");
+            options.setServerName(sentryAttributes.serverName());
             options.setRelease(SuiteConstants.VERSION.toString());
         });
 

--- a/megamek/src/megamek/utilities/StartupUtil.java
+++ b/megamek/src/megamek/utilities/StartupUtil.java
@@ -1,0 +1,121 @@
+/*
+ * * MegaMek - Copyright (C) 2025 The MegaMek Team
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ */
+
+package megamek.utilities;
+
+import io.sentry.Sentry;
+import megamek.MMLoggingConstants;
+import megamek.SuiteConstants;
+import megamek.common.net.marshalling.SanityInputFilter;
+import megamek.logging.MMLogger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
+import javax.swing.*;
+import java.io.*;
+import java.nio.file.Files;
+
+/**
+ * Common tasks to be performed when any of the suite programs first start.
+ */
+public final class StartupUtil {
+
+    /**
+     * Enable ObjectInputFilter, logging and Sentry, set global exception handler,
+     * and other startup tasks to prepare the execution environment.
+     * @param topLevelLogger The logger for uncaught exceptions
+     */
+    public static void setupEnvironment(MMLogger topLevelLogger) {
+        setOif();
+        setSentry();
+        setTooltips();
+        setExceptionHandler(topLevelLogger);
+    }
+
+
+    private static void setExceptionHandler(MMLogger logger) {
+        Thread.setDefaultUncaughtExceptionHandler((thread, t) -> {
+            final String name = t.getClass().getName();
+            final String message = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION, name);
+            final String title = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION_TITLE, name);
+            logger.error(t, message, title);
+        });
+    }
+
+    private static void setTooltips() {
+        ToolTipManager.sharedInstance().setDismissDelay(Integer.MAX_VALUE);
+    }
+
+    private static final SanityInputFilter sanityInputFilter = new SanityInputFilter();
+    private static void setOif() {
+        ObjectInputFilter.Config.setSerialFilter(sanityInputFilter);
+    }
+
+    private static void setSentry() {
+        querySentry();
+        initSentry();
+    }
+
+    /**
+     * // Configure Sentry with defaults. Although the client defaults to enabled, the
+     *         // properties file is used to disable it and additional configuration can be
+     *         // done inside the sentry.properties file. The defaults for everything else
+     *         // is set here.
+     */
+    private static void initSentry() {
+        Sentry.init(options -> {
+            options.setEnableExternalConfiguration(true);
+            options.setDsn("https://b1720cb789ec56df7df9610dfa463c09@sentry.tapenvy.us/8");
+            options.setEnvironment("production");
+            options.setTracesSampleRate(0.2);
+            options.setDebug(true);
+            options.setServerName("MegaMekClient");
+            options.setRelease(SuiteConstants.VERSION.toString());
+        });
+
+    }
+
+    // Logging doesn't exist yet, so we just print stack trace
+    @SuppressWarnings("CallToPrintStackTrace")
+    private static void querySentry() {
+        var propFile = new File("sentry.properties");
+        if (propFile.isFile()) {
+            return;
+        }
+
+        var window = new JFrame();
+        var shouldSentry = JOptionPane.YES_OPTION == JOptionPane.showConfirmDialog(
+            window,
+            // todo: bother Tex and Hammer about appropriate legalese
+            "Would you like to enable Sentry", "Sentry",
+            JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+
+        try (var writer = new FileWriter(propFile)) {
+            if (shouldSentry) {
+                writer.write("enabled=true\n");
+            } else {
+                writer.write("enabled=false\n");
+            }
+        } catch (IOException e) {
+            JOptionPane.showMessageDialog(window,
+                "Fatal error trying to save Sentry settings. The program will now exit.\n"
+                + ExceptionUtils.getStackTrace(e)
+            );
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+    }
+
+    private StartupUtil() {}
+}


### PR DESCRIPTION
This PR does two things.

First, it moves the common startup code which all three suite programs perform (sentry, OIF, global exception handler) into it's own utility class to avoid duplicating code.

Second, on startup, asks the user if they would like Sentry to be enabled if the `sentry.properties` file doesn't already exist. If this change goes through, releases should be created without a `sentry.properties` file so that one can be created through this method.