### PR TITLE
Fix 3425: swarm missiles have wrong mods for secondary targets

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -419,6 +419,9 @@ public class Princess extends BotClient {
     }
 
     public UnitBehavior getUnitBehaviorTracker() {
+        if (unitBehaviorTracker == null) {
+            unitBehaviorTracker = new UnitBehavior();
+        }
         return unitBehaviorTracker;
     }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -16,7 +16,6 @@
 package megamek.common;
 
 import java.util.*;
-import java.util.Map.Entry;
 
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.*;

--- a/megamek/src/megamek/common/TargetRoll.java
+++ b/megamek/src/megamek/common/TargetRoll.java
@@ -223,16 +223,32 @@ public class TargetRoll implements Serializable {
      * @return
      */
     public TargetRollModifier removeModifier(String fragment) {
-        Pattern pattern = Pattern.compile(fragment);
-        int index = IntStream.range(0, modifiers.size())
-            .filter(i -> pattern.matcher(modifiers.get(i).getDesc()).find())
-            .findFirst().orElse(-1);
-        if (index == -1) {
-            return null;
+        List<TargetRollModifier> mods = removeModifiers(List.of(fragment));
+        return (mods.isEmpty()) ? null : mods.get(0);
+    }
+
+    /**
+     * Attempts to remove and return (if needed) the first mod that matches
+     * each provided string
+     * @param fragments List of strings / regexes to match
+     * @return List of mods that are matched and removed
+     */
+    public List<TargetRollModifier> removeModifiers(List<String> fragments) {
+        List<TargetRollModifier> matches = new ArrayList<>();
+        TargetRollModifier mod;
+        for (String fragment : fragments) {
+            Pattern pattern = Pattern.compile(fragment);
+            int index = IntStream.range(0, modifiers.size())
+                .filter(i -> pattern.matcher(modifiers.get(i).getDesc()).find())
+                .findFirst().orElse(-1);
+            if (index != -1) {
+                mod = modifiers.get(index);
+                matches.add(mod);
+                modifiers.remove(mod);
+            }
         }
-        TargetRollModifier mod = modifiers.get(index);
-        removeModifier(mod);
-        return mod;
+        recalculate();
+        return matches;
     }
 
     /**

--- a/megamek/src/megamek/common/TargetRoll.java
+++ b/megamek/src/megamek/common/TargetRoll.java
@@ -23,6 +23,9 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.IntStream;
 
 /**
  * Keeps track of a target for a roll. Allows adding modifiers with
@@ -202,6 +205,34 @@ public class TargetRoll implements Serializable {
      */
     public void addModifier(TargetRollModifier modifier) {
         addModifierImpl(modifier);
+    }
+
+    /**
+     * Base removal method
+     * @param modifier
+     */
+    public void removeModifier(TargetRollModifier modifier) {
+        modifiers.remove(modifier);
+        recalculate();
+    }
+
+    /**
+     * Attempts to remove and return (if needed) the first mod that matches
+     * the provided string
+     * @param fragment of mod description to match
+     * @return
+     */
+    public TargetRollModifier removeModifier(String fragment) {
+        Pattern pattern = Pattern.compile(fragment);
+        int index = IntStream.range(0, modifiers.size())
+            .filter(i -> pattern.matcher(modifiers.get(i).getDesc()).find())
+            .findFirst().orElse(-1);
+        if (index == -1) {
+            return null;
+        }
+        TargetRollModifier mod = modifiers.get(index);
+        removeModifier(mod);
+        return mod;
     }
 
     /**

--- a/megamek/src/megamek/common/ToHitData.java
+++ b/megamek/src/megamek/common/ToHitData.java
@@ -337,37 +337,29 @@ public class ToHitData extends TargetRoll {
      * mods.
      */
     public void adjustSwarmToHit() {
-        // Remove first movement modifier (this does not need localization yet; see Compute.getTargetMovementModifier())
-        removeModifier("target (did not |)move(d \\S* hex)?");
-
-        // Remove jumped/airborne
-        removeModifier("target jumped");
-        removeModifier("target was airborne");
-
-        // Remove assault dropped
-        removeModifier("target is assault dropping");
-
-        // Remove skidded
-        removeModifier("target skidded");
-
-        // Remove possible Aerospace Side Mod (this needs to be localized)
-        String sideModRegex = megamek.client.ui.Messages.getString("WeaponAttackAction.AeroNoseAttack") + "|" + megamek.client.ui.Messages.getString("WeaponAttackAction.AeroSideAttack");
-        removeModifier(sideModRegex);
-
-        // Remove possible called shot mods
-        List<String> calls = List.of(
-            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledHigh"),
-            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledLow"),
-            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledLeft"),
-            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledRight")
+        removeModifiers(
+            List.of(
+                // Remove first movement modifier (this does not need localization yet; see Compute.getTargetMovementModifier())
+                "target (did not |)move(d \\S* hex)?",
+                // Remove jumped/airborne
+                "target jumped",
+                "target was airborne",
+                // Remove assault dropped
+                "target is assault dropping",
+                // Remove skidded
+                "target skidded",
+                // Remove possible Aerospace Side Mod (this needs to be localized)
+                megamek.client.ui.Messages.getString("WeaponAttackAction.AeroNoseAttack") + "|" + megamek.client.ui.Messages.getString("WeaponAttackAction.AeroSideAttack"),
+                // Remove possible called shot mods
+                megamek.client.ui.Messages.getString("WeaponAttackAction.CalledHigh"),
+                megamek.client.ui.Messages.getString("WeaponAttackAction.CalledLow"),
+                megamek.client.ui.Messages.getString("WeaponAttackAction.CalledLeft"),
+                megamek.client.ui.Messages.getString("WeaponAttackAction.CalledRight"),
+                // Remove target prone mods:
+                megamek.client.ui.Messages.getString("WeaponAttackAction.ProneAdj"),
+                Messages.getString("WeaponAttackAction.ProneRange")
+            )
         );
-        for (String call: calls) {
-            removeModifier(call);
-        }
-
-        // Remove target prone mods:
-        removeModifier(megamek.client.ui.Messages.getString("WeaponAttackAction.ProneAdj"));
-        removeModifier(Messages.getString("WeaponAttackAction.ProneRange"));
     }
 
 }

--- a/megamek/src/megamek/common/ToHitData.java
+++ b/megamek/src/megamek/common/ToHitData.java
@@ -348,7 +348,7 @@ public class ToHitData extends TargetRoll {
                 "target is assault dropping",
                 // Remove skidded
                 "target skidded",
-                // Remove possible Aerospace Side Mod (this needs to be localized)
+                // Remove possible Aerospace Side Mod (these all need to be localized)
                 megamek.client.ui.Messages.getString("WeaponAttackAction.AeroNoseAttack") + "|" + megamek.client.ui.Messages.getString("WeaponAttackAction.AeroSideAttack"),
                 // Remove possible called shot mods
                 megamek.client.ui.Messages.getString("WeaponAttackAction.CalledHigh"),
@@ -357,7 +357,7 @@ public class ToHitData extends TargetRoll {
                 megamek.client.ui.Messages.getString("WeaponAttackAction.CalledRight"),
                 // Remove target prone mods:
                 megamek.client.ui.Messages.getString("WeaponAttackAction.ProneAdj"),
-                Messages.getString("WeaponAttackAction.ProneRange")
+                megamek.client.ui.Messages.getString("WeaponAttackAction.ProneRange")
             )
         );
     }

--- a/megamek/src/megamek/common/ToHitData.java
+++ b/megamek/src/megamek/common/ToHitData.java
@@ -15,6 +15,10 @@
 package megamek.common;
 
 
+import megamek.client.ui.Messages;
+
+import java.util.List;
+
 /**
  * Contains the to-hit number and a short description of how it was reached
  */
@@ -326,6 +330,44 @@ public class ToHitData extends TargetRoll {
 
     public void setThruBldg(Building b) {
         thruBldg = b;
+    }
+
+    /**
+     * Remove extraneous mods from a ToHitData instance in preparation for recalculating
+     * mods.
+     */
+    public void adjustSwarmToHit() {
+        // Remove first movement modifier (this does not need localization yet; see Compute.getTargetMovementModifier())
+        removeModifier("target (did not |)move(d \\S* hex)?");
+
+        // Remove jumped/airborne
+        removeModifier("target jumped");
+        removeModifier("target was airborne");
+
+        // Remove assault dropped
+        removeModifier("target is assault dropping");
+
+        // Remove skidded
+        removeModifier("target skidded");
+
+        // Remove possible Aerospace Side Mod (this needs to be localized)
+        String sideModRegex = megamek.client.ui.Messages.getString("WeaponAttackAction.AeroNoseAttack") + "|" + megamek.client.ui.Messages.getString("WeaponAttackAction.AeroSideAttack");
+        removeModifier(sideModRegex);
+
+        // Remove possible called shot mods
+        List<String> calls = List.of(
+            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledHigh"),
+            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledLow"),
+            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledLeft"),
+            megamek.client.ui.Messages.getString("WeaponAttackAction.CalledRight")
+        );
+        for (String call: calls) {
+            removeModifier(call);
+        }
+
+        // Remove target prone mods:
+        removeModifier(megamek.client.ui.Messages.getString("WeaponAttackAction.ProneAdj"));
+        removeModifier(Messages.getString("WeaponAttackAction.ProneRange"));
     }
 
 }

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5098,7 +5098,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Remove first movement modifier
+        // We may wish to log these removed mods
         TargetRollModifier oldMoveMod = toHit.removeModifier("target (did not |)move(d \\S* hex)?");
+        TargetRollModifier oldAeroSideMod = toHit.removeModifier("attack against (side|nose)");
         toHit.append(Compute.getImmobileMod(swarmSecondaryTarget, aimingAt, aimingMode));
         toHit.append(Compute.getTargetTerrainModifier(game,
                 game.getTarget(swarmSecondaryTarget.getTargetType(), swarmSecondaryTarget.getId()), eistatus,

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5097,7 +5097,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
             toHit = new ToHitData();
         }
 
-        // toHit.addModifier(-toSubtract, Messages.getString("WeaponAttackAction.OriginalTargetMods"));
         // Remove first movement modifier
         TargetRollModifier oldMoveMod = toHit.removeModifier("target (did not |)move(d \\S* hex)?");
         toHit.append(Compute.getImmobileMod(swarmSecondaryTarget, aimingAt, aimingMode));

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -574,7 +574,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 isINarcGuided = true;
             }
         }
