### PR TITLE
Chain Drape (Construction Only)

### DIFF
--- a/megamek/src/megamek/common/BipedMek.java
+++ b/megamek/src/megamek/common/BipedMek.java
@@ -119,6 +119,10 @@ public class BipedMek extends MekWithArms {
             mp--;
         }
 
+        if (!mpCalculationSetting.ignoreChainDrape && hasChainDrape()) {
+            mp--;
+        }
+
         if (!mpCalculationSetting.ignoreHeat) {
             // factor in heat
             if ((game != null) && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HEAT)) {

--- a/megamek/src/megamek/common/MPCalculationSetting.java
+++ b/megamek/src/megamek/common/MPCalculationSetting.java
@@ -63,7 +63,7 @@ public class MPCalculationSetting {
      * A setting for checking if a unit moved too fast under the effects of low
      * gravity.
      */
-    public static final MPCalculationSetting SAFE_MOVE = new Builder().noGravity().noHeat().noModularArmor().build();
+    public static final MPCalculationSetting SAFE_MOVE = new Builder().noGravity().noHeat().noModularArmor().noChainDrape().build();
 
     /**
      * A setting for testing if a unit is permanently immobilized. It excludes
@@ -86,7 +86,7 @@ public class MPCalculationSetting {
      * well as myomer boosters, DWP, BA burden and modular armor.
      */
     public static final MPCalculationSetting AS_CONVERSION = new Builder().noGravity().noWeather()
-            .noHeat().noCargo().baNoBurden().noMyomerBooster().noDWP().noModularArmor().noGrounded()
+            .noHeat().noCargo().baNoBurden().noMyomerBooster().noDWP().noModularArmor().noChainDrape().noGrounded()
             .noConversion().noOptionalRules().build();
 
     /**
@@ -110,6 +110,7 @@ public class MPCalculationSetting {
     public final boolean ignoreGravity;
     public final boolean ignoreHeat;
     public final boolean ignoreModularArmor;
+    public final boolean ignoreChainDrape;
     public final boolean ignoreDWP;
     public final boolean ignoreMyomerBooster;
     public final boolean ignoreMASC;
@@ -123,7 +124,7 @@ public class MPCalculationSetting {
     public final boolean ignoreSubmergedJumpJets;
     public final boolean forceTSM;
 
-    private MPCalculationSetting(boolean ignoreGravity, boolean ignoreHeat, boolean ignoreModularArmor,
+    private MPCalculationSetting(boolean ignoreGravity, boolean ignoreHeat, boolean ignoreModularArmor, boolean ignoreChainDrape,
             boolean ignoreMASC, boolean ignoreMyomerBooster, boolean ignoreDWP,
             boolean ignoreBurden, boolean ignoreCargo, boolean ignoreWeather,
             boolean singleMASC, boolean ignoreSubmergedJumpJets, boolean ignoreGrounded,
@@ -131,6 +132,7 @@ public class MPCalculationSetting {
         this.ignoreGravity = ignoreGravity;
         this.ignoreHeat = ignoreHeat;
         this.ignoreModularArmor = ignoreModularArmor;
+        this.ignoreChainDrape = ignoreChainDrape;
         this.ignoreMASC = ignoreMASC;
         this.ignoreMyomerBooster = ignoreMyomerBooster;
         this.ignoreDWP = ignoreDWP;
@@ -150,6 +152,7 @@ public class MPCalculationSetting {
         private boolean ignoreGravity = false;
         private boolean ignoreHeat = false;
         private boolean ignoreModularArmor = false;
+        private boolean ignoreChainDrape = false;
         private boolean ignoreBADWP = false;
         private boolean ignoreMyomerBooster = false;
         private boolean ignoreMASC = false;
@@ -164,7 +167,7 @@ public class MPCalculationSetting {
         private boolean forceTSM = false;
 
         MPCalculationSetting build() {
-            return new MPCalculationSetting(ignoreGravity, ignoreHeat, ignoreModularArmor, ignoreMASC,
+            return new MPCalculationSetting(ignoreGravity, ignoreHeat, ignoreModularArmor, ignoreChainDrape, ignoreMASC,
                     ignoreMyomerBooster, ignoreBADWP, ignoreBABurden, ignoreCargo, ignoreWeather, singleMASC,
                     ignoreSubmergedJumpJets, ignoreGrounded, ignoreOptionalRules, ignoreConversion, forceTSM);
         }
@@ -230,6 +233,12 @@ public class MPCalculationSetting {
         /** Disregards the effects of modular armor. */
         private Builder noModularArmor() {
             ignoreModularArmor = true;
+            return this;
+        }
+
+        /** Disregards the effects of a chain drape */
+        private Builder noChainDrape() {
+            ignoreChainDrape = true;
             return this;
         }
 

--- a/megamek/src/megamek/common/Mek.java
+++ b/megamek/src/megamek/common/Mek.java
@@ -1113,6 +1113,16 @@ public abstract class Mek extends Entity {
         return Math.max(mp, 0);
     }
 
+    public boolean hasChainDrape() {
+        for (MiscMounted mount : getMisc()) {
+            if (!mount.isDestroyed() && mount.getType().hasFlag(MiscType.F_CHAIN_DRAPE)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public int getPartialWingJumpWeightClassBonus() {
         return (getWeightClass() <= EntityWeightClass.WEIGHT_MEDIUM) ? 2 : 1;
     }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -285,6 +285,11 @@ public class MiscType extends EquipmentType {
     public static final MiscTypeFlag F_TRENCH_CAPABLE = MiscTypeFlag.F_TRENCH_CAPABLE;
     public static final MiscTypeFlag F_SUPPORT_VEE_BAR_ARMOR = MiscTypeFlag.F_SUPPORT_VEE_BAR_ARMOR;
 
+    public static final MiscTypeFlag F_CHAIN_DRAPE = MiscTypeFlag.F_CHAIN_DRAPE;
+    public static final MiscTypeFlag F_CHAIN_DRAPE_CAPE = MiscTypeFlag.F_CHAIN_DRAPE_CAPE;
+    public static final MiscTypeFlag F_CHAIN_DRAPE_APRON = MiscTypeFlag.F_CHAIN_DRAPE_APRON;
+    public static final MiscTypeFlag F_CHAIN_DRAPE_PONCHO = MiscTypeFlag.F_CHAIN_DRAPE_PONCHO;
+
     // Secondary Flags for Physical Weapons
     public static final long S_CLUB = 1L << 0; // BMR - Indicates an Improvised Club
     public static final long S_TREE_CLUB = 1L << 1;// BMR
@@ -521,6 +526,8 @@ public class MiscType extends EquipmentType {
             }
         } else if (hasFlag(F_PARTIAL_WING) && hasFlag(F_PROTOMEK_EQUIPMENT)) {
             return RoundWeight.nearestKg(entity.getWeight() / 5.0);
+        } else if (hasFlag(F_CHAIN_DRAPE)) {
+            return RoundWeight.nextHalfTon(entity.getWeight() / 10.0);
         } else if (hasFlag(F_CLUB) && hasSubType(S_HATCHET)) {
             return RoundWeight.nextTon(entity.getWeight() / 15.0);
         } else if (hasFlag(F_CLUB) && hasSubType(S_LANCE)) {
@@ -1839,6 +1846,9 @@ public class MiscType extends EquipmentType {
         EquipmentType.addType(MiscType.createISSneakIRECMInfArmor());
         EquipmentType.addType(MiscType.createISSneakThreeSystemInfArmor());
 
+        EquipmentType.addType(MiscType.createChainDrape("Cape", F_CHAIN_DRAPE_CAPE));
+        EquipmentType.addType(MiscType.createChainDrape("Apron", F_CHAIN_DRAPE_APRON));
+        EquipmentType.addType(MiscType.createChainDrape("Poncho", F_CHAIN_DRAPE_PONCHO));
     }
 
     // Advanced Mek/ProtoMek/Vehicular Motive Systems
@@ -2114,6 +2124,28 @@ public class MiscType extends EquipmentType {
                 .setProductionFactions(F_FS, F_LC).setTechRating(RATING_E)
                 .setAvailability(RATING_X, RATING_X, RATING_F, RATING_E)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
+        return misc;
+    }
+
+    public static MiscType createChainDrape(String configurationName, MiscTypeFlag configurationFlag) {
+        MiscType misc = new MiscType();
+
+        misc.name = "Chain Drape (%s)".formatted(configurationName);
+        misc.setInternalName("ChainDrape%s".formatted(configurationName));
+        misc.addLookupName("ChainDrape %s".formatted(configurationName));
+        misc.addLookupName("Chain Drape %s".formatted(configurationName));
+        misc.shortName = "Chain Drape %s".formatted(configurationName);
+        misc.tonnage = TONNAGE_VARIABLE;
+        misc.criticals = 6;
+        misc.spreadable = true;
+        misc.flags = misc.flags.or(F_CHAIN_DRAPE).or(configurationFlag).or(F_MEK_EQUIPMENT);
+        // Arcade Ops: UrbanFest
+        misc.rulesRefs = "16, UF";
+        // No information about this is provided so we fill in essentially "blank" data
+        misc.techAdvancement.setTechBase(TECH_BASE_IS).setStaticTechLevel(SimpleTechLevel.EXPERIMENTAL).setTechRating(RATING_X)
+            .setAvailability(RATING_X, RATING_X, RATING_X, RATING_X)
+            .setISAdvancement(DATE_ES).setISApproximate(true);
+
         return misc;
     }
 

--- a/megamek/src/megamek/common/MiscTypeFlag.java
+++ b/megamek/src/megamek/common/MiscTypeFlag.java
@@ -298,4 +298,11 @@ public enum MiscTypeFlag implements EquipmentFlag {
     F_HYPERSPECTRAL_IMAGER, // TODO: add game rules for the following imagers/radars, construction data only
     F_INFRARED_IMAGER, // TODO: add game rules for the following imagers/radars, construction data only
     F_LOOKDOWN_RADAR, // TODO: add game rules for the following imagers/radars, construction data only
+
+    // UrbanFest Chain Drape
+    F_CHAIN_DRAPE,
+    F_CHAIN_DRAPE_APRON,
+    F_CHAIN_DRAPE_CAPE,
+    F_CHAIN_DRAPE_PONCHO,
+
 }

--- a/megamek/src/megamek/common/QuadMek.java
+++ b/megamek/src/megamek/common/QuadMek.java
@@ -150,6 +150,10 @@ public class QuadMek extends Mek {
             mp--;
         }
 
+        if (!mpCalculationSetting.ignoreChainDrape && hasChainDrape()) {
+            mp--;
+        }
+
         if (!mpCalculationSetting.ignoreHeat) {
             // factor in heat
             if ((game != null) && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_HEAT)) {

--- a/megamek/src/megamek/common/TripodMek.java
+++ b/megamek/src/megamek/common/TripodMek.java
@@ -155,6 +155,10 @@ public class TripodMek extends MekWithArms {
             mp--;
         }
 
+        if (!mpCalculationSetting.ignoreChainDrape && hasChainDrape()) {
+            mp--;
+        }
+
         if (!mpCalculationSetting.ignoreHeat) {
             // factor in heat
             if ((game != null)

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -440,6 +440,16 @@ public class TestMek extends TestEntity {
                 return false;
             }
         }
+        if (mt.hasFlag(MiscType.F_CHAIN_DRAPE)) {
+            if (countCriticalSlotsFromEquipInLocation(entity, mounted, Mek.LOC_LT) != 3) {
+                buff.append("incorrect number of chain draop crits in left torso\n");
+                return false;
+            }
+            if (countCriticalSlotsFromEquipInLocation(entity, mounted, Mek.LOC_RT) != 3) {
+                buff.append("incorrect number of chain draop crits in right torso\n");
+                return false;
+            }
+        }
         return true;
     }
 
@@ -1061,6 +1071,13 @@ public class TestMek extends TestEntity {
                                     && (misc.getSubType() == MiscType.S_BACKHOE)
                                     || (misc.getSubType() == MiscType.S_COMBINE)))) {
                 buff.append("LAMs may not mount ").append(misc.getName()).append("\n");
+                illegal = true;
+            }
+
+            if ((misc.hasFlag(MiscType.F_CHAIN_DRAPE_APRON) || misc.hasFlag(MiscType.F_CHAIN_DRAPE_PONCHO))
+                && (mek.isQuadMek() || mek.getCockpitType() == Mek.COCKPIT_TORSO_MOUNTED)
+                ) {
+                buff.append("Quad meks and meks with torso cockpits may only mount a chain drape as a Cape");
                 illegal = true;
             }
         }


### PR DESCRIPTION
Adds the Chain Drape equipment from Arcade Operations: UrbanFest.
Gameplay is not implemented, only construction in Lab. 
Some implementation notes:
- UrbanFest says to construct the three configurations of the Chain Drape by mounting it forwards, backwards, or both forwards and backwards. As far as I know MegaMek doesn't support some but not all of a Mounted's slots being rear-facing, and the three configurations have different names, so I just created them as three separate equipment types. 
- While I said gameplay isn't implemented, mp _is_ reduced, since that's visible on record sheets.
- There is no published BV information, so a chain drape doesn't affect BV. Maybe the mp reduction cancels out the added protection?
- There is also no tech information, so I filled in the chain drape as X/X-X-X-X with an intro date of early spaceflight. If I had not filled in this information at all, it would never be selectable in lab.