### PR TITLE
MekHQ Issue 6165: Canonicity should be determined by MUL ID.

### DIFF
--- a/megamek/src/megamek/client/ui/advancedsearch/MekSearchFilter.java
+++ b/megamek/src/megamek/client/ui/advancedsearch/MekSearchFilter.java
@@ -18,15 +18,15 @@
  */
 package megamek.client.ui.advancedsearch;
 
-import java.util.*;
-import java.util.stream.IntStream;
-
 import megamek.common.Entity;
 import megamek.common.MekSummary;
 import megamek.common.Messages;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.StringUtil;
 import megamek.logging.MMLogger;
+
+import java.util.*;
+import java.util.stream.IntStream;
 
 /**
  * Class to perform filtering on units. This class stores a list of
@@ -464,7 +464,7 @@ public class MekSearchFilter {
             return false;
         }
 
-        if (!isMatch(f.iOfficial, (mek.getMulId() != -1))) {
+        if (!isMatch(f.iOfficial, (mek.getMulId() > -1))) {
             return false;
         }
 

--- a/megamek/src/megamek/client/ui/advancedsearch/MekSearchFilter.java
+++ b/megamek/src/megamek/client/ui/advancedsearch/MekSearchFilter.java
@@ -464,7 +464,7 @@ public class MekSearchFilter {
             return false;
         }
 
-        if (!isMatch(f.iOfficial, (mek.getMulId() > -1))) {
+        if (!isMatch(f.iOfficial, (mek.getMulId() > 0))) {
             return false;
         }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10971,12 +10971,12 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     /**
      * Is this unit canon in Battletech? For Meks and
      * other normal entities we should check the MUL ID.
-     * MUL ID is -1, not canon - Any entity type that
+     * MUL ID less than 1, not canon - Any entity type that
      * doesn't follow this rule should override this
      * @return true if this unit is canon
      */
     public boolean isCanon() {
-        return hasMulId() && getMulId() > -1;
+        return hasMulId() && getMulId() > 0;
     }
 
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10976,7 +10976,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      * @return true if this unit is canon
      */
     public boolean isCanon() {
-        return hasMulId() && getMulId() != -1;
+        return hasMulId() && getMulId() > -1;
     }
 
     /**

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -10968,12 +10968,15 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         return false;
     }
 
+    /**
+     * Is this unit canon in Battletech? For Meks and
+     * other normal entities we should check the MUL ID.
+     * MUL ID is -1, not canon - Any entity type that
+     * doesn't follow this rule should override this
+     * @return true if this unit is canon
+     */
     public boolean isCanon() {
-        return canon;
-    }
-
-    public void setCanon(boolean canon) {
-        this.canon = canon;
+        return hasMulId() && getMulId() != -1;
     }
 
     /**

--- a/megamek/src/megamek/common/MekFileParser.java
+++ b/megamek/src/megamek/common/MekFileParser.java
@@ -14,39 +14,22 @@
  */
 package megamek.common;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Vector;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.zip.ZipFile;
-
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.loaders.*;
 import megamek.common.util.BuildingBlock;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.TestInfantry;
-import megamek.common.weapons.ppc.CLERPPC;
-import megamek.common.weapons.ppc.CLEnhancedPPC;
-import megamek.common.weapons.ppc.CLImprovedPPC;
-import megamek.common.weapons.ppc.ISERPPC;
-import megamek.common.weapons.ppc.ISHeavyPPC;
-import megamek.common.weapons.ppc.ISKinsSlaughterPPC;
-import megamek.common.weapons.ppc.ISLightPPC;
-import megamek.common.weapons.ppc.ISPPC;
-import megamek.common.weapons.ppc.ISSnubNosePPC;
+import megamek.common.weapons.ppc.*;
 import megamek.logging.MMLogger;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Vector;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.zip.ZipFile;
 
 /**
  * Switches between the various type-specific parsers depending on suffix
@@ -55,8 +38,18 @@ public class MekFileParser {
     private static final MMLogger logger = MMLogger.create(MekFileParser.class);
 
     private Entity m_entity = null;
+    /**
+     * @deprecated
+     * Canonicity is now determined by MUL ID. See
+     * {@link Entity#isCanon()}
+     */
     private static Vector<String> canonUnitNames = null;
-    public static final String FILENAME_OFFICIAL_UNITS = "OfficialUnitList.txt"; // TODO : Remove inline filename
+    /**
+     * @deprecated
+     * Canonicity is now determined by MUL ID. See
+     * {@link Entity#isCanon()}
+     */
+    public static final String FILENAME_OFFICIAL_UNITS = "OfficialUnitList.txt";
 
     public MekFileParser(File f) throws EntityLoadingException {
         this(f, null);
@@ -103,6 +96,13 @@ public class MekFileParser {
         }
     }
 
