### PR TITLE
fix: fixes AeroDamageApplier so it stops killing aero units

### DIFF
--- a/megamek/src/megamek/common/autoresolve/acar/report/StartingScenarioPhaseReporter.java
+++ b/megamek/src/megamek/common/autoresolve/acar/report/StartingScenarioPhaseReporter.java
@@ -15,6 +15,7 @@ package megamek.common.autoresolve.acar.report;
 
 import megamek.client.ui.swing.util.UIUtil;
 import megamek.common.Entity;
+import megamek.common.IAero;
 import megamek.common.IGame;
 import megamek.common.Player;
 import megamek.common.autoresolve.acar.SimulationContext;
@@ -101,9 +102,10 @@ public class StartingScenarioPhaseReporter implements IStartingScenarioPhaseRepo
                 }
                 for (var element : unit.getElements()) {
                     var entity = (Entity) game.getInGameObject(element.getId()).orElseThrow();
-                    var armor = entity.getArmorRemainingPercent();
-                    var internal = entity.getInternalRemainingPercent();
                     var crew = entity.getCrew();
+                    var armor = Math.max(entity.getArmorRemainingPercent(), 0d);
+                    var internal = entity instanceof IAero ? ((IAero) entity).getSI() / (double) ((IAero) entity).get0SI()
+                        : entity.getInternalRemainingPercent();
                     reportConsumer.accept(new PublicReportEntry("acar.startingScenario.unitStats")
                         .add(new EntityNameReportEntry(entity).reportText())
                         .add(String.format("%.2f%%", armor * 100))

--- a/megamek/src/megamek/common/autoresolve/acar/report/VictoryPhaseReporter.java
+++ b/megamek/src/megamek/common/autoresolve/acar/report/VictoryPhaseReporter.java
@@ -14,6 +14,7 @@
 package megamek.common.autoresolve.acar.report;
 
 import megamek.common.Entity;
+import megamek.common.IAero;
 import megamek.common.IGame;
 import megamek.common.Player;
 import megamek.common.autoresolve.acar.SimulationContext;
@@ -91,14 +92,13 @@ public class VictoryPhaseReporter implements IVictoryPhaseReporter {
 
 
         for (var entity : playerEntities) {
-            var armor = entity.getArmorRemainingPercent();
-            if (armor < 0d) {
-                armor = 0d;
-            }
+            double armor = Math.max(entity.getArmorRemainingPercent(), 0d);
+            double internal = entity instanceof IAero ? ((IAero) entity).getSI() / (double) ((IAero) entity).get0SI()
+                : entity.getInternalRemainingPercent();
             reportConsumer.accept(new PublicReportEntry("acar.endOfCombat.teamUnitStats")
                 .add(new EntityNameReportEntry(entity).reportText())
                 .add(String.format("%.2f%%", armor * 100))
-                .add(String.format("%.2f%%", entity.getInternalRemainingPercent() * 100))
+                .add(String.format("%.2f%%", internal * 100))
                 .add(entity.getCrew().getName())
                 .add(entity.getCrew().getHits())
                 .indent(2));
@@ -117,15 +117,14 @@ public class VictoryPhaseReporter implements IVictoryPhaseReporter {
             .indent(1));
 
         for (var entity : deadEntities) {
-            var armor = entity.getArmorRemainingPercent();
-            if (armor < 0d) {
-                armor = 0d;
-            }
+            double armor = Math.max(entity.getArmorRemainingPercent(), 0d);
+            double internal = entity instanceof IAero ? ((IAero) entity).getSI() / (double) ((IAero) entity).get0SI()
+                : entity.getInternalRemainingPercent();
 
             reportConsumer.accept(new PublicReportEntry("acar.endOfCombat.teamUnitStats")
                 .add(new EntityNameReportEntry(entity).reportText())
                 .add(String.format("%.2f%%", armor * 100))
-                .add(String.format("%.2f%%", entity.getInternalRemainingPercent() * 100))
+                .add(String.format("%.2f%%", internal * 100))
                 .add(entity.getCrew().getName())
                 .add(entity.getCrew().getHits())
                 .indent(2));
@@ -143,14 +142,13 @@ public class VictoryPhaseReporter implements IVictoryPhaseReporter {
 
 
         for (var entity : retreatingEntities) {
-            var armor = entity.getArmorRemainingPercent();
-            if (armor < 0d) {
-                armor = 0d;
-            }
+            double armor = Math.max(entity.getArmorRemainingPercent(), 0d);
+            double internal = entity instanceof IAero ? ((IAero) entity).getSI() / (double) ((IAero) entity).get0SI()
+                : entity.getInternalRemainingPercent();
             reportConsumer.accept(new PublicReportEntry("acar.endOfCombat.teamUnitStats")
                 .add(new EntityNameReportEntry(entity).reportText())
                 .add(String.format("%.2f%%", armor * 100))
-                .add(String.format("%.2f%%", entity.getInternalRemainingPercent() * 100))
+                .add(String.format("%.2f%%", internal * 100))
                 .add(entity.getCrew().getName())
                 .add(entity.getCrew().getHits())
                 .indent(2)

--- a/megamek/src/megamek/common/autoresolve/damage/AeroDamageApplier.java
+++ b/megamek/src/megamek/common/autoresolve/damage/AeroDamageApplier.java
@@ -79,7 +79,7 @@ public record AeroDamageApplier(Aero entity, EntityFinalState entityFinalState) 
         int newInternalValue = entity.getSI();
         if (hitDetails.setArmorValueTo() < 0) {
             int halfDamage = (int) Math.floor(hitDetails.setArmorValueTo() / 2.0);
-            newInternalValue = Math.max(newInternalValue - halfDamage, 0);
+            newInternalValue = Math.max(newInternalValue + halfDamage, 0);
             if (newInternalValue == 0 && entityFinalState().entityMustSurvive) {
                 newInternalValue = 1;
             }

--- a/megamek/src/megamek/common/autoresolve/damage/DamageApplier.java
+++ b/megamek/src/megamek/common/autoresolve/damage/DamageApplier.java
@@ -64,8 +64,8 @@ public interface DamageApplier<E extends Entity> {
         return entityFinalState().crewMustSurvive;
     }
 
-    default boolean entityMystBeDevastated() {
-        return entityFinalState().entityMystBeDevastated;
+    default boolean entityMustBeDevastated() {
+        return entityFinalState().entityMustBeDevastated;
     }
 
     /**
@@ -88,7 +88,7 @@ public interface DamageApplier<E extends Entity> {
             totalDamage -= clusterDamage;
             damageApplied += clusterDamage;
         }
-        if (entityMystBeDevastated()) {
+        if (entityMustBeDevastated()) {
             damageApplied += devastateUnit();
         }
         return damageApplied;
@@ -111,7 +111,7 @@ public interface DamageApplier<E extends Entity> {
             totalDamage -= clusterDamage;
             damageApplied += clusterDamage;
         }
-        if (entityMystBeDevastated()) {
+        if (entityMustBeDevastated()) {
             damageApplied += devastateUnit();
         }
         return damageApplied;

--- a/megamek/src/megamek/common/autoresolve/damage/EntityFinalState.java
+++ b/megamek/src/megamek/common/autoresolve/damage/EntityFinalState.java
@@ -27,13 +27,13 @@ public enum EntityFinalState {
     final boolean crewMustSurvive;
     final boolean entityMustSurvive;
     final boolean noCrewDamage;
-    final boolean entityMystBeDevastated;
+    final boolean entityMustBeDevastated;
 
-    EntityFinalState(boolean crewMustSurvive, boolean entityMustSurvive, boolean noCrewDamage, boolean entityMystBeDevastated) {
+    EntityFinalState(boolean crewMustSurvive, boolean entityMustSurvive, boolean noCrewDamage, boolean entityMustBeDevastated) {
         this.crewMustSurvive = crewMustSurvive;
         this.entityMustSurvive = entityMustSurvive;
         this.noCrewDamage = noCrewDamage;
-        this.entityMystBeDevastated  = entityMystBeDevastated;
+        this.entityMustBeDevastated = entityMustBeDevastated;
     }
 
     public static EntityFinalState fromEntityRemovalState(int removalState) {

--- a/megamek/src/megamek/common/autoresolve/damage/MekDamageApplier.java
+++ b/megamek/src/megamek/common/autoresolve/damage/MekDamageApplier.java
@@ -33,9 +33,6 @@ public record MekDamageApplier(Mek entity, EntityFinalState entityFinalState) im
 
     // Target roll to hit the rear arc of the mek randomly
     private static final int REAR_ARC_HIT_CHANCE = 11;
-    private static final Set<Integer> criticalSystems = Set.of(Mek.SYSTEM_ENGINE, Mek.SYSTEM_GYRO, Mek.SYSTEM_LIFE_SUPPORT,
-        Mek.SYSTEM_SENSORS, Mek.SYSTEM_COCKPIT);
-    private static final Set<Integer> criticalLocations = Set.of(Mek.LOC_CT, Mek.LOC_HEAD, Mek.LOC_LT, Mek.LOC_RT);
 
     @Override
     public int devastateUnit() {
@@ -244,8 +241,7 @@ public record MekDamageApplier(Mek entity, EntityFinalState entityFinalState) im
     }
 
     private boolean canHaveAmmoExplosion() {
-        return entityFinalState.equals(ENTITY_MUST_BE_DEVASTATED) || entityFinalState.equals(DAMAGE_ONLY_THE_ENTITY)
-            || entityFinalState.equals(ANY);
+        return entityFinalState.equals(ENTITY_MUST_BE_DEVASTATED) || entityFinalState.equals(ANY);
     }
 
     private static ArrayList<CriticalSlot> getCriticalSlots(Mek entity, HitData hit) {


### PR DESCRIPTION
# What it does?

Fixes AeroDamageApplier so it stops killing aero units when they should survive.
I wasn't looking at Structural Integrity of Aero units and it was causing problems.

- closes [mekhq #6026](https://github.com/MegaMek/mekhq/issues/6026)