### PR TITLE
Fix 6461: clean up ASF / VTOL / Hover / WiGE deployment hex display

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -679,7 +679,7 @@ public abstract class BotClient extends Client {
                 Coords c = new Coords(x, y);
                 if (board.isLegalDeployment(c, deployed_ent)
                         && !deployed_ent.isLocationProhibited(c,
-                            ((deployed_ent.isAirborne() | deployed_ent.getMovementMode().isHoverVTOLOrWiGE())
+                            ((deployed_ent.isAirborne() || deployed_ent.getMovementMode().isHoverVTOLOrWiGE())
                                 ? deployed_ent.getElevation() : 0))
                         && !deployed_ent.isLocationDeadly(c)) {
                     validCoords.add(new RankedCoords(c, 0));

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -678,7 +678,9 @@ public abstract class BotClient extends Client {
             for (int y = 0; y <= board.getHeight(); y++) {
                 Coords c = new Coords(x, y);
                 if (board.isLegalDeployment(c, deployed_ent)
-                        && !deployed_ent.isLocationProhibited(c, (deployed_ent.isAirborne() ? deployed_ent.getElevation() : 0))
+                        && !deployed_ent.isLocationProhibited(c,
+                            ((deployed_ent.isAirborne() | deployed_ent.getMovementMode().isHoverVTOLOrWiGE())
+                                ? deployed_ent.getElevation() : 0))
                         && !deployed_ent.isLocationDeadly(c)) {
                     validCoords.add(new RankedCoords(c, 0));
                 }

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -678,7 +678,7 @@ public abstract class BotClient extends Client {
             for (int y = 0; y <= board.getHeight(); y++) {
                 Coords c = new Coords(x, y);
                 if (board.isLegalDeployment(c, deployed_ent)
-                        && !deployed_ent.isLocationProhibited(c)
+                        && !deployed_ent.isLocationProhibited(c, (deployed_ent.isAirborne() ? deployed_ent.getElevation() : 0))
                         && !deployed_ent.isLocationDeadly(c)) {
                     validCoords.add(new RankedCoords(c, 0));
                 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1285,11 +1285,26 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         int drawHeight = (view.height / (int) (HEX_H * scale)) + 3;
 
         Board board = game.getBoard();
+        boolean airDeployGround = en_Deployer.getMovementMode().isHoverVTOLOrWiGE();
         // loop through the hexes
         for (int i = 0; i < drawHeight; i++) {
             for (int j = 0; j < drawWidth; j++) {
                 Coords c = new Coords(j + drawX, i + drawY);
-                if (board.isLegalDeployment(c, en_Deployer) &&
+                if (en_Deployer.isAero()) {
+                    // Aeros are always above it all
+                    if (board.isLegalDeployment(c, en_Deployer) &&
+                        !en_Deployer.isLocationProhibited(c, board.getMaxElevation())) {
+                        drawHexBorder(g, getHexLocation(c), Color.yellow);
+                    }
+                } else if (airDeployGround) {
+                    // Draw hexes that are legal at a higher deployment elevation
+                    Hex hex = board.getHex(c);
+                    if (board.isLegalDeployment(c, en_Deployer) &&
+                        !en_Deployer.isLocationProhibited(c, hex.ceiling() + 1)) {
+                        drawHexBorder(g, getHexLocation(c), Color.cyan);
+                    }
+                } else if (board.isLegalDeployment(c, en_Deployer) &&
+                    // Draw hexes that are legal at current deployment elevation
                         !en_Deployer.isLocationProhibited(c)) {
                     drawHexBorder(g, getHexLocation(c), Color.yellow);
                 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1285,7 +1285,8 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         int drawHeight = (view.height / (int) (HEX_H * scale)) + 3;
 
         Board board = game.getBoard();
-        boolean airDeployGround = en_Deployer.getMovementMode().isHoverVTOLOrWiGE();
+        boolean isAirDeployGround = en_Deployer.getMovementMode().isHover() || en_Deployer.getMovementMode().isVTOL();
+        boolean isWiGE = en_Deployer.getMovementMode().isWiGE();
         // loop through the hexes
         for (int i = 0; i < drawHeight; i++) {
             for (int j = 0; j < drawWidth; j++) {
@@ -1296,15 +1297,18 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                         !en_Deployer.isLocationProhibited(c, board.getMaxElevation())) {
                         drawHexBorder(g, getHexLocation(c), Color.yellow);
                     }
-                } else if (airDeployGround) {
+                } else if (isAirDeployGround || isWiGE) {
                     // Draw hexes that are legal at a higher deployment elevation
                     Hex hex = board.getHex(c);
+                    int maxHeight = (isWiGE) ? 1 : (hex != null) ? hex.ceiling() + 1 : 1;
                     if (board.isLegalDeployment(c, en_Deployer) &&
-                        !en_Deployer.isLocationProhibited(c, hex.ceiling() + 1)) {
+                        !en_Deployer.isLocationProhibited(c, maxHeight)) {
                         drawHexBorder(g, getHexLocation(c), Color.cyan);
                     }
-                } else if (board.isLegalDeployment(c, en_Deployer) &&
-                    // Draw hexes that are legal at current deployment elevation
+                }
+
+                if (board.isLegalDeployment(c, en_Deployer) &&
+                    // Draw hexes that are legal at lowest deployment elevation
                         !en_Deployer.isLocationProhibited(c)) {
                     drawHexBorder(g, getHexLocation(c), Color.yellow);
                 }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1291,13 +1291,13 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         for (int i = 0; i < drawHeight; i++) {
             for (int j = 0; j < drawWidth; j++) {
                 Coords c = new Coords(j + drawX, i + drawY);
-                if (en_Deployer.isAero()) {
-                    // Aeros are always above it all
+                if (en_Deployer.isAero() && en_Deployer.getAltitude() > 0) {
+                    // Flying Aeros are always above it all
                     if (board.isLegalDeployment(c, en_Deployer) &&
                         !en_Deployer.isLocationProhibited(c, board.getMaxElevation())) {
                         drawHexBorder(g, getHexLocation(c), Color.yellow);
                     }
-                } else if (isAirDeployGround || isWiGE) {
+                } else if (isAirDeployGround || isWiGE || en_Deployer.isAero() && en_Deployer.getAltitude() == 0) {
                     // Draw hexes that are legal at a higher deployment elevation
                     Hex hex = board.getHex(c);
                     int maxHeight = (isWiGE) ? 1 : (hex != null) ? hex.ceiling() + 1 : 1;

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1291,16 +1291,25 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         for (int i = 0; i < drawHeight; i++) {
             for (int j = 0; j < drawWidth; j++) {
                 Coords c = new Coords(j + drawX, i + drawY);
-                if (en_Deployer.isAero() && en_Deployer.getAltitude() > 0) {
-                    // Flying Aeros are always above it all
-                    if (board.isLegalDeployment(c, en_Deployer) &&
-                        !en_Deployer.isLocationProhibited(c, board.getMaxElevation())) {
-                        drawHexBorder(g, getHexLocation(c), Color.yellow);
+                if (en_Deployer.isAero()) {
+                    if (en_Deployer.getAltitude() > 0) {
+                        // Flying Aeros are always above it all
+                        if (board.isLegalDeployment(c, en_Deployer) &&
+                            !en_Deployer.isLocationProhibited(c, board.getMaxElevation())) {
+                            drawHexBorder(g, getHexLocation(c), Color.yellow);
+                        }
+                    } else if (en_Deployer.getAltitude() == 0){
+                        // Show prospective Altitude 1+ hexes
+                        if (board.isLegalDeployment(c, en_Deployer) &&
+                            !en_Deployer.isLocationProhibited(c, 1)) {
+                            drawHexBorder(g, getHexLocation(c), Color.cyan);
+                        }
                     }
-                } else if (isAirDeployGround || isWiGE || en_Deployer.isAero() && en_Deployer.getAltitude() == 0) {
+                } else if (isAirDeployGround || isWiGE ) {
                     // Draw hexes that are legal at a higher deployment elevation
                     Hex hex = board.getHex(c);
-                    int maxHeight = (isWiGE) ? 1 : (hex != null) ? hex.ceiling() + 1 : 1;
+                    // Default to Elevation 1 if ceiling + 1 <= 0.
+                    int maxHeight = (isWiGE) ? 1 : (hex != null) ? Math.max(hex.ceiling() + 1, 1) : 1;
                     if (board.isLegalDeployment(c, en_Deployer) &&
                         !en_Deployer.isLocationProhibited(c, maxHeight)) {
                         drawHexBorder(g, getHexLocation(c), Color.cyan);

--- a/megamek/src/megamek/common/AllowedDeploymentHelper.java
+++ b/megamek/src/megamek/common/AllowedDeploymentHelper.java
@@ -187,7 +187,7 @@ public record AllowedDeploymentHelper(Entity entity, Coords coords, Board board,
 
     private List<ElevationOption> findAllowedVTOLElevations() {
         List<ElevationOption> result = new ArrayList<>();
-        if (entity instanceof VTOL) {
+        if (entity instanceof VTOL || entity.getMovementMode().isHoverVTOLOrWiGE()) {
             for (int elevation = 1; elevation < Math.max(10, hex.ceiling() + 1); elevation++) {
                 result.add(new ElevationOption(elevation, ELEVATION));
             }

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -229,6 +229,8 @@ public class Dropship extends SmallCraft {
         int elevMinCount = 2;
         // Check elevation difference and make sure that the counts of different
         // elevations will allow for a legal deployment to exist
+        // TODO: get updated ruling; this code causes a hex with one single lower- or higher-level neighbor
+        // to be disqualified, but it would seem that a single lower-level neighbor should be fine.
         if ((elevDifference > 1) || (elevations.get(elevs[0]) < elevMinCount)
                 || (elevations.get(elevs[1]) < elevMinCount)) {
             return true;

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -178,6 +178,11 @@ public class Dropship extends SmallCraft {
         // treat grounded Dropships like wheeled tanks,
         // plus buildings are prohibited
         boolean isProhibited = hexContainsProhibitedTerrain(hex);
+        // Also check for any crushable entities
+        isProhibited |= game.getEntities(c).hasNext();
+        if (isProhibited) {
+            return true;
+        }
 
         HashMap<Integer, Integer> elevations = new HashMap<>();
         elevations.put(hex.getLevel(), 1);

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -184,11 +184,13 @@ public class Dropship extends SmallCraft {
         for (int dir = 0; dir < 6; dir++) {
             Coords secondaryCoord = c.translated(dir);
             Hex secondaryHex = game.getBoard().getHex(secondaryCoord);
+            boolean occupied = game.getEntities(secondaryCoord).hasNext();
             if (secondaryHex == null) {
                 // Don't allow landed dropships to hang off the board
                 isProhibited = true;
             } else {
                 isProhibited |= hexContainsProhibitedTerrain(secondaryHex);
+                isProhibited |= occupied;
 
                 int elev = secondaryHex.getLevel();
                 if (elevations.containsKey(elev)) {


### PR DESCRIPTION
Per the attached issue, the existing code is 90% correct but gives no hint that a unit with VTOL, Hover, WiGE, or Aerospace attributes might have more deployment hex options at a different elevation / altitude.

This fix:
1. Places Aerospace units at max _elevation_ for the purpose of determining determining valid deployment hexes.  This is separate from Altitude.
2. Adds Cyan-colored hexes denoting currently-illegal hexes that would be legal deployment hexes at a different ~~altitude~~ elevation; the existing code will prompt the user for a different elevation within the legal range of elevations when clicked.
3. Corrects an issue where VTOL or Hover Infantry units were considered ineligible to deploy over water at any elevation.

N.B. WiGE require special handling because, while it is _possible_ that a WiGE unit could perform a maneuver that would let it clear terrain features of height 1 or more, it cannot deploy above 1 elevation.  So `isLocationProhibited(coords, 3)` returns `false` for a WiGE in a light woods hex because it could traverse that terrain _if_ it could reach that elevation, but we need to restrict them to elevation 1 for the purposes of finding deployable hexes.

Examples:
1. Deploying a VTOL at ground level in a crowded, multi-level city:
<img width="821" alt="image" src="https://github.com/user-attachments/assets/c9e3c05b-9cc0-40de-bfd9-13b9a68f3f8a" />

2. Same VTOL with its elevation set to "2":
<img width="841" alt="image" src="https://github.com/user-attachments/assets/15486bea-b202-4702-818a-edf4201666f8" />

3. Now at elevation "4":
<img width="841" alt="image" src="https://github.com/user-attachments/assets/c0e1de91-54f8-4666-98ef-00c780e253c8" />

Note that the minimap displays all hexes where this elevation is valid for deployment, while the main map highlights taller hexes with blue.

Testing:
- Deployed a number of types of flying units manually over various terrain.
- Confirmed that the Bot can also do so for units with elevations/altitudes set in the lobby (this was broken but not reported yet).
- Ran all 3 projects' unit tests.

Close: #6461 