### PR TITLE
QOL fix to allow pasting units into selected player list if selected

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -2799,7 +2799,9 @@ public class ChatLounge extends AbstractPhaseDisplay implements
                         if (ms != null) {
                             Entity newEntity = ms.loadEntity();
                             if (newEntity != null) {
-                                newEntity.setOwner(localPlayer());
+                                // Change this to use the player selected in the UI if localPlayer() can do so
+                                Client c = getSelectedClient();
+                                newEntity.setOwner((c != null) ? c.getLocalPlayer() : localPlayer());
                                 newEntities.add(newEntity);
                             }
                         }


### PR DESCRIPTION
QOL update to let the player copy units and then paste them into a selected player's list, rather than pasting them as their own units and then changing ownership.

Testing:
- I did the thing.
- Ran unit tests for all 3 projects.