### PR TITLE
Issue 6569: Trailers towed on a tow hitch are no longer returned as an unloadable unit - they should not be unloaded, they should be disconnected.

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8728,14 +8728,16 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * @return All Entities that can at this point be unloaded from any transports
      *         of this Entity which are
-     *         no Bays. This does not include any units that were loaded this turn.
-     *         Note that the returned list may be unmodifiable.
+     *         not Bays. This does not include any units that were loaded this turn.
+     *         Note that the returned list may be unmodifiable.This shouldn't return
+     *         towed entities, they're tracked separately.
      *
+     * @see #getLoadedTrailers()
      * @see #wasLoadedThisTurn()
      */
     public List<Entity> getUnitsUnloadableFromNonBays() {
         return transports.stream()
-                .filter(t -> !(t instanceof Bay))
+                .filter(t -> !(t instanceof Bay) && !(t instanceof TankTrailerHitch))
                 .flatMap(b -> b.getLoadedUnits().stream())
                 .filter(e -> !e.wasLoadedThisTurn())
                 .toList();


### PR DESCRIPTION
Fixes #6569 

Trailers/tow hitches are a real special kinda' Transport. When something is towed on a tow-hitch it shouldn't be unloaded, it should be disconnected - so it shouldn't be returned as something that's unloadable. There's a separate method that returns the list of trailers that can be disconnected, and I've included that in the JavaDoc. 