### PR TITLE
MML #1527: Armor validation 

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -593,6 +593,8 @@ public class TestAdvancedAerospace extends TestAero {
             correct = false;
         }
 
+        correct &= correctArmorOverAllocation(vessel, buff);
+
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -526,6 +526,8 @@ public class TestAero extends TestEntity {
             correct = false;
         }
 
+        correct &= correctArmorOverAllocation(aero, buff);
+
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -663,7 +663,7 @@ public class TestMek extends TestEntity {
         if (!getEntity().hasPatchworkArmor()
                 && (getEntity().getLabTotalArmorPoints() < getEntity().getTotalOArmor())) {
             correct = false;
-            buff.append("Too many armor points allocated");
+            buff.append("Too many armor points allocated.\n");
         }
 
         return correct;

--- a/megamek/src/megamek/common/verifier/TestProtoMek.java
+++ b/megamek/src/megamek/common/verifier/TestProtoMek.java
@@ -407,6 +407,8 @@ public class TestProtoMek extends TestEntity {
                 correct = false;
             }
         }
+
+        correct &= correctArmorOverAllocation(proto, buffer);
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -469,6 +469,8 @@ public class TestSmallCraft extends TestAero {
             correct = false;
         }
 
+        correct &= correctArmorOverAllocation(smallCraft, buff);
+
         return correct;
     }
 

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -1038,6 +1038,8 @@ public class TestSupportVehicle extends TestEntity {
             correct = false;
         }
 
+        correct &= correctArmorOverAllocation(supportVee, buff);
+
         if (supportVee.hasBARArmor(supportVee.firstArmorIndex())) {
             int bar = supportVee.getBARRating(supportVee.firstArmorIndex());
 

--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -320,6 +320,9 @@ public class TestTank extends TestEntity {
             buff.append(".\n\n");
             correct = false;
         }
+
+        correct &= correctArmorOverAllocation(tank, buff);
+
         if (tank instanceof VTOL) {
             long mastMountCount = tank.countEquipment(EquipmentTypeLookup.MAST_MOUNT);
             if (mastMountCount > 1) {


### PR DESCRIPTION
This PR adds an item to TestEntity unit validation that tests if more armor points are allocated on a unit than its armor tonnage allows. It moves some required code from MML's UnitUtil to TestEntity. Fixes MegaMek/megameklab#1527