-        int toSubtract = 0;
 
         // Convenience variable to test the targetable type value
         final int ttype = target.getTargetType();
@@ -803,7 +802,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         usesAmmo);
                 // Everyone else
             } else {
-                toHit = compileAttackerToHitMods(game, ae, target, los, toHit, toSubtract, aimingAt, aimingMode, wtype,
+                toHit = compileAttackerToHitMods(game, ae, target, los, toHit, aimingAt, aimingMode, wtype,
                         weapon, weaponId, atype, munition, isFlakAttack, isHaywireINarced, isNemesisConfused,
                         isWeaponFieldGuns, usesAmmo);
             }
@@ -827,14 +826,14 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Collect the modifiers for the target's condition/actions
-        toHit = compileTargetToHitMods(game, ae, target, ttype, los, toHit, toSubtract, aimingAt, aimingMode, distance,
+        toHit = compileTargetToHitMods(game, ae, target, ttype, los, toHit, aimingAt, aimingMode, distance,
                 wtype, weapon, atype, munition, isArtilleryDirect, isArtilleryIndirect, isAttackerInfantry,
                 exchangeSwarmTarget, isIndirect, isPointblankShot, usesAmmo);
 
         // Collect the modifiers for terrain and line-of-sight. This includes any
         // related to-hit table changes
         toHit = compileTerrainAndLosToHitMods(game, ae, target, ttype, aElev, tElev, targEl, distance, los, toHit,
-                losMods, toSubtract, eistatus, wtype, weapon, weaponId, atype, ammo, munition, isAttackerInfantry,
+                losMods, eistatus, wtype, weapon, weaponId, atype, ammo, munition, isAttackerInfantry,
                 inSameBuilding, isIndirect, isPointblankShot, underWater);
 
         // If this is a swarm LRM secondary attack, remove old target movement and
@@ -842,7 +841,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // add those for new target.
         if (exchangeSwarmTarget) {
             toHit = handleSwarmSecondaryAttacks(game, ae, target, swarmPrimaryTarget, swarmSecondaryTarget, toHit,
-                    toSubtract, eistatus, aimingAt, aimingMode, weapon, atype, munition, isECMAffected,
+                eistatus, aimingAt, aimingMode, weapon, atype, munition, isECMAffected,
                     inSameBuilding, underWater);
         }
 
@@ -886,7 +885,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
             targEl = te.relHeight();
         }
 
-        int toSubtract = 0;
         int distance = Compute.effectiveDistance(game, ae, target);
 
         // EI system
@@ -932,14 +930,14 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         false, false, false, false, false);
                 // Everyone else
             } else {
-                toHit = compileAttackerToHitMods(game, ae, target, los, toHit, toSubtract, Entity.LOC_NONE,
+                toHit = compileAttackerToHitMods(game, ae, target, los, toHit, Entity.LOC_NONE,
                         AimingMode.NONE, null, null, weaponId, null, EnumSet.of(AmmoType.Munitions.M_STANDARD),
                         false, false, false, false, false);
             }
         }
 
         // Collect the modifiers for the target's condition/actions
