### PR TITLE
Final Fix 6146: princess bombing flying infantry

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -195,6 +195,7 @@ public class FireControl {
     static final TargetRollModifier TH_AIR_STRIKE = new TargetRollModifier(2, "strike attack");
     private static final TargetRollModifier TH_STABLE_WEAPON = new TargetRollModifier(1, "stabilized weapon quirk");
     private static final TargetRollModifier TH_PHY_LARGE = new TargetRollModifier(-2, "target large vehicle");
+    static final TargetRollModifier TH_TOO_HIGH_FOR_AE = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "target flying too high!");
 
     /**
      * The possible fire control types.
@@ -1118,6 +1119,15 @@ public class FireControl {
             }
             if (0 == firingAmmo.getUsableShotsLeft()) {
                 return new ToHitData(TH_WEAPON_NO_AMMO);
+            }
+
+            // If bombing with actual bombs, make sure the target isn't flying too high to catch in the blast!
+            if (firingAmmo.isGroundBomb()
+                    && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE)
+                )
+                && targetState.isAirborne() && target.getElevation() > 1
+            ) {
+                return new ToHitData(TH_TOO_HIGH_FOR_AE);
             }
         }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1123,11 +1123,11 @@ public class FireControl {
 
             // If bombing with actual bombs, make sure the target isn't flying too high to catch in the blast!
             if (firingAmmo.isGroundBomb()
-                    && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE)
-                )
-                && targetState.isAirborne() && target.getElevation() > 1
+                    && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE))
             ) {
-                return new ToHitData(TH_TOO_HIGH_FOR_AE);
+                if (Compute.allEnemiesAboveHeight(1, target, game.getEntitiesVector(target.getPosition()), shooter)) {
+                    return new ToHitData(TH_TOO_HIGH_FOR_AE);
+                }
             }
         }
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1516,15 +1516,20 @@ public class FireControl {
             // HP in damage), target as normal (don't want to spread damage in these cases).
             // Also want to disregard damage allocation weighting if the target is a
             // building, or infantry/BA that won't be killed off in one shot.
-        } else if ((damageFraction < 0.5) && ((target.getTargetType() == Targetable.TYPE_BUILDING)
-                || (target.getTargetType() == Targetable.TYPE_HEX_CLEAR))
-                || (owner.getGame().getEntity(target.getId()) instanceof Infantry) && damageFraction < 1.0) {
+        }
+        if ((damageFraction < 0.5)
+                || (target.getTargetType() == Targetable.TYPE_BUILDING)
+                || (target.getTargetType() == Targetable.TYPE_HEX_CLEAR)
+        ){
             return 0;
+        }
+        if ((owner.getGame().getEntity(target.getId()) instanceof Infantry)) {
+            // Don't disincentivize possible overkill attacks against Infantry too much.
+            return Math.min(4.0, damageFraction);
         }
 
         // In the remaining case, namely 0.5 <= damage, return the fraction of target HP
-        // dealt as
-        // the penalty scaling factor (multiplied by the weight value to produce a
+        // dealt as the penalty scaling factor (multiplied by the weight value to produce a
         // penalty).
         return damageFraction;
     }
@@ -2012,6 +2017,7 @@ public class FireControl {
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
             Entity entity = (Entity) target;
             Hex hex = game.getBoard().getHex(entity.getPosition());
+            hexToBomb.setTargetLevel(hex.getLevel());
 
             if (entity.isAirborne()) {
                 return diveBombPlan;

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1122,10 +1122,14 @@ public class FireControl {
             }
 
             // If bombing with actual bombs, make sure the target isn't flying too high to catch in the blast!
-            if (firingAmmo.isGroundBomb()
+            if (weapon.isGroundBomb()
                     && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE))
             ) {
-                if (Compute.allEnemiesAboveHeight(1, target, game.getEntitiesVector(target.getPosition()), shooter)) {
+                // See if we can catch the target in the blast
+                Hex targetHex = game.getBoard().getHex(target.getPosition());
+                int height = (targetHex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER))) ? 1 : 0;
+                height *= (BombType.getBlastRadius(weapon.getType().getInternalName()) == 0) ? 1 : 2;
+                if (Compute.allEnemiesAboveHeight(height, target, game.getEntitiesVector(target.getPosition()), shooter)) {
                     return new ToHitData(TH_TOO_HIGH_FOR_AE);
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2002,7 +2002,7 @@ public class FireControl {
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
             Entity entity = (Entity) target;
             Hex hex = game.getBoard().getHex(entity.getPosition());
-            hexToBomb.setTargetLevel(hex.getLevel());
+            hexToBomb.setTargetLevel((hex != null) ? hex.getLevel() : 0);
 
             if (entity.isAirborne()) {
                 return diveBombPlan;

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1126,10 +1126,12 @@ public class FireControl {
                     && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE))
             ) {
                 // See if we can catch the target in the blast
-                Hex targetHex = game.getBoard().getHex(target.getPosition());
-                int height = (targetHex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER))) ? 1 : 0;
-                height *= (BombType.getBlastRadius(weapon.getType().getInternalName()) == 0) ? 1 : 2;
-                if (Compute.allEnemiesAboveHeight(height, target, game.getEntitiesVector(target.getPosition()), shooter)) {
+                if (
+                    Compute.allEnemiesOutsideBlast(
+                        target.getElevation(), target, game.getEntitiesVector(target.getPosition()),
+                        shooter, firingAmmo.getType(), false, false, false, game
+                    )
+                ) {
                     return new ToHitData(TH_TOO_HIGH_FOR_AE);
                 }
             }

--- a/megamek/src/megamek/client/bot/princess/FiringPlan.java
+++ b/megamek/src/megamek/client/bot/princess/FiringPlan.java
@@ -79,7 +79,23 @@ public class FiringPlan extends ArrayList<WeaponFireInfo> implements Comparable<
     synchronized double getExpectedDamage() {
         double expectedDamage = 0;
         for (WeaponFireInfo weaponFireInfo : this) {
-            expectedDamage += weaponFireInfo.getExpectedDamageOnHit() * weaponFireInfo.getProbabilityToHit();
+            expectedDamage += weaponFireInfo.getDamageOnHit() * weaponFireInfo.getProbabilityToHit();
+        }
+        return expectedDamage;
+    }
+
+    synchronized double getExpectedFriendlyDamage() {
+        double expectedDamage = 0;
+        for (WeaponFireInfo weaponFireInfo : this) {
+            expectedDamage += weaponFireInfo.getMaxFriendlyDamage() * weaponFireInfo.getProbabilityToHit();
+        }
+        return expectedDamage;
+    }
+
+    synchronized double getExpectedBuildingDamage() {
+        double expectedDamage = 0;
+        for (WeaponFireInfo weaponFireInfo : this) {
+            expectedDamage += weaponFireInfo.getMaxBuildingDamage() * weaponFireInfo.getProbabilityToHit();
         }
         return expectedDamage;
     }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -623,7 +623,14 @@ public class WeaponFireInfo {
                     return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
                 }
             }
-        }
+        } else if (weapon.isGroundBomb()
+                && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE))
+            ) {
+                // If bombing with actual bombs, make sure the target isn't flying too high to catch in the blast!
+                if (Compute.allEnemiesAboveHeight(1, target, game.getEntitiesVector(target.getPosition()), shooter)) {
+                    return new ToHitData(FireControl.TH_TOO_HIGH_FOR_AE);
+                }
+            }
 
         return realToHitData;
     }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -673,7 +673,7 @@ public class WeaponFireInfo {
                 : ((HexTarget) target).getTargetLevel();
 
             if (hex != null && hex.containsAnyTerrainOf(Terrains.WATER, Terrains.BLDG_ELEV)) {
-                if ((hex.ceiling() + 2 ) < hex.getLevel() + targetLevel) {
+                if ((hex.ceiling() + 2 ) < (hex.getLevel() + targetLevel)) {
                     return new ToHitData(FireControl.TH_TOO_HIGH_FOR_AE);
                 }
             }
@@ -798,10 +798,11 @@ public class WeaponFireInfo {
                             continue;
                         }
                         hitVictims.add(currentVictim);
+                        // Infantry take at least double damage from AE, if not 4x or 8x.
                         if (currentVictim.getOwner().getTeam() != shooter.getOwner().getTeam()) {
-                            damage += blastShape.get(entry);
+                            damage += (currentVictim.isInfantry() ? 2 : 1) * blastShape.get(entry);
                         } else { // we prefer not to blow up friendlies if we can help it
-                            friendlyDamage += blastShape.get(entry);
+                            friendlyDamage += (currentVictim.isInfantry() ? 2 : 1) * blastShape.get(entry);
                         }
                     }
                 }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -627,14 +627,17 @@ public class WeaponFireInfo {
                     return new ToHitData(ToHitData.AUTOMATIC_FAIL, msg);
                 }
             }
-        } else if (weapon.isGroundBomb()
+        } else if (weapon.isGroundBomb() && !(preferredAmmo == null)
+            // If bombing with actual bombs, make sure the target isn't flying too high to catch in the blast!
             && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE))
         ) {
-            // If bombing with actual bombs, make sure the target isn't flying too high to catch in the blast!
-            Hex targetHex = game.getBoard().getHex(target.getPosition());
-            int height = (targetHex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER))) ? 1 : 0;
-            height *= (BombType.getBlastRadius(weapon.getType().getInternalName()) == 0) ? 1 : 2;
-            if (Compute.allEnemiesAboveHeight(height, target, game.getEntitiesVector(target.getPosition()), shooter)) {
+            // See if we can catch the target in the blast
+            if (
+                Compute.allEnemiesOutsideBlast(
+                    target.getElevation(), target, game.getEntitiesVector(target.getPosition()),
+                    shooter, preferredAmmo.getType(), false, false, false, game
+                )
+            ) {
                 return new ToHitData(FireControl.TH_TOO_HIGH_FOR_AE);
             }
         }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -439,7 +439,7 @@ public class WeaponFireInfo {
         // bombs require some special consideration
         if (weapon.isGroundBomb()) {
             // We can only bomb hex targets, officially
-            return computeExpectedBombDamage(getShooter(), weapon, (HexTarget) getTarget());
+            return computeExpectedBombDamage(getShooter(), weapon, getTarget());
         }
 
         // XXX: update this and other utility munition handling with smarter deployment, a la TAG above
@@ -747,12 +747,12 @@ public class WeaponFireInfo {
      * @param targetHex The target hex.
      * @return The array of expected damages of the attack.
      */
