### PR TITLE
Add test task that includes GUI tests and enable GUI tests for this task

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -333,6 +333,16 @@ jacocoTestReport {
     }
 }
 
+// Test task including GUI tests
+task testWithGUITests(type: Test) {
+    useJUnitPlatform()
+    jvmArgs = mmJvmOptions
+    environment 'GUITests', "true"
+
+    group 'verification'
+    description 'Sets environment var to include GUI unit tests; no report generated.'
+}
+
 // These are utility classes for all of the classes with the src/utilities folder.
 
 task alphaStrikeMassConvert(type: JavaExec, dependsOn: jar) {

--- a/megamek/unittests/megamek/logging/MMLoggerTest.java
+++ b/megamek/unittests/megamek/logging/MMLoggerTest.java
@@ -21,6 +21,8 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 
@@ -83,6 +85,7 @@ public class MMLoggerTest {
         verifyLog(Level.DEBUG, "Debug message: test", e);
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testErrorLogging() {
         if (GraphicsEnvironment.isHeadless()) {
@@ -94,6 +97,7 @@ public class MMLoggerTest {
         verifyLog(Level.ERROR, "Error message: test");
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testErrorLoggingWithStringFormat() {
         if (GraphicsEnvironment.isHeadless()) {
@@ -105,6 +109,7 @@ public class MMLoggerTest {
         verifyLog(Level.ERROR, "Error message: test");
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testDeprecatedErrorLoggingWithExceptionNoParams() {
         if (GraphicsEnvironment.isHeadless()) {
@@ -117,6 +122,7 @@ public class MMLoggerTest {
         verifyLog(Level.ERROR, "Error message: noparameter accepted", e);
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testErrorLoggingWithException() {
         if (GraphicsEnvironment.isHeadless()) {
@@ -135,6 +141,7 @@ public class MMLoggerTest {
         verifyLog(Level.FATAL, "Fatal without dialog without exception");
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testFatalLoggingWithDialog() {
         if (GraphicsEnvironment.isHeadless()) {
@@ -146,6 +153,7 @@ public class MMLoggerTest {
         verifyLog(Level.FATAL, "Fatal with dialog with exception");
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testDeprecatedFatalLoggingWithDialog() {
         if (GraphicsEnvironment.isHeadless()) {
@@ -164,6 +172,7 @@ public class MMLoggerTest {
         verifyLog(Level.FATAL, "Fatal without dialog with exception", e);
     }
 
+    @EnabledIfEnvironmentVariable(named = "GUITests", matches = "true")
     @Test
     public void testDeprecatedFatalLoggingWithException() {
         if (GraphicsEnvironment.isHeadless()) {


### PR DESCRIPTION
#### Changes

1. Updates GUI tests to only run if the appropriate environment variable is set, so that people running unit tests in their IDE don't get startled.

2. Adds a new Verification task, `testWithGUITests`, to the Gradle tasks.  This task sets the environment variable and runs all unit tests.

#### Rationale

In general, GUI unit tests are frowned on as they A) can be disruptive, and B) depend a lot more on the run environment than tests of code "units" generally want to.
However, there is definitely value in being able to configure different suites or levels of test running for different users or environments.

#### Configuration

I chose the environment variable approach rather than tags or other mechanisms as it seemed the simplest while allowing a large degree of customization.
To set up an environment that will always run GUI tests no matter what, a dev may:
- Set an actual environment variable in their OS, e.g. `export GUITests="true"`.
- Change their local `test` task to set this env var in their IDE, and continue running the `test` task as before.
- Use the new `testWithGUITests` task.

New task in Intellij IDEA:
<img width="234" alt="image" src="https://github.com/user-attachments/assets/93e99a34-318e-4914-a54a-90800d06963c" />


#### Testing

- Ran all 3 projects' unit tests, with and without env var set, and confirmed GUI tests get disabled/enabled appropriately.