### PR TITLE
feat: MMLogger using parametrized message and string formatter

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -92,7 +92,7 @@ public class MegaMek {
             final String name = t.getClass().getName();
             final String message = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION, name);
             final String title = String.format(MMLoggingConstants.UNHANDLED_EXCEPTION_TITLE, name);
-            logger.error(t, message, title);
+            logger.errorDialog(t, message, title);
         });
 
         // Second, let's handle logging

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -240,7 +240,7 @@ public final class Version implements Comparable<Version>, Serializable {
             final String nullOrBlank = ((text == null) ? "a null string" : "a blank string");
             final String message = String.format(MMLoggingConstants.VERSION_ERROR_CANNOT_PARSE_VERSION_FROM_STRING,
                     nullOrBlank);
-            logger.fatal(message, MMLoggingConstants.VERSION_PARSE_FAILURE);
+            logger.fatalDialog(message, MMLoggingConstants.VERSION_PARSE_FAILURE);
             return;
         }
 
@@ -249,7 +249,7 @@ public final class Version implements Comparable<Version>, Serializable {
 
         if ((snapshotSplit.length > 2) || (versionSplit.length < 3)) {
             final String message = String.format(MMLoggingConstants.VERSION_ILLEGAL_VERSION_FORMAT, text);
-            logger.fatal(message, MMLoggingConstants.VERSION_PARSE_FAILURE);
+            logger.fatalDialog(message, MMLoggingConstants.VERSION_PARSE_FAILURE);
             return;
         }
 
@@ -257,7 +257,7 @@ public final class Version implements Comparable<Version>, Serializable {
             setRelease(Integer.parseInt(versionSplit[0]));
         } catch (Exception e) {
             final String message = String.format(MMLoggingConstants.VERSION_FAILED_TO_PARSE_RELEASE, text);
-            logger.fatal(e, message, MMLoggingConstants.VERSION_PARSE_FAILURE);
+            logger.fatalDialog(e, message, MMLoggingConstants.VERSION_PARSE_FAILURE);
             return;
         }
 
@@ -265,7 +265,7 @@ public final class Version implements Comparable<Version>, Serializable {
             setMajor(Integer.parseInt(versionSplit[1]));
         } catch (Exception e) {
             final String message = String.format(MMLoggingConstants.VERSION_FAILED_TO_PARSE_MAJOR, text);
-            logger.fatal(e, message, MMLoggingConstants.VERSION_PARSE_FAILURE);
+            logger.fatalDialog(e, message, MMLoggingConstants.VERSION_PARSE_FAILURE);
             return;
         }
 
@@ -273,7 +273,7 @@ public final class Version implements Comparable<Version>, Serializable {
             setMinor(Integer.parseInt(versionSplit[2]));
         } catch (Exception e) {
             final String message = String.format(MMLoggingConstants.VERSION_FAILED_TO_PARSE_MINOR, text);
-            logger.fatal(e, message, MMLoggingConstants.VERSION_PARSE_FAILURE);
+            logger.fatalDialog(e, message, MMLoggingConstants.VERSION_PARSE_FAILURE);
             return;
         }
 

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -2250,7 +2250,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
             // If something goes wrong, probably ProcessBuild.start if anything,
             // Make sure to set the button text back to what it started as no matter what.
             button.setText(Messages.getString("ChatLounge.butPrintList"));
-            logger.error(e, "Operation failed", "Error printing unit list");
+            logger.errorDialog(e, "Operation failed", "Error printing unit list");
 
         }
     }

--- a/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/swing/MegaMekGUI.java
@@ -442,9 +442,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                 mailProperties.load(propsReader);
                 mailer = new EmailService(mailProperties);
             } catch (Exception ex) {
-                logger.error(ex,
-                        Messages.getFormattedString("MegaMek.StartServerError", port, ex.getMessage()),
-                        Messages.getString("MegaMek.LoadGameAlert.title"));
+                logger.errorDialog(ex,
+                    Messages.getFormattedString("MegaMek.StartServerError", port, ex.getMessage()),
+                    Messages.getString("MegaMek.LoadGameAlert.title"));
                 return false;
             }
         }
