### PR TITLE
Add VTOL/WiGE exemption for AAA and LAA missiles

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -3363,8 +3363,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Air-to-air Arrow and Light Air-to-air missiles
         if (((atype.getAmmoType() == AmmoType.T_AAA_MISSILE) || (atype.getAmmoType() == AmmoType.T_LAA_MISSILE))
                 && Compute.isAirToGround(ae, target)) {
-            // +4 penalty if trying to use one against a ground target
-            toHit.addModifier(+4, Messages.getString("WeaponAttackAction.AaaGroundAttack"));
+            // +4 penalty if trying to use one against a ground target that is not flying
+            // (Errata: https://bg.battletech.com/forums/index.php?topic=87401.msg2060972#msg2060972 )
+            if (!target.isAirborneVTOLorWIGE()) {
+                toHit.addModifier(+4, Messages.getString("WeaponAttackAction.AaaGroundAttack"));
+            }
             // +3 additional if the attacker is flying at Altitude 3 or less
             if (ae.getAltitude() < 4) {
                 toHit.addModifier(+3, Messages.getString("WeaponAttackAction.AaaLowAlt"));
@@ -3844,7 +3847,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if (ae.isAero()) {
             IAero aero = (IAero) ae;
 
-            // check for heavy gauss rifle on fighter of small craft
+            // check for heavy gauss rifle on fighter or small craft
             // Arguably a weapon effect, except that it only applies when used by a fighter
             // (isn't recoil fun?)
             // So it's here instead of with other weapon mods that apply across the board


### PR DESCRIPTION
Per errata here: https://bg.battletech.com/forums/index.php?topic=87401.msg2060972#msg2060972
Remove +4 for attacking targets on the ground when targeting VTOL / WiGE ground units.

Notes:
While this does have the effect of making VTOL and WiGE units slightly more enticing for ASF on the ground map, it does not make them any _better_ targets for AAA or LAA missile attacks than other ground units... except in cases where a VTOL has only moved a handful of hexes:

Before:
3 Gunnery + 2 (Ground Strike) + 4 (AAA vs Ground Target) + TMM (usually +3 ~ +4) + 1 (Flying VTOL) ~= TN of 13 - 14

After:
3 Gunnery + 2 (Ground Strike) + TMM (usually +3 ~ +4) + 1 (Flying VTOL) ~= TN of 9 - 10

Compare to attacking a slow-moving Mek target:
3 Gunnery + 2 (Ground Strike) + 4 (AAA vs Ground Target) + TMM (usually +1 ~ +2) ~= TN of 10 - 11

So most VTOL will be _marginally_ better targets than slow ground units, but not at all sitting ducks.

Notably, VTOLs are slightly better platforms for AAA / LAA missiles against ASFs than the reverse:
4 Gunner + 0 ~ 2 (target side) + AMM (usually +1 ~ +2) + range (usually +2 for medium) ~= TN of 7 ~ 10

Testing:
- Ran several Bot v Bot tests.
- Ran all 3 projects' unit tests