### PR TITLE
feat: disable ACAR for all clients if using real-blind-drop

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -1285,10 +1285,13 @@ public class ChatLounge extends AbstractPhaseDisplay implements
         refreshTeams();
         refreshMapSettings();
         refreshDoneButton();
+        refreshAcar();
     }
 
     public void refreshAcar() {
-        panAutoResolveInfo.setVisible(CLIENT_PREFERENCES.getShowAutoResolvePanel());
+        boolean clientEnabledAcar = CLIENT_PREFERENCES.getShowAutoResolvePanel();
+        boolean notRealBlindDrop = !game().getOptions().booleanOption(OptionsConstants.BASE_REAL_BLIND_DROP);
+        panAutoResolveInfo.setVisible(clientEnabledAcar && notRealBlindDrop);
     }
 
     /**


### PR DESCRIPTION
Disables ACAR for all players in the lobby if Real Blind Drop is enabled
- Closes #6517