### PR TITLE
Fix 6593: counterbattery icon hidden in double blind

### DIFF
--- a/megamek/src/megamek/client/ui/swing/OffBoardTargetOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/OffBoardTargetOverlay.java
@@ -288,9 +288,21 @@ public class OffBoardTargetOverlay implements IDisplayable {
                 int extraXOffset = GUIP.getShowUnitOverview() ? UnitOverview.getUIWidth() : 0;
                 xPosition = boundingRectangle.x + boundingRectangle.width - WIDE_EDGE_SIZE - EDGE_OFFSET - extraXOffset;
                 yPosition = boundingRectangle.y + (int) (boundingRectangle.height / 2) - (int) (NARROW_EDGE_SIZE / 2);
-                return new Rectangle(xPosition, yPosition, WIDE_EDGE_SIZE, NARROW_EDGE_SIZE); // used to be
-                                                                                              // NARROW_EDGE_SIZE,
-                                                                                              // WIDE_EDGE_SIZE);
+                Rectangle myRectangle = new Rectangle(xPosition, yPosition, WIDE_EDGE_SIZE, NARROW_EDGE_SIZE);  // used to be
+                                                                                                                // NARROW_EDGE_SIZE,
+                                                                                                                // WIDE_EDGE_SIZE);
+
+                // Account for possible floating Unit Display blocking arrow icon
+                if (GUIP.getUnitDisplayEnabled() && GUIP.getUnitDisplayLocaton() == 0) {
+                    // Move arrow inward if either side overlaps with the Unit Display
+                    Rectangle udRectangle = clientgui.getUnitDisplayDialog().getBounds();
+                    if ((myRectangle.x + myRectangle.width + 5 > udRectangle.x && myRectangle.x <= udRectangle.x + udRectangle.width) ||
+                        (myRectangle.x <= udRectangle.x + udRectangle.width && myRectangle.x + 5 >= udRectangle.x))
+                    {
+                        myRectangle.translate(-GUIP.getUnitDisplaySizeWidth(), 0);
+                    }
+                }
+                return myRectangle;
             default:
                 return null;
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -3611,11 +3611,13 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
         // no re-use possible, add a new one
         // don't add a sprite for an artillery attack made by the other player
-        if (aa instanceof WeaponAttackAction) {
-            WeaponAttackAction waa = (WeaponAttackAction) aa;
+        if (aa instanceof WeaponAttackAction waa) {
+            int ownerId = waa.getEntity(game).getOwner().getId();
+            int teamId = waa.getEntity(game).getOwner().getTeam();
+
             if (aa.getTargetType() != Targetable.TYPE_HEX_ARTILLERY) {
                 attackSprites.add(new AttackSprite(this, aa));
-            } else if (waa.getEntity(game).getOwner().getId() == localPlayer.getId()) {
+            } else if (ownerId == localPlayer.getId() || teamId == localPlayer.getTeam()) {
                 attackSprites.add(new AttackSprite(this, aa));
             }
         } else {

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -26061,9 +26061,14 @@ public class TWGameManager extends AbstractGameManager {
             addTeammates(vCanSee, entity.getOwner());
         }
 
-        // Deal with players who can see all.
+        // Deal with special states
         for (Player player : game.getPlayersList()) {
+            // Deal with players who can see all.
             if (player.canIgnoreDoubleBlind() && !vCanSee.contains(player)) {
+                vCanSee.addElement(player);
+            }
+            // Players on a team who have a unit that observed this entity's off-board shots can see it.
+            if (entity.isOffBoard() && entity.isOffBoardObserved(player.getTeam()) && !vCanSee.contains(player)) {
                 vCanSee.addElement(player);
             }
         }


### PR DESCRIPTION
Fixes two issues:
1. Counter-battery fire arrow icon being hidden due to overzealous entity pruning on the game manager side;
2. The arrow icon being hidden by the Unit Display dialog when undocked.

Testing:
- Ran various repros (from original issue and new)
- Ran all 3 projects' unit tests.

Close #6593