-        toHit = compileTargetToHitMods(game, ae, target, ttype, los, toHit, toSubtract, Entity.LOC_NONE,
+        toHit = compileTargetToHitMods(game, ae, target, ttype, los, toHit, Entity.LOC_NONE,
                 AimingMode.NONE, distance, null, null, null, EnumSet.of(AmmoType.Munitions.M_STANDARD),
                 false, false, isAttackerInfantry, false,
                 false, false, false);
@@ -947,7 +945,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Collect the modifiers for terrain and line-of-sight. This includes any
         // related to-hit table changes
         toHit = compileTerrainAndLosToHitMods(game, ae, target, ttype, aElev, tElev, targEl, distance, los, toHit,
-                losMods, toSubtract, eistatus, null, null, weaponId, null, null,
+                losMods, eistatus, null, null, weaponId, null, null,
                 EnumSet.of(AmmoType.Munitions.M_STANDARD), isAttackerInfantry,
                 inSameBuilding, false, false, false);
 
@@ -3467,9 +3465,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param los               The calculated LOS between attacker and target
      * @param toHit             The running total ToHitData for this
      *                          WeaponAttackAction
-     * @param toSubtract        An int value representing a running total of mods to
-     *                          disregard - used for some special attacks
-     *
      * @param aimingAt          An int value representing the location being aimed
      *                          at
      * @param aimingMode        An int value that determines the reason aiming is
@@ -3496,7 +3491,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
      */
     private static ToHitData compileAttackerToHitMods(Game game, Entity ae, Targetable target,
             LosEffects los, ToHitData toHit,
-            int toSubtract, int aimingAt,
+            int aimingAt,
             AimingMode aimingMode, WeaponType wtype,
             Mounted<?> weapon, int weaponId, AmmoType atype,
             EnumSet<AmmoType.Munitions> munition, boolean isFlakAttack,
@@ -3557,11 +3552,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     // handled by Compute#targetSideTable
                     toHit.addModifier(+3, Messages.getString("WeaponAttackAction.CalledRight"));
                     break;
-            }
-            // If we're making a called shot with swarm LRMs, then the penalty
-            // only applies to the original attack.
-            if (call != CalledShot.CALLED_NONE) {
-                toSubtract += 3;
             }
         }
 
