### PR TITLE
fix: adds fallback to default skin if it cant load the skin

### DIFF
--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -2123,9 +2123,6 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             Collections.sort(xmlFiles);
             var model = new DefaultComboBoxModel<>(xmlFiles.toArray(new String[0]));
             skinFiles.setModel(model);
-            // Select the default file first
-            skinFiles.setSelectedItem(SkinXMLHandler.defaultSkinXML);
-            // If this select fails, the default skin will be selected
             skinFiles.setSelectedItem(GUIP.getSkinFile());
 
             uiThemes.removeAllItems();

--- a/megamek/src/megamek/client/ui/swing/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/swing/GUIPreferences.java
@@ -1577,6 +1577,10 @@ public class GUIPreferences extends PreferenceStoreProxy {
         return store.getString(SKIN_FILE);
     }
 
+    public String getDefaultSkinFile() {
+        return store.getDefaultString(SKIN_FILE);
+    }
+
     public String getUITheme() {
         return store.getString(UI_THEME);
     }

--- a/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
+++ b/megamek/src/megamek/client/ui/swing/widget/SkinXMLHandler.java
@@ -196,9 +196,11 @@ public class SkinXMLHandler {
             // relative path
             file = new MegaMekFile(Configuration.skinsDir(), filename).getFile();
             if (!file.exists() || !file.isFile()) {
-                logger
-                        .error("Cannot initialize skin based on a non-existent file with filename " + filename);
-                return false;
+                file = new MegaMekFile(Configuration.skinsDir(), GUIPreferences.getInstance().getDefaultSkinFile()).getFile();
+                if (!file.exists() || !file.isFile()) {
+                    logger.error("Cannot initialize skin based on a non-existent file with filename " + filename);
+                    return false;
+                }
             }
         }
 


### PR DESCRIPTION
# What it does?

Adds fallback to default skin if it cant load the skin it has in store. It will still crash if the default skin is deleted.

- closes #6654