### PR TITLE
Issue 6577: Fix duplicate LoS effects for to-hit

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -4667,7 +4667,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // target in partial water
                 && (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) && (targEl == 0) && (te.height() > 0)) {
             los.setTargetCover(los.getTargetCover() | LosEffects.COVER_HORIZONTAL);
-            toHit.append(los.losModifiers(game, eistatus, underWater));
         }
 
         // Change hit table for partial cover, accommodate for partial underwater (legs)


### PR DESCRIPTION
Fixes #6577

The line changed was `losMods = los.losModifiers(game, eistatus, underWater);` before #6307 and was never used again after being updated.

The change in #6307 looks to be doubling the effect now, so I've just removed the line. 

![image](https://github.com/user-attachments/assets/9f272eaf-e70a-42be-b049-618ce24c87e6)