@@ -4214,9 +4204,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param los                 The calculated LOS between attacker and target
      * @param toHit               The running total ToHitData for this
      *                            WeaponAttackAction
-     * @param toSubtract          An int value representing a running total of mods
-     *                            to disregard - used for some special attacks
-     *
      * @param aimingAt            An int value representing the location being aimed
      *                            at - used by immobile target calculations
      * @param aimingMode          An int value that determines the reason aiming is
@@ -4246,7 +4233,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
      */
     private static ToHitData compileTargetToHitMods(Game game, Entity ae, Targetable target,
             int ttype, LosEffects los, ToHitData toHit,
-            int toSubtract, int aimingAt,
+            int aimingAt,
             AimingMode aimingMode, int distance,
             WeaponType wtype, WeaponMounted weapon, AmmoType atype,
             EnumSet<AmmoType.Munitions> munition, boolean isArtilleryDirect,
@@ -4298,10 +4285,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // Harder at range.
                 proneMod = new ToHitData(1, Messages.getString("WeaponAttackAction.ProneRange"));
             }
-        }
-        if (proneMod != null) {
-            toHit.append(proneMod);
-            toSubtract += proneMod.getValue();
         }
 
         // Special effects affecting the target
@@ -4369,7 +4352,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if ((te != null) && !isPointBlankShot) {
             ToHitData thTemp = Compute.getTargetMovementModifier(game, target.getId());
             toHit.append(thTemp);
-            toSubtract += thTemp.getValue();
 
             // semiguided ammo negates this modifier, if TAG succeeded
             if ((atype != null) && ((atype.getAmmoType() == AmmoType.T_LRM)
@@ -4433,11 +4415,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 } else {
                     immobileMod = Compute.getImmobileMod(target, aimingAt, AimingMode.NONE);
                 }
-            }
-
-            if (immobileMod != null) {
-                toHit.append(immobileMod);
-                toSubtract += immobileMod.getValue();
             }
         }
 