-    protected double[] computeExpectedBombDamage(final Entity shooter, final Mounted<?> weapon, final HexTarget targetHex) {
+    protected double[] computeExpectedBombDamage(final Entity shooter, final Mounted<?> weapon, final Targetable targetHex) {
         double damage = 0D, friendlyDamage = 0D, buildingDamage = 0D;
         Coords bombedCoords = targetHex.getPosition();
         int targetLevel = 0;
         if (List.of(Targetable.TYPE_HEX_AERO_BOMB, Targetable.TYPE_HEX_BOMB).contains(targetHex.getTargetType())) {
-            targetLevel = targetHex.getTargetLevel();
+            targetLevel = ((HexTarget) targetHex).getTargetLevel();
         }
 
         // for dive attacks, we can pretty much assume that we're going to drop

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -674,7 +674,7 @@ public class WeaponFireInfo {
 
             if (hex != null && hex.containsAnyTerrainOf(Terrains.WATER, Terrains.BLDG_ELEV)) {
                 if ((hex.ceiling() + 2 ) < (hex.getLevel() + targetLevel)) {
-                    return new ToHitData(FireControl.TH_TOO_HIGH_FOR_AE);
+                    return new ToHitData(FireControl.TH_NO_TARGETS_IN_BLAST);
                 }
             }
         }

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -14329,17 +14329,6 @@ public class AmmoType extends EquipmentType {
                 cost = 3000;
             }
 
-            // Generate blast radius values for various alternate munitions
-            if (((munition.getAmmoType() == T_LONG_TOM) || (munition.getAmmoType() == T_LONG_TOM_CANNON)
-                || (munition.getAmmoType() == T_SNIPER) || (munition.getAmmoType() == T_SNIPER_CANNON)
-                || (munition.getAmmoType() == T_THUMPER) || (munition.getAmmoType() == T_THUMPER_CANNON)
-                || (munition.getAmmoType() == T_ARROWIV_PROTO) || (munition.getAmmoType() == T_ARROW_IV)
-                || (munition.getAmmoType() == T_CRUISE_MISSILE)
-                || (munition.getAmmoType() == T_BA_TUBE)
-            )) {
-                blastRadius.put(munition.internalName, generateBlastRadiusForMunition(munition));
-            }
-
             // Account for floating point imprecision
             munition.bv = Math.round(bv * 1000.0) / 1000.0;
             munition.cost = Math.round(cost * 1000.0) / 1000.0;
@@ -14478,93 +14467,5 @@ public class AmmoType extends EquipmentType {
     public boolean isArmorable() {
         // Coolant pods are implemented as ammo, but are not ammo bins for rules purposes
         return getAmmoType() == AmmoType.T_COOLANT_POD;
-
-    /**
-     * Get the blast radius of a particular bomb type, given the internal name.
-     */
-    public static int getBlastRadius(@Nullable String name) {
-        return blastRadius.getOrDefault(name, 0);
-    }
-
-    protected static int generateBlastRadiusForMunition(AmmoType munition) {
-        // base (HE) munitions use the fall-through value
-        String baseName = (munition.baseName == null)
-            ? munition.internalName.toLowerCase() : munition.baseName.toLowerCase();
-        String muniName = (munition.baseName == null)
-            ? "" : munition.internalName.toLowerCase();
-        if (baseName.contains("longtom")) {
-            if (muniName.contains("copperhead") || muniName.contains("fascam")) {
-                return 0;
-            }
-            if (muniName.contains("cluster") || muniName.contains("smoke")) {
-                return 1;
-            }
-            if (muniName.contains("illumination")) {
-                return 3;
-            }
-            return 2;
-
-        } else if (baseName.contains("sniper")) {
-            if (muniName.contains("copperhead") || muniName.contains("fascam")) {
-                return 0;
-            }
-            if (muniName.contains("cluster") || muniName.contains("smoke")) {
-                return 1;
-            }
-            if (muniName.contains("illumination")) {
-                return 2;
-            }
-            return 1;
-
-        } else if (baseName.contains("thumper")) {
-            if (muniName.contains("copperhead") || muniName.contains("fascam")) {
-                return 0;
-            }
-            if (muniName.contains("cluster") || muniName.contains("smoke")) {
-                return 1;
-            }
-            if (muniName.contains("illumination")) {
-                return 1;
-            }
-            return 1;
-
-        } else if (baseName.contains("batube")) {
-            if (muniName.contains("smoke")) {
-                return 1;
-            }
-            return 1;
-
-        } else if (baseName.contains("arrow")) {
-            if (muniName.contains("thunder")) {
-                return 0;
-            }
-            if (muniName.contains("cluster") || muniName.contains("smoke")
-                || muniName.contains("inferno") || muniName.contains("laser")) {
-                return 1;
-            }
-            if (muniName.contains("illumination")) {
-                return 4;
-            }
-            if (muniName.contains("ada") || muniName.contains("homing")) {
-                // No radius/special radius for blast column purposes
-                return -1;
-            }
-            return 1;
-
-        } else if (baseName.contains("cruise")) {
-            if (muniName.contains("120")) {
-                return 4;
-            }
-            if (muniName.contains("90")) {
-                return 3;
-            }
-            if (muniName.contains("70")) {
-                return 2;
-            }
-            return 1;
-        }
-
-        // safety value
-        return -1;
     }
 }

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -76,13 +76,6 @@ public class BombType extends AmmoType {
         blastRadius = new HashMap<>();
     }
 
-    /**
-     * Get the blast radius of a particular bomb type, given the internal name.
-     */
-    public static int getBlastRadius(String name) {
-        return blastRadius.getOrDefault(name, -1);
-    }
-
     public static String getBombName(int type) {
         if ((type >= B_NUM) || (type < 0)) {
             return "Unknown bomb type";

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -80,7 +80,7 @@ public class BombType extends AmmoType {
      * Get the blast radius of a particular bomb type, given the internal name.
      */
     public static int getBlastRadius(String name) {
-        return blastRadius.getOrDefault(name, 0);
+        return blastRadius.getOrDefault(name, -1);
     }
 
     public static String getBombName(int type) {

--- a/megamek/src/megamek/common/BombType.java
+++ b/megamek/src/megamek/common/BombType.java
@@ -69,9 +69,9 @@ public class BombType extends AmmoType {
 
     public static final int[] bombCosts = { 1, 1, 1, 1, 1, 5, 6, 6, 5, 5, 1, 2, 1, 1, 10, 1, 2, 1 };
 
-    public static final Map<String, Integer> blastRadius;
     private int bombType;
 
+    public static final Map<String, Integer> blastRadius;
     static {
         blastRadius = new HashMap<>();
     }
@@ -79,7 +79,7 @@ public class BombType extends AmmoType {
     /**
      * Get the blast radius of a particular bomb type, given the internal name.
      */
-    public static int getBombBlastRadius(String name) {
+    public static int getBlastRadius(String name) {
         return blastRadius.getOrDefault(name, 0);
     }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7920,9 +7920,16 @@ public class Compute {
     public static boolean allEnemiesOutsideBlast(
         Targetable target, Entity attacker, AmmoType ammoType, final boolean artillery, final boolean flak, final boolean asfFlak, Game game
     ) {
+       return enemiesInsideBlast(target, attacker, ammoType, artillery, flak, asfFlak, game).isEmpty();
+    }
+
+    public static Set<Entity> enemiesInsideBlast(
+        Targetable target, Entity attacker, AmmoType ammoType, final boolean artillery, final boolean flak, final boolean asfFlak, Game game
+    ) {
+        Set<Entity> entities = new HashSet<>();
         Coords position = target.getPosition();
         if (position == null) {
-            return true;
+            return entities;
         }
 
         // We don't need exact positional details to show entities are outside of the blast zone of a given
@@ -7970,8 +7977,8 @@ public class Compute {
         );
 
         int radius = falloff.radius;
-        if (flak) {
-            // Flak shots only affect the target hex
+        if (asfFlak) {
+            // Anti-ASF Flak shots only affect the target hex
             radius = 0;
         }
 
@@ -7980,13 +7987,13 @@ public class Compute {
         boolean cruiseMissile = ammoType.hasFlag(AmmoType.F_CRUISE_MISSILE);
         final int verticalLevels;
         if (cruiseMissile || artillery) {
-            // e.g. LT has damage 25, falloff 10, radius 2 -> round up (25/10) -> 3, -1 = R2.
+            // Levels above (and possibly below) level/center hex
+            // e.g. LT has damage 25, falloff 10, radius 2 -> round up (25/10) -> 3, -1 = 2.
             verticalLevels = (int) Math.ceil(damage / ((cruiseMissile) ? 25.0 : 10.0)) - 1;
         } else {
             verticalLevels = (radius >= 0) ? ((radius > 1) ? 2 : 1) : 0;
         }
 
-        Set<Entity> entities = new HashSet<>();
         if (causeAEBlast || flak || asfFlak) {
             // Both artillery and bombs cause AE blast spheres when hitting water or buildings.
             // For
@@ -8028,6 +8035,6 @@ public class Compute {
 
         }
         // No enemies in the volume == all outside
-        return entities.isEmpty();
+        return entities;
     }
 } // End public class Compute

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7933,4 +7933,39 @@ public class Compute {
         }
         return false;
     }
+
+    public static HashMap<Map.Entry<Integer, Coords>, Integer> shapeBlast(
+        AmmoType ammo, Coords center, int height, int baseDamage, Game game, boolean excludeCenter
+    ) {
+        HashMap<Map.Entry<Integer, Coords>, Integer> blastShape = new HashMap<>();
+
+        if (game == null) {
+            return blastShape;
+        }
+
+
+        if (!excludeCenter) {
+            blastShape.put(Map.entry(height, center), baseDamage);
+        }
+
+        // 1. Handle Artillery-specific blast column (damage/25 levels up from _any_ hit)
+
+        // If this is the center of an AE explosion, also deal damage 1 (or 2) levels up,
+        // and 1 (or 2) levels down.  TW: pp. 113, 172, 173.
+        // If this is an Artillery AE explosion, also deal damage D/25 levels up from center hex only
+        // TODO: implement MOF-based building level drift, building target level selection for user.
+        if (!flak && hex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER))
+            && coords.equals(attackSource)) {
+
+            // Most will be 0; test this
+            int radius = Math.max(
+                BombType.getBlastRadius(BombType.getBombInternalName(((BombType) ammo).getBombType())),
+                AmmoType.getBlastRadius(ammo.getInternalName())
+            );
+
+
+        }
+
+        return blastShape;
+    }
 } // End public class Compute

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7948,10 +7948,6 @@ public class Compute {
         // Assume that offboard units are at or above 0; any underwater units should have negative elevation.
         Hex hex = game.getBoard().getHex(position);
         final int baseHeight = (hex != null) ? hex.getLevel() : 0;
-        if (target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB && hex != null) {
-            // Hex Targetables don't record actual height
-            height = baseHeight;
-        }
 
         // Create the projected blast shape from the ammo, target, height, etc.
         var blastShape = AreaEffectHelper.shapeBlast(
@@ -7961,7 +7957,11 @@ public class Compute {
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
             // check if the target unit is in the computed blast zone;
             return (!blastShape.containsKey(Map.entry(baseHeight + target.getElevation(), target.getPosition())));
-        } else if (target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB) {
+        }
+        if (
+            List.of(Targetable.TYPE_HEX_AERO_BOMB, Targetable.TYPE_HEX_BOMB, Targetable.TYPE_HEX_ARTILLERY, Targetable.TYPE_BUILDING)
+                .contains(target.getTargetType())
+        ) {
             // Check if any of the possible targets are in the blast zone
             return (
                 entities.stream().noneMatch(
@@ -7971,6 +7971,7 @@ public class Compute {
                 )
             );
         }
-        return false;
+        // If we got here, the enemies are outside the blast somehow.
+        return true;
     }
 } // End public class Compute

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7916,19 +7916,21 @@ public class Compute {
     }
 
     public static boolean allEnemiesAboveHeight(int height, Targetable target, List<Entity> entities, Entity attacker) {
-        return (
-            // Airborne ground targets can be bomb targets for e.g. laser-guided bombs
-            (target.getTargetType() == Targetable.TYPE_ENTITY
-                && target.isAirborne()
-                && target.getElevation() > height)
-                // Otherwise if all enemy targets in the hex are airborne above 1 elevation
-            || (target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB
-                && entities.stream().allMatch(
-                entity ->
-                    entity.isVisibleToEnemy() && entity.isEnemyOf(attacker) && entity.isAirborne()
-                        && entity.getElevation() > height
+        if (target.getTargetType() == Targetable.TYPE_ENTITY) {
+            return (
+                (target.isAirborneVTOLorWIGE() || target.isAirborne())
+                && target.getElevation() > height
+            );
+        } else if (target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB) {
+            return (
+                entities.stream().allMatch(
+                    entity ->
+                        entity.isVisibleToEnemy() && entity.isEnemyOf(attacker)
+                            && (entity.isAirborneVTOLorWIGE() || entity.isAirborne())
+                            && entity.getElevation() > height
                 )
-            )
-        );
+            );
+        }
+        return false;
     }
 } // End public class Compute

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -7914,4 +7914,21 @@ public class Compute {
         // Anything not explicitly detected is not detected.
         return false;
     }
+
+    public static boolean allEnemiesAboveHeight(int height, Targetable target, List<Entity> entities, Entity attacker) {
+        return (
+            // Airborne ground targets can be bomb targets for e.g. laser-guided bombs
+            (target.getTargetType() == Targetable.TYPE_ENTITY
+                && target.isAirborne()
+                && target.getElevation() > height)
+                // Otherwise if all enemy targets in the hex are airborne above 1 elevation
+            || (target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB
+                && entities.stream().allMatch(
+                entity ->
+                    entity.isVisibleToEnemy() && entity.isEnemyOf(attacker) && entity.isAirborne()
+                        && entity.getElevation() > height
+                )
+            )
+        );
+    }
 } // End public class Compute

--- a/megamek/src/megamek/common/HexTarget.java
+++ b/megamek/src/megamek/common/HexTarget.java
@@ -22,6 +22,7 @@ public class HexTarget implements Targetable {
     private boolean m_bIgnite;
     private int m_type;
     private HexTarget originalTarget = null;
+    private int targetLevel = 0;
 
     public HexTarget(Coords c, int nType) {
         m_coords = c;
@@ -211,6 +212,15 @@ public class HexTarget implements Targetable {
     // For artillery leading
     public HexTarget getOriginalTarget() {
         return this.originalTarget;
+    }
+
+    // For bombing
+    public int getTargetLevel() {
+        return targetLevel;
+    }
+
+    public void setTargetLevel(int targetLevel) {
+        this.targetLevel = targetLevel;
     }
 
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -20,7 +20,6 @@ import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.common.*;
 import megamek.common.enums.AimingMode;
-import megamek.common.enums.GamePhase;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -1004,7 +1004,7 @@ public class AreaEffectHelper {
         AmmoType ammo, Coords center, DamageFalloff falloff, int height, boolean artillery,
         boolean flak, boolean asfFlak, Game game, boolean excludeCenter
     ) {
-        HashMap<Entry<Integer, Coords>, Integer> blastShape = new HashMap<>();
+        HashMap<Entry<Integer, Coords>, Integer> blastShape = new LinkedHashMap<>();
 
         if (game == null) {
             // Nothing to be done

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -715,6 +715,16 @@ public class AreaEffectHelper {
                 radius = 1;
                 clusterMunitionsFlag = true;
             }
+            if (bomb.getBombType() == BombType.B_ARROW) {
+                damage = bomb.getRackSize();
+                falloff = 10;
+                radius = 1;
+            }
+            if (bomb.getBombType() == BombType.B_HOMING) {
+                damage = bomb.getRackSize();
+                falloff = 20;
+                radius = -1;
+            }
         }
 
         if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
@@ -1011,6 +1021,11 @@ public class AreaEffectHelper {
             blastShape.put(Map.entry(height, center), baseDamage);
             if (asfFlak) {
                 // Only the central hex matters for altitude-level attacks
+                return blastShape;
+            }
+            if (radius == -1) {
+                // No blast effects at all, only central hex affected
+                // e.g. Arrow IV Homing
                 return blastShape;
             }
         }

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -14,6 +14,7 @@
 package megamek.common.weapons;
 
 import java.util.*;
+import java.util.Map.Entry;
 
 import megamek.common.*;
 import megamek.common.planetaryconditions.Atmosphere;
@@ -631,8 +632,9 @@ public class AreaEffectHelper {
             return empty;
         }
 
-        int damage = ammo.getRackSize();
+        int damage = (ammo instanceof BombType) ? ammo.getDamagePerShot() : ammo.getRackSize();
         int falloff = 10;
+        int radius = 0;
         boolean clusterMunitionsFlag = false;
 
         // Capital and Sub-capital missiles
@@ -641,6 +643,7 @@ public class AreaEffectHelper {
                 || ammo.getAmmoType() == AmmoType.T_MANTA_RAY) {
             damage = 50;
             falloff = 25;
+            radius = 1;
         }
         if (ammo.getAmmoType() == AmmoType.T_KILLER_WHALE
                 || ammo.getAmmoType() == AmmoType.T_KILLER_WHALE_T
@@ -648,10 +651,12 @@ public class AreaEffectHelper {
                 || ammo.hasFlag(AmmoType.F_AR10_KILLER_WHALE)) {
             damage = 40;
             falloff = 20;
+            radius = 1;
         }
         if (ammo.getAmmoType() == AmmoType.T_STINGRAY) {
             damage = 35;
             falloff = 17;
+            radius = 2;
         }
         if (ammo.getAmmoType() == AmmoType.T_WHITE_SHARK
                 || ammo.getAmmoType() == AmmoType.T_WHITE_SHARK_T
@@ -659,25 +664,45 @@ public class AreaEffectHelper {
                 || ammo.hasFlag(AmmoType.F_AR10_WHITE_SHARK)) {
             damage = 30;
             falloff = 15;
+            radius = 1;
         }
         if (ammo.getAmmoType() == AmmoType.T_BARRACUDA
                 || ammo.getAmmoType() == AmmoType.T_BARRACUDA_T
                 || ammo.hasFlag(AmmoType.F_AR10_BARRACUDA)) {
             damage = 20;
             falloff = 10;
+            radius = 1;
         }
         if (ammo.getAmmoType() == AmmoType.T_CRUISE_MISSILE) {
             falloff = 25;
+            radius = (int)(Math.ceil(1.0 * damage / falloff) - 1);
         }
         if (ammo.getAmmoType() == AmmoType.T_BA_TUBE) {
             damage *= attackingBA;
             falloff = 2 * attackingBA;
+            // All BA Tube attacks are R1
+            radius = 1;
         }
         // Air-Defense Arrow IV missiles
         if (ammo.getAmmoType() == AmmoType.T_ARROW_IV
                 && ammo.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
             falloff = damage;
+            // ADA does not have a radius as per normal Artillery / AE weapons.
+            radius = -1;
         }
+
+        // Bombs require specific handling
+        if (ammo instanceof BombType bomb) {
+            if (List.of(BombType.B_FAE_SMALL, BombType.B_FAE_LARGE).contains(bomb.getBombType())) {
+                radius = getFuelAirBlastRadiusIndex((bomb.getInternalName()));
+            }
+            if (bomb.getBombType() == BombType.B_CLUSTER) {
+                falloff = 5;
+                radius = 1;
+                clusterMunitionsFlag = true;
+            }
+        }
+
         if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
             // non-arrow-iv cluster does 5 less than standard
             if (ammo.getAmmoType() != AmmoType.T_ARROW_IV) {
@@ -688,21 +713,28 @@ public class AreaEffectHelper {
                 falloff = 9;
             }
 
+            // All Cluster munitions are R1.
+            radius = 1;
             clusterMunitionsFlag = true;
+
         } else if (ammo.getMunitionType().contains(AmmoType.Munitions.M_FLECHETTE)) {
+            // TODO: update to current TacOps rules (damage differs between armor types)
             falloff = switch (ammo.getAmmoType()) {
                 // for flechette, damage and falloff is number of d6, not absolute
                 // damage
                 case AmmoType.T_LONG_TOM -> {
                     damage = 4;
+                    radius = 2;
                     yield 2;
                 }
                 case AmmoType.T_SNIPER -> {
                     damage = 2;
+                    radius = 1;
                     yield 1;
                 }
                 case AmmoType.T_THUMPER -> {
                     damage = 1;
+                    radius = 1;
                     yield 1;
                 }
                 default -> falloff;
@@ -710,11 +742,13 @@ public class AreaEffectHelper {
             // if this was a mine clearance, then it only affects the hex hit
         } else if (mineClear) {
             falloff = damage;
+            radius = 0;
         }
 
         DamageFalloff retVal = new DamageFalloff();
         retVal.damage = damage;
         retVal.falloff = falloff;
+        retVal.radius = radius;
         retVal.clusterMunitionsFlag = clusterMunitionsFlag;
 
         return retVal;
@@ -841,6 +875,7 @@ public class AreaEffectHelper {
     public static class DamageFalloff {
         public int damage;
         public int falloff;
+        public int radius = 0;
         public boolean clusterMunitionsFlag;
     }
 
@@ -875,5 +910,177 @@ public class AreaEffectHelper {
          * Note that the crater radius is this number multiplied by 2
          */
         public int craterDepth;
+    }
+
+    /**
+     * Computes the semi-3D blast shapes of AE and Artillery explosions using rules from:
+     * - Total Warfare pp. 173, XXX, and
+     * - Tactical Operations: Advanced Rules pp. 150, YYY
+     *
+     * The shape of an Area Effect explosion always includes a ring, but may have radius 0.
+     * In this case only units in the hit hex are affected.
+     * Additionally, an AE attack that hits a building or water hex deals damage above and below
+     * the level that was hit:
+     * - For R0 AE attacks: 1/2 to the level above, and 1/2 damage to the level below, the level
+     *                      that was hit/targeted in the central hex.  E.g. a WiGE vehicle at
+     *                      elevation 1 in a water hex would take 1/2 damage from any AE attack
+     *                      that targeted and hit that hex.  Any underwater vehicle at depth 1
+     *                      below the surface, likewise.
+     * - For R1 and larger: full damage to 1 level above and below the targeted level in that hex.
+     *                      1/2 damage to the levels 2 above and 2 below the level hit.
+     *                      Also 1/2 damage in an R1 ring at 1 level above and 1 level below.
+     *
+     * Further, cumulatively, Artillery attacks deal extra damage above the hexes they hit no
+     * matter what type of hex they are (except Building and Mobile Structures):
+     * - For any Artillery: apply base damage - (10 * level) for every level above the base hex
+     *                      until no damage would be dealt.
+     *                      Each unit hit can only be hit once by this damage
+     * - For Flak Artillery: apply base damage - (10 * level) for every level below the target's
+     *                      elevation as well.
+     *
+     * We do not currently support artillery flak fire at Low-Altitude units.
+     *
+     * Specific edge cases to consider:
+     * 1. Counter-battery fire - only worry about the ring at surface level.
+     *
+     * @param ammo              AmmoType of the attack.
+     * @param center            Coordinates of center of blast.
+     * @param height            Elevation/level of target, or Altitude if firing on ASFs
+     * @param artillery         true if artillery attack; false if other AE attack
+     * @param flak              true if flak attack.
+     * @param asfFlak           true if flak attack on an Aerospace unit.
+     * @param game              Reference to game, for terrain checks
+     * @param excludeCenter     Used for creating all height, hex values but the center
+     * @return                  (height, Coords): damage map.
+     */
+    public static HashMap<Entry<Integer, Coords>, Integer> shapeBlast(
+        AmmoType ammo, Coords center, int height, boolean artillery,
+        boolean flak, boolean asfFlak, Game game, boolean excludeCenter
+    ) {
+        HashMap<Entry<Integer, Coords>, Integer> blastShape = new HashMap<>();
+
+        if (game == null) {
+            // Nothing to be done
+            return blastShape;
+        }
+
+        // Falloff is defined separately for each weapon and ammo type, unfortunately.
+        DamageFalloff falloff = calculateDamageFallOff(ammo, 0, false);
+        int baseDamage = falloff.damage;
+        int radius = falloff.radius;
+        boolean isBomb = (ammo instanceof BombType);
+        // Hack until we have a better system for mapping blast falloff
+        if (isBomb && falloff.clusterMunitionsFlag) {
+            baseDamage = 5;
+        }
+
+        // We may want to calculate the blast zone without the center hex, for separate handling.
+        if (!excludeCenter) {
+            blastShape.put(Map.entry(height, center), baseDamage);
+            if (asfFlak) {
+                // Only the central hex matters for altitude-level attacks
+                return blastShape;
+            }
+        }
+
+        // 1. Handle Artillery-specific blast column (N levels up from _any_ hit where N
+        // is base damage / 10 for most artillery, damage / 25 for Cruise Missiles)
+        // Note that this falloff is separate from horizontal blast falloff, above.
+        if (artillery) {
+            int levelMinus = (ammo.getAmmoType() == AmmoType.T_CRUISE_MISSILE) ? 25 : 10;
+            for (int d=(baseDamage - levelMinus), l=height+1; d>0; d-=levelMinus, l++) {
+                blastShape.put(Map.entry(l, center), d);
+            }
+            if (flak) {
+                for (int d=(baseDamage - levelMinus), l=height-1; d>0; d-=levelMinus, l--) {
+                    blastShape.put(Map.entry(l, center), d);
+                }
+            }
+        }
+
+        // 2. Handle normal blast shaping.  Applies to both Artillery and AE in general.
+        // This is a donut of a set radius around the center hex coordinates.
+        // This can be applied to off-board units (see: counter-battery fire)
+        // so we don't check for terrain type here.
+        // Always exclude the center here: either we already made it, above, or we don't want it.
+        blastShape.putAll(AreaEffectHelper.shapeBlastRing(
+            center, height, falloff.damage, falloff.falloff, true
+        ));
+
+        // 2.1 For FAE munitions, add an additional ring of 5 damage
+        // at.getMunitionType().contains(AmmoType.Munitions.M_FAE)
+        if (ammo.getMunitionType().contains(AmmoType.Munitions.M_FAE) ||
+            (isBomb && List.of(
+                BombType.B_FAE_SMALL, BombType.B_FAE_LARGE).contains(((BombType) ammo).getBombType())
+            )
+        ) {
+            List<Coords> ringCoords = center.allAtDistance(radius);
+            for (Coords c : ringCoords) {
+                blastShape.put(Map.entry(height, c), 5);
+            }
+        }
+
+
+        // 3. Handle additional AE blast shaping.
+        // If this is the center of an AE explosion hitting a building or water hex,
+        // also deal damage 1 (or 2) levels up, and 1 (or 2) levels down.  TW: pp. 113, 172, 173.
+        // Note: Artillery does its own thing for the center column
+        // TODO: implement MOF-based building level drift, building target level selection for user.
+        Hex hex = game.getBoard().getHex(center);
+        if (hex != null && hex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER))) {
+            // Artillery can only target ground level, Homing target units, or Flak target entities so
+            // we only do this part for non-Artillery shots.
+            if (!artillery) {
+                // Calculate the center height and depth.
+                if (radius > 0) {
+                    blastShape.put(Map.entry(height+1, center), baseDamage);
+                    blastShape.put(Map.entry(height+2, center), (int) Math.ceil(baseDamage/2.0));
+                    blastShape.put(Map.entry(height-1, center), baseDamage);
+                    blastShape.put(Map.entry(height-2, center), (int) Math.ceil(baseDamage/2.0));
+                } else {
+                    blastShape.put(Map.entry(height+1, center), (int) Math.ceil(baseDamage/2.0));
+                    blastShape.put(Map.entry(height-1, center), (int) Math.ceil(baseDamage/2.0));
+                }
+            }
+            // R1+ AE attacks also generate 1/2-damage rings around the +1 and -1 levels of the center hex.
+            if (radius > 0) {
+                // Damage for upper and lower rings are 1/2 base, rounded up.
+                int donutDamage = (int) Math.ceil(baseDamage/2.0);
+
+                // Upper blast ring looks like >> | 1/2 damage || center || 1/2 damage | << so we need a different
+                // falloff value.  We automatically subtract the falloff value for each radius outside of 1 so
+                // double the computed damage and set the falloff to equal it.
+                blastShape.putAll(AreaEffectHelper.shapeBlastRing(
+                    center, height+1, donutDamage * 2, donutDamage, true
+                ));
+                blastShape.putAll(AreaEffectHelper.shapeBlastRing(
+                    center, height-1, donutDamage * 2, donutDamage, true
+                ));
+            }
+
+        }
+
+        return blastShape;
+    }
+
+    public static HashMap<Entry<Integer, Coords>, Integer> shapeBlastRing(
+        Coords center, int height, int baseDamage, int falloff, boolean excludeCenter
+    ) {
+        HashMap<Entry<Integer, Coords>, Integer> blastRing = new HashMap<>();
+
+        // We may want to calculate the blast zone without the center hex, for separate handling.
+        if (!excludeCenter) {
+            blastRing.put(Map.entry(height, center), baseDamage);
+        }
+
+        int blastDamage = baseDamage - falloff;
+        for (int ring = 1; blastDamage > 0; ring++, blastDamage -= falloff) {
+            List<Coords> ringCoords = center.allAtDistance(ring);
+            for (Coords c: ringCoords) {
+                blastRing.put(Map.entry(height, c), blastDamage);
+            }
+        }
+
+        return blastRing;
     }
 }

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -1091,9 +1091,6 @@ public class AreaEffectHelper {
 
             // R1+ AE attacks also generate 1/2-damage rings around the +1 and -1 levels of the center hex.
             if (radius > 0) {
-                // Damage for upper and lower rings are 1/2 base, rounded up.
-                int donutDamage = (int) Math.ceil(baseDamage/2.0);
-
                 // Upper blast ring looks like >> | 1/2 damage || center || 1/2 damage | << so we need a different
                 // falloff value.  We automatically subtract the falloff value for each radius outside of 1 so
                 // double the computed damage and set the falloff to equal it.

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -399,29 +399,19 @@ public class AreaEffectHelper {
             return;
         }
 
+        // Flak should only hit VTOLs or similar craft.
         if (flak) {
             // Check: is entity not a VTOL in flight or an ASF
             if (!((entity instanceof VTOL)
-                    || (entity.getMovementMode() == EntityMovementMode.VTOL)
-                    || entity.isAero())) {
+                || (entity.getMovementMode() == EntityMovementMode.VTOL)
+                || entity.isAero())) {
                 return;
             }
             // Check: is entity at correct elevation?
             if (entity.getElevation() != altitude) {
                 return;
             }
-        } else {
-            // Check: is entity a VTOL or Aero in flight?
-            if ((entity instanceof VTOL)
-                    || (entity.getMovementMode() == EntityMovementMode.VTOL)
-                    || entity.isAero()) {
-                // VTOLs take no damage from normal artillery unless landed
-                if ((entity.getElevation() != 0)
-                        && (entity.getElevation() != hex.terrainLevel(Terrains.BLDG_ELEV))
-                        && (entity.getElevation() != hex.terrainLevel(Terrains.BRIDGE_ELEV))) {
-                    return;
-                }
-            }
+            // But VTOLs can also be hit by AE blasts while flying!
         }
 
         // Work out hit table to use

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -550,7 +550,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             while (nweaponsHit > 0) {
                 gameManager.artilleryDamageArea(targetPos, aaa.getCoords(), atype,
                         subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
-                        asfFlak, -1);
+                        asfFlak);
                 nweaponsHit--;
             }
         } else {
@@ -572,7 +572,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 }
                 handleArtilleryDriftMarker(origPos, c, aaa,
                         gameManager.artilleryDamageArea(c, aaa.getCoords(), atype, subjectId, ae, isFlak,
-                                altitude, mineClear, vPhaseReport, asfFlak, -1));
+                                altitude, mineClear, vPhaseReport, asfFlak));
             }
 
         }

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -224,7 +224,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
 
         gameManager.artilleryDamageArea(targetPos, ae.getPosition(), ammoType,
                 subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
-                asfFlak, -1);
+                asfFlak);
 
         // artillery may unintentionally clear minefields, but only if it wasn't trying
         // to

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -194,7 +194,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                             targetPos, atype, targetPos, false, ae, null, target.getElevation(),
                             vPhaseReport, gameManager);
                 } else {
-                    AreaEffectHelper.processFuelAirDamage(targetPos,
+                    AreaEffectHelper.processFuelAirDamage(targetPos, target.getElevation(),
                             ammoType, ae, vPhaseReport, gameManager);
                 }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -407,28 +407,26 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         // so we need to carry out offboard/null checks against the "current" version of
         // the target.
         if ((updatedTarget != null) && updatedTarget.isOffBoard()) {
+            // Calculate blast damage falloff and shape
             DamageFalloff df = AreaEffectHelper.calculateDamageFallOff(atype, shootingBA, mineClear);
             HashMap<Map.Entry<Integer, Coords>, Integer> blastShape = AreaEffectHelper.shapeBlast(
-                atype, aaa.getCoords(), df, 0, true, false, false, game, false
+                atype, finalPos, df, 0, true, false, false, game, false
             );
 
-            for (Map.Entry<Integer, Coords> entry: blastShape.keySet()) {
-                Coords bCoords = entry.getValue();
-                int bLevel = entry.getKey();
-                if (blastShape.containsKey(entry)) {
-                    AreaEffectHelper.artilleryDamageEntity(
-                        (Entity) updatedTarget, blastShape.get(entry), null,
-                        0, false, asfFlak, isFlak, altitude,
-                        aaa.getCoords(), atype, finalPos, false, ae, null, altitude,
-                        vPhaseReport, gameManager);
-                }
+            Map.Entry<Integer, Coords> entry = Map.entry(updatedTarget.getElevation(), updatedTarget.getPosition());
+            if (blastShape.containsKey(entry)) {
+                AreaEffectHelper.artilleryDamageEntity(
+                    (Entity) updatedTarget, blastShape.get(entry), null,
+                    0, false, asfFlak, isFlak, entry.getKey(),
+                    finalPos, atype, entry.getValue(), false, ae, null, updatedTarget.getId(),
+                    vPhaseReport, gameManager
+                );
             }
         } else {
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     gameManager.artilleryDamageArea(finalPos, aaa.getCoords(), atype,
                             subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
                             asfFlak));
-
         }
 
         // artillery may unintentionally clear minefields, but only if it wasn't trying

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -319,7 +319,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         if (atype.getMunitionType().contains(Munitions.M_FAE)) {
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     AreaEffectHelper.processFuelAirDamage(
-                            finalPos, atype, aaa.getEntity(game), vPhaseReport, gameManager));
+                            finalPos, aaa.getTarget(game).getElevation(), atype, aaa.getEntity(game), vPhaseReport, gameManager));
             return false;
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -302,6 +302,11 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             return false;
         }
 
+        int altitude = 0;
+        if (isFlak) {
+            altitude = target.getElevation();
+        }
+
         // if attacker is an off-board artillery piece, check to see if we need to set
         // observation flags
         if (aaa.getEntity(game).isOffBoard()) {
@@ -317,9 +322,11 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         }
 
         if (atype.getMunitionType().contains(Munitions.M_FAE)) {
+            Hex finalHex = game.getBoard().getHex(finalPos);
+            altitude = (finalHex != null) ? finalHex.getLevel() : altitude;
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     AreaEffectHelper.processFuelAirDamage(
-                            finalPos, aaa.getTarget(game).getElevation(), atype, aaa.getEntity(game), vPhaseReport, gameManager));
+                            finalPos, altitude, atype, aaa.getEntity(game), vPhaseReport, gameManager));
             return false;
         }
 
@@ -379,11 +386,6 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         if (atype.getMunitionType().contains(Munitions.M_LASER_INHIB)) {
             gameManager.deliverLIsmoke(finalPos, vPhaseReport);
             return false;
-        }
-
-        int altitude = 0;
-        if (isFlak) {
-            altitude = target.getElevation();
         }
 
         // check to see if this is a mine clearing attack

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -13,7 +13,9 @@
  */
 package megamek.common.weapons;
 
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Vector;
 
 import megamek.common.*;
@@ -404,27 +406,28 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         // generated
         // so we need to carry out offboard/null checks against the "current" version of
         // the target.
-        // TODO: update to use blastShape
         if ((updatedTarget != null) && updatedTarget.isOffBoard()) {
             DamageFalloff df = AreaEffectHelper.calculateDamageFallOff(atype, shootingBA, mineClear);
-            int actualDamage = df.damage - (df.falloff * finalPos.distance(target.getPosition()));
-            Coords effectiveTargetPos = aaa.getCoords();
+            HashMap<Map.Entry<Integer, Coords>, Integer> blastShape = AreaEffectHelper.shapeBlast(
+                atype, aaa.getCoords(), df, 0, true, false, false, game, false
+            );
 
-            if (df.clusterMunitionsFlag) {
-                effectiveTargetPos = finalPos;
-            }
-
-            if (actualDamage > 0) {
-                AreaEffectHelper.artilleryDamageEntity((Entity) updatedTarget, actualDamage, null,
+            for (Map.Entry<Integer, Coords> entry: blastShape.keySet()) {
+                Coords bCoords = entry.getValue();
+                int bLevel = entry.getKey();
+                if (blastShape.containsKey(entry)) {
+                    AreaEffectHelper.artilleryDamageEntity(
+                        (Entity) updatedTarget, blastShape.get(entry), null,
                         0, false, asfFlak, isFlak, altitude,
-                        effectiveTargetPos, atype, finalPos, false, ae, null, altitude,
+                        aaa.getCoords(), atype, finalPos, false, ae, null, altitude,
                         vPhaseReport, gameManager);
+                }
             }
         } else {
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     gameManager.artilleryDamageArea(finalPos, aaa.getCoords(), atype,
                             subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
-                            asfFlak, shootingBA));
+                            asfFlak));
 
         }
 

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -404,6 +404,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         // generated
         // so we need to carry out offboard/null checks against the "current" version of
         // the target.
+        // TODO: update to use blastShape
         if ((updatedTarget != null) && updatedTarget.isOffBoard()) {
             DamageFalloff df = AreaEffectHelper.calculateDamageFallOff(atype, shootingBA, mineClear);
             int actualDamage = df.damage - (df.falloff * finalPos.distance(target.getPosition()));

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectHomingHandler.java
@@ -285,7 +285,6 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         // on the other hand, if the hex *is* the target, do full damage
         int hexDamage = targetingHex ? wtype.getRackSize() : ratedDamage * 2;
 
-        bldg = null;
         bldg = game.getBoard().getBuildingAt(coords);
         bldgAbsorbs = (bldg != null) ? bldg.getAbsorbtion(coords) : 0;
         bldgAbsorbs = Math.min(bldgAbsorbs, ratedDamage);

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -277,8 +277,11 @@ public class BombAttackHandler extends WeaponHandler {
                     hitIds = AreaEffectHelper.processFuelAirDamage(drop,
                             EquipmentType.get(BombType.getBombInternalName(type)), ae, vPhaseReport, gameManager);
                 } else {
-                    // We know we can cast this to a HexTarget
-                    hitIds = gameManager.deliverBombDamage((HexTarget) target, type, subjectId, ae, vPhaseReport);
+                    // We want to make this a HexTarget so we can ensure drifts happen at the same elevation
+                    // (Currently this is not working correctly because we don't pass targetLevel over the wire)
+                    HexTarget dropHex = new HexTarget(drop, target.getTargetType());
+                    dropHex.setTargetLevel(((HexTarget) target).getTargetLevel());
+                    hitIds = gameManager.deliverBombDamage(dropHex, type, subjectId, ae, vPhaseReport);
                 }
 
                 // Display drifts that hit nothing separately from drifts that dealt damage

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -277,7 +277,8 @@ public class BombAttackHandler extends WeaponHandler {
                     hitIds = AreaEffectHelper.processFuelAirDamage(drop,
                             EquipmentType.get(BombType.getBombInternalName(type)), ae, vPhaseReport, gameManager);
                 } else {
-                    hitIds = gameManager.deliverBombDamage(drop, type, subjectId, ae, vPhaseReport);
+                    // We know we can cast this to a HexTarget
+                    hitIds = gameManager.deliverBombDamage((HexTarget) target, type, subjectId, ae, vPhaseReport);
                 }
 
                 // Display drifts that hit nothing separately from drifts that dealt damage

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -277,9 +277,6 @@ public class BombAttackHandler extends WeaponHandler {
                     for (Coords c : hexes) {
                         gameManager.deliverThunderMinefield(c, ae.getOwner().getId(), 20, ae.getId());
                     }
-                } else if (type == BombType.B_FAE_SMALL || type == BombType.B_FAE_LARGE) {
-                    hitIds = AreaEffectHelper.processFuelAirDamage(drop, dropHex.getTargetLevel(),
-                        (BombType) EquipmentType.get(BombType.getBombInternalName(type)), ae, vPhaseReport, gameManager);
                 } else {
                     // We want to make this a HexTarget so we can ensure drifts happen at the same elevation
                     // (Currently this is not working correctly because we don't pass targetLevel over the wire)

--- a/megamek/src/megamek/common/weapons/BombAttackHandler.java
+++ b/megamek/src/megamek/common/weapons/BombAttackHandler.java
@@ -265,6 +265,10 @@ public class BombAttackHandler extends WeaponHandler {
                         continue;
                     }
                 }
+                // Capture drop hex info
+                HexTarget dropHex = new HexTarget(drop, target.getTargetType());
+                dropHex.setTargetLevel(((HexTarget) target).getTargetLevel());
+
                 if (type == BombType.B_INFERNO) {
                     hitIds = gameManager.deliverBombInferno(drop, ae, subjectId, vPhaseReport);
                 } else if (type == BombType.B_THUNDER) {
@@ -274,13 +278,11 @@ public class BombAttackHandler extends WeaponHandler {
                         gameManager.deliverThunderMinefield(c, ae.getOwner().getId(), 20, ae.getId());
                     }
                 } else if (type == BombType.B_FAE_SMALL || type == BombType.B_FAE_LARGE) {
-                    hitIds = AreaEffectHelper.processFuelAirDamage(drop,
-                            EquipmentType.get(BombType.getBombInternalName(type)), ae, vPhaseReport, gameManager);
+                    hitIds = AreaEffectHelper.processFuelAirDamage(drop, dropHex.getTargetLevel(),
+                        (BombType) EquipmentType.get(BombType.getBombInternalName(type)), ae, vPhaseReport, gameManager);
                 } else {
                     // We want to make this a HexTarget so we can ensure drifts happen at the same elevation
                     // (Currently this is not working correctly because we don't pass targetLevel over the wire)
-                    HexTarget dropHex = new HexTarget(drop, target.getTargetType());
-                    dropHex.setTargetLevel(((HexTarget) target).getTargetLevel());
                     hitIds = gameManager.deliverBombDamage(dropHex, type, subjectId, ae, vPhaseReport);
                 }
 

--- a/megamek/src/megamek/common/weapons/MicroBombHandler.java
+++ b/megamek/src/megamek/common/weapons/MicroBombHandler.java
@@ -24,8 +24,11 @@ import megamek.common.Infantry;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.weapons.AreaEffectHelper.DamageFalloff;
 import megamek.common.options.OptionsConstants;
 import megamek.server.totalwarfare.TWGameManager;
+
+import static megamek.common.weapons.AreaEffectHelper.calculateDamageFallOff;
 
 /**
  * @author Sebastian Brocks
@@ -45,7 +48,7 @@ public class MicroBombHandler extends AmmoWeaponHandler {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see
      * megamek.common.weapons.WeaponHandler#specialResolution(java.util.Vector,
      * megamek.common.Entity, boolean)
@@ -82,11 +85,11 @@ public class MicroBombHandler extends AmmoWeaponHandler {
                 return !bMissed;
             }
         }
+        // Not mine clearing if we are shooting an entity
         Infantry ba = (Infantry) ae;
-        int ratedDamage = ba.getShootingStrength();
+        DamageFalloff falloff = calculateDamageFallOff((AmmoType) ammo.getType(), ba.getShootingStrength(), false);
         gameManager.artilleryDamageArea(coords, ae.getPosition(),
-                (AmmoType) ammo.getType(), subjectId, ae, ratedDamage * 2,
-                ratedDamage, false, 0, vPhaseReport, false);
+                (AmmoType) ammo.getType(), subjectId, ae, falloff, false, 0, vPhaseReport, false);
         return true;
     }
 }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31454,7 +31454,7 @@ public class TWGameManager extends AbstractGameManager {
                     buildingDamage = damage * ((falloff.radius > 0) ? 3 : 2);
                     // Lower damage as distance increases
                     int hDist = coords.distance(attackSource);
-                    int vDist = Math.abs(targetLevel = altitude);
+                    int vDist = Math.abs(targetLevel - altitude);
                     if (falloff.radius == 0) {
                         // For single-hex AE attacks, damage above and below center is normal damage
                         if (hDist == 0 && vDist == 1) {
@@ -31519,6 +31519,10 @@ public class TWGameManager extends AbstractGameManager {
                 continue;
             } else if ((entity.getElevation() + hex.getLevel() > altitude)
                 || (entity.getElevation() + entity.getHeight() + hex.getLevel() < altitude) ) {
+                StringBuilder msg = new StringBuilder("Missed due to elevation difference: ")
+                    .append("entity lvl/ht: ").append(hex.getLevel()).append("/").append(entity.getElevation())
+                        .append("; current blast level: ").append(altitude);
+                logger.warn(msg.toString());
                 // We now track the blast on a per-level basis
                 continue;
             }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31625,6 +31625,8 @@ public class TWGameManager extends AbstractGameManager {
         Hex hex = game.getBoard().getHex(center);
 
         // Unfortunately this HexTarget is a new instance and contains no level data
+        // Pretend we know what level the user was aiming at.
+        // TODO: remove once we can pass targetLevel info between client and server
         int targetLevel = 0;
         if (hex != null) {
             targetLevel = hex.getLevel();
@@ -31634,6 +31636,8 @@ public class TWGameManager extends AbstractGameManager {
                 Iterator<Entity> targetEnemies = game.getEnemyEntities(center, killer);
                 while (targetEnemies.hasNext()) {
                     Entity next = targetEnemies.next();
+                    // Find the enemies in the target hex; if one's on a valid building or
+                    // water level, make its elevation the target level.
                     if (next.getElevation() + hex.getLevel() <= hex.ceiling() + 1) {
                         targetLevel = next.getElevation() + hex.getLevel();
                         break;

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31522,7 +31522,7 @@ public class TWGameManager extends AbstractGameManager {
                 StringBuilder msg = new StringBuilder("Missed due to elevation difference: ")
                     .append("entity lvl/ht: ").append(hex.getLevel()).append("/").append(entity.getElevation())
                         .append("; current blast level: ").append(altitude);
-                logger.warn(msg.toString());
+                logger.debug(msg.toString());
                 // We now track the blast on a per-level basis
                 continue;
             }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31648,18 +31648,24 @@ public class TWGameManager extends AbstractGameManager {
             }
         }
 
-        DamageFalloff falloff = AreaEffectHelper.calculateDamageFallOff(ammo, 0, false);
+        if (type == BombType.B_FAE_SMALL || type == BombType.B_FAE_LARGE) {
+            // pass FAE bombs with the special handler
+            alreadyHit = AreaEffectHelper.processFuelAirDamage(center, targetLevel,
+                (BombType) EquipmentType.get(BombType.getBombInternalName(type)), killer, vPhaseReport, this);
+        } else {
+            // All other damage-dealing bombs
+            DamageFalloff falloff = AreaEffectHelper.calculateDamageFallOff(ammo, 0, false);
+            HashMap<Map.Entry<Integer, Coords>, Integer> blastShape = AreaEffectHelper.shapeBlast(
+                ammo, center, falloff, targetLevel, false, false, false, game, false);
 
-        HashMap<Map.Entry<Integer, Coords>, Integer> blastShape = AreaEffectHelper.shapeBlast(
-            ammo, center, falloff, targetLevel, false, false, false, game, false);
-
-        for (Map.Entry<Integer, Coords> entry: blastShape.keySet()) {
-            Coords bCoords = entry.getValue();
-            int bLevel = entry.getKey();
-            alreadyHit = artilleryDamageHex(
-                bCoords, center, blastShape.get(entry), ammo, subjectId, killer, null, false,
-                bLevel, targetLevel, vPhaseReport, false, alreadyHit, false, falloff
-            );
+            for (Map.Entry<Integer, Coords> entry : blastShape.keySet()) {
+                Coords bCoords = entry.getValue();
+                int bLevel = entry.getKey();
+                alreadyHit = artilleryDamageHex(
+                    bCoords, center, blastShape.get(entry), ammo, subjectId, killer, null, false,
+                    bLevel, targetLevel, vPhaseReport, false, alreadyHit, false, falloff
+                );
+            }
         }
 
         // Lets reports assess if anything was caught in area

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31576,10 +31576,8 @@ public class TWGameManager extends AbstractGameManager {
      *                     Subject for reports
      * @param killer
      *                     Who should be credited with kills
-     * @param damage
-     *                     Damage at ground zero
      * @param falloff
-     *                     Reduction in damage for each hex of distance
+     *                     Lightweight class describing base damage, falloff per level/ring, cluster y/n, and radius
      * @param flak
      *                     Flak, hits flying units only, instead of flyers being
      *                     immune

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31403,10 +31403,10 @@ public class TWGameManager extends AbstractGameManager {
      *                       to roll
      */
     public Vector<Integer> artilleryDamageHex(Coords coords,
-            Coords attackSource, int damage, AmmoType ammo, int subjectId,
-            Entity killer, Entity exclude, boolean flak, int altitude,
-            Vector<Report> vPhaseReport, boolean asfFlak,
-            Vector<Integer> alreadyHit, boolean variableDamage) {
+          Coords attackSource, int damage, AmmoType ammo, int subjectId,
+          Entity killer, Entity exclude, boolean flak, int altitude,
+          Vector<Report> vPhaseReport, boolean asfFlak,
+          Vector<Integer> alreadyHit, boolean variableDamage) {
 
         Hex hex = game.getBoard().getHex(coords);
         if (hex == null) {
@@ -31575,6 +31575,19 @@ public class TWGameManager extends AbstractGameManager {
             Entity killer, int damage, int falloff, boolean flak, int altitude,
             Vector<Report> vPhaseReport, boolean asfFlak) {
         Vector<Integer> alreadyHit = new Vector<>();
+
+        HashMap<Map.Entry<Integer, Coords>, Integer> blastShape = Compute.shapeBlast(ammo, centre, altitude, damage, game, true);
+
+        for (Map.Entry entry: blastShape.keySet()) {
+            Coords bCoords = (Coords) entry.getValue();
+            int bLevel = (int) entry.getKey();
+            alreadyHit = artilleryDamageHex(
+                bCoords, attackSource, blastShape.get(entry), ammo, subjectId, killer, null, flak,
+                bLevel, vPhaseReport, asfFlak, alreadyHit, false
+            );
+        }
+
+        /**
         for (int ring = 0; damage > 0; ring++, damage -= falloff) {
             List<Coords> hexes = centre.allAtDistance(ring);
             for (Coords c : hexes) {
@@ -31584,6 +31597,7 @@ public class TWGameManager extends AbstractGameManager {
             }
             attackSource = centre; // all splash comes from ground zero
         }
+         */
 
         // Lets reports assess if anything was caught in area
         return alreadyHit;

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -252,6 +252,7 @@ class FireControlTest {
         when(mockTarget.getDisplayName()).thenReturn("mock target");
         when(mockTarget.getId()).thenReturn(MOCK_TARGET_ID);
         when(mockTarget.isMilitary()).thenReturn(true);
+        when(mockTarget.getMovementMode()).thenReturn(EntityMovementMode.BIPED);
 
         testFireControl = spy(new FireControl(mockPrincess));
         doReturn(mockShooterMoveMod)

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -2369,7 +2369,7 @@ class FireControlTest {
 
         when(mockPPCFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockPPCFireInfo.getHeat()).thenReturn(10);
-        when(mockPPCFireInfo.getExpectedDamageOnHit()).thenReturn(10.0);
+        when(mockPPCFireInfo.getDamageOnHit()).thenReturn(10.0);
         when(mockPPCFireInfo.getExpectedCriticals()).thenReturn(0.46);
         when(mockPPCFireInfo.getKillProbability()).thenReturn(0.002);
         when(mockPPCFireInfo.getWeapon()).thenReturn(mockPPC);
@@ -2379,7 +2379,7 @@ class FireControlTest {
 
         when(mockMLFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockMLFireInfo.getHeat()).thenReturn(3);
-        when(mockMLFireInfo.getExpectedDamageOnHit()).thenReturn(5.0);
+        when(mockMLFireInfo.getDamageOnHit()).thenReturn(5.0);
         when(mockMLFireInfo.getExpectedCriticals()).thenReturn(0.0);
         when(mockMLFireInfo.getKillProbability()).thenReturn(0.0);
         when(mockMLFireInfo.getWeapon()).thenReturn(mockML);
@@ -2389,7 +2389,7 @@ class FireControlTest {
 
         when(mockLRMFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockLRMFireInfo.getHeat()).thenReturn(1);
-        when(mockLRMFireInfo.getExpectedDamageOnHit()).thenReturn(3.0);
+        when(mockLRMFireInfo.getDamageOnHit()).thenReturn(3.0);
         when(mockLRMFireInfo.getExpectedCriticals()).thenReturn(0.0);
         when(mockLRMFireInfo.getKillProbability()).thenReturn(0.0);
         when(mockLRMFireInfo.getWeapon()).thenReturn(mockLRM5);
@@ -2402,7 +2402,7 @@ class FireControlTest {
         final WeaponFireInfo mockMGFireInfo = mock(WeaponFireInfo.class);
         when(mockMGFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockMGFireInfo.getHeat()).thenReturn(0);
-        when(mockMGFireInfo.getExpectedDamageOnHit()).thenReturn(2.0);
+        when(mockMGFireInfo.getDamageOnHit()).thenReturn(2.0);
         when(mockMGFireInfo.getExpectedCriticals()).thenReturn(0.0);
         when(mockMGFireInfo.getKillProbability()).thenReturn(0.0);
         when(mockMGFireInfo.getWeapon()).thenReturn(mockMG);
@@ -2528,15 +2528,15 @@ class FireControlTest {
         mockTarget = mock(MekWarrior.class);
         when(mockPPCFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockPPCFireInfo.getHeat()).thenReturn(10);
-        when(mockPPCFireInfo.getExpectedDamageOnHit()).thenReturn(10.0);
+        when(mockPPCFireInfo.getDamageOnHit()).thenReturn(10.0);
 
         when(mockMLFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockMLFireInfo.getHeat()).thenReturn(3);
-        when(mockMLFireInfo.getExpectedDamageOnHit()).thenReturn(5.0);
+        when(mockMLFireInfo.getDamageOnHit()).thenReturn(5.0);
 
         when(mockLRMFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockLRMFireInfo.getHeat()).thenReturn(1);
-        when(mockLRMFireInfo.getExpectedDamageOnHit()).thenReturn(3.0);
+        when(mockLRMFireInfo.getDamageOnHit()).thenReturn(3.0);
 
         doReturn(0.0).when(testFireControl).calcDamageAllocationUtility(any(Targetable.class), anyDouble());
 

--- a/megamek/unittests/megamek/client/bot/princess/FiringPlanTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FiringPlanTest.java
@@ -100,11 +100,11 @@ class FiringPlanTest {
 
     @Test
     void testGetExpectedDamage() {
-        when(mockWeaponFireInfoMG.getExpectedDamageOnHit()).thenReturn(2.0);
+        when(mockWeaponFireInfoMG.getDamageOnHit()).thenReturn(2.0);
         when(mockWeaponFireInfoMG.getProbabilityToHit()).thenReturn(0.1666);
-        when(mockWeaponFireInfoPPC.getExpectedDamageOnHit()).thenReturn(10.0);
+        when(mockWeaponFireInfoPPC.getDamageOnHit()).thenReturn(10.0);
         when(mockWeaponFireInfoPPC.getProbabilityToHit()).thenReturn(0.7222);
-        when(mockWeaponFireInfoERML.getExpectedDamageOnHit()).thenReturn(5.0);
+        when(mockWeaponFireInfoERML.getDamageOnHit()).thenReturn(5.0);
         when(mockWeaponFireInfoERML.getProbabilityToHit()).thenReturn(0.4166);
 
         double expected = (2 * 0.1666) + (10 * 0.7222) + (5 * 0.4166);

--- a/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
@@ -208,8 +208,8 @@ class WeaponFireInfoTest {
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
-        assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(),
-                testWeaponFireInfo.getExpectedDamageOnHit());
+        assertEquals(expectedMaxDamage * expectedProbabilityToHit,
+                testWeaponFireInfo.getExpectedDamage());
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
 
@@ -223,11 +223,11 @@ class WeaponFireInfoTest {
         expectedKill = 0.0;
         doReturn(mockToHitEight).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
-        doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
+        doReturn(new double [] {expectedMaxDamage, 0D, 0D}).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
         assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(),
-                testWeaponFireInfo.getExpectedDamageOnHit());
+                testWeaponFireInfo.getExpectedDamage());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
@@ -242,11 +242,11 @@ class WeaponFireInfoTest {
         expectedKill = 0.02005;
         doReturn(mockToHitSix).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
-        doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
+        doReturn(new double [] {expectedMaxDamage, 0D, 0D}).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
         assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(),
-                testWeaponFireInfo.getExpectedDamageOnHit());
+                testWeaponFireInfo.getExpectedDamage());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
@@ -261,11 +261,11 @@ class WeaponFireInfoTest {
         expectedKill = 0.0;
         doReturn(mockToHitEight).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
-        doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
+        doReturn(new double [] {expectedMaxDamage, 0D, 0D}).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
         assertEquals(expectedMaxDamage * testWeaponFireInfo.getProbabilityToHit(),
-                testWeaponFireInfo.getExpectedDamageOnHit());
+                testWeaponFireInfo.getExpectedDamage());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
@@ -280,10 +280,10 @@ class WeaponFireInfoTest {
         expectedKill = 0;
         doReturn(mockToHitThirteen).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
-        doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
+        doReturn(new double [] {expectedMaxDamage, 0D, 0D}).when(testWeaponFireInfo).computeExpectedDamage();
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());
-        assertEquals(expectedMaxDamage, testWeaponFireInfo.getExpectedDamageOnHit());
+        assertEquals(expectedMaxDamage, testWeaponFireInfo.getDamageOnHit());
         assertEquals(expectedProbabilityToHit, testWeaponFireInfo.getProbabilityToHit(), DELTA);
         assertEquals(expectedCriticals, testWeaponFireInfo.getExpectedCriticals(), DELTA);
         assertEquals(expectedKill, testWeaponFireInfo.getKillProbability(), DELTA);
@@ -338,5 +338,11 @@ class WeaponFireInfoTest {
         assertEquals(expectedTHD.getValue(), processed.getValue());
         assertEquals(expectedTHD.getDesc(), processed.getDesc());
         assertNotEquals(originalTHD, processed);
+    }
+
+    @Test
+    void testComputeExpectedBombDamageOnlyEnemy() {
+//        WeaponFireInfo testBombWFI = setupBombWFI();
+
     }
 }

--- a/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
@@ -203,7 +203,7 @@ class WeaponFireInfoTest {
         double expectedKill = 0;
         doReturn(mockToHitSix).when(testWeaponFireInfo).calcToHit();
         doReturn(mockWeaponAttackAction).when(testWeaponFireInfo).buildWeaponAttackAction();
-        doReturn(expectedMaxDamage).when(testWeaponFireInfo).computeExpectedDamage();
+        doReturn(new double [] {expectedMaxDamage, 0D, 0D}).when(testWeaponFireInfo).computeExpectedDamage();
         when(mockShooter.getEquipment(anyInt())).thenReturn((Mounted) mockWeapon);
         testWeaponFireInfo.initDamage(null, false, true, null);
         assertEquals(expectedMaxDamage, testWeaponFireInfo.getMaxDamage());

--- a/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/WeaponFireInfoTest.java
@@ -339,10 +339,4 @@ class WeaponFireInfoTest {
         assertEquals(expectedTHD.getDesc(), processed.getDesc());
         assertNotEquals(originalTHD, processed);
     }
-
-    @Test
-    void testComputeExpectedBombDamageOnlyEnemy() {
-//        WeaponFireInfo testBombWFI = setupBombWFI();
-
-    }
 }

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
 package megamek.common;
 
 import megamek.client.Client;

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
@@ -241,5 +243,150 @@ class ComputeTest {
         target.setAltitude(3);
 
         assertTrue(Compute.canPointBlankShot(attacker, target));
+    }
+
+    @Test
+    void allEnemiesOutsideBlastLongTomDirectlyOnMek() {
+        // Basic test: Artillery at target's hex
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target = createMek("Target", "TGT-2", "Bob");
+
+        attacker.setOwnerId(player1.getId());
+        attacker.setId(1);
+        Coords attackerCoords = new Coords(0,0);
+        attacker.setPosition(attackerCoords);
+        attacker.setHidden(true);
+        attacker.setDeployed(true);
+        target.setOwnerId(player2.getId());
+        target.setId(2);
+        Coords targetCoords = new Coords(5, 5);
+        target.setPosition(targetCoords);
+        target.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target));
+
+        assertFalse(Compute.allEnemiesOutsideBlast(target, attacker, mockLTAmmoType, true, false, false, game));
+    }
+
+    @Test
+    void allEnemiesOutsideBlastLongTomAdjacentToMek() {
+        // Basic test: Artillery at target's hex
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target = createMek("Target", "TGT-2", "Bob");
+
+        attacker.setOwnerId(player1.getId());
+        attacker.setId(1);
+        Coords attackerCoords = new Coords(0,0);
+        attacker.setPosition(attackerCoords);
+        attacker.setHidden(true);
+        attacker.setDeployed(true);
+        target.setOwnerId(player2.getId());
+        target.setId(2);
+        Coords targetCoords = new Coords(5, 5);
+        target.setPosition(targetCoords);
+        target.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target));
+
+        HexTarget hTarget = new HexTarget(new Coords(6,5), HexTarget.TYPE_HEX_ARTILLERY);
+        assertFalse(Compute.allEnemiesOutsideBlast(hTarget, attacker, mockLTAmmoType, true, false, false, game));
+    }
+
+    @Test
+    void allEnemiesOutsideBlastLongTomTwoFromMek() {
+        // Basic test: Artillery at target's hex
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target = createMek("Target", "TGT-2", "Bob");
+
+        attacker.setOwnerId(player1.getId());
+        attacker.setId(1);
+        Coords attackerCoords = new Coords(0,0);
+        attacker.setPosition(attackerCoords);
+        attacker.setHidden(true);
+        attacker.setDeployed(true);
+        target.setOwnerId(player2.getId());
+        target.setId(2);
+        Coords targetCoords = new Coords(5, 5);
+        target.setPosition(targetCoords);
+        target.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target));
+
+        HexTarget hTarget = new HexTarget(new Coords(6,4), HexTarget.TYPE_HEX_ARTILLERY);
+        assertFalse(Compute.allEnemiesOutsideBlast(hTarget, attacker, mockLTAmmoType, true, false, false, game));
+    }
+
+    @Test
+    void allEnemiesOutsideBlastLongTomThreeFromMek() {
+        // Basic test: Artillery at target's hex
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target = createMek("Target", "TGT-2", "Bob");
+
+        attacker.setOwnerId(player1.getId());
+        attacker.setId(1);
+        Coords attackerCoords = new Coords(0,0);
+        attacker.setPosition(attackerCoords);
+        attacker.setHidden(true);
+        attacker.setDeployed(true);
+        target.setOwnerId(player2.getId());
+        target.setId(2);
+        Coords targetCoords = new Coords(5, 5);
+        target.setPosition(targetCoords);
+        target.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target));
+
+        HexTarget hTarget = new HexTarget(new Coords(8,6), HexTarget.TYPE_HEX_ARTILLERY);
+        assertTrue(Compute.allEnemiesOutsideBlast(hTarget, attacker, mockLTAmmoType, true, false, false, game));
+    }
+
+    @Test
+    void allEnemiesOutsideBlastLongTomTwoUnderMek() {
+        // Basic test: Artillery at target's hex
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target = createMek("Target", "TGT-2", "Bob");
+
+        attacker.setOwnerId(player1.getId());
+        attacker.setId(1);
+        Coords attackerCoords = new Coords(0,0);
+        attacker.setPosition(attackerCoords);
+        attacker.setHidden(true);
+        attacker.setDeployed(true);
+        target.setOwnerId(player2.getId());
+        target.setId(2);
+        Coords targetCoords = new Coords(5, 5);
+        target.setPosition(targetCoords);
+        target.setElevation(2);
+        target.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target));
+
+        HexTarget hTarget = new HexTarget(new Coords(5,5), HexTarget.TYPE_HEX_ARTILLERY);
+        assertFalse(Compute.allEnemiesOutsideBlast(hTarget, attacker, mockLTAmmoType, true, false, false, game));
+    }
+
+    @Test
+    void allEnemiesOutsideBlastLongTomThreeUnderMek() {
+        // Basic test: Artillery at target's hex
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target = createMek("Target", "TGT-2", "Bob");
+
+        attacker.setOwnerId(player1.getId());
+        attacker.setId(1);
+        Coords attackerCoords = new Coords(0, 0);
+        attacker.setPosition(attackerCoords);
+        attacker.setHidden(true);
+        attacker.setDeployed(true);
+        target.setOwnerId(player2.getId());
+        target.setId(2);
+        Coords targetCoords = new Coords(5, 5);
+        target.setPosition(targetCoords);
+        target.setElevation(3);
+        target.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target));
+
+        HexTarget hTarget = new HexTarget(new Coords(5, 5), HexTarget.TYPE_HEX_ARTILLERY);
+        assertTrue(Compute.allEnemiesOutsideBlast(hTarget, attacker, mockLTAmmoType, true, false, false, game));
     }
 }

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -29,6 +29,7 @@ class ComputeTest {
     static Player player2 = new Player(1, "Test2");
     static WeaponType mockAC5 = (WeaponType) EquipmentType.get("ISAC5");
     static AmmoType mockAC5AmmoType = (AmmoType) EquipmentType.get("ISAC5 Ammo");
+    static AmmoType mockLTAmmoType = (AmmoType) EquipmentType.get("ISLongTom Ammo");
 
     @BeforeAll
     static void setUpAll() {
@@ -241,5 +242,4 @@ class ComputeTest {
 
         assertTrue(Compute.canPointBlankShot(attacker, target));
     }
-
 }

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -23,7 +23,7 @@ class ComputeTest {
     static GameOptions mockGameOptions = mock(GameOptions.class);
     static ClientGUI cg = mock(ClientGUI.class);
     static Client client = mock(Client.class);
-    static Game game = new Game();
+    static Game game;
 
     static Team team1 = new Team(0);
     static Team team2 = new Team(1);
@@ -41,6 +41,7 @@ class ComputeTest {
 
     @BeforeEach
     void setUp() {
+        game = new Game();
         when(cg.getClient()).thenReturn(client);
         when(cg.getClient().getGame()).thenReturn(game);
         game.setOptions(mockGameOptions);

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -1,0 +1,247 @@
+package megamek.common.weapons;
+
+import megamek.client.Client;
+import megamek.client.ui.swing.ClientGUI;
+import megamek.common.*;
+import megamek.common.enums.BuildingType;
+import megamek.common.options.GameOptions;
+import megamek.common.options.Option;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.PilotOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static megamek.common.weapons.AreaEffectHelper.calculateDamageFallOff;
+import static megamek.common.weapons.AreaEffectHelper.DamageFalloff;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AreaEffectHelperTest {
+
+    static GameOptions mockGameOptions = mock(GameOptions.class);
+    static ClientGUI cg = mock(ClientGUI.class);
+    static Client client = mock(Client.class);
+    static Game game = new Game();
+
+    static Team team1 = new Team(0);
+    static Team team2 = new Team(1);
+    static Player player1 = new Player(0, "Test1");
+    static Player player2 = new Player(1, "Test2");
+    static AmmoType mockLTAmmoType = (AmmoType) EquipmentType.get("ISLongTom Ammo");
+    static AmmoType mockSniperAmmoType = (AmmoType) EquipmentType.get("ISSniper Ammo");
+    static AmmoType mockBombHEAmmoType = (AmmoType) EquipmentType.get("HEBomb");
+    static AmmoType mockBombFAEAmmoType = (AmmoType) EquipmentType.get("FABombSmall Ammo");
+
+    @BeforeAll
+    static void setUpAll() {
+        // Need equipment initialized
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(cg.getClient()).thenReturn(client);
+        when(cg.getClient().getGame()).thenReturn(game);
+        game.setOptions(mockGameOptions);
+
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ALLOWED_NO_CLAN_PHYSICAL))).thenReturn(false);
+        when(mockGameOptions.stringOption(OptionsConstants.ALLOWED_TECHLEVEL)).thenReturn("Experimental");
+        when(mockGameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED)).thenReturn(true);
+        when(mockGameOptions.booleanOption(OptionsConstants.ALLOWED_SHOW_EXTINCT)).thenReturn(false);
+        Option mockTrueBoolOpt = mock(Option.class);
+        Option mockFalseBoolOpt = mock(Option.class);
+        when(mockTrueBoolOpt.booleanValue()).thenReturn(true);
+        when(mockFalseBoolOpt.booleanValue()).thenReturn(false);
+        when(mockGameOptions.getOption(anyString())).thenReturn(mockTrueBoolOpt);
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3151);
+
+        team1.addPlayer(player1);
+        team2.addPlayer(player2);
+        game.addPlayer(0, player1);
+        game.addPlayer(1, player2);
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    Mek createMek(String chassis, String model, String crewName) {
+        // Create a real Mek with some mocked fields
+        Mek mockMek = new BipedMek();
+        mockMek.setGame(game);
+        mockMek.setChassis(chassis);
+        mockMek.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockMek.setCrew(mockCrew);
+
+        return mockMek;
+    }
+
+    Infantry createInfantry(String chassis, String model, String crewName) {
+        // Create a real Infantry unit with some mocked fields
+        Infantry mockInfantry = new Infantry();
+        mockInfantry.setGame(game);
+        mockInfantry.setChassis(chassis);
+        mockInfantry.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockInfantry.setCrew(mockCrew);
+
+        return mockInfantry;
+    }
+
+    AeroSpaceFighter createASF(String chassis, String model, String crewName) {
+        // Create a real AeroSpaceFighter unit with some mocked fields
+        AeroSpaceFighter mockAeroSpaceFighter = new AeroSpaceFighter();
+        mockAeroSpaceFighter.setGame(game);
+        mockAeroSpaceFighter.setChassis(chassis);
+        mockAeroSpaceFighter.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockAeroSpaceFighter.setCrew(mockCrew);
+
+        return mockAeroSpaceFighter;
+    }
+
+    @Test
+    void testShapeBlastRingR2ArtilleryAttackOnBoardNoAETerrainLevel0() {
+        game.setBoard(new Board(16,17));
+        Coords centerPoint = new Coords(7,7);
+        DamageFalloff falloff = calculateDamageFallOff(mockLTAmmoType, 0, false);
+        HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlastRing(
+            centerPoint, 0, falloff.damage, falloff.falloff,false
+        );
+
+        // We expect a disk of 1 + 6 + 12 hexes centered around the centerPoint
+        assertEquals(19, shape.size());
+        assertTrue(shape.containsKey(Map.entry(0, centerPoint)));
+
+        // Now create the disk minus the center point
+        shape = AreaEffectHelper.shapeBlastRing(
+            centerPoint, 0, falloff.damage, falloff.falloff,true
+        );
+        // We expect a disk of 6 + 12 hexes centered around the centerPoint, but no centerPoint
+        assertEquals(18, shape.size());
+        assertFalse(shape.containsKey(Map.entry(0, centerPoint)));
+    }
+
+    @Test
+    void testShapeBlastR2ArtilleryAttackOnBoardNoAETerrainLevel0() {
+        game.setBoard(new Board(16,17));
+        Coords centerPoint = new Coords(7,7);
+        HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
+            mockLTAmmoType,
+            centerPoint, 0, true, false, false, game, false
+        );
+
+        // We expect a column of two levels above the target level, plus a disk of 1 + 6 + 12 hexes at level
+        assertEquals(21, shape.size());
+    }
+
+    @Test
+    void testShapeBlastR1ArtilleryAttackOnBoardNoAETerrainLevel0() {
+        game.setBoard(new Board(16,17));
+        Coords centerPoint = new Coords(7,7);
+        HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
+            mockSniperAmmoType,
+            centerPoint, 0, true, false, false, game, false
+        );
+
+        // We expect a column of one level above the target level, plus a disk of 1 + 6 hexes at level
+        assertEquals(8, shape.size());
+    }
+
+    @Test
+    void testShapeBlastR1ArtilleryAttackOnBoardNoAETerrainLevel2Flak() {
+        game.setBoard(new Board(16,17));
+        Coords centerPoint = new Coords(7,7);
+        int height = 2;
+        HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
+            mockSniperAmmoType,
+            centerPoint, height, true, true, false, game, false
+        );
+
+        // We expect a column of one level above and below the target level,
+        // plus a disk of 1 + 6 hexes at level
+        assertEquals(9, shape.size());
+        assertTrue(shape.containsKey(Map.entry(1, centerPoint)));
+        assertTrue(shape.containsKey(Map.entry(3, centerPoint)));
+    }
+
+    @Test
+    void testShapeBlastR0BombAttackOnBoardAETerrainLevel2() {
+        int height = 2;
+        int expectedHalfDamage = (int) Math.ceil(mockBombHEAmmoType.getDamagePerShot() / 2.0);
+        game.setBoard(new Board(16,17));
+        Coords centerPoint = new Coords(7,7);
+        Hex hex = new Hex(0);
+        hex.addTerrain(new Terrain(Terrains.BUILDING, height, true, 63));
+        game.getBoard().setHex(centerPoint, hex);
+
+        // This a non-artillery attack.
+        HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
+            mockBombHEAmmoType,
+            centerPoint, height, false, false, false, game, false
+        );
+
+        // We expect a column of one level above and below the target level,
+        // plus a disk of 1 + 6 hexes at level
+        assertEquals(3, shape.size());
+        assertEquals(expectedHalfDamage, shape.get(Map.entry(1, centerPoint)));
+        assertEquals(expectedHalfDamage, shape.get(Map.entry(3, centerPoint)));
+    }
+
+    @Test
+    void testShapeBlastR2BombAttackOnBoardAETerrainLevel2() {
+        int height = 2;
+        int expectedHalfDamage = (int) Math.ceil(mockBombFAEAmmoType.getDamagePerShot() / 2.0);
+        game.setBoard(new Board(16,17));
+        Coords centerPoint = new Coords(7,7);
+        Hex hex = new Hex(0);
+        hex.addTerrain(new Terrain(Terrains.BUILDING, height, true, 63));
+        game.getBoard().setHex(centerPoint, hex);
+
+        // This a non-artillery attack.
+        HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
+            mockBombFAEAmmoType,
+            centerPoint, height, false, false, false, game, false
+        );
+
+        // We expect a column of two levels above and below the target level,
+        // plus a disk of 6 half-damage hexes above and below the target level,
+        // plus a disk of 1 + 6 + 12 hexes at level
+        assertEquals(35, shape.size());
+        assertEquals(expectedHalfDamage, shape.get(Map.entry(0, centerPoint)));
+        assertEquals(mockBombFAEAmmoType.getDamagePerShot(), shape.get(Map.entry(1, centerPoint)));
+        assertEquals(mockBombFAEAmmoType.getDamagePerShot(), shape.get(Map.entry(2, centerPoint)));
+        assertEquals(mockBombFAEAmmoType.getDamagePerShot(), shape.get(Map.entry(3, centerPoint)));
+        assertEquals(expectedHalfDamage, shape.get(Map.entry(4, centerPoint)));
+        for (Coords c: centerPoint.allAtDistance(1)) {
+            assertEquals(expectedHalfDamage, shape.get(Map.entry(3, c)));
+            assertEquals(expectedHalfDamage, shape.get(Map.entry(1, c)));
+        }
+        for (Coords c: centerPoint.allAtDistance(2)) {
+            assertEquals(5, shape.get(Map.entry(2, c)));
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -129,7 +129,7 @@ class AreaEffectHelperTest {
         Coords centerPoint = new Coords(7,7);
         DamageFalloff falloff = calculateDamageFallOff(mockLTAmmoType, 0, false);
         HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlastRing(
-            centerPoint, 0, falloff.damage, falloff.falloff,false
+            centerPoint, falloff, 0, false
         );
 
         // We expect a disk of 1 + 6 + 12 hexes centered around the centerPoint
@@ -138,7 +138,7 @@ class AreaEffectHelperTest {
 
         // Now create the disk minus the center point
         shape = AreaEffectHelper.shapeBlastRing(
-            centerPoint, 0, falloff.damage, falloff.falloff,true
+            centerPoint, falloff, 0,true
         );
         // We expect a disk of 6 + 12 hexes centered around the centerPoint, but no centerPoint
         assertEquals(18, shape.size());
@@ -149,9 +149,10 @@ class AreaEffectHelperTest {
     void testShapeBlastR2ArtilleryAttackOnBoardNoAETerrainLevel0() {
         game.setBoard(new Board(16,17));
         Coords centerPoint = new Coords(7,7);
+        AmmoType ammo = mockLTAmmoType;
+        DamageFalloff falloff = calculateDamageFallOff(ammo, 0, false);
         HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
-            mockLTAmmoType,
-            centerPoint, 0, true, false, false, game, false
+            ammo, centerPoint, falloff, 0, true, false, false, game, false
         );
 
         // We expect a column of two levels above the target level, plus a disk of 1 + 6 + 12 hexes at level

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
 package megamek.common.weapons;
 
 import megamek.client.Client;

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -3,7 +3,6 @@ package megamek.common.weapons;
 import megamek.client.Client;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.common.*;
-import megamek.common.enums.BuildingType;
 import megamek.common.options.GameOptions;
 import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
@@ -245,4 +244,6 @@ class AreaEffectHelperTest {
             assertEquals(5, shape.get(Map.entry(2, c)));
         }
     }
+
+
 }

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -183,6 +183,7 @@ class AreaEffectHelperTest {
 
         // We expect a column of one level above and below the target level,
         // plus a disk of 1 + 6 hexes at level
+        // Ref: TO:AR page 153 'Aerospace Units on Ground Mapsheets'
         assertEquals(9, shape.size());
         assertTrue(shape.containsKey(Map.entry(1, centerPoint)));
         assertTrue(shape.containsKey(Map.entry(3, centerPoint)));


### PR DESCRIPTION
This PR constitutes a major rework of AE blast handling and Princess bombing.

### Issues With Existing Bombing and Artillery Handling ###
During the initial work to fix #6146 I identified some differences between our AE blast damage implementation and the rules per Total Warfare and Tactical Operations:

1. AE attacks that hit buildings and water are supposed to generate a blast "sphere"; we only create a disk.
2. Artillery shots are supposed to create a "top" shape, disk + spindle, but we only create the disk.
3. Artillery shots that hit buildings are supposed to be handled per 1); we just do 2).
4. Bombs should be able to target specific levels of buildings; we just target the ground.
5. Flak Artillery shots at VTOLs should create a blast "top" shape, with a spindle up and down and the normal blast disk; we don't do that.
6. Princess should be able to target VTOL and UMU/Submarine units within 1 (or 2) levels of Building tops and Water surface levels; initially she targeted any unit including Aerospace and high-flying VTOL units.
7. Princess should spread bombing damage out; currently she concentrates all bomb attacks on a single hex or target unit.
8. Princess doesn't evaluate bombing plans based on enemy damage and friendly damage; instead, she just _subtracts_ friendly damage from enemy damage, which exacerbates 7) above.
9. Non-Flak blast damage should be capable of hitting low-flying VTOLs per above; we were skipping VTOLs completely when applying Artillery and Bomb damage, even if they would have fallen within the existing blast area calculations.

### Fixes and Updates ###

The fixes consist of three major changes:
1. I started by creating a method to build a "3D" blast shape according to RAW, encoding AE base damage at specific level-hex coordinates, per TW and TacOps.  This allows dealing damage to various target types just by iterating through the blast "shape" entries in order.

2. Overhauled much of the way that Princess estimates bombing and artillery damage, along with cleaning up some of the expected damage code and variable names.  This includes new blast damage estimation code, similar to the code for 1) above, but faster (if slightly less accurate).
It is now possible to evaluate building and friendly fire damage separately from damage to enemies, which should allow for finer aggression tuning.
Princess will also _try_ to avoid massively overkilling a single target, including infantry, with concentrated bomb attacks.

4. Began work on consolidating all blast radius info into `AreaEffectHelper.calculateDamageFallOff()`.  
Initially I was considering putting the blast radius info into AmmoType, similar to how some (but not all!) BombTypes were doing, but that actually would have been more work, and anyhow `calculateDamageFallOff()` was already being used in a lot of places.

These three major pieces of work should fix the issues identified above without massively increasing processing time.

### Still to Do ###

There is still some work needed to make MegaMek fully TW / TacOps-compliant:

1. Add targetLevel field to information passed over the wire when sending attack packets from client to server.  This is a relatively small change but non-trivial.
2. Provide mechanism for players to specify a target level when bombing buildings; this is expressly described in Total Warfare.

There are also some updates to Princess that would allow her to more effectively utilize bombs:
1. Allow adjusting Dive Bomb attacks to use fewer bombs if the chance of overkill is very high; we already do something similar to bring normal firing plans under heat limits.
2. Teach Princess to use level bombing; the new functions to estimate blast damage should help here.

### Testing ###

I conducted numerous manual, semi-manual, and bot-on-bot tests to validate this code, but stress testing is definitely needed to find edge cases that need better handling.

I did add unit tests for some of the new code, as well as updating existing tests to use the new method of reporting expected damage.