### PR TITLE
Support multiselect in the Add Unit dialog

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -354,12 +354,13 @@ public class Client extends AbstractClient {
      * Sends an "add entity" packet that contains a collection of Entity
      * objects.
      *
-     * @param entities
-     *                 The collection of Entity objects to add.
+     * @see megamek.server.totalwarfare.TWGameManager#receiveEntityAdd(Packet, int)
+     *
+     * @param entities The collection of Entity objects to add.
+     *                 This should ideally be an {@link ArrayList<Entity>}, but other kinds of {@link List} will be converted to an {@link ArrayList}.
      */
     public void sendAddEntity(List<Entity> entities) {
         // Trying to pass a non-ArrayList jams the receiving client and prevents it from ever receiving more packets.
-        // I have no idea why this happens.
         if (!(entities instanceof ArrayList<Entity>)) {
             entities = new ArrayList<>(entities);
         }

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -16,22 +16,6 @@
  */
 package megamek.client;
 
-import java.awt.Image;
-import java.awt.image.BufferedImage;
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.zip.GZIPInputStream;
-
 import megamek.MMConstants;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
@@ -42,21 +26,9 @@ import megamek.client.ui.swing.tileset.TilesetManager;
 import megamek.client.ui.swing.tooltip.PilotToolTip;
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.*;
-import megamek.common.actions.ArtilleryAttackAction;
-import megamek.common.actions.AttackAction;
-import megamek.common.actions.ClubAttackAction;
-import megamek.common.actions.DodgeAction;
-import megamek.common.actions.EntityAction;
-import megamek.common.actions.FlipArmsAction;
-import megamek.common.actions.TorsoTwistAction;
-import megamek.common.actions.WeaponAttackAction;
+import megamek.common.actions.*;
 import megamek.common.enums.GamePhase;
-import megamek.common.event.GameBoardChangeEvent;
-import megamek.common.event.GameCFREvent;
-import megamek.common.event.GameEntityChangeEvent;
-import megamek.common.event.GameReportEvent;
-import megamek.common.event.GameSettingsChangeEvent;
-import megamek.common.event.GameVictoryEvent;
+import megamek.common.event.*;
 import megamek.common.force.Force;
 import megamek.common.force.Forces;
 import megamek.common.net.enums.PacketCommand;
@@ -71,6 +43,16 @@ import megamek.common.util.SerializationHelper;
 import megamek.common.util.StringUtil;
 import megamek.logging.MMLogger;
 import megamek.server.SmokeCloud;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.util.List;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
 
 /**
  * This class is instantiated for each client and for each bot running on that
@@ -369,18 +351,6 @@ public class Client extends AbstractClient {
     }
 
     /**
-     * Sends an "add entity" packet with only one Entity.
-     *
-     * @param entity
-     *               The Entity to add.
-     */
-    public void sendAddEntity(Entity entity) {
-        ArrayList<Entity> entities = new ArrayList<>(1);
-        entities.add(entity);
-        sendAddEntity(entities);
-    }
-
-    /**
      * Sends an "add entity" packet that contains a collection of Entity
      * objects.
      *
@@ -388,6 +358,11 @@ public class Client extends AbstractClient {
      *                 The collection of Entity objects to add.
      */
     public void sendAddEntity(List<Entity> entities) {
+        // Trying to pass a non-ArrayList jams the receiving client and prevents it from ever receiving more packets.
+        // I have no idea why this happens.
+        if (!(entities instanceof ArrayList<Entity>)) {
+            entities = new ArrayList<>(entities);
+        }
         for (Entity entity : entities) {
             checkDuplicateNamesDuringAdd(entity);
         }

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -50,6 +50,7 @@ import java.text.Normalizer;
 import java.util.List;
 import java.util.*;
 import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 /**
  * This is a heavily reworked version of the original MekSelectorDialog which
@@ -717,7 +718,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         }
     }
 
-    public List<Entity> getSelectedEntities() {
+    public ArrayList<Entity> getSelectedEntities() {
         return getSelectedMekSummaries().stream().map(
             ms -> {
                 try {
@@ -727,7 +728,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
                     return null;
                 }
             }
-        ).filter(Objects::nonNull).toList();
+        ).filter(Objects::nonNull).collect(Collectors.toCollection(ArrayList::new));
     }
 
     /** @return The MekSummary for the selected unit. */

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -14,23 +14,25 @@
  */
 package megamek.client.ui.swing.dialog;
 
-import java.awt.Component;
-import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.awt.Insets;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
-import java.awt.event.WindowEvent;
-import java.text.Normalizer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.PatternSyntaxException;
+import megamek.MegaMek;
+import megamek.client.ui.Messages;
+import megamek.client.ui.advancedsearch.AdvancedSearchDialog2;
+import megamek.client.ui.advancedsearch.MekSearchFilter;
+import megamek.client.ui.dialogs.BVDisplayDialog;
+import megamek.client.ui.models.XTableColumnModel;
+import megamek.client.ui.panes.EntityViewPane;
+import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.UnitLoadingDialog;
+import megamek.common.*;
+import megamek.common.annotations.Nullable;
+import megamek.common.battlevalue.BVCalculator;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
+import megamek.common.preference.ClientPreferences;
+import megamek.common.preference.PreferenceManager;
+import megamek.common.util.sorter.NaturalOrderComparator;
+import megamek.logging.MMLogger;
 
 import javax.swing.*;
 import javax.swing.RowSorter.SortKey;
@@ -42,31 +44,12 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
-
-import megamek.MegaMek;
-import megamek.client.ui.Messages;
-import megamek.client.ui.advancedsearch.AdvancedSearchDialog2;
-import megamek.client.ui.dialogs.BVDisplayDialog;
-import megamek.client.ui.models.XTableColumnModel;
-import megamek.client.ui.panes.EntityViewPane;
-import megamek.client.ui.swing.GUIPreferences;
-import megamek.client.ui.swing.UnitLoadingDialog;
-import megamek.common.Entity;
-import megamek.common.EntityWeightClass;
-import megamek.common.MekFileParser;
-import megamek.client.ui.advancedsearch.MekSearchFilter;
-import megamek.common.MekSummary;
-import megamek.common.MekSummaryCache;
-import megamek.common.TechConstants;
-import megamek.common.UnitType;
-import megamek.common.annotations.Nullable;
-import megamek.common.battlevalue.BVCalculator;
-import megamek.common.options.GameOptions;
-import megamek.common.options.OptionsConstants;
-import megamek.common.preference.ClientPreferences;
-import megamek.common.preference.PreferenceManager;
-import megamek.common.util.sorter.NaturalOrderComparator;
-import megamek.logging.MMLogger;
+import java.awt.*;
+import java.awt.event.*;
+import java.text.Normalizer;
+import java.util.List;
+import java.util.*;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * This is a heavily reworked version of the original MekSelectorDialog which
@@ -122,6 +105,8 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     // how long after a key is typed does a new search begin
     private static final int KEY_TIMEOUT = 1000;
 
+    protected final boolean multiSelect;
+
     protected static MekSummaryCache mscInstance = MekSummaryCache.getInstance();
     protected MekSummary[] meks;
 
@@ -152,10 +137,15 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     // endregion Variable Declarations
 
     protected AbstractUnitSelectorDialog(JFrame frame, UnitLoadingDialog unitLoadingDialog) {
+        this(frame, unitLoadingDialog, false);
+    }
+
+    protected AbstractUnitSelectorDialog(JFrame frame, UnitLoadingDialog unitLoadingDialog, boolean multiSelect) {
         super(frame, Messages.getString("MekSelectorDialog.title"), true);
         setName("UnitSelectorDialog");
         this.frame = frame;
         this.unitLoadingDialog = unitLoadingDialog;
+        this.multiSelect = multiSelect;
         super.setVisible(false);
     }
 
@@ -233,7 +223,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         tableUnits.setDefaultRenderer(Integer.class, centeredRenderer);
         tableUnits.getColumnModel().getColumn(MekTableModel.COL_LEVEL).setCellRenderer(centeredRenderer);
 
-        tableUnits.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        tableUnits.setSelectionMode(multiSelect ? ListSelectionModel.MULTIPLE_INTERVAL_SELECTION : ListSelectionModel.SINGLE_SELECTION);
         sorter = new TableRowSorter<>(unitModel);
         sorter.setComparator(MekTableModel.COL_CHASSIS, new NaturalOrderComparator());
         sorter.setComparator(MekTableModel.COL_MODEL, new NaturalOrderComparator());
@@ -727,15 +717,31 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
         }
     }
 
+    public List<Entity> getSelectedEntities() {
+        return getSelectedMekSummaries().stream().map(
+            ms -> {
+                try {
+                    return new MekFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
+                } catch (EntityLoadingException e) {
+                    logger.error(e, "Unable to load mek: " + ms.getSourceFile() + ": " + ms.getEntryName());
+                    return null;
+                }
+            }
+        ).filter(Objects::nonNull).toList();
+    }
+
     /** @return The MekSummary for the selected unit. */
     public @Nullable MekSummary getSelectedMekSummary() {
-        int view = tableUnits.getSelectedRow();
-        if (view < 0) {
-            // selection got filtered away
+        var summaries = getSelectedMekSummaries();
+        if (summaries.size() != 1) {
             return null;
         }
-        int selected = tableUnits.convertRowIndexToModel(view);
-        return meks[selected];
+        return summaries.get(0);
+    }
+
+    public List<MekSummary> getSelectedMekSummaries() {
+        var rows = tableUnits.getSelectedRows();
+        return Arrays.stream(rows).map(tableUnits::convertRowIndexToModel).mapToObj(i -> meks[i]).toList();
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
@@ -18,17 +18,6 @@
  */
 package megamek.client.ui.swing.dialog;
 
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
-import java.util.Arrays;
-import java.util.Map;
-
-import javax.swing.JButton;
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.SwingConstants;
-
 import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.generator.RandomGenderGenerator;
@@ -46,6 +35,11 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
 
+import javax.swing.*;
+import java.awt.*;
+import java.util.Arrays;
+import java.util.Map;
+
 public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
 
     private static final long serialVersionUID = -5717009055093904636L;
@@ -55,7 +49,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     //endregion Variable Declarations
 
     public MegaMekUnitSelectorDialog(ClientGUI clientGUI, UnitLoadingDialog unitLoadingDialog) {
-        super(clientGUI.getFrame(), unitLoadingDialog);
+        super(clientGUI.getFrame(), unitLoadingDialog, true);
         this.clientGUI = clientGUI;
 
         updateOptionValues();
@@ -107,8 +101,8 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
 
     @Override
     protected void select(boolean close) {
-        Entity e = getSelectedEntity();
-        if (e != null) {
+        java.util.List<Entity> entities = getSelectedEntities();
+        if (!entities.isEmpty()) {
             Client client = null;
             String name = (String) comboPlayer.getSelectedItem();
 
@@ -119,11 +113,15 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
             if (client == null) {
                 client = clientGUI.getClient();
             }
-            autoSetSkillsAndName(e, client.getLocalPlayer());
-            e.setOwner(client.getLocalPlayer());
-            client.sendAddEntity(e);
 
-            String msg = clientGUI.getClient().getLocalPlayer() + " selected a unit for player: " + name;
+
+            for (var e : entities) {
+                autoSetSkillsAndName(e, client.getLocalPlayer());
+                e.setOwner(client.getLocalPlayer());
+            }
+            client.sendAddEntity(entities);
+
+            String msg = clientGUI.getClient().getLocalPlayer() + " selected " + (entities.size() == 1 ? "a unit" : entities.size() + " units") + " for player: " + name;
             clientGUI.getClient().sendServerChat(Player.PLAYER_NONE, msg);
         }
 

--- a/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/MegaMekUnitSelectorDialog.java
@@ -37,6 +37,7 @@ import megamek.common.preference.PreferenceManager;
 
 import javax.swing.*;
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -101,7 +102,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
 
     @Override
     protected void select(boolean close) {
-        java.util.List<Entity> entities = getSelectedEntities();
+        ArrayList<Entity> entities = getSelectedEntities();
         if (!entities.isEmpty()) {
             Client client = null;
             String name = (String) comboPlayer.getSelectedItem();

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -26556,7 +26556,7 @@ public class TWGameManager extends AbstractGameManager {
         // Map MUL force ids to real Server-given force ids;
         Map<Integer, Integer> forceMapping = new HashMap<>();
 
-        // Need to use a new ArrayLiut to prevent a concurrent modification exception
+        // Need to use a new ArrayList to prevent a concurrent modification exception
         // when removing
         // illegal entities
         for (final Entity entity : new ArrayList<>(entities)) {


### PR DESCRIPTION
Allows selecting multiple units in the Select Unit dialog, instead of having to hit Select for each unit one at a time:

![image](https://github.com/user-attachments/assets/87690ea9-1bdf-4c55-bd17-6fd7fff816c1)

This might not be _incredibly_ useful for MegaMek, but this sets up for this functionality to be made available in Lab, where it should help Hammer make fluff edits to every unit of a given chassis in bulk.