@@ -4562,9 +4539,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param toHit            The running total ToHitData for this
      *                         WeaponAttackAction
      * @param losMods          A cached set of LOS-related modifiers
-     * @param toSubtract       An int value representing a running total of mods to
-     *                         disregard - used for some special attacks
-     *
      * @param eistatus         An int value representing the ei cockpit/pilot
      *                         upgrade status
      *
@@ -4587,7 +4561,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
      */
     private static ToHitData compileTerrainAndLosToHitMods(Game game, Entity ae, Targetable target, int ttype,
             int aElev, int tElev,
-            int targEl, int distance, LosEffects los, ToHitData toHit, ToHitData losMods, int toSubtract, int eistatus,
+            int targEl, int distance, LosEffects los, ToHitData toHit, ToHitData losMods, int eistatus,
             WeaponType wtype, WeaponMounted weapon, int weaponId, AmmoType atype, AmmoMounted ammo,
             EnumSet<AmmoType.Munitions> munition, boolean isAttackerInfantry,
             boolean inSameBuilding, boolean isIndirect, boolean isPointBlankShot, boolean underWater) {
@@ -5056,21 +5030,16 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param swarmSecondaryTarget The current Targetable object being attacked
      * @param toHit                The running total ToHitData for this
      *                             WeaponAttackAction
-     * @param toSubtract           An int value representing a running total of mods
-     *                             to disregard
-     *
      * @param eistatus             An int value representing the ei cockpit/pilot
      *                             upgrade status - used for terrain calculation
      * @param aimingAt             An int value representing the location being
      *                             aimed at - used for immobile target
      * @param aimingMode           An int value that determines the reason aiming is
      *                             allowed - used for immobile target
-     *
      * @param weapon               The Mounted weapon being used
      * @param atype                The AmmoType being used for this attack
      * @param munition             Long indicating the munition type flag being
      *                             used, if applicable
-     *
      * @param isECMAffected        flag that indicates whether the target is inside
      *                             an ECM bubble
      * @param inSameBuilding       flag that indicates whether this attack
@@ -5081,7 +5050,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     private static ToHitData handleSwarmSecondaryAttacks(Game game, Entity ae, Targetable target,
             Targetable swarmPrimaryTarget,
             Targetable swarmSecondaryTarget,
-            ToHitData toHit, int toSubtract,
+            ToHitData toHit,
             int eistatus, int aimingAt,
             AimingMode aimingMode, Mounted<?> weapon,
             AmmoType atype, EnumSet<AmmoType.Munitions> munition,
@@ -5097,10 +5066,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
             toHit = new ToHitData();
         }
 
-        // Remove first movement modifier
-        // We may wish to log these removed mods
-        TargetRollModifier oldMoveMod = toHit.removeModifier("target (did not |)move(d \\S* hex)?");
-        TargetRollModifier oldAeroSideMod = toHit.removeModifier("attack against (side|nose)");
+        // Remove extraneous mods
+        toHit.adjustSwarmToHit();
+
         toHit.append(Compute.getImmobileMod(swarmSecondaryTarget, aimingAt, aimingMode));
         toHit.append(Compute.getTargetTerrainModifier(game,
                 game.getTarget(swarmSecondaryTarget.getTargetType(), swarmSecondaryTarget.getId()), eistatus,

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -5097,7 +5097,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
             toHit = new ToHitData();
         }
 
-        toHit.addModifier(-toSubtract, Messages.getString("WeaponAttackAction.OriginalTargetMods"));
+        // toHit.addModifier(-toSubtract, Messages.getString("WeaponAttackAction.OriginalTargetMods"));
+        // Remove first movement modifier
+        TargetRollModifier oldMoveMod = toHit.removeModifier("target (did not |)move(d \\S* hex)?");
         toHit.append(Compute.getImmobileMod(swarmSecondaryTarget, aimingAt, aimingMode));
         toHit.append(Compute.getTargetTerrainModifier(game,
                 game.getTarget(swarmSecondaryTarget.getTargetType(), swarmSecondaryTarget.getId()), eistatus,

--- a/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
+++ b/megamek/src/megamek/common/weapons/LRMSwarmHandler.java
@@ -224,6 +224,10 @@ public class LRMSwarmHandler extends LRMHandler {
             vPhaseReport.addElement(r);
         }
 
+        // Handle full-salvo hit on initial attack so we don't accidentally spawn another full shot
+        if (hits == wtype.getRackSize()) {
+            swarmMissilesNowLeft = 0;
+        }
         // for each cluster of hits, do a chunk of damage
         while (hits > 0) {
             int nDamage;
@@ -255,6 +259,7 @@ public class LRMSwarmHandler extends LRMHandler {
                 firstHit = false;
             }
         } // Handle the next cluster.
+
         Report.addNewline(vPhaseReport);
         if (swarmMissilesNowLeft > 0) {
             Entity swarmTarget = Compute.getSwarmMissileTarget(game,
@@ -263,7 +268,7 @@ public class LRMSwarmHandler extends LRMHandler {
                     target.getPosition(), target.getPosition())
                     && !(this instanceof LRMSwarmIHandler);
             if (swarmTarget != null && !stoppedByECM) {
-                r = new Report(3420);
+                r = new Report(3420, Report.HIDDEN);
                 r.subject = subjectId;
                 r.indent(2);
                 r.add(swarmMissilesNowLeft);
@@ -355,7 +360,7 @@ public class LRMSwarmHandler extends LRMHandler {
                 target.getPosition(), target.getPosition())
                 && !(this instanceof LRMSwarmIHandler);
         if (swarmTarget != null && !stoppedByECM) {
-            Report r = new Report(3420);
+            Report r = new Report(3420, Report.HIDDEN);
             r.subject = subjectId;
             r.indent(2);
             r.add(swarmMissilesNowLeft);
@@ -445,14 +450,14 @@ public class LRMSwarmHandler extends LRMHandler {
             swarmMissilesLeft = wtype.getRackSize();
         }
         swarmMissilesNowLeft = swarmMissilesLeft - missilesHit;
-        Report r = new Report(3325);
+        Report r = new Report(3325, Report.HIDDEN);
         r.subject = subjectId;
         r.add(missilesHit);
         r.add(sSalvoType);
         r.add(toHit.getTableDesc());
         r.newlines = 0;
         vPhaseReport.addElement(r);
-        r = new Report(3345);
+        r = new Report(3345, Report.HIDDEN);
         r.subject = subjectId;
         vPhaseReport.addElement(r);
         bSalvo = true;

--- a/megamek/unittests/megamek/common/ToHitDataTest.java
+++ b/megamek/unittests/megamek/common/ToHitDataTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025 - The MegaMek Team. All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * for more details.
+ *
+ */
+
+package megamek.common;
+
+import megamek.client.Client;
+import megamek.client.ui.swing.ClientGUI;
+import megamek.common.options.GameOptions;
+import megamek.common.options.Option;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.PilotOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ToHitDataTest {
+    static GameOptions mockGameOptions = mock(GameOptions.class);
+    static ClientGUI cg = mock(ClientGUI.class);
+    static Client client = mock(Client.class);
+    static Game game;
+
+    static Team team1 = new Team(0);
+    static Team team2 = new Team(1);
+    static Player player1 = new Player(0, "Test1");
+    static Player player2 = new Player(1, "Test2");
+    static WeaponType mockAC5 = (WeaponType) EquipmentType.get("ISAC5");
+    static AmmoType mockAC5AmmoType = (AmmoType) EquipmentType.get("ISAC5 Ammo");
+    static AmmoType mockLTAmmoType = (AmmoType) EquipmentType.get("ISLongTom Ammo");
+
+
+    @BeforeAll
+    static void setUpAll() {
+        // Need equipment initialized
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        game = new Game();
+        when(cg.getClient()).thenReturn(client);
+        when(cg.getClient().getGame()).thenReturn(game);
+        game.setOptions(mockGameOptions);
+
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ALLOWED_NO_CLAN_PHYSICAL))).thenReturn(false);
+        when(mockGameOptions.stringOption(OptionsConstants.ALLOWED_TECHLEVEL)).thenReturn("Experimental");
+        when(mockGameOptions.booleanOption(OptionsConstants.ALLOWED_ERA_BASED)).thenReturn(true);
+        when(mockGameOptions.booleanOption(OptionsConstants.ALLOWED_SHOW_EXTINCT)).thenReturn(false);
+        Option mockTrueBoolOpt = mock(Option.class);
+        Option mockFalseBoolOpt = mock(Option.class);
+        when(mockTrueBoolOpt.booleanValue()).thenReturn(true);
+        when(mockFalseBoolOpt.booleanValue()).thenReturn(false);
+        when(mockGameOptions.getOption(anyString())).thenReturn(mockTrueBoolOpt);
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3151);
+
+        team1.addPlayer(player1);
+        team2.addPlayer(player2);
+        game.addPlayer(0, player1);
+        game.addPlayer(1, player2);
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    Mek createMek(String chassis, String model, String crewName) {
+        // Create a real Mek with some mocked fields
+        Mek mockMek = new BipedMek();
+        mockMek.setGame(game);
+        mockMek.setChassis(chassis);
+        mockMek.setModel(model);
+
+        Crew mockCrew = mock(Crew.class);
+        PilotOptions pOpt = new PilotOptions();
+        when(mockCrew.getName(anyInt())).thenCallRealMethod();
+        when(mockCrew.getNames()).thenReturn(new String[] { crewName });
+        when(mockCrew.getOptions()).thenReturn(pOpt);
+        mockMek.setCrew(mockCrew);
+
+        return mockMek;
+    }
+
+    @Test
+    void adjustSwarmToHitRemoveTargetMovementMod() {
+        Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+        Mek target1 = createMek("Target", "TGT-2", "Bob");
+        Mek target2 = createMek("Target", "TGT-2", "Charlie");
+
+        attacker.setOwnerId(player1.getId());
+        Coords attackerCoords = new Coords(0,0);
+        attacker.setPosition(attackerCoords);
+        attacker.setId(1);
+        attacker.setDeployed(true);
+
+        target1.setOwnerId(player2.getId());
+        target1.setId(2);
+        Coords targetCoords1 = new Coords(5, 5);
+        target1.setPosition(targetCoords1);
+        target1.setDeployed(true);
+
+        target2.setOwnerId(player2.getId());
+        target2.setId(3);
+        Coords targetCoords2 = new Coords(5, 6);
+        target1.setPosition(targetCoords2);
+        target1.setDeployed(true);
+
+        game.addEntities(List.of(attacker, target1, target2));
+
+        ToHitData toHitData = new ToHitData();
+        int gunnery = 4;
+        int amm = 2;
+        int rangeMod = 2;
+
+        toHitData.addModifier(gunnery, "Gunnery Skill");
+        toHitData.addModifier(amm, "Attacker ran");
+        toHitData.append(Compute.getTargetMovementModifier(game, target1.getId()));
+        toHitData.addModifier(rangeMod, "Range Mod");
+
+        // Run adjustment
+        toHitData.adjustSwarmToHit();
+
+        assertEquals(3, toHitData.getModifiers().size());
+        assertEquals(gunnery + amm + rangeMod, toHitData.getValue());
+
+    }
+}

--- a/megamek/unittests/megamek/common/ToHitDataTest.java
+++ b/megamek/unittests/megamek/common/ToHitDataTest.java
@@ -129,17 +129,21 @@ class ToHitDataTest {
         int gunnery = 4;
         int amm = 2;
         int rangeMod = 2;
+        int targetMove = 3;
+        target1.delta_distance = targetMove;
 
         toHitData.addModifier(gunnery, "Gunnery Skill");
         toHitData.addModifier(amm, "Attacker ran");
         toHitData.append(Compute.getTargetMovementModifier(game, target1.getId()));
         toHitData.addModifier(rangeMod, "Range Mod");
 
+        assertEquals(4, toHitData.getModifiers().size());
+        assertEquals(gunnery + amm + rangeMod + 1, toHitData.getValue());
+
         // Run adjustment
         toHitData.adjustSwarmToHit();
 
         assertEquals(3, toHitData.getModifiers().size());
         assertEquals(gunnery + amm + rangeMod, toHitData.getValue());
-
     }
 }

--- a/megamek/unittests/megamek/common/ToHitDataTest.java
+++ b/megamek/unittests/megamek/common/ToHitDataTest.java
@@ -135,7 +135,7 @@ class ToHitDataTest {
     void adjustSwarmToHitRemoveTargetMovementMod() throws ValidationException {
         // Verify that removal of just movement mod works
         List<Mek> meks = basicConfig(List.of(new Coords(0,0), new Coords(5, 5), new Coords(5, 6)));
-        Mek attacker = meks.get(0), target1 = meks.get(1), target2 = meks.get(2);
+        Mek target1 = meks.get(1);
         ToHitData toHitData = new ToHitData();
         int gunnery = 4;
         int amm = 2;
@@ -162,7 +162,7 @@ class ToHitDataTest {
     void adjustSwarmToHitRemoveTargetMovedJumpedMod() throws ValidationException {
         // Verify removal of movement and jumped mods
         List<Mek> meks = basicConfig(List.of(new Coords(0,0), new Coords(5, 5), new Coords(5, 6)));
-        Mek attacker = meks.get(0), target1 = meks.get(1), target2 = meks.get(2);
+        Mek target1 = meks.get(1);
         ToHitData toHitData = new ToHitData();
         int gunnery = 4;
         int amm = 2;
@@ -191,7 +191,7 @@ class ToHitDataTest {
     void adjustSwarmToHitRemoveTargetSkiddedProneRangeCalledShotMods() throws ValidationException {
         // Verify removal of movement and jumped mods
         List<Mek> meks = basicConfig(List.of(new Coords(0,0), new Coords(5, 5), new Coords(5, 6)));
-        Mek attacker = meks.get(0), target1 = meks.get(1), target2 = meks.get(2);
+        Mek target1 = meks.get(1);
         ToHitData toHitData = new ToHitData();
         int gunnery = 4;
         int amm = 2;


### PR DESCRIPTION
Fixes the issue where we were not removing movement mods from swarm attack to-hit values for secondary targets.
Also removes Aerospace side mods if Swarm attack switches from an Aerospace unit to a ground unit.

It doesn't appear that we need to remove LOS-related mods (cover, submerged, etc.) as they are regenerated for the secondary target from the prior target.

Testing:
- Several tests of Swarm munitions against a variety of targets in various conditions
- Ran all three projects' unit tests.

Close #3425 