### PR TITLE
feat: allow princess to deploy mines in random clear hexes on the map

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -24,14 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Vector;
+import java.util.*;
 
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
@@ -402,6 +395,9 @@ public abstract class BotClient extends Client {
             switch (phase) {
                 case LOUNGE:
                     sendChat(Messages.getString("BotClient.Hi"));
+                    break;
+                case DEPLOY_MINEFIELDS:
+                    deployMinefields();
                     break;
                 case DEPLOYMENT:
                     initialize();
@@ -1235,6 +1231,85 @@ public abstract class BotClient extends Client {
 
     public void endOfTurnProcessing() {
         // Do nothing;
+    }
+
+    private record MinefieldNumbers(int number, int type) {}
+
+    /**
+     * Deploy minefields for the bot
+     */
+    protected void deployMinefields() {
+        MinefieldNumbers[] minefieldNumbers = getMinefieldNumbers();
+        int totalMines = Arrays.stream(minefieldNumbers).mapToInt(MinefieldNumbers::number).sum();
+        Deque<Coords> coordsSet = getMinefieldDeploymentPlanner().getRandomMinefieldPositions(totalMines);
+        Vector<Minefield> deployedMinefields = new Vector<>();
+        for (MinefieldNumbers minefieldNumber : minefieldNumbers) {
+            deployMinefields(minefieldNumber, coordsSet, deployedMinefields);
+        }
+        performMinefieldDeployment(deployedMinefields);
+    }
+
+    /**
+     * Deploy the specified number of minefields
+     * @param deployedMinefields the vector to add the deployed minefields to
+     */
+    private void performMinefieldDeployment(Vector<Minefield> deployedMinefields) {
+        sendDeployMinefields(deployedMinefields);
+        resetMinefieldCounters();
+    }
+
+    /**
+     * Reset the minefield counters for the bot and push the updated player info to the server
+     */
+    private void resetMinefieldCounters() {
+        getLocalPlayer().setNbrMFActive(0);
+        getLocalPlayer().setNbrMFCommand(0);
+        getLocalPlayer().setNbrMFConventional(0);
+        getLocalPlayer().setNbrMFInferno(0);
+        getLocalPlayer().setNbrMFVibra(0);
+        sendPlayerInfo();
+    }
+
+    /**
+     * Deploy the specified number of minefields of the specified type
+     * @param minefieldNumber the number of minefields to deploy and the type of minefield to deploy
+     * @param coordsSet the set of coordinates to deploy the minefields to
+     * @param deployedMinefields the vector to add the deployed minefields to
+     */
+    private void deployMinefields(MinefieldNumbers minefieldNumber, Deque<Coords> coordsSet, Vector<Minefield> deployedMinefields) {
+        int minesToDeploy = minefieldNumber.number();
+        while(!coordsSet.isEmpty() && minesToDeploy > 0) {
+            Coords coords = coordsSet.poll();
+            int density = Compute.randomIntInclusive(30) + 5;
+            Minefield minefield = Minefield.createMinefield(
+                  coords, getLocalPlayer().getId(), minefieldNumber.type(), density);
+            deployedMinefields.add(minefield);
+            minesToDeploy--;
+        }
+    }
+
+    /**
+     * Get the number of minefields of each type that the bot should deploy
+     * @return an array of MinefieldNumbers, each representing the number of a specific type of minefield to deploy
+     */
+    private MinefieldNumbers[] getMinefieldNumbers() {
+        return new MinefieldNumbers[]{
+              new MinefieldNumbers(getLocalPlayer().getNbrMFActive(), Minefield.TYPE_ACTIVE),
+              new MinefieldNumbers(getLocalPlayer().getNbrMFInferno(), Minefield.TYPE_INFERNO),
+              new MinefieldNumbers(getLocalPlayer().getNbrMFConventional(), Minefield.TYPE_CONVENTIONAL),
+              new MinefieldNumbers(getLocalPlayer().getNbrMFVibra(), Minefield.TYPE_VIBRABOMB),
+              // the following are added for completeness, but are not used by the bot
+              new MinefieldNumbers(0, Minefield.TYPE_COMMAND_DETONATED), // no command detonated mines
+              new MinefieldNumbers(0, Minefield.TYPE_EMP), // no field for EMP mines exists
+        };
+    }
+
+    /**
+     * Get the minefield deployment planner to use for this bot
+     * @return the minefield deployment planner
+     */
+    protected MinefieldDeploymentPlanner getMinefieldDeploymentPlanner() {
+        return new RandomMinefieldDeploymentPlanner(getBoard());
     }
 
     @Override

--- a/megamek/src/megamek/client/bot/MinefieldDeploymentPlanner.java
+++ b/megamek/src/megamek/client/bot/MinefieldDeploymentPlanner.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 2 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package megamek.client.bot;
+
+import megamek.common.Coords;
+
+import java.util.Deque;
+
+/**
+ * Interface for classes that can plan minefield deployments.
+ * @author Luana Coppio
+ */
+public interface MinefieldDeploymentPlanner {
+
+    /**
+     * Get a set of planed positions on the board to be used to lay minefields.
+     * @param numberOfCoords the number of positions to get
+     * @return a deque of positions
+     */
+    Deque<Coords> getRandomMinefieldPositions(int numberOfCoords);
+}

--- a/megamek/src/megamek/client/bot/RandomMinefieldDeploymentPlanner.java
+++ b/megamek/src/megamek/client/bot/RandomMinefieldDeploymentPlanner.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 2 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+package megamek.client.bot;
+
+import megamek.common.Board;
+import megamek.common.Compute;
+import megamek.common.Coords;
+import megamek.common.Hex;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Minefield deployment planner that randomly selects positions on the board. It focuses on
+ * positions that are paved or have vegetation, but will also select clear hexes if it runs out of
+ * other options.
+ * @author Luana Coppio
+ */
+public class RandomMinefieldDeploymentPlanner implements MinefieldDeploymentPlanner {
+
+    private final Board board;
+
+    public RandomMinefieldDeploymentPlanner(Board board) {
+        this.board = board;
+    }
+
+    @Override
+    public Deque<Coords> getRandomMinefieldPositions(int numberOfCoords) {
+        Set<Coords> coordsSet = new HashSet<>();
+        int maxTries = numberOfCoords * 50;
+
+        while (coordsSet.size() < numberOfCoords && maxTries > 0) {
+            Coords coords = new Coords(Compute.randomInt(board.getWidth()),
+                  Compute.randomInt(board.getHeight()));
+            Hex hex = board.getHex(coords);
+            if ((hex != null)
+                  && !hex.hasDepth1WaterOrDeeper()
+                  && (hex.hasPavementOrRoad() || hex.hasVegetation()
+                  || (hex.isClearHex() && (maxTries < numberOfCoords * 10))))
+            {
+                coordsSet.add(coords);
+            }
+            maxTries--;
+        }
+        return new ArrayDeque<>(coordsSet);
+    }
+}


### PR DESCRIPTION
# What does it do?

Gives Princess the ability to deploy minefields.

# How it does that?

It simply chooses at random coordinates in the map that would accept the mine and then deploy the mine in there.

This also gives the basis for more complex behavior in the future.

- closes #6236