+    /**
+     * @deprecated
+     * Canonicity is now determined by MUL ID. See
+     * {@link Entity#isCanon()}
+     *
+     */
+    @Deprecated (since="0.50.04")
     public static void initCanonUnitNames() {
         initCanonUnitNames(Configuration.docsDir(), FILENAME_OFFICIAL_UNITS);
     }
@@ -112,9 +112,14 @@ public class MekFileParser {
      * canonUnitNames is null or
      * needs to be reinitialized.
      *
+     * @deprecated
+     * Canonicity is now determined by MUL ID. See
+     * {@link Entity#isCanon()}
+     *
      * @param dir      location where the canonUnitNames file should be
      * @param fileName String name of the file containing canon unit names
      */
+    @Deprecated (since="0.50.04")
     protected static void initCanonUnitNames(File dir, String fileName) {
         Vector<String> unitNames = new Vector<>();
         try (FileReader fr = new FileReader(new MegaMekFile(
@@ -131,7 +136,6 @@ public class MekFileParser {
             }
             Collections.sort(unitNames);
         } catch (Exception ignored) {
-
         }
 
         // Update names
@@ -140,9 +144,13 @@ public class MekFileParser {
 
     /**
      * Directly assign a Vector of unit names; protected for unit testing purposes
+     * @deprecated
+     * Canonicity is now determined by MUL ID. See
+     * {@link Entity#isCanon()}
      *
      * @param unitNames
      */
+    @Deprecated (since="0.50.04")
     protected static void setCanonUnitNames(Vector<String> unitNames) {
         canonUnitNames = unitNames;
     }
@@ -785,16 +793,6 @@ public class MekFileParser {
             TestInfantry.adaptAntiMekAttacks((Infantry) ent);
         }
 
-        // Check if it's canon; if it is, mark it as such.
-        ent.setCanon(false);// Guilty until proven innocent
-        if (canonUnitNames == null) {
-            initCanonUnitNames();
-        }
-
-        int index = Collections.binarySearch(canonUnitNames, ent.getShortNameRaw());
-        if (index >= 0) {
-            ent.setCanon(true);
-        }
         ent.initMilitary();
         linkDumpers(ent);
     }
@@ -948,6 +946,12 @@ public class MekFileParser {
         return entity;
     }
 
+    /**
+     * @deprecated
+     * Canonicity is now determined by MUL ID. See
+     * {@link Entity#isCanon()}
+     */
+    @Deprecated (since="0.50.04")
     public static void dispose() {
         canonUnitNames = null;
     }

--- a/megamek/unittests/megamek/common/EntityTest.java
+++ b/megamek/unittests/megamek/common/EntityTest.java
@@ -19,27 +19,20 @@
  */
 package megamek.common;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import megamek.client.ui.swing.calculationReport.CalculationReport;
+import megamek.common.battlevalue.BVCalculator;
+import megamek.common.equipment.WeaponMounted;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import megamek.client.ui.swing.calculationReport.CalculationReport;
-import megamek.common.battlevalue.BVCalculator;
-import megamek.common.equipment.WeaponMounted;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
@@ -131,17 +124,13 @@ class EntityTest {
     }
 
     /**
-     * Verify that if a unit's name appears in the list of canon unit names, it is
-     * canon
+     * Verify that if a unit's has a mul id that it is canon
      */
     @Test
     void testCanon() {
         File f;
         MekFileParser mfp;
         Entity e;
-        Vector<String> unitNames = new Vector<>();
-        unitNames.add("Exterminator EXT-4A");
-        MekFileParser.setCanonUnitNames(unitNames);
 
         // Test 1/1
         try {
@@ -155,22 +144,19 @@ class EntityTest {
     }
 
     /**
-     * Verify that if a unit's name does _not_ appear in the list of canon unit
-     * names, it is not canon
+     * Verify that if a unit does not have a MUL ID that it is not canon
      */
     @Test
     void testForceCanonicityFailure() {
         File f;
         MekFileParser mfp;
         Entity e;
-        Vector<String> unitNames = new Vector<>();
-        unitNames.add("Beheadanator BHD-999.666Z");
-        MekFileParser.setCanonUnitNames(unitNames);
 
         try {
             f = new File("testresources/megamek/common/units/Exterminator EXT-4A.mtf");
             mfp = new MekFileParser(f);
             e = mfp.getEntity();
+            e.setMulId(-1);
             assertFalse(e.isCanon());
         } catch (Exception ex) {
             fail(ex.getMessage());
@@ -186,8 +172,6 @@ class EntityTest {
         File f;
         MekFileParser mfp;
         Entity e;
-        File oulDir = new File("testresources/megamek/common/units/");
-        MekFileParser.initCanonUnitNames(oulDir, "mockOfficialUnitList.txt");
 
         try {
             // MTF file check


### PR DESCRIPTION
Fixes Megamek/MekHQ#6165

Canonicity should be determined by MUL ID, not the Official Unit List which was deprecated. 