### PR TITLE
fix: fix a parsing error and turns it into a singleton using enum

### DIFF
--- a/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
@@ -37,74 +37,14 @@ import megamek.logging.MMLogger;
  * Callsign is a String that does not include a ','
  * Weight is an integer weight that is used during generation
  */
-public class RandomCallsignGenerator implements Serializable {
+public enum RandomCallsignGenerator {
+    INSTANCE;
+
     private final static MMLogger logger = MMLogger.create(RandomCallsignGenerator.class);
 
-    // region Variable Declarations
-    private static final long serialVersionUID = 4721410214327210288L;
+    private final WeightedIntMap<String> weightedCallsigns = new WeightedIntMap<>();
 
-    private static WeightedIntMap<String> weightedCallsigns;
-
-    private static RandomCallsignGenerator rcg;
-
-    private static volatile boolean initialized = false; // volatile to ensure readers get the current version
-    // endregion Variable Declarations
-
-    // region Constructors
-    protected RandomCallsignGenerator() {
-
-    }
-    // endregion Constructors
-
-    // region Getters/Setters
-    public static WeightedIntMap<String> getWeightedCallsigns() {
-        return weightedCallsigns;
-    }
-
-    public static void setWeightedCallsigns(final WeightedIntMap<String> weightedCallsigns) {
-        RandomCallsignGenerator.weightedCallsigns = weightedCallsigns;
-    }
-    // endregion Getters/Setters
-
-    // region Synchronization
-    /**
-     * @return the instance of the RandomCallsignGenerator to use
-     */
-    public static synchronized RandomCallsignGenerator getInstance() {
-        // only this code reads and writes 'rcg'
-        if (rcg == null) {
-            // synchronized ensures this will only be entered exactly once
-            rcg = new RandomCallsignGenerator();
-            rcg.runThreadLoader();
-        }
-        // when getInstance returns, rcg will always be non-null
-        return rcg;
-    }
-    // endregion Synchronization
-
-    // region Generation
-    public String generate() {
-        String callsign = "";
-
-        if (initialized) {
-            callsign = getWeightedCallsigns().randomItem();
-        } else {
-            logger.warn("Attempted to generate a callsign before the list was initialized.");
-        }
-
-        return callsign;
-    }
-    // endregion Generation
-
-    // region Initialization
-    private void runThreadLoader() {
-        Thread loader = new Thread(() -> rcg.populateCallsigns(), "Random Callsign Generator initializer");
-        loader.setPriority(Thread.NORM_PRIORITY - 1);
-        loader.start();
-    }
-
-    private void populateCallsigns() {
-        setWeightedCallsigns(new WeightedIntMap<>());
+    RandomCallsignGenerator() {
         final Map<String, Integer> callsigns = new HashMap<>();
         loadCallsignsFromFile(new File(MMConstants.CALLSIGN_FILE_PATH), callsigns);
         loadCallsignsFromFile(new File(MMConstants.USER_CALLSIGN_FILE_PATH), callsigns);
@@ -112,11 +52,24 @@ public class RandomCallsignGenerator implements Serializable {
         for (final Map.Entry<String, Integer> entry : callsigns.entrySet()) {
             getWeightedCallsigns().add(entry.getValue(), entry.getKey());
         }
-
-        initialized = true;
     }
 
-    private void loadCallsignsFromFile(final File file, final Map<String, Integer> callsigns) {
+    public static RandomCallsignGenerator getInstance() {
+        return INSTANCE;
+    }
+
+    // region Getters/Setters
+    public WeightedIntMap<String> getWeightedCallsigns() {
+        return weightedCallsigns;
+    }
+
+    // region Generation
+    public String generate() {
+        return getWeightedCallsigns().randomItem();
+    }
+    // endregion Generation
+
+    private void loadCallsignsFromFile(File file, Map<String, Integer> callsigns) {
         if (!file.exists()) {
             return;
         }
@@ -124,7 +77,7 @@ public class RandomCallsignGenerator implements Serializable {
         int lineNumber = 0;
 
         try (InputStream is = new FileInputStream(file);
-                Scanner input = new Scanner(is, StandardCharsets.UTF_8.name())) {
+                Scanner input = new Scanner(is, StandardCharsets.UTF_8)) {
             // skip the first line, as that's the header
             lineNumber++;
             input.nextLine();
@@ -133,11 +86,11 @@ public class RandomCallsignGenerator implements Serializable {
                 lineNumber++;
                 String[] values = input.nextLine().split(",");
                 if (values.length == 2) {
-                    callsigns.put(values[0], Integer.parseInt(values[1]));
+                    callsigns.put(values[0], Integer.parseInt(values[1].trim()));
                 } else if (values.length < 2) {
-                    logger.error("Not enough fields in " + file + " on " + lineNumber);
+                    logger.warn("Not enough fields in {} on {}",file, lineNumber);
                 } else {
-                    logger.error("Too many fields in " + file + " on " + lineNumber);
+                    logger.warn("Too many fields in {} on {}", file, lineNumber);
                 }
             }
         } catch (Exception e) {

--- a/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
@@ -84,13 +84,19 @@ public enum RandomCallsignGenerator {
 
             while (input.hasNextLine()) {
                 lineNumber++;
-                String[] values = input.nextLine().split(",");
-                if (values.length == 2) {
+                String line = input.nextLine();
+                int lastCommaIndex = line.lastIndexOf(",");
+                if (lastCommaIndex == -1 || line.length() == lastCommaIndex + 1) {
+                    logger.debug("Not enough fields in {} on {}",file, lineNumber);
+                    continue;
+                }
+
+                String[] values = {line.substring(0, lastCommaIndex), line.substring(lastCommaIndex + 1)};
+
+                try {
                     callsigns.put(values[0], Integer.parseInt(values[1].trim()));
-                } else if (values.length < 2) {
-                    logger.warn("Not enough fields in {} on {}",file, lineNumber);
-                } else {
-                    logger.warn("Too many fields in {} on {}", file, lineNumber);
+                } catch (NumberFormatException e) {
+                    logger.warn("Invalid weight in {} on {}", file, lineNumber);
                 }
             }
         } catch (Exception e) {

--- a/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
@@ -18,18 +18,17 @@
  */
 package megamek.client.generator;
 
+import megamek.MMConstants;
+import megamek.common.util.weightedMaps.WeightedIntMap;
+import megamek.logging.MMLogger;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Scanner;
-
-import megamek.MMConstants;
-import megamek.common.util.weightedMaps.WeightedIntMap;
-import megamek.logging.MMLogger;
 
 /**
  * Save File Formatting:
@@ -37,9 +36,8 @@ import megamek.logging.MMLogger;
  * Callsign is a String that does not include a ','
  * Weight is an integer weight that is used during generation
  */
-public enum RandomCallsignGenerator {
-    INSTANCE;
-
+public class RandomCallsignGenerator {
+    private final static RandomCallsignGenerator INSTANCE = new RandomCallsignGenerator();
     private final static MMLogger logger = MMLogger.create(RandomCallsignGenerator.class);
 
     private final WeightedIntMap<String> weightedCallsigns = new WeightedIntMap<>();


### PR DESCRIPTION
fix: fix a parsing error in random callsign generator and turns it into a singleton using enum