### PR TITLE
Fix Failing Unit Tests on Windows

### DIFF
--- a/megamek/unittests/megamek/client/ui/swing/util/ImageAtlasMapTest.java
+++ b/megamek/unittests/megamek/client/ui/swing/util/ImageAtlasMapTest.java
@@ -47,7 +47,7 @@ class ImageAtlasMapTest {
         imageAtlasMap.put(originalFilePath, atlasFilePath);
 
         String result = imageAtlasMap.get(originalFilePath);
-        assertEquals(atlasFilePath.toString(), result);
+        assertEquals("data/images/foo.png", result);
     }
 
     @Test
@@ -95,6 +95,6 @@ class ImageAtlasMapTest {
 
         ImageAtlasMap readImageAtlasMap = ImageAtlasMap.readFromFile(testFilePath);
         String result = readImageAtlasMap.get(originalFilePath);
-        assertEquals(atlasFilePath.toString(), result);
+        assertEquals("data/images/atlas/foo.png", result);
     }
 }


### PR DESCRIPTION
These tests were failing on windows because the expected value had backslashes. I switched it to be the exact string expected to ensure it tests for the same value regardless of system.