@@ -457,14 +457,14 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             gameManager = getGameManager(gameType);
             server = new Server(serverPassword, port, gameManager, isRegister, metaServer, mailer, false);
         } catch (Exception ex) {
-            logger.error(ex,
-                    Messages.getFormattedString("MegaMek.StartServerError", port, ex.getMessage()),
-                    Messages.getString("MegaMek.LoadGameAlert.title"));
+            logger.errorDialog(ex,
+                Messages.getFormattedString("MegaMek.StartServerError", port, ex.getMessage()),
+                Messages.getString("MegaMek.LoadGameAlert.title"));
             return false;
         }
 
         if (saveGameFile != null && !server.loadGame(saveGameFile)) {
-            logger.error(Messages.getFormattedString("MegaMek.LoadGameAlert.message", saveGameFile.getAbsolutePath()),
+            logger.errorDialog(Messages.getFormattedString("MegaMek.LoadGameAlert.message", saveGameFile.getAbsolutePath()),
                     Messages.getString("MegaMek.LoadGameAlert.title"));
             server.die();
             server = null;
@@ -520,7 +520,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             serverAddress = Server.validateServerAddress(serverAddress);
             port = Server.validatePort(port);
         } catch (Exception ex) {
-            logger.error(ex,
+            logger.errorDialog(ex,
                     Messages.getFormattedString("MegaMek.ServerConnectionError", serverAddress, port),
                     Messages.getString("MegaMek.LoadGameAlert.title"));
             return;
@@ -617,7 +617,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                 }
             }
         } catch (Exception ex) {
-            logger.error(ex,
+            logger.errorDialog(ex,
                     Messages.getFormattedString("MegaMek.LoadGameAlert.message",
                             fc.getSelectedFile().getAbsolutePath()),
                     Messages.getString("MegaMek.LoadGameAlert.title"));
@@ -764,15 +764,15 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             scenario = sl.load();
             game = scenario.createGame();
         } catch (Exception e) {
-            logger.error(e, Messages.getString("MegaMek.HostScenarioAlert.message", e.getMessage()),
+            logger.errorDialog(e, Messages.getString("MegaMek.HostScenarioAlert.message", e.getMessage()),
                     Messages.getString("MegaMek.HostScenarioAlert.title"));
             return;
         }
 
         // popup options dialog
         if (!scenario.hasFixedGameOptions() && game instanceof Game twGame) {
-            GameOptionsDialog god = new GameOptionsDialog(frame, (GameOptions) twGame.getOptions(), false);
-            god.update((GameOptions) twGame.getOptions());
+            GameOptionsDialog god = new GameOptionsDialog(frame, twGame.getOptions(), false);
+            god.update(twGame.getOptions());
             god.setEditable(true);
             god.setVisible(true);
             for (IBasicOption opt : god.getOptions()) {

--- a/megamek/src/megamek/logging/MMLogger.java
+++ b/megamek/src/megamek/logging/MMLogger.java
@@ -24,10 +24,13 @@ import javax.swing.JOptionPane;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
 
 import io.sentry.Sentry;
+
+import java.util.Collections;
 
 /**
  * MMLogger
@@ -56,10 +59,11 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Private constructor as there should never be an instance of this
      * class.
      */
-    private MMLogger(final Logger logger) {
+    MMLogger(final Logger logger) {
         super((AbstractLogger) logger, logger.getName(), logger.getMessageFactory());
         this.exLoggerWrapper = this;
     }
+
 
     /**
      * Returns a custom Logger with the name of the calling class.
@@ -93,7 +97,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     @Override
     public void info(String message, Object... args) {
-        message = String.format(message, args);
+        message = parametrizedStringIfEnabled(Level.INFO, message, args);
         exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.INFO, null, message);
     }
 
@@ -107,7 +111,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     @Override
     public void warn(String message, Object... args) {
-        message = String.format(message, args);
+        message = parametrizedStringIfEnabled(Level.WARN, message, args);
         exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.WARN, null, message);
     }
 
@@ -122,8 +126,21 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     public void warn(Throwable exception, String message, Object... args) {
         Sentry.captureException(exception);
-        message = String.format(message, args);
+        message = parametrizedStringIfEnabled(Level.WARN, message, args);
         exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.WARN, null, message, exception);
+    }
+
+    /**
+     * Debug Level Logging
+     *
+     * @param message Message to be written to the log file.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     */
+    @Override
+    public void debug(final String message, final Object p0, final Object p1, final Object p2) {
+        logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2);
     }
 
     /**
@@ -135,7 +152,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     @Override
     public void debug(String message, Object... args) {
-        message = String.format(message, args);
+        message = parametrizedStringIfEnabled(Level.DEBUG, message, args);
         exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.DEBUG, null, message);
     }
 
@@ -150,7 +167,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     public void debug(Throwable exception, String message, Object... args) {
         Sentry.captureException(exception);
-        message = String.format(message, args);
+        message = parametrizedStringIfEnabled(Level.DEBUG, message, args);
         exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.DEBUG, null, message, exception);
     }
 
@@ -161,6 +178,18 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * @param message   Additional message to report to the log file.
      */
     public void error(Throwable exception, String message) {
+        Sentry.captureException(exception);
+        exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.ERROR, null, message, exception);
+    }
+
+    /**
+     * Error Level Logging w/ Exception
+     *
+     * @param exception Exception that was caught via a try/catch block.
+     * @param message   Additional message to report to the log file.
+     */
+    public void error(Throwable exception, String message, Object... args) {
+        message = parametrizedStringIfEnabled(Level.ERROR, message, args);
         Sentry.captureException(exception);
         exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.ERROR, null, message, exception);
     }
@@ -190,15 +219,72 @@ public class MMLogger extends ExtendedLoggerWrapper {
 
     /**
      * Error Level Logging w/ Exception w/ Dialog.
-     *
+     * @deprecated (since 01-feb-2025) Use {@link #errorDialog(Throwable, String, String, Object...)} instead.
      * @param exception Exception that was caught.
      * @param message   Message to write to the log file AND be displayed in the
      *                  error pane.
      * @param title     Title of the error message box.
      */
+    @Deprecated
     public void error(Throwable exception, String message, String title) {
-        error(exception, message);
+        errorDialog(exception, message, title, Collections.emptyList());
+    }
 
+    /**
+     * Formatted Error Level Logging w/ Exception w/ Dialog.
+     *
+     * @param message Message to write to the log file AND be displayed in the
+     *                error pane.
+     * @param title   Title of the error message box.
+     */
+    public void errorDialog(Throwable e, String message, String title, Object... args) {
+        Sentry.captureException(e);
+        message = parametrizedStringAnyway(message, args);
+        exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.ERROR, null, message, e);
+        popupErrorDialog(title, message);
+    }
+
+    private String parametrizedStringIfEnabled(Level level, String message, Object... args) {
+        if (isEnabled(level, null, message) && args.length > 0) {
+            message = parametrizedStringAnyway(message, args);
+        }
+        return message;
+    }
+
+
+    private String parametrizedStringAnyway(String message, Object... args) {
+        if (args.length > 0) {
+            if (message.contains("{}")) {
+                message = new ParameterizedMessage(message, args).getFormattedMessage();
+            } else {
+                message = String.format(message, args);
+            }
+        }
+        return message;
+    }
+
+    /**
+     * Formatted Error Level Logging w/o Exception w/ Dialog.
+     *
+     * @param message Message to write to the log file AND be displayed in the
+     *                error pane.
+     * @param title   Title of the error message box.
+     */
+    public void errorDialog(String title, String message, Object... args) {
+        message = parametrizedStringAnyway(message, args);
+        exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.ERROR, null, message);
+        popupErrorDialog(title, message, args);
+    }
+
+    /**
+     * Formatted Error Level Logging w/o Exception w/ Dialog.
+     *
+     * @param message Message to write to the log file AND be displayed in the
+     *                error pane.
+     * @param title   Title of the error message box.
+     */
+    private void popupErrorDialog(String title, String message, Object... args) {
+        message = parametrizedStringAnyway(message, args);
         try {
             JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
         } catch (Exception ignored) {
@@ -215,7 +301,6 @@ public class MMLogger extends ExtendedLoggerWrapper {
      */
     public void error(String message, String title) {
         error(message);
-
         try {
             JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
         } catch (Exception ignored) {
@@ -237,14 +322,40 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Fatal Level Logging w/ Exception w/ Dialog
      *
+     * @deprecated (since 01-feb-2025) Use {@link #fatalDialog(Throwable, String, String)} instead.
      * @param exception Exception that was triggered. Probably uncaught.
      * @param message   Message to report to the log file.
      * @param title     Title of the error message box.
      *
      */
+    @Deprecated
     public void fatal(Throwable exception, String message, String title) {
+        fatalDialog(exception, message, title);
+    }
+
+    /**
+     * Fatal Level Logging w/ Exception w/ Dialog
+     *
+     * @param exception Exception that was triggered. Probably uncaught.
+     * @param message   Message to report to the log file.
+     * @param title     Title of the error message box.
+     *
+     */
+    public void fatalDialog(Throwable exception, String message, String title) {
         fatal(exception, message);
         JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
+    }
+
+    /**
+     *  Fatal Level Logging w/o Exception w/ Dialog
+     * @deprecated (since 01-feb-2025) Use {@link #fatalDialog(String, String)} instead.
+     * @param message Message to report to the log file.
+     * @param title   Title of the error message box.
+     *
+     */
+    @Deprecated
+    public void fatal(String message, String title) {
+        fatalDialog(message, title);
     }
 
     /**
@@ -254,7 +365,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * @param title   Title of the error message box.
      *
      */
-    public void fatal(String message, String title) {
+    public void fatalDialog(String message, String title) {
         fatal(message);
         JOptionPane.showMessageDialog(null, message, title, JOptionPane.ERROR_MESSAGE);
     }
@@ -265,7 +376,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * method.
      *
      * @param checkedLevel Passed in Level to compare to.
-     * @return
+     * @return True if the current log level is more specific than the passed in
      */
     public boolean isLevelMoreSpecificThan(Level checkedLevel) {
         return exLoggerWrapper.getLevel().isMoreSpecificThan(checkedLevel);

--- a/megamek/src/megamek/logging/MMLogger.java
+++ b/megamek/src/megamek/logging/MMLogger.java
@@ -19,8 +19,7 @@
 
 package megamek.logging;
 
-import javax.swing.JOptionPane;
-
+import io.sentry.Sentry;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,27 +27,30 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
 
-import io.sentry.Sentry;
-
+import javax.swing.*;
 import java.util.Collections;
 
 /**
- * MMLogger
- *
- * Utility class to handle logging functions as well as reporting exceptions to
+ * <h1>MMLogger</h1>
+ * <p>Utility class to handle logging functions as well as reporting exceptions to
  * Sentry. To deal with general recommendations of confirming log level before
  * logging, additional checks are added to ensure we're only ever logging data
- * based upon the currently active log level.
- *
- * To utilize this class properly, it must be initialized within each class that
- * will use it. For example for use with the megamek.MegaMek class,
- *
- * private static final MMLogger logger = MMLogger.create(MegaMek.class);
- *
- * And then for use, use logger.info(message) and pass a string to it. Currently
- * supported levels include info, warn, debug, error, and fatal. Error and Fatal
+ * based upon the currently active log level.</p>
+ * <h2>How to use:</h2>
+ * <p>To utilize this class properly, it must be initialized within each class that
+ * will use it. For example for use with the {@code megamek.MegaMek.class}.</p>
+ * <pre>{@code private static final MMLogger logger = MMLogger.create(MegaMek.class);}</pre>
+ * <p>And then for use, use {@code logger.info(message)} and pass a string to it. Currently
+ * supported levels include trace, info, warn, debug, error, and fatal. Warn, Error and Fatal
  * can take any Throwable for sending to Sentry and has an overload for a title
- * to allow for displaying of a dialog box
+ * to allow for displaying of a dialog box.</p>
+ * <p>This class also implements both the parametric pattern and the string format
+ * for the functions that are overriden and added here. This means that you can
+ * use the following formats for the messages in some cases:</p>
+ * <pre>{@code logger.info("number: {} string: {}", 42, "Hello");
+ * logger.info("number: %d string: %s", 42, "Hello");}</pre>
+ * <p>Due to how the logger works, the first format using curly braces is preferred, but the second one
+ * is grandfathered exclusively for logs already existing, and it is not recommended for any new log.</p>
  */
 public class MMLogger extends ExtendedLoggerWrapper {
     private final ExtendedLoggerWrapper exLoggerWrapper;
@@ -56,8 +58,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
     private static final String FQCN = MMLogger.class.getName();
 
     /**
-     * Private constructor as there should never be an instance of this
-     * class.
+     * Package protected constructor, this class should not be created directly.
      */
     MMLogger(final Logger logger) {
         super((AbstractLogger) logger, logger.getName(), logger.getMessageFactory());
@@ -92,8 +93,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Info Level Logging.
      *
      * @param message Message to be sent to the log file.
-     * @param args    Variable list of arguments for message to be passed to
-     *                String.format()
+     * @param args    Variable list of arguments for the message
      */
     @Override
     public void info(String message, Object... args) {
@@ -104,10 +104,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Warning Level Logging
      *
-     * @param message Message to be written to the log file.
-     * @param args    Variable list of arguments for message to be
-     *                passed to String.format()
-     *
+     * @param message Message to be logged.
+     * @param args    Variable list of arguments for the message
      */
     @Override
     public void warn(String message, Object... args) {
@@ -118,11 +116,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Warning Level Logging
      *
-     * @param exception Exception that was caught via a try/catch block.
-     * @param message   Message to be written to the log file.
-     * @param args      Variable list of arguments for message to be
-     *                  passed to String.format()
-     *
+     * @param exception Exception to be logged.
+     * @param message   Message to be logged.
+     * @param args      Variable list of arguments for the message
      */
     public void warn(Throwable exception, String message, Object... args) {
         Sentry.captureException(exception);
@@ -133,22 +129,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Debug Level Logging
      *
-     * @param message Message to be written to the log file.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     * @param p2 parameter to the message.
-     */
-    @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2) {
-        logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2);
-    }
-
-    /**
-     * Debug Level Logging
-     *
-     * @param message Message to be written to the log file.
-     * @param args    Variable list of arguments for message to be passed to
-     *                String.format()
+     * @param message Message to be logged.
+     * @param args    Variable list of arguments for the message
      */
     @Override
     public void debug(String message, Object... args) {
@@ -159,11 +141,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Debug Level Logging
      *
-     * @param exception Exception that was caught via a try/catch block.
-     * @param message   Message to be written to the log file.
-     * @param args      Variable list of arguments for message to be
-     *                  passed to String.format()
-     *
+     * @param exception Exception to be logged.
+     * @param message   Message to be logged.
+     * @param args      Variable list of arguments for the message
      */
     public void debug(Throwable exception, String message, Object... args) {
         Sentry.captureException(exception);
@@ -174,8 +154,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Error Level Logging w/ Exception
      *
-     * @param exception Exception that was caught via a try/catch block.
-     * @param message   Additional message to report to the log file.
+     * @param exception Exception to be logged.
+     * @param message   Additional message.
      */
     public void error(Throwable exception, String message) {
         Sentry.captureException(exception);
@@ -185,8 +165,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Error Level Logging w/ Exception
      *
-     * @param exception Exception that was caught via a try/catch block.
-     * @param message   Additional message to report to the log file.
+     * @param exception Exception to be logged.
+     * @param message   Additional message to be logged.
+     * @param args      Variable list of arguments for the message
      */
     public void error(Throwable exception, String message, Object... args) {
         message = parametrizedStringIfEnabled(Level.ERROR, message, args);
@@ -196,11 +177,10 @@ public class MMLogger extends ExtendedLoggerWrapper {
 
     /**
      * Error Level Logging w/ Exception
-     *
      * This one was made to make it easier to replace the Log4J Calls
      *
-     * @param message   Additional message to report to the log file.
-     * @param exception Exception that was caught via a try/catch block.
+     * @param message   Message to be logged.
+     * @param exception Exception to be logged.
      */
     public void error(String message, Throwable exception) {
         Sentry.captureException(exception);
@@ -210,7 +190,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Error Level Logging w/o Exception.
      *
-     * @param message Message to be written to the log file.
+     * @param message Message to be logged.
      */
     @Override
     public void error(String message) {
@@ -219,8 +199,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
 
     /**
      * Error Level Logging w/ Exception w/ Dialog.
-     * @deprecated (since 01-feb-2025) Use {@link #errorDialog(Throwable, String, String, Object...)} instead.
-     * @param exception Exception that was caught.
+     * @deprecated (since 21-feb-2025) Use {@link #errorDialog(Throwable, String, String, Object...)} instead.
+     * @param exception Exception to be logged.
      * @param message   Message to write to the log file AND be displayed in the
      *                  error pane.
      * @param title     Title of the error message box.
@@ -232,35 +212,17 @@ public class MMLogger extends ExtendedLoggerWrapper {
 
     /**
      * Formatted Error Level Logging w/ Exception w/ Dialog.
-     *
+     * @param exception Exception to be logged.
      * @param message Message to write to the log file AND be displayed in the
      *                error pane.
      * @param title   Title of the error message box.
+     * @param args    Variable list of arguments for the message.
      */
-    public void errorDialog(Throwable e, String message, String title, Object... args) {
-        Sentry.captureException(e);
+    public void errorDialog(Throwable exception, String message, String title, Object... args) {
+        Sentry.captureException(exception);
         message = parametrizedStringAnyway(message, args);
-        exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.ERROR, null, message, e);
+        exLoggerWrapper.logIfEnabled(MMLogger.FQCN, Level.ERROR, null, message, exception);
         popupErrorDialog(title, message);
-    }
-
-    private String parametrizedStringIfEnabled(Level level, String message, Object... args) {
-        if (isEnabled(level, null, message) && args.length > 0) {
-            message = parametrizedStringAnyway(message, args);
-        }
-        return message;
-    }
-
-
-    private String parametrizedStringAnyway(String message, Object... args) {
-        if (args.length > 0) {
-            if (message.contains("{}")) {
-                message = new ParameterizedMessage(message, args).getFormattedMessage();
-            } else {
-                message = String.format(message, args);
-            }
-        }
-        return message;
     }
 
     /**
@@ -269,6 +231,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * @param message Message to write to the log file AND be displayed in the
      *                error pane.
      * @param title   Title of the error message box.
+     * @param args      Variable list of arguments for the message
      */
     public void errorDialog(String title, String message, Object... args) {
         message = parametrizedStringAnyway(message, args);
@@ -282,6 +245,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * @param message Message to write to the log file AND be displayed in the
      *                error pane.
      * @param title   Title of the error message box.
+     * @param args      Variable list of arguments for the message
      */
     private void popupErrorDialog(String title, String message, Object... args) {
         message = parametrizedStringAnyway(message, args);
@@ -322,11 +286,10 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Fatal Level Logging w/ Exception w/ Dialog
      *
-     * @deprecated (since 01-feb-2025) Use {@link #fatalDialog(Throwable, String, String)} instead.
+     * @deprecated (since 21-feb-2025) Use {@link #fatalDialog(Throwable, String, String)} instead.
      * @param exception Exception that was triggered. Probably uncaught.
      * @param message   Message to report to the log file.
      * @param title     Title of the error message box.
-     *
      */
     @Deprecated
     public void fatal(Throwable exception, String message, String title) {
@@ -339,7 +302,6 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * @param exception Exception that was triggered. Probably uncaught.
      * @param message   Message to report to the log file.
      * @param title     Title of the error message box.
-     *
      */
     public void fatalDialog(Throwable exception, String message, String title) {
         fatal(exception, message);
@@ -348,10 +310,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
 
     /**
      *  Fatal Level Logging w/o Exception w/ Dialog
-     * @deprecated (since 01-feb-2025) Use {@link #fatalDialog(String, String)} instead.
+     * @deprecated (since 21-feb-2025) Use {@link #fatalDialog(String, String)} instead.
      * @param message Message to report to the log file.
      * @param title   Title of the error message box.
-     *
      */
     @Deprecated
     public void fatal(String message, String title) {
@@ -363,7 +324,6 @@ public class MMLogger extends ExtendedLoggerWrapper {
      *
      * @param message Message to report to the log file.
      * @param title   Title of the error message box.
-     *
      */
     public void fatalDialog(String message, String title) {
         fatal(message);
@@ -388,10 +348,28 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * method.
      *
      * @param checkedLevel Passed in Level to compare to.
-     * @return
+     * @return True if the current log level is less specific than the passed in
      */
     public boolean isLevelLessSpecificThan(Level checkedLevel) {
         return exLoggerWrapper.getLevel().isLessSpecificThan(checkedLevel);
+    }
+
+    private String parametrizedStringIfEnabled(Level level, String message, Object... args) {
+        if (isEnabled(level, null, message) && args.length > 0) {
+            message = parametrizedStringAnyway(message, args);
+        }
+        return message;
+    }
+
+    private String parametrizedStringAnyway(String message, Object... args) {
+        if (args.length > 0) {
+            if (message.contains("{}")) {
+                message = new ParameterizedMessage(message, args).getFormattedMessage();
+            } else {
+                message = String.format(message, args);
+            }
+        }
+        return message;
     }
 
 }

--- a/megamek/unittests/megamek/logging/MMLoggerTest.java
+++ b/megamek/unittests/megamek/logging/MMLoggerTest.java
@@ -65,6 +65,13 @@ public class MMLoggerTest {
     @Test
     public void testWarnLoggingWithException() {
         Exception e = new Exception("Test exception");
+        testMMLogger.warn(e, "Warn message: {}", "test");
+        verifyLog(Level.WARN, "Warn message: test", e);
+    }
+
+    @Test
+    public void testWarnLoggingWithExceptionWithStringFormat() {
+        Exception e = new Exception("Test exception");
         testMMLogger.warn(e, "Warn message: %s", "test");
         verifyLog(Level.WARN, "Warn message: test", e);
     }
@@ -83,12 +90,23 @@ public class MMLoggerTest {
             return;
         }
         automaticallyDismissDialog();
+        testMMLogger.errorDialog("test", "Error message: {}", "test");
+        verifyLog(Level.ERROR, "Error message: test");
+    }
+
+    @Test
+    public void testErrorLoggingWithStringFormat() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
         testMMLogger.errorDialog("test", "Error message: %s", "test");
         verifyLog(Level.ERROR, "Error message: test");
     }
 
     @Test
-    public void testErrorLoggingWithExceptionNoParams() {
+    public void testDeprecatedErrorLoggingWithExceptionNoParams() {
         if (GraphicsEnvironment.isHeadless()) {
             // Skip this test if running in headless mode
             return;
@@ -111,7 +129,6 @@ public class MMLoggerTest {
         verifyLog(Level.ERROR, "Error message: test", e);
     }
 
-
     @Test
     public void testFatalLogging() {
         testMMLogger.fatal("Fatal without dialog without exception");
@@ -130,9 +147,32 @@ public class MMLoggerTest {
     }
 
     @Test
+    public void testDeprecatedFatalLoggingWithDialog() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
+        testMMLogger.fatal("Fatal with dialog with exception", "Fatal dialog title");
+        verifyLog(Level.FATAL, "Fatal with dialog with exception");
+    }
+
+    @Test
     public void testFatalLoggingWithException() {
         Exception e = new Exception("Test exception");
         testMMLogger.fatal(e, "Fatal without dialog with exception");
+        verifyLog(Level.FATAL, "Fatal without dialog with exception", e);
+    }
+
+    @Test
+    public void testDeprecatedFatalLoggingWithException() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
+        Exception e = new Exception("Test exception");
+        testMMLogger.fatal(e, "Fatal without dialog with exception" , "Fatal dialog title");
         verifyLog(Level.FATAL, "Fatal without dialog with exception", e);
     }
 

--- a/megamek/unittests/megamek/logging/MMLoggerTest.java
+++ b/megamek/unittests/megamek/logging/MMLoggerTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
+package megamek.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.spi.AbstractLogger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockitoAnnotations;
+
+import java.awt.*;
+import java.awt.event.KeyEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class MMLoggerTest {
+    private final static MMLogger logger = MMLogger.create(MMLoggerTest.class);
+
+    private CustomLogger mockLogger;
+    private MMLogger testMMLogger;
+    private final static String LOGGER_NAME = "TestLogger";
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockLogger = spy(new CustomLogger(LOGGER_NAME));
+        testMMLogger = new MMLogger(mockLogger);
+    }
+
+    @Test
+    public void testDebugLogging() {
+        testMMLogger.debug("Debug message: {}", "test");
+        verifyLog(Level.DEBUG, "Debug message: test");
+    }
+
+    @Test
+    public void testInfoLogging() {
+        testMMLogger.info("Info message: {}", "test");
+        verifyLog(Level.INFO, "Info message: test");
+    }
+
+    @Test
+    public void testWarnLogging() {
+        testMMLogger.warn("Warn message: {}", "test");
+        verifyLog(Level.WARN, "Warn message: test");
+    }
+
+    @Test
+    public void testWarnLoggingWithException() {
+        Exception e = new Exception("Test exception");
+        testMMLogger.warn(e, "Warn message: %s", "test");
+        verifyLog(Level.WARN, "Warn message: test", e);
+    }
+
+    @Test
+    public void testDebugLoggingWithException() {
+        Exception e = new Exception("Test exception");
+        testMMLogger.debug(e, "Debug message: %s", "test");
+        verifyLog(Level.DEBUG, "Debug message: test", e);
+    }
+
+    @Test
+    public void testErrorLogging() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
+        testMMLogger.errorDialog("test", "Error message: %s", "test");
+        verifyLog(Level.ERROR, "Error message: test");
+    }
+
+    @Test
+    public void testErrorLoggingWithExceptionNoParams() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
+        Exception e = new Exception("Test exception");
+        testMMLogger.error(e, "Error message: noparameter accepted", "test");
+        verifyLog(Level.ERROR, "Error message: noparameter accepted", e);
+    }
+
+    @Test
+    public void testErrorLoggingWithException() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
+        Exception e = new Exception("Test exception");
+        testMMLogger.errorDialog(e, "Error message: {}", "test", "test");
+        verifyLog(Level.ERROR, "Error message: test", e);
+    }
+
+
+    @Test
+    public void testFatalLogging() {
+        testMMLogger.fatal("Fatal without dialog without exception");
+        verifyLog(Level.FATAL, "Fatal without dialog without exception");
+    }
+
+    @Test
+    public void testFatalLoggingWithDialog() {
+        if (GraphicsEnvironment.isHeadless()) {
+            // Skip this test if running in headless mode
+            return;
+        }
+        automaticallyDismissDialog();
+        testMMLogger.fatalDialog("Fatal with dialog with exception", "Fatal dialog title");
+        verifyLog(Level.FATAL, "Fatal with dialog with exception");
+    }
+
+    @Test
+    public void testFatalLoggingWithException() {
+        Exception e = new Exception("Test exception");
+        testMMLogger.fatal(e, "Fatal without dialog with exception");
+        verifyLog(Level.FATAL, "Fatal without dialog with exception", e);
+    }
+
+    private void verifyLog(Level level, String message) {
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(mockLogger).logMessage(anyString(), eq(level), nullable(Marker.class), messageCaptor.capture(), nullable(Throwable.class));
+        assertEquals(message, messageCaptor.getValue().getFormattedMessage());
+    }
+
+    private void verifyLog(Level level, String message, Throwable e) {
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
+        verify(mockLogger).logMessage(anyString(), eq(level), nullable(Marker.class), messageCaptor.capture(), throwableCaptor.capture());
+        assertEquals(message, messageCaptor.getValue().getFormattedMessage());
+        assertEquals(e, throwableCaptor.getValue());
+    }
+
+    // Simulate pressing the Enter key, necessary to dismiss the dialogs created by the logger on some types of logs
+    private static void automaticallyDismissDialog() {
+        try {
+            Robot robot = new Robot();
+            new Thread(() -> {
+                try {
+                    Thread.sleep(1500);
+                    robot.keyPress(KeyEvent.VK_ENTER);
+                    Thread.sleep(100);
+                    robot.keyRelease(KeyEvent.VK_ENTER);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }).start();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Custom logger implementation for testing
+    private static class CustomLogger extends AbstractLogger {
+        protected CustomLogger(String name) {
+            super(name, null);
+        }
+
+        @Override
+        public void logMessage(String fqcn, Level level, org.apache.logging.log4j.Marker marker, String message, Throwable t) {
+            // Custom implementation for logging messages
+        }
+
+        @Override
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, String message) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, String message, Throwable t) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, String message, Object... params) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9) {
+            return true;
+        }
+
+        @Override
+        public void logMessage(String fqcn, Level level, Marker marker, Message message, Throwable t) {
+
+        }
+
+        @Override
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, Object message, Throwable t) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, org.apache.logging.log4j.message.Message message, Throwable t) {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, CharSequence message, Throwable t) {
+            return true;
+        }
+
+        @Override
+        public Level getLevel() {
+            return Level.ALL;
+        }
+    }
+}


### PR DESCRIPTION
# What it does?

Adds parametrized messages and string formatter to the MMLogger, and makes obvious when the error command will open a dialog screen with the error.

This also shows how to properly use the different ways to setup parameters for the logs