### PR TITLE
Implement RFE 6147: move infantry loading to interface and allow cargo bays

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/TransportCalculator.java
+++ b/megamek/src/megamek/client/ratgenerator/TransportCalculator.java
@@ -86,7 +86,7 @@ public class TransportCalculator {
             } else if (en.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
                 // Here we need to count the transport weight of the platoon rather than just
                 // the number
-                unitCounts.merge(UnitType.INFANTRY, InfantryBay.PlatoonType.getPlatoonType(en).getWeight(),
+                unitCounts.merge(UnitType.INFANTRY, InfantryTransporter.PlatoonType.getPlatoonType(en).getWeight(),
                         Integer::sum);
             } else if (en.hasETypeFlag(Entity.ETYPE_DROPSHIP)) {
                 unitCounts.merge(UnitType.DROPSHIP, 1, Integer::sum);

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2585,6 +2585,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         // *(excluding Infantry, see StratOps pg. 20)
         int doorsEligibleForDrop = bay.getCurrentDoors();
         List <Entity> droppableUnits = bay.getDroppableUnits();
+        boolean infantryTransporter = (bay instanceof InfantryTransporter);
 
         // No units == no drops
         if (droppableUnits.isEmpty()) {
@@ -2601,7 +2602,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         boolean hasDroppableUnit = false;
         for (Entity droppableUnit : droppableUnits) {
-            if (doorsEligibleForDrop > 0) {
+            if (infantryTransporter || doorsEligibleForDrop > 0) {
                 if (droppedUnits.contains(droppableUnit.getId())) {
                     // Infantry don't count against door usage
                     if (!droppableUnit.isInfantry()) {
@@ -2615,7 +2616,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 }
             }
         }
-        if (doorsEligibleForDrop > 0 && hasDroppableUnit) {
+        if (hasDroppableUnit && (infantryTransporter || (doorsEligibleForDrop > 0))) {
             return true;
         }
         return false;
@@ -4052,8 +4053,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 isInfantryT = true;
 
                 // Can't drop infantry from above 8 Altitude
-                if (isInfantryT && cmd.getLastStep().getAltitude() > 8) {
-                    continue;
+                if (isInfantryT) {
+                    int currAlt = (cmd.getLastStep() != null) ? cmd.getLastStep().getAltitude() : ce.getAltitude();
+                    if (currAlt > 8) {
+                        continue;
+                    }
                 }
 
                 for (Entity entity : iTransporter.getDroppableUnits()) {

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -2573,6 +2573,80 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 || !ce.getLaunchableDropships().isEmpty());
     }
 
+    /**
+     *
+     * @param bay Instance
+     * @param droppedUnits Set of unit ids of entities already dropped this turn.
+     * @return true if there are available droppable units in this bay
+     */
+    private boolean checkBayDropEnable(Bay bay, Set<Integer> droppedUnits) {
+        // If this bay has unloaded more units this turn than
+        // it has doors* for, we should move on
+        // *(excluding Infantry, see StratOps pg. 20)
+        int doorsEligibleForDrop = bay.getCurrentDoors();
+        List <Entity> droppableUnits = bay.getDroppableUnits();
+
+        // No units == no drops
+        if (droppableUnits.isEmpty()) {
+            return false;
+        }
+
+        // If we have droppable units and we haven't
+        // dropped any, let's enable the button.
+        // doorsEligibleForDrop can be 0 even before
+        // dropping units if it's damaged.
+        if (doorsEligibleForDrop > 0 && droppedUnits.isEmpty()) {
+            return true;
+        }
+
+        boolean hasDroppableUnit = false;
+        for (Entity droppableUnit : droppableUnits) {
+            if (doorsEligibleForDrop > 0) {
+                if (droppedUnits.contains(droppableUnit.getId())) {
+                    // Infantry don't count against door usage
+                    if (!droppableUnit.isInfantry()) {
+                        doorsEligibleForDrop--;
+                    }
+                } else {
+                    // Cannot set the button enabled yet,
+                    // need to make sure we consider every
+                    // unit in the bay that's already dropped
+                    hasDroppableUnit = true;
+                }
+            }
+        }
+        if (doorsEligibleForDrop > 0 && hasDroppableUnit) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param compartment Instance
+     * @param droppedUnits Set of unit ids of entities already dropped this turn.
+     * @return true if there are available droppable units in this compartment
+     */
+    private boolean checkCompartmentDropEnable(InfantryCompartment compartment, Set<Integer> droppedUnits) {
+        // A compartment can drop any number of infantry and is "assumed to have one door".
+        List <Entity> droppableUnits = compartment.getDroppableUnits();
+        boolean hasDroppableUnits = !droppableUnits.isEmpty();
+
+        // No units == no drops
+        if (!hasDroppableUnits) {
+            return false;
+        }
+
+        for (Entity droppableUnit : droppableUnits) {
+            if (!droppedUnits.contains(droppableUnit.getId())) {
+                // If we have even one boarded, droppable unit that didn't already drop, activate the button.
+                return true;
+            }
+        }
+        // No droppers means no enable
+        return false;
+    }
+
     private void updateDropButton() {
         final Entity ce = ce();
         if (ce == null) {
@@ -2581,40 +2655,18 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         if (ce.isAirborne() && !ce.getDroppableUnits().isEmpty()) {
             Set<Integer> droppedUnits = cmd.getDroppedUnits();
+            boolean setEnabled = false;
 
-            for (Bay bay : ce.getTransportBays()) {
-                // If this bay has unloaded more units this turn than
-                // it has doors* for, we should move on
-                // *(excluding Infantry, see StratOps pg. 20)
-                int doorsEligibleForDrop = bay.getCurrentDoors();
-
-                // If we have droppable units and we haven't
-                // dropped any, let's enable the button.
-                // doorsEligibleForDrop can be 0 even before
-                // dropping units if it's damaged.
-                if (doorsEligibleForDrop > 0 && droppedUnits.isEmpty()) {
-                    setDropEnabled(true);
-                    return;
+            // check bays and compartments
+            for (Transporter t : ce.getTransports()) {
+                if (t instanceof Bay tBay) {
+                    setEnabled = checkBayDropEnable(tBay, droppedUnits);
+                } else if (t instanceof InfantryCompartment tCompartment) {
+                    setEnabled = checkCompartmentDropEnable(tCompartment, droppedUnits);
                 }
-
-                boolean hasDroppableUnit = false;
-                for (Entity droppableUnit : bay.getDroppableUnits()) {
-                    if (doorsEligibleForDrop > 0) {
-                        if (droppedUnits.contains(droppableUnit.getId())) {
-                            // Infantry don't count against door usage
-                            if (!droppableUnit.isInfantry()) {
-                                doorsEligibleForDrop--;
-                            }
-                        } else {
-                            // Cannot set the button enabled yet,
-                            // need to make sure we consider every
-                            // unit in the bay that's already dropped
-                            hasDroppableUnit = true;
-                        }
-                    }
-                }
-                if (doorsEligibleForDrop > 0 && hasDroppableUnit) {
-                    setDropEnabled(true);
+                setDropEnabled(setEnabled);
+                // Only need one viable drop bay/compartment to enable the button
+                if (setEnabled) {
                     return;
                 }
             }
@@ -3985,32 +4037,48 @@ public class MovementDisplay extends ActionPhaseDisplay {
         Set<Integer> alreadyDropped = cmd.getDroppedUnits();
         // cycle through the bays
         int bayNum = 1;
-        Vector<Bay> Bays = ce.getTransportBays();
-        for (int i = 0; i < Bays.size(); i++) {
-            Bay currentBay = Bays.elementAt(i);
-            boolean infantryBay = (currentBay instanceof InfantryTransporter);
+        Vector<Transporter> transporters = ce.getTransports();
+        List<Entity> currentUnits;
 
-            // Can't drop infantry from above 8 Altitude
-            if (infantryBay && cmd.getLastStep().getAltitude() > 8) {
-                continue;
-            }
-
+        for (int i = 0; i < transporters.size(); i++) {
+            Transporter currentT = transporters.elementAt(i);
+            boolean isInfantryT = false;
+            currentUnits = new ArrayList<>();
             Vector<Integer> bayChoices = new Vector<>();
-            int doorsEligibleForDrop = currentBay.getCurrentDoors();
-            List<Entity> currentUnits = new ArrayList<>();
-            for (Entity entity : currentBay.getDroppableUnits()) {
-                // Do account for already-dropped Infantry
-                if (alreadyDropped.contains(entity.getId())) {
-                    // But exclude infantry from count of doors used/usable
-                    if (!entity.isInfantry()) {
-                        doorsEligibleForDrop--; //If a unit is set to drop from a bay, we should reduce our capacity
+            int doorsEligibleForDrop = 0;
+
+            // Handle infantry first
+            if (currentT instanceof InfantryTransporter iTransporter) {
+                isInfantryT = true;
+
+                // Can't drop infantry from above 8 Altitude
+                if (isInfantryT && cmd.getLastStep().getAltitude() > 8) {
+                    continue;
+                }
+
+                for (Entity entity : iTransporter.getDroppableUnits()) {
+                    if (!alreadyDropped.contains(entity.getId())) {
+                        currentUnits.add(entity);
                     }
-                } else {
-                    currentUnits.add(entity);
+                }
+            // Handle other stuff
+            } else if (currentT instanceof Bay currentBay) {
+                doorsEligibleForDrop = currentBay.getCurrentDoors();
+
+                for (Entity entity : currentBay.getDroppableUnits()) {
+                    // Do account for already-dropped Infantry
+                    if (alreadyDropped.contains(entity.getId())) {
+                        // But exclude infantry from count of doors used/usable
+                        if (!entity.isInfantry()) {
+                            doorsEligibleForDrop--; //If a unit is set to drop from a bay, we should reduce our capacity
+                        }
+                    } else {
+                        currentUnits.add(entity);
+                    }
                 }
             }
 
-            if (!currentUnits.isEmpty() && (infantryBay || (doorsEligibleForDrop > 0))) {
+            if (!currentUnits.isEmpty() && (isInfantryT || (doorsEligibleForDrop > 0))) {
                 String[] names = new String[currentUnits.size()];
                 String question = Messages.getString("MovementDisplay.DropUnitDialog.message",
                         doorsEligibleForDrop, bayNum);
@@ -4018,10 +4086,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     names[loop] = currentUnits.get(loop).getShortName();
                 }
                 // If this is an infantry-transporting bay (cargo, Infantry Bay, etc.) no limit on drops
-                int max = (infantryBay) ? -1 : doorsEligibleForDrop;
+                int max = (isInfantryT) ? -1 : doorsEligibleForDrop;
                 ChoiceDialog choiceDialog = new ChoiceDialog(clientgui.frame,
                         Messages.getString("MovementDisplay.DropUnitDialog.title",
-                                currentBay.getType(), bayNum),
+                                currentT.getType(), bayNum),
                         question, names, false, max);
                 choiceDialog.setVisible(true);
                 if (choiceDialog.getAnswer()) {

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -95,6 +95,8 @@ public abstract class Aero extends Entity implements IAero, IBomber {
     public static final int CRIT_GRAV_DECK = 20;
     public static final int CRIT_WEAPON_BROAD = 21;
 
+    // Effective elevation of airborne Aerospace units
+    public static final int AERO_EFFECTIVE_ELEVATION = 999;
     // aeros have no critical slot limitations
     // this needs to be larger, it is too easy to go over when you get to
     // warships
@@ -2476,7 +2478,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
         // and uses elevation normally. Otherwise, just set elevation to a very large
         // number so that
         // a flying aero won't interact with the ground maps in any way
-        return isAirborne() ? 999 : super.getElevation();
+        return isAirborne() ? AERO_EFFECTIVE_ELEVATION : super.getElevation();
     }
 
     @Override

--- a/megamek/src/megamek/common/BattleArmorBay.java
+++ b/megamek/src/megamek/common/BattleArmorBay.java
@@ -18,7 +18,7 @@ package megamek.common;
  * Represents a volume of space set aside for carrying Battle Armor squads aboard large spacecraft
  * and mobile structures
  */
-public final class BattleArmorBay extends Bay {
+public final class BattleArmorBay extends Bay implements InfantryTransporter {
     private static final long serialVersionUID = 7091227399812361916L;
 
     private boolean isClan = false;

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -310,10 +310,6 @@ public class Bay implements Transporter, ITechnology {
         return 0;
     }
 
-    public String getType() {
-        return "Unknown";
-    }
-
     /** Destroys a door for next turn. */
     public void destroyDoorNext() {
         if (getDoorsNext() > 0) {

--- a/megamek/src/megamek/common/Bay.java
+++ b/megamek/src/megamek/common/Bay.java
@@ -345,7 +345,7 @@ public class Bay implements Transporter, ITechnology {
     }
 
     public int getNumberLoadedThisTurn() {
-        return unloadedThisTurn;
+        return loadedThisTurn;
     }
 
     /**

--- a/megamek/src/megamek/common/BayType.java
+++ b/megamek/src/megamek/common/BayType.java
@@ -16,6 +16,7 @@ package megamek.common;
 import java.util.function.Predicate;
 
 import megamek.common.annotations.Nullable;
+import megamek.common.InfantryTransporter.PlatoonType;
 
 /**
  * Data for various transport bay types. This is used by MekHQ for cubicle
@@ -94,7 +95,7 @@ public enum BayType implements ITechnologyDelegator {
      * CATEGORY_NON_INFANTRY calculates cost per cubicle. Capacity is the number of
      * entities that can fit
      * in a single cubicle.
-     * 
+     *
      * @return The category index.
      */
     public int getCategory() {
@@ -190,12 +191,12 @@ public enum BayType implements ITechnologyDelegator {
         } else if (bay instanceof LivestockCargoBay) {
             return LIVESTOCK_CARGO;
         } else if (bay instanceof InfantryBay) {
-            InfantryBay.PlatoonType ptype = ((InfantryBay) bay).getPlatoonType();
-            if (ptype == InfantryBay.PlatoonType.JUMP) {
+            PlatoonType ptype = ((InfantryBay) bay).getPlatoonType();
+            if (ptype == PlatoonType.JUMP) {
                 return INFANTRY_JUMP;
-            } else if (ptype == InfantryBay.PlatoonType.MOTORIZED) {
+            } else if (ptype == PlatoonType.MOTORIZED) {
                 return INFANTRY_MOTORIZED;
-            } else if (ptype == InfantryBay.PlatoonType.MECHANIZED) {
+            } else if (ptype == PlatoonType.MECHANIZED) {
                 return INFANTRY_MECHANIZED;
             } else {
                 return INFANTRY_FOOT;

--- a/megamek/src/megamek/common/CargoBay.java
+++ b/megamek/src/megamek/common/CargoBay.java
@@ -44,6 +44,11 @@ public final class CargoBay extends Bay implements InfantryTransporter {
     }
 
     @Override
+    public double spaceForUnit(Entity unit) {
+        return unit.getWeight();
+    }
+
+    @Override
     public String getUnusedString(boolean showRecovery) {
         StringBuffer returnString = new StringBuffer("Cargo Space "
                 + numDoorsString() + " - ");

--- a/megamek/src/megamek/common/CargoBay.java
+++ b/megamek/src/megamek/common/CargoBay.java
@@ -43,21 +43,6 @@ public final class CargoBay extends Bay {
         currentdoors = doors;
     }
 
-    /**
-     * Determines if this object can accept the given unit. The unit may not be
-     * of the appropriate type or there may be no room for the unit.
-     *
-     * @param unit
-     *            - the <code>Entity</code> to be loaded.
-     * @return <code>true</code> if the unit can be loaded, <code>false</code>
-     *         otherwise.
-     */
-    @Override
-    public boolean canLoad(Entity unit) {
-        // Assume that we cannot carry the unit.
-        return false;
-    }
-
     @Override
     public String getUnusedString(boolean showRecovery) {
         StringBuffer returnString = new StringBuffer("Cargo Space "

--- a/megamek/src/megamek/common/CargoBay.java
+++ b/megamek/src/megamek/common/CargoBay.java
@@ -17,7 +17,7 @@ package megamek.common;
  * Represents a volume of space set aside for carrying general cargo aboard large spacecraft and
  * mobile structures.
  */
-public final class CargoBay extends Bay {
+public final class CargoBay extends Bay implements InfantryTransporter {
     private static final long serialVersionUID = 4161027191694822726L;
 
     /**

--- a/megamek/src/megamek/common/CargoBay.java
+++ b/megamek/src/megamek/common/CargoBay.java
@@ -44,8 +44,17 @@ public final class CargoBay extends Bay implements InfantryTransporter {
     }
 
     @Override
+    public boolean canLoad(Entity unit) {
+        if (!unit.isInfantry()) {
+            return false;
+        }
+        return super.canLoad(unit);
+    }
+
+    // Use the calculated original weight for infantry in cargo bays
+    @Override
     public double spaceForUnit(Entity unit) {
-        return unit.getWeight();
+        return Math.round(unit.getWeight() / unit.getInternalRemainingPercent());
     }
 
     @Override

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8749,15 +8749,16 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
         // I should only add entities in bays that are functional
         for (Transporter next : transports) {
-            if (next instanceof Bay nextbay) {
-                if (nextbay.getCurrentDoors() > 0) {
-                    for (Entity e : nextbay.getDroppableUnits()) {
-                        result.addElement(e);
-                    }
-                }
-            } else if (next instanceof InfantryCompartment nextCompartment) {
+            if (next instanceof InfantryCompartment nextCompartment) {
                 for (Entity e : nextCompartment.getDroppableUnits()) {
                     result.addElement(e);
+                }
+            } else if (next instanceof Bay nextBay) {
+                // Infantry (Conventional and BA) do not need doors to deploy (TM 209)
+                if (nextBay instanceof InfantryTransporter || nextBay.getCurrentDoors() > 0) {
+                    for (Entity e : nextBay.getDroppableUnits()) {
+                        result.addElement(e);
+                    }
                 }
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8755,6 +8755,10 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                         result.addElement(e);
                     }
                 }
+            } else if (next instanceof InfantryCompartment nextCompartment) {
+                for (Entity e : nextCompartment.getDroppableUnits()) {
+                    result.addElement(e);
+                }
             }
         }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8750,15 +8750,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         // I should only add entities in bays that are functional
         for (Transporter next : transports) {
             if (next instanceof InfantryCompartment nextCompartment) {
-                for (Entity e : nextCompartment.getDroppableUnits()) {
-                    result.addElement(e);
-                }
+                result.addAll(nextCompartment.getDroppableUnits());
             } else if (next instanceof Bay nextBay) {
                 // Infantry (Conventional and BA) do not need doors to deploy (TM 209)
                 if (nextBay instanceof InfantryTransporter || nextBay.getCurrentDoors() > 0) {
-                    for (Entity e : nextBay.getDroppableUnits()) {
-                        result.addElement(e);
-                    }
+                    result.addAll(nextBay.getDroppableUnits());
                 }
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -8749,9 +8749,11 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
         // I should only add entities in bays that are functional
         for (Transporter next : transports) {
-            if ((next instanceof Bay nextbay) && (nextbay.getCurrentDoors() > 0)) {
-                for (Entity e : nextbay.getDroppableUnits()) {
-                    result.addElement(e);
+            if (next instanceof Bay nextbay) {
+                if (nextbay.getCurrentDoors() > 0) {
+                    for (Entity e : nextbay.getDroppableUnits()) {
+                        result.addElement(e);
+                    }
                 }
             }
         }
@@ -13263,8 +13265,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
     public boolean hasUnloadedUnitsFromBays() {
         for (Transporter next : transports) {
-            if ((next instanceof Bay)
-                    && (((Bay) next).getNumberUnloadedThisTurn() > 0)) {
+            if ((next instanceof Bay nextBay)
+                    && (nextBay.getNumberUnloadedThisTurn() > 0)) {
                 return true;
             }
         }

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1156,7 +1156,15 @@ public class Infantry extends Entity {
 
     @Override
     public boolean canAssaultDrop() {
-        return game.getOptions().booleanOption(OptionsConstants.ADVANCED_PARATROOPERS);
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_PARATROOPERS)) {
+            return true;
+        };
+        EntityMovementMode moveMode = getMovementMode();
+        return (List.of(
+                EntityMovementMode.INF_JUMP, EntityMovementMode.HOVER, EntityMovementMode.VTOL
+            ).contains(moveMode)
+            || hasSpecialization(PARATROOPS)
+        );
     }
 
     @Override

--- a/megamek/src/megamek/common/InfantryBay.java
+++ b/megamek/src/megamek/common/InfantryBay.java
@@ -72,6 +72,34 @@ public final class InfantryBay extends Bay implements InfantryTransporter {
         return sb.toString();
     }
 
+    /**
+     * Determines if this object can accept the given unit. The unit may not be
+     * of the appropriate type or there may be no room for the unit.
+     *
+     * @param unit
+     *            - the <code>Entity</code> to be loaded.
+     * @return <code>true</code> if the unit can be loaded, <code>false</code>
+     *         otherwise.
+     */
+    @Override public boolean canLoad(Entity unit) {
+        // Only infantry
+        boolean result = unit.hasETypeFlag(Entity.ETYPE_INFANTRY);
+
+        // We must have enough space for the new troops.
+        // POSSIBLE BUG: we may have to take the Math.ceil() of the weight.
+        if (getUnused() < spaceForUnit(unit)) {
+            result = false;
+        }
+
+        // is the door functional
+        if (getCurrentDoors() < getNumberLoadedThisTurn()) {
+            result = false;
+        }
+
+        // Return our result.
+        return result;
+    }
+
     @Override
     public double spaceForUnit(Entity unit) {
         PlatoonType type = PlatoonType.getPlatoonType(unit);

--- a/megamek/src/megamek/common/InfantryBay.java
+++ b/megamek/src/megamek/common/InfantryBay.java
@@ -73,6 +73,16 @@ public final class InfantryBay extends Bay implements InfantryTransporter {
     }
 
     @Override
+    public double spaceForUnit(Entity unit) {
+        PlatoonType type = PlatoonType.getPlatoonType(unit);
+        if ((unit instanceof Infantry) && (type == PlatoonType.MECHANIZED)) {
+            return type.getWeight() * ((Infantry) unit).getSquadCount();
+        } else {
+            return type.getWeight();
+        }
+    }
+
+    @Override
     public double getUnusedSlots() {
         return currentSpace / platoonType.getWeight() - getBayDamage();
     }

--- a/megamek/src/megamek/common/InfantryBay.java
+++ b/megamek/src/megamek/common/InfantryBay.java
@@ -12,6 +12,7 @@
  * details.
  */
 package megamek.common;
+import megamek.common.InfantryTransporter.PlatoonType;
 
 /**
  * Represents a volume of space set aside for carrying infantry platoons aboard large spacecraft
@@ -19,61 +20,6 @@ package megamek.common;
  */
 public final class InfantryBay extends Bay {
     private static final long serialVersionUID = 946578184870030662L;
-
-    /** The amount of space taken up by an infantry unit in a transport bay differs from the space
-     * in an infantry compartment (used in APCs) due to quarters, equipment storage, and maintenance
-     * equipment. A single cubicle holds a platoon, except in the case of mechanized which requires
-     * a cubicle per squad. */
-    public enum PlatoonType {
-        FOOT (5, 28, 25),
-        JUMP (6, 21, 20),
-        MOTORIZED (7, 28, 25),
-        MECHANIZED (8, 7, 5);
-
-        private int weight;
-        private int isPersonnel;
-        private int clanPersonnel;
-
-        PlatoonType(int weight, int isPersonnel, int clanPersonnel) {
-            this.weight = weight;
-            this.isPersonnel = isPersonnel;
-            this.clanPersonnel = clanPersonnel;
-        }
-
-        public int getWeight() {
-            return weight;
-        }
-
-        public int getISPersonnel() {
-            return isPersonnel;
-        }
-
-        public int getClanPersonnel() {
-            return clanPersonnel;
-        }
-
-        @Override
-        public String toString() {
-            return name().charAt(0) + name().substring(1).toLowerCase();
-        }
-
-        public static PlatoonType getPlatoonType(Entity en) {
-            switch (en.getMovementMode()) {
-                case TRACKED:
-                case WHEELED:
-                case HOVER:
-                case VTOL:
-                case SUBMARINE:
-                    return MECHANIZED;
-                case INF_MOTORIZED:
-                    return MOTORIZED;
-                case INF_JUMP:
-                    return JUMP;
-                default:
-                    return FOOT;
-            }
-        }
-    }
 
     // This represents the "factory setting" of the bay, and is used primarily by the construction rules.
     // In practice we support loading any type of infantry into the bay as long as there is room to avoid

--- a/megamek/src/megamek/common/InfantryBay.java
+++ b/megamek/src/megamek/common/InfantryBay.java
@@ -18,7 +18,7 @@ import megamek.common.InfantryTransporter.PlatoonType;
  * Represents a volume of space set aside for carrying infantry platoons aboard large spacecraft
  * and mobile structures. Marines count as crew and should have at least steerage quarters.
  */
-public final class InfantryBay extends Bay {
+public final class InfantryBay extends Bay implements InfantryTransporter {
     private static final long serialVersionUID = 946578184870030662L;
 
     // This represents the "factory setting" of the bay, and is used primarily by the construction rules.
@@ -53,45 +53,6 @@ public final class InfantryBay extends Bay {
         this.bayNumber = bayNumber;
         currentdoors = doors;
         this.platoonType = bayType;
-    }
-
-    @Override
-    public double spaceForUnit(Entity unit) {
-        PlatoonType type = PlatoonType.getPlatoonType(unit);
-        if ((unit instanceof Infantry) && (type == PlatoonType.MECHANIZED)) {
-            return type.getWeight() * ((Infantry) unit).getSquadCount();
-        } else {
-            return type.getWeight();
-        }
-    }
-
-    /**
-     * Determines if this object can accept the given unit. The unit may not be
-     * of the appropriate type or there may be no room for the unit.
-     *
-     * @param unit
-     *            - the <code>Entity</code> to be loaded.
-     * @return <code>true</code> if the unit can be loaded, <code>false</code>
-     *         otherwise.
-     */
-    @Override
-    public boolean canLoad(Entity unit) {
-        // Only infantry
-        boolean result = unit.hasETypeFlag(Entity.ETYPE_INFANTRY);
-
-        // We must have enough space for the new troops.
-        // POSSIBLE BUG: we may have to take the Math.ceil() of the weight.
-        if (getUnused() < spaceForUnit(unit)) {
-            result = false;
-        }
-
-        // is the door functional
-        if (currentdoors < loadedThisTurn) {
-            result = false;
-        }
-
-        // Return our result.
-        return result;
     }
 
     @Override

--- a/megamek/src/megamek/common/InfantryCompartment.java
+++ b/megamek/src/megamek/common/InfantryCompartment.java
@@ -225,11 +225,13 @@ public final class InfantryCompartment implements Transporter, InfantryTransport
      *         of space (such as infantry bays) this calculates the number of the default unit size
      *         that can fit into the remaining space.
      */
+    @Override
     public double getUnusedSlots() {
         return currentSpace;
     }
 
     /** @return A (possibly empty) list of units from this bay that can be assault-dropped. */
+    @Override
     public List<Entity> getDroppableUnits() {
         return troops.keySet().stream().map(game::getEntity).filter(Objects::nonNull).filter(Entity::canAssaultDrop).collect(toList());
     }

--- a/megamek/src/megamek/common/InfantryCompartment.java
+++ b/megamek/src/megamek/common/InfantryCompartment.java
@@ -13,17 +13,15 @@
  */
 package megamek.common;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Vector;
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
 
 /**
  * Represents a volume of space set aside for carrying troops and their equipment under battle
  * conditions. Typically, a component of an APC.
  */
-public final class InfantryCompartment implements Transporter {
+public final class InfantryCompartment implements Transporter, InfantryTransporter {
     private static final long serialVersionUID = 7837499891552862932L;
 
     /**
@@ -221,6 +219,26 @@ public final class InfantryCompartment implements Transporter {
         return null;
     }
 
+    /**
+     * @return The amount of unused space in the bay expressed in slots. For most bays this is the
+     *         same as the unused space, but bays for units that can take up a variable amount
+     *         of space (such as infantry bays) this calculates the number of the default unit size
+     *         that can fit into the remaining space.
+     */
+    public double getUnusedSlots() {
+        return currentSpace;
+    }
+
+    /** @return A (possibly empty) list of units from this bay that can be assault-dropped. */
+    public List<Entity> getDroppableUnits() {
+        return troops.keySet().stream().map(game::getEntity).filter(Objects::nonNull).filter(Entity::canAssaultDrop).collect(toList());
+    }
+    // Use the calculated original weight for infantry in cargo bays
+    @Override
+    public double spaceForUnit(Entity unit) {
+        return Math.round(unit.getWeight() / unit.getInternalRemainingPercent());
+    }
+
     @Override
     public List<Entity> getExternalUnits() {
         return new ArrayList<>(1);
@@ -234,6 +252,11 @@ public final class InfantryCompartment implements Transporter {
     @Override
     public String toString() {
         return "troopspace:" + totalSpace;
+    }
+
+    @Override
+    public String getType() {
+        return "Infantry Compartment";
     }
 
     @Override

--- a/megamek/src/megamek/common/InfantryTransporter.java
+++ b/megamek/src/megamek/common/InfantryTransporter.java
@@ -13,10 +13,7 @@
  */
 package megamek.common;
 
-import megamek.common.annotations.Nullable;
-
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * Classes that implement this interface have the ability to load, carry, and
@@ -82,4 +79,49 @@ public interface InfantryTransporter extends Serializable {
             }
         }
     }
+
+    default public double spaceForUnit(Entity unit) {
+        PlatoonType type = PlatoonType.getPlatoonType(unit);
+        if ((unit instanceof Infantry) && (type == PlatoonType.MECHANIZED)) {
+            return type.getWeight() * ((Infantry) unit).getSquadCount();
+        } else {
+            return type.getWeight();
+        }
+    }
+
+    /**
+     * @return the number of unused spaces in this transporter.
+     */
+    double getUnused();
+    int getCurrentDoors();
+    int getNumberLoadedThisTurn();
+
+    /**
+     * Determines if this object can accept the given unit. The unit may not be
+     * of the appropriate type or there may be no room for the unit.
+     *
+     * @param unit
+     *            - the <code>Entity</code> to be loaded.
+     * @return <code>true</code> if the unit can be loaded, <code>false</code>
+     *         otherwise.
+     */
+    default public boolean canLoad(Entity unit) {
+        // Only infantry
+        boolean result = unit.hasETypeFlag(Entity.ETYPE_INFANTRY);
+
+        // We must have enough space for the new troops.
+        // POSSIBLE BUG: we may have to take the Math.ceil() of the weight.
+        if (getUnused() < spaceForUnit(unit)) {
+            result = false;
+        }
+
+        // is the door functional
+        if (getCurrentDoors() < getNumberLoadedThisTurn()) {
+            result = false;
+        }
+
+        // Return our result.
+        return result;
+    }
+
 }

--- a/megamek/src/megamek/common/InfantryTransporter.java
+++ b/megamek/src/megamek/common/InfantryTransporter.java
@@ -14,6 +14,7 @@
 package megamek.common;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Vector;
 
 /**
@@ -86,11 +87,16 @@ public interface InfantryTransporter extends Serializable {
      * In practice, all are provided by Bay() or overridden in transports
      * that can carry infantry.
      */
+    boolean canLoad(Entity unit);
+    List<Entity> getDroppableUnits();
+    Vector<Entity> getLoadedUnits();
     double getUnused();
     double getUnusedSlots();
-    int getCurrentDoors();
-    Vector<Entity> getLoadedUnits();
+    String getType();
+    void load(Entity unit);
     double spaceForUnit(Entity unit);
-    boolean canLoad(Entity unit);
 
+    default int getCurrentDoors() {
+        return 0;
+    }
 }

--- a/megamek/src/megamek/common/InfantryTransporter.java
+++ b/megamek/src/megamek/common/InfantryTransporter.java
@@ -82,40 +82,15 @@ public interface InfantryTransporter extends Serializable {
     }
 
     /**
-     * @return the number of unused spaces in this transporter.
+     * These methods are required for Infantry unit loading/unloading.
+     * In practice, all are provided by Bay() or overridden in transports
+     * that can carry infantry.
      */
     double getUnused();
+    double getUnusedSlots();
     int getCurrentDoors();
-    int getNumberLoadedThisTurn();
     Vector<Entity> getLoadedUnits();
     double spaceForUnit(Entity unit);
-
-    /**
-     * Determines if this object can accept the given unit. The unit may not be
-     * of the appropriate type or there may be no room for the unit.
-     *
-     * @param unit
-     *            - the <code>Entity</code> to be loaded.
-     * @return <code>true</code> if the unit can be loaded, <code>false</code>
-     *         otherwise.
-     */
-    default public boolean canLoad(Entity unit) {
-        // Only infantry
-        boolean result = unit.hasETypeFlag(Entity.ETYPE_INFANTRY);
-
-        // We must have enough space for the new troops.
-        // POSSIBLE BUG: we may have to take the Math.ceil() of the weight.
-        if (getUnused() < spaceForUnit(unit)) {
-            result = false;
-        }
-
-        // is the door functional
-        if (getCurrentDoors() < getNumberLoadedThisTurn()) {
-            result = false;
-        }
-
-        // Return our result.
-        return result;
-    }
+    boolean canLoad(Entity unit);
 
 }

--- a/megamek/src/megamek/common/InfantryTransporter.java
+++ b/megamek/src/megamek/common/InfantryTransporter.java
@@ -1,5 +1,5 @@
 /*
- * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -17,11 +17,11 @@ import java.io.Serializable;
 import java.util.Vector;
 
 /**
- * Classes that implement this interface have the ability to load, carry, and
- * unload units in the game. It is anticipated that classes will exist for
- * passenger compartments, battle armor steps, Mek bays, Aerospace hangers, and
- * vehicle garages. Other possible classes include cargo bays and Dropship
- * docks.
+ * Classes that implement this interface have the ability to load, carry, drop, and
+ * unload Infantry units in the game.
+ * This interface includes a subset of the Bay.java class methods and Transporter interface.
+ * @see megamek.common.Bay
+ * @see megamek.common.Transporter
  */
 public interface InfantryTransporter extends Serializable {
 

--- a/megamek/src/megamek/common/InfantryTransporter.java
+++ b/megamek/src/megamek/common/InfantryTransporter.java
@@ -14,6 +14,7 @@
 package megamek.common;
 
 import java.io.Serializable;
+import java.util.Vector;
 
 /**
  * Classes that implement this interface have the ability to load, carry, and
@@ -80,21 +81,14 @@ public interface InfantryTransporter extends Serializable {
         }
     }
 
-    default public double spaceForUnit(Entity unit) {
-        PlatoonType type = PlatoonType.getPlatoonType(unit);
-        if ((unit instanceof Infantry) && (type == PlatoonType.MECHANIZED)) {
-            return type.getWeight() * ((Infantry) unit).getSquadCount();
-        } else {
-            return type.getWeight();
-        }
-    }
-
     /**
      * @return the number of unused spaces in this transporter.
      */
     double getUnused();
     int getCurrentDoors();
     int getNumberLoadedThisTurn();
+    Vector<Entity> getLoadedUnits();
+    double spaceForUnit(Entity unit);
 
     /**
      * Determines if this object can accept the given unit. The unit may not be

--- a/megamek/src/megamek/common/InfantryTransporter.java
+++ b/megamek/src/megamek/common/InfantryTransporter.java
@@ -1,0 +1,85 @@
+/*
+ * MegaMek - Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ */
+package megamek.common;
+
+import megamek.common.annotations.Nullable;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Classes that implement this interface have the ability to load, carry, and
+ * unload units in the game. It is anticipated that classes will exist for
+ * passenger compartments, battle armor steps, Mek bays, Aerospace hangers, and
+ * vehicle garages. Other possible classes include cargo bays and Dropship
+ * docks.
+ */
+public interface InfantryTransporter extends Serializable {
+
+    /** The amount of space taken up by an infantry unit in a transport bay differs from the space
+     * in an infantry compartment (used in APCs) due to quarters, equipment storage, and maintenance
+     * equipment. A single cubicle holds a platoon, except in the case of mechanized which requires
+     * a cubicle per squad. */
+
+    public enum PlatoonType {
+        FOOT (5, 28, 25),
+        JUMP (6, 21, 20),
+        MOTORIZED (7, 28, 25),
+        MECHANIZED (8, 7, 5);
+
+        private int weight;
+        private int isPersonnel;
+        private int clanPersonnel;
+
+        PlatoonType(int weight, int isPersonnel, int clanPersonnel) {
+            this.weight = weight;
+            this.isPersonnel = isPersonnel;
+            this.clanPersonnel = clanPersonnel;
+        }
+
+        public int getWeight() {
+            return weight;
+        }
+
+        public int getISPersonnel() {
+            return isPersonnel;
+        }
+
+        public int getClanPersonnel() {
+            return clanPersonnel;
+        }
+
+        @Override
+        public String toString() {
+            return name().charAt(0) + name().substring(1).toLowerCase();
+        }
+
+        public static PlatoonType getPlatoonType(Entity en) {
+            switch (en.getMovementMode()) {
+                case TRACKED:
+                case WHEELED:
+                case HOVER:
+                case VTOL:
+                case SUBMARINE:
+                    return MECHANIZED;
+                case INF_MOTORIZED:
+                    return MOTORIZED;
+                case INF_JUMP:
+                    return JUMP;
+                default:
+                    return FOOT;
+            }
+        }
+    }
+}

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -1630,7 +1630,7 @@ public class LosEffects {
     /**
      * Finds out if the left or right side of the divided LOS is better for the
      * target
-     * 
+     *
      * @param in
      * @param game             The current {@link Game}
      * @param ai

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1352,7 +1352,12 @@ public class MiscType extends EquipmentType {
             }
         } else if (hasFlag(F_FUEL)) {
             return (int) Math.ceil(getTonnage(entity));
-        } else if (hasFlag(F_CARGO) || hasFlag(F_LIQUID_CARGO) || hasFlag(F_COMMUNICATIONS)) {
+        } else if (hasFlag(F_CARGO)) {
+            if (entity.isAero()) {
+                return 0;
+            }
+            return (int) Math.ceil(size);
+        } else if (hasFlag(F_LIQUID_CARGO) || hasFlag(F_COMMUNICATIONS)) {
             return (int) Math.ceil(size);
         }
         // right, well I'll just guess then
@@ -6855,7 +6860,7 @@ public class MiscType extends EquipmentType {
         misc.name = "Cargo Container (10 tons)";
         misc.setInternalName(misc.name);
         misc.tonnage = 10;
-        misc.criticals = 1;
+        misc.criticals = CRITICALS_VARIABLE;
         misc.cost = 0;
         misc.flags = misc.flags.or(F_CARGO).or(F_MEK_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT)
                 .or(F_SC_EQUIPMENT).or(F_FIGHTER_EQUIPMENT)

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -6858,7 +6858,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.cost = 0;
         misc.flags = misc.flags.or(F_CARGO).or(F_MEK_EQUIPMENT).or(F_TANK_EQUIPMENT).or(F_SUPPORT_TANK_EQUIPMENT)
-                .or(F_SC_EQUIPMENT)
+                .or(F_SC_EQUIPMENT).or(F_FIGHTER_EQUIPMENT)
                 .or(F_DS_EQUIPMENT).or(F_JS_EQUIPMENT).or(F_WS_EQUIPMENT).or(F_SS_EQUIPMENT);
         misc.industrial = true;
         misc.tankslots = 1;

--- a/megamek/src/megamek/common/Transporter.java
+++ b/megamek/src/megamek/common/Transporter.java
@@ -36,7 +36,7 @@ public interface Transporter extends Serializable {
      *         otherwise.
      */
     boolean canLoad(Entity unit);
-    
+
     /**
      * Determines if this transporter can tow the given unit. By default, no.
      */
@@ -119,12 +119,12 @@ public interface Transporter extends Serializable {
     int getCargoMpReduction(Entity carrier);
 
     void setGame(Game game);
-    
+
     /**
      * clear out all troops listed in the transporter. Used by MHQ to reset units after game
      */
     void resetTransporter();
-    
+
     /**
      * Returns the number of Docking Collars (hardpoints) this transporter counts as toward
      * the maximum that a JumpShip (or WS, SS) may carry. TO:AUE p.146
@@ -134,4 +134,22 @@ public interface Transporter extends Serializable {
     default int hardpointCost() {
         return 0;
     }
+
+    /**
+     * Returns the number of units loaded on to this transporter this turn.
+     * Used to determine loading eligibility
+     * @return the number of units loaded
+     */
+    default int getNumberLoadedThisTurn() {
+        return 0;
+    };
+
+    /**
+     * Returns the number of units loaded on to this transporter this turn.
+     * Used to determine loading eligibility
+     * @return the number of units loaded
+     */
+    default int getNumberUnloadedThisTurn() {
+        return 0;
+    };
 }

--- a/megamek/src/megamek/common/Transporter.java
+++ b/megamek/src/megamek/common/Transporter.java
@@ -152,4 +152,8 @@ public interface Transporter extends Serializable {
     default int getNumberUnloadedThisTurn() {
         return 0;
     };
+
+    default String getType() {
+        return "Unknown";
+    }
 }

--- a/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
@@ -284,7 +284,8 @@ public class BLKAeroSpaceFighterFile extends BLKFile implements IMekLoader {
                         if ((etype instanceof MiscType) && etype.hasFlag(MiscType.F_CARGO)) {
                             // Treat F_CARGO equipment as cargo bays with 1 door, e.g. for ASF with IBB.
                             int idx = t.getTransportBays().size();
-                            t.addTransporter(new CargoBay(mount.getSize(), 1, idx), omniMounted);
+                            double baySize = (mount.getName().contains("Container")) ? mount.getTonnage() : mount.getSize();
+                            t.addTransporter(new CargoBay(baySize, 1, idx), omniMounted);
                         }
                     } catch (LocationFullException ex) {
                         throw new EntityLoadingException(ex.getMessage());

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -15,7 +15,7 @@
 package megamek.common.loaders;
 
 import megamek.common.*;
-import megamek.common.InfantryBay.PlatoonType;
+import megamek.common.InfantryTransporter.PlatoonType;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.WeaponMounted;
@@ -1419,7 +1419,7 @@ public class BLKFile {
         private double size;
         private int doors;
         private int bayNumber = -1;
-        private PlatoonType platoonType = InfantryBay.PlatoonType.FOOT;
+        private PlatoonType platoonType = InfantryTransporter.PlatoonType.FOOT;
         private boolean isComstarBay;
         private boolean isClanBay;
         private int facing = Entity.LOC_NONE;

--- a/megamek/src/megamek/common/verifier/BayData.java
+++ b/megamek/src/megamek/common/verifier/BayData.java
@@ -19,6 +19,7 @@ import java.util.function.BiFunction;
 
 import megamek.common.*;
 import megamek.common.annotations.Nullable;
+import megamek.common.InfantryTransporter.PlatoonType;
 
 /**
  * Construction data used by transport bays for meks, vees, and aerospace units.
@@ -38,13 +39,13 @@ public enum BayData {
     VEHICLE_SH ("Superheavy Vehicle", 200.0, 15, SuperHeavyVehicleBay.techAdvancement(),
             (size, num) -> new SuperHeavyVehicleBay(size, 1, num)),
     INFANTRY_FOOT ("Infantry (Foot)", 5.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.FOOT)),
+            (size, num) -> new InfantryBay(size, 0, num, PlatoonType.FOOT)),
     INFANTRY_JUMP ("Infantry (Jump)", 6.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.JUMP)),
+            (size, num) -> new InfantryBay(size, 0, num, PlatoonType.JUMP)),
     INFANTRY_MOTORIZED ("Infantry (Motorized)", 7.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.MOTORIZED)),
+            (size, num) -> new InfantryBay(size, 0, num, PlatoonType.MOTORIZED)),
     INFANTRY_MECHANIZED ("Infantry (Mek. Squad)", 8.0, 0, InfantryBay.techAdvancement(),
-            (size, num) -> new InfantryBay(size, 0, num, InfantryBay.PlatoonType.MECHANIZED)),
+            (size, num) -> new InfantryBay(size, 0, num, PlatoonType.MECHANIZED)),
     IS_BATTLE_ARMOR ("BattleArmor (IS)", 8.0, 6, BattleArmorBay.techAdvancement(),
             (size, num) -> new BattleArmorBay(size, 0, num, false, false)),
     CLAN_BATTLE_ARMOR ("BattleArmor (Clan)", 10.0, 6, BattleArmorBay.techAdvancement(),

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -1851,8 +1851,14 @@ class MovePathHandler extends AbstractTWRuleHandler {
                         r.subject = entity.getId();
                         r.add(nDropped);
                         addReport(r);
+                        Report dropEntityReport;
                         for (int unitId : drops) {
-                            if (Compute.d6(2) == 2) {
+                            Entity drop = getGame().getEntity(unitId);
+                            dropEntityReport = new Report(9374);
+                            dropEntityReport.add(drop.getShortName(), true);
+                            addReport(dropEntityReport);
+                            // Infantry don't have a chance to destory doors
+                            if (!drop.isInfantry() && Compute.d6(2) == 2) {
                                 r = new Report(9390);
                                 r.subject = entity.getId();
                                 r.indent(1);
@@ -1860,7 +1866,6 @@ class MovePathHandler extends AbstractTWRuleHandler {
                                 addReport(r);
                                 currentBay.destroyDoorNext();
                             }
-                            Entity drop = getGame().getEntity(unitId);
                             gameManager.dropUnit(drop, entity, curPos, step.getAltitude());
                         }
                     }

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -1839,10 +1839,10 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     TreeMap<Integer, Vector<Integer>> dropped = step.getLaunched();
                     Set<Integer> bays = dropped.keySet();
                     Iterator<Integer> bayIter = bays.iterator();
-                    Bay currentBay;
+                    Transporter currentBay;
                     while (bayIter.hasNext()) {
                         int bayId = bayIter.next();
-                        currentBay = entity.getTransportBays().elementAt(bayId);
+                        currentBay = entity.getTransports().elementAt(bayId);
                         Vector<Integer> drops = dropped.get(bayId);
                         int nDropped = drops.size();
                         // ok, now lets drop them
@@ -1857,14 +1857,17 @@ class MovePathHandler extends AbstractTWRuleHandler {
                             dropEntityReport = new Report(9374);
                             dropEntityReport.add(drop.getShortName(), true);
                             addReport(dropEntityReport);
-                            // Infantry don't have a chance to destory doors
+                            // Infantry don't have a chance to destroy doors, and
+                            // currently this applies to Bays only.
                             if (!drop.isInfantry() && Compute.d6(2) == 2) {
-                                r = new Report(9390);
-                                r.subject = entity.getId();
-                                r.indent(1);
-                                r.add(currentBay.getType());
-                                addReport(r);
-                                currentBay.destroyDoorNext();
+                                if (currentBay instanceof Bay cbBay) {
+                                    r = new Report(9390);
+                                    r.subject = entity.getId();
+                                    r.indent(1);
+                                    r.add(currentBay.getType());
+                                    addReport(r);
+                                    cbBay.destroyDoorNext();
+                                }
                             }
                             gameManager.dropUnit(drop, entity, curPos, step.getAltitude());
                         }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -3762,7 +3762,34 @@ public class TWGameManager extends AbstractGameManager {
         drop.setFacing(entity.getFacing());
         drop.setSecondaryFacing(entity.getFacing());
 
-        drop.setAltitude(altitude);
+        // Units dropped at NOE / Altitude 1 are instantly placed on the ground,
+        // or at elevation 8 for VTOL (TW pg. 225)
+        if (altitude == 1) {
+            Hex hex = getGame().getBoard().getHex(curPos);
+            int elevation = 0;
+            if (hex != null) {
+                elevation = hex.ceiling();
+            }
+            EntityMovementMode moveMode = drop.getMovementMode();
+            if (moveMode == EntityMovementMode.VTOL) {
+                elevation = 8;
+                // Set "jumping now" for +1 to-hit mod (TW pg. 225)
+                drop.setIsJumpingNow(true);
+            } else if (moveMode == EntityMovementMode.INF_JUMP) {
+                // Set "jumping now" for +1 to-hit mod (TW pg. 225)
+                drop.setIsJumpingNow(true);
+            } else if (moveMode == EntityMovementMode.WIGE) {
+                elevation = 1;
+            }
+
+            // Remove Airborne by setting Altitude to 0
+            drop.setAltitude(0);
+            drop.setElevation(elevation);
+        } else {
+            drop.setAltitude(altitude);
+            // For non-aeros, we need to temporarily set elevation to 999 until they land
+            drop.setElevation(Aero.AERO_EFFECTIVE_ELEVATION);
+        }
         entityUpdate(drop.getId());
     }
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -3764,22 +3764,19 @@ public class TWGameManager extends AbstractGameManager {
 
         // Units dropped at NOE / Altitude 1 are instantly placed on the ground,
         // or at elevation 8 for VTOL (TW pg. 225)
+        // Infantry treated as did not move; Jump/VTOL infantry get a +1 "Jumped" mod
         if (altitude == 1) {
             Hex hex = getGame().getBoard().getHex(curPos);
             int elevation = 0;
             if (hex != null) {
-                elevation = hex.ceiling();
+                elevation = (hex.getTerrain(Terrains.BLDG_ELEV) != null) ? hex.maxTerrainFeatureElevation(false) : 0;
             }
             EntityMovementMode moveMode = drop.getMovementMode();
             if (moveMode == EntityMovementMode.VTOL) {
+                drop.moved = EntityMovementType.MOVE_JUMP;
                 elevation = 8;
-                // Set "jumping now" for +1 to-hit mod (TW pg. 225)
-                drop.setIsJumpingNow(true);
-            } else if (moveMode == EntityMovementMode.INF_JUMP) {
-                // Set "jumping now" for +1 to-hit mod (TW pg. 225)
-                drop.setIsJumpingNow(true);
-            } else if (moveMode == EntityMovementMode.WIGE) {
-                elevation = 1;
+            } else if (moveMode == EntityMovementMode.INF_JUMP || drop.getOriginalJumpMP() > 0) {
+                drop.moved = EntityMovementType.MOVE_JUMP;
             }
 
             // Remove Airborne by setting Altitude to 0
@@ -3790,6 +3787,7 @@ public class TWGameManager extends AbstractGameManager {
             // For non-aeros, we need to temporarily set elevation to 999 until they land
             drop.setElevation(Aero.AERO_EFFECTIVE_ELEVATION);
         }
+        drop.setUnloaded(true);
         entityUpdate(drop.getId());
     }
 

--- a/megamek/unittests/megamek/common/CargoBayTest.java
+++ b/megamek/unittests/megamek/common/CargoBayTest.java
@@ -1,0 +1,152 @@
+package megamek.common;
+
+import megamek.client.Client;
+import megamek.client.ui.swing.ClientGUI;
+import megamek.common.options.GameOptions;
+import megamek.common.options.Option;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.PilotOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CargoBayTest {
+
+    static GameOptions mockGameOptions = mock(GameOptions.class);
+    static ClientGUI cg = mock(ClientGUI.class);
+    static Client client = mock(Client.class);
+    static Game game = new Game();
+
+    static Team team1 = new Team(0);
+    static Team team2 = new Team(1);
+    static Player player1 = new Player(0, "Test1");
+    static Player player2 = new Player(1, "Test2");
+    static AmmoType mockLTAmmoType = (AmmoType) EquipmentType.get("ISLongTom Ammo");
+    static AmmoType mockSniperAmmoType = (AmmoType) EquipmentType.get("ISSniper Ammo");
+    static AmmoType mockBombHEAmmoType = (AmmoType) EquipmentType.get("HEBomb");
+    static AmmoType mockBombFAEAmmoType = (AmmoType) EquipmentType.get("FABombSmall Ammo");
+
+    @BeforeAll
+    static void setUpAll() {
+        // Need equipment initialized
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        when(cg.getClient()).thenReturn(client);
+        when(cg.getClient().getGame()).thenReturn(game);
+        game.setOptions(mockGameOptions);
+
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ALLOWED_NO_CLAN_PHYSICAL))).thenReturn(false);
+        when(mockGameOptions.stringOption(OptionsConstants.ALLOWED_TECHLEVEL)).thenReturn("Experimental");
+        when(mockGameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED)).thenReturn(true);
+        when(mockGameOptions.booleanOption(OptionsConstants.ALLOWED_SHOW_EXTINCT)).thenReturn(false);
+        Option mockTrueBoolOpt = mock(Option.class);
+        Option mockFalseBoolOpt = mock(Option.class);
+        when(mockTrueBoolOpt.booleanValue()).thenReturn(true);
+        when(mockFalseBoolOpt.booleanValue()).thenReturn(false);
+        when(mockGameOptions.getOption(anyString())).thenReturn(mockTrueBoolOpt);
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3151);
+
+        team1.addPlayer(player1);
+        team2.addPlayer(player2);
+        game.addPlayer(0, player1);
+        game.addPlayer(1, player2);
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    Mek createMek(String chassis, String model, String crewName) {
+        // Create a real Mek with some mocked fields
+        Mek mockMek = new BipedMek();
+        mockMek.setGame(game);
+        mockMek.setChassis(chassis);
+        mockMek.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockMek.setCrew(mockCrew);
+
+        return mockMek;
+    }
+
+    Infantry createInfantry(String chassis, String model, String crewName) {
+        // Create a real Infantry unit with some mocked fields
+        Infantry mockInfantry = new Infantry();
+        mockInfantry.setGame(game);
+        mockInfantry.setChassis(chassis);
+        mockInfantry.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockInfantry.setCrew(mockCrew);
+
+        return mockInfantry;
+    }
+
+    AeroSpaceFighter createASF(String chassis, String model, String crewName) {
+        // Create a real AeroSpaceFighter unit with some mocked fields
+        AeroSpaceFighter mockAeroSpaceFighter = new AeroSpaceFighter();
+        mockAeroSpaceFighter.setGame(game);
+        mockAeroSpaceFighter.setChassis(chassis);
+        mockAeroSpaceFighter.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockAeroSpaceFighter.setCrew(mockCrew);
+
+        return mockAeroSpaceFighter;
+    }
+
+    @ParameterizedTest()
+    @EnumSource(names = {"INF_LEG", "INF_MOTORIZED", "INF_JUMP", "INF_UMU", "HOVER", "SUBMARINE", "TRACKED", "VTOL", "WHEELED"})
+    void testCargoBayCanLoadInfantry(EntityMovementMode mode) {
+        CargoBay bay = new CargoBay(100.0, 1, 1);
+        Infantry unit = createInfantry(mode.name(), "", "John Q. Test");
+        unit.setMovementMode(mode);
+        assertTrue(bay.canLoad(unit));
+    }
+
+    @ParameterizedTest()
+    @EnumSource(names = {"INF_LEG", "INF_MOTORIZED", "INF_JUMP", "INF_UMU", "HOVER", "SUBMARINE", "TRACKED", "VTOL", "WHEELED"})
+    void testCargoBayCanUnLoadInfantry(EntityMovementMode mode) {
+        CargoBay bay = new CargoBay(100.0, 1, 1);
+        Infantry unit = createInfantry(mode.name(), "", "John Q. Test");
+        unit.setMovementMode(mode);
+        assertTrue(bay.canUnloadUnits());
+    }
+
+    @Test
+    void testCargoBayCannotLoadMek() {
+        CargoBay bay = new CargoBay(100.0, 1, 1);
+        Mek mek = createMek("TST-01", "Testor", "Alyce B. Carlos");
+        assertFalse(bay.canLoad(mek));
+    }
+
+    @Test
+    void testCargoBayCannotLoadASF() {
+        CargoBay bay = new CargoBay(100.0, 1, 1);
+        AeroSpaceFighter asf = createASF("TST-02", "Testor", "Alyce B. Carlos");
+        assertFalse(bay.canLoad(asf));
+    }
+}

--- a/megamek/unittests/megamek/common/CargoBayTest.java
+++ b/megamek/unittests/megamek/common/CargoBayTest.java
@@ -6,6 +6,7 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
+import megamek.common.InfantryTransporter.PlatoonType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,10 +30,6 @@ class CargoBayTest {
     static Team team2 = new Team(1);
     static Player player1 = new Player(0, "Test1");
     static Player player2 = new Player(1, "Test2");
-    static AmmoType mockLTAmmoType = (AmmoType) EquipmentType.get("ISLongTom Ammo");
-    static AmmoType mockSniperAmmoType = (AmmoType) EquipmentType.get("ISSniper Ammo");
-    static AmmoType mockBombHEAmmoType = (AmmoType) EquipmentType.get("HEBomb");
-    static AmmoType mockBombFAEAmmoType = (AmmoType) EquipmentType.get("FABombSmall Ammo");
 
     @BeforeAll
     static void setUpAll() {
@@ -134,6 +131,19 @@ class CargoBayTest {
         Infantry unit = createInfantry(mode.name(), "", "John Q. Test");
         unit.setMovementMode(mode);
         assertTrue(bay.canUnloadUnits());
+    }
+
+    @ParameterizedTest()
+    @EnumSource(names = {"INF_LEG", "INF_MOTORIZED", "INF_JUMP", "INF_UMU", "HOVER", "SUBMARINE", "TRACKED", "VTOL", "WHEELED"})
+    void testCargoBaySpaceUsage(EntityMovementMode mode) {
+        Infantry unit = createInfantry(mode.name(), "", "John Q. Test");
+        unit.setMovementMode(mode);
+        unit.setSquadSize(7);
+        unit.setSquadCount(4);
+        double space = unit.getWeight();
+        CargoBay bay = new CargoBay(space, 1, 1);
+        bay.load(unit);
+        assertEquals(0, bay.getUnused());
     }
 
     @Test

--- a/megamek/unittests/megamek/common/CargoBayTest.java
+++ b/megamek/unittests/megamek/common/CargoBayTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ *  This program is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License as published by the Free
+ *  Software Foundation; either version 2 of the License, or (at your option)
+ *  any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but
+ *  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ *  or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ *  for more details.
+ */
+
 package megamek.common;
 
 import megamek.client.Client;
@@ -6,7 +20,6 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
-import megamek.common.InfantryTransporter.PlatoonType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/megamek/unittests/megamek/common/loaders/BLKFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BLKFileTest.java
@@ -31,7 +31,7 @@ import megamek.common.BattleArmorBay;
 import megamek.common.Bay;
 import megamek.common.DropshuttleBay;
 import megamek.common.InfantryBay;
-import megamek.common.InfantryBay.PlatoonType;
+import megamek.common.InfantryTransporter.PlatoonType;
 import megamek.common.Jumpship;
 import megamek.common.MekBay;
 import megamek.common.NavalRepairFacility;

--- a/megamek/unittests/megamek/common/verifier/BayDataTest.java
+++ b/megamek/unittests/megamek/common/verifier/BayDataTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 
 import megamek.common.*;
-import megamek.common.InfantryBay.PlatoonType;
+import megamek.common.InfantryTransporter.PlatoonType;
 
 class BayDataTest {
 

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -86,57 +86,6 @@ class AreaEffectHelperTest {
     void tearDown() {
     }
 
-    Mek createMek(String chassis, String model, String crewName) {
-        // Create a real Mek with some mocked fields
-        Mek mockMek = new BipedMek();
-        mockMek.setGame(game);
-        mockMek.setChassis(chassis);
-        mockMek.setModel(model);
-
-        Crew mockCrew = mock(Crew.class);
-        PilotOptions pOpt = new PilotOptions();
-        when(mockCrew.getName(anyInt())).thenCallRealMethod();
-        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
-        when(mockCrew.getOptions()).thenReturn(pOpt);
-        mockMek.setCrew(mockCrew);
-
-        return mockMek;
-    }
-
-    Infantry createInfantry(String chassis, String model, String crewName) {
-        // Create a real Infantry unit with some mocked fields
-        Infantry mockInfantry = new Infantry();
-        mockInfantry.setGame(game);
-        mockInfantry.setChassis(chassis);
-        mockInfantry.setModel(model);
-
-        Crew mockCrew = mock(Crew.class);
-        PilotOptions pOpt = new PilotOptions();
-        when(mockCrew.getName(anyInt())).thenCallRealMethod();
-        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
-        when(mockCrew.getOptions()).thenReturn(pOpt);
-        mockInfantry.setCrew(mockCrew);
-
-        return mockInfantry;
-    }
-
-    AeroSpaceFighter createASF(String chassis, String model, String crewName) {
-        // Create a real AeroSpaceFighter unit with some mocked fields
-        AeroSpaceFighter mockAeroSpaceFighter = new AeroSpaceFighter();
-        mockAeroSpaceFighter.setGame(game);
-        mockAeroSpaceFighter.setChassis(chassis);
-        mockAeroSpaceFighter.setModel(model);
-
-        Crew mockCrew = mock(Crew.class);
-        PilotOptions pOpt = new PilotOptions();
-        when(mockCrew.getName(anyInt())).thenCallRealMethod();
-        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
-        when(mockCrew.getOptions()).thenReturn(pOpt);
-        mockAeroSpaceFighter.setCrew(mockCrew);
-
-        return mockAeroSpaceFighter;
-    }
-
     @Test
     void testShapeBlastRingR2ArtilleryAttackOnBoardNoAETerrainLevel0() {
         game.setBoard(new Board(16,17));


### PR DESCRIPTION
1. Moves some data from InfantryBay.java into InfantryTransporter.java, a new Interface that should provide the minimum functionality for an Infantry-loading bay.
2. Implement missing Infantry drop prerequisites to align with TW and SO rules.
3. Remove restriction on number of infantry units dropped per turn, per SO rules.
4. Add the ability to load Infantry units (but currently no others) to CargoBay.java
5. Return ability to use Cargo Container bays to Fighter units (this had worked but was broken by the Mounted changes)
6. Removed unused entity builders from AreaEffectHelperTest.java while adding them for CargoBayTest.java.

See https://discord.com/channels/458705327911731231/1344135419180351560 for rationale for some design decisions taken here.

Testing:
- Many manual drops to confirm UI, space usage, and unit compatilibity.
- Added unit tests for CargoBay class.
- Ran all three projects' unit tests.

Merging this should unblock MegaMek/mekhq#5929

Close #6147