### PR TITLE
fix: makes gif writer finish the gif at victory phase

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -238,8 +238,6 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
     public static final String CG_FILEEXTENTIONMUL = ".mul";
     public static final String CG_FILEEXTENTIONXML = ".xml";
     public static final String CG_FILEEXTENTIONPNG = ".png";
-    public static final String CG_FILEEXTENTIONGIF = ".gif";
-    public static final String CG_FILEPATHGIF = "gif";
     public static final String CG_FILEFORMATNAMEPNG = "png";
 
     // a frame, to show stuff in
@@ -2261,70 +2259,6 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
         }
     }
 
-    private void saveGifGameSummary() {
-        String filename = StringUtil.addDateTimeStamp("combat_summary_");
-        String gameUuid = client.getGame().getUUIDString();
-        File tempGifFile = new File(gameSummaryImagesMMDir(), gameUuid + CG_FILEEXTENTIONGIF);
-
-        // Build the "save gif" dialog, if necessary.
-        if (dlgSaveGifList == null) {
-            dlgSaveGifList = new JFileChooser(".");
-            dlgSaveGifList.setLocation(frame.getLocation().x + 150, frame.getLocation().y + 100);
-            dlgSaveGifList.setDialogTitle(Messages.getString("ClientGUI.saveGameSummaryGifFileDialog.title"));
-            FileNameExtensionFilter filter = new FileNameExtensionFilter(
-                Messages.getString("ClientGUI.descriptionGIFFiles"), CG_FILEPATHGIF);
-            dlgSaveGifList.setFileFilter(filter);
-        }
-
-        dlgSaveGifList.setSelectedFile(new File(filename + CG_FILEEXTENTIONGIF));
-
-        int returnVal = dlgSaveGifList.showSaveDialog(frame);
-        if ((returnVal != JFileChooser.APPROVE_OPTION) || (dlgSaveGifList.getSelectedFile() == null)) {
-            // without a file there is no saving for the file, which them means we can't save the gif
-            // and instead we delete it
-            if (tempGifFile.delete()) {
-                logger.info("Game summary GIF deleted");
-            } else {
-                logger.warn("Failed to delete game summary GIF");
-            }
-            return;
-        }
-
-        // Did the player select a file?
-        File gifFile = dlgSaveGifList.getSelectedFile();
-        if (gifFile != null) {
-            if (!gifFile.getName().toLowerCase().endsWith(CG_FILEEXTENTIONGIF)) {
-                try {
-                    gifFile = new File(gifFile.getCanonicalPath() + CG_FILEEXTENTIONGIF);
-                } catch (Exception ignored) {
-                    // without a file there is no saving for the file, which them means we can't save the gif
-                    // and instead we delete it
-                    if (tempGifFile.delete()) {
-                        logger.info("Game summary GIF deleted");
-                    } else {
-                        logger.error("Failed to delete game summary GIF");
-                    }
-                    return;
-                }
-            }
-            File finalGifFile = gifFile;
-            SwingUtilities.invokeLater(() -> {
-                try {
-                    if (tempGifFile.renameTo(finalGifFile)) {
-                        logger.info("Game summary GIF saved to {}", finalGifFile);
-                    } else {
-                        logger.error("Unable to rename {} to {}", tempGifFile, finalGifFile);
-                        doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"),
-                            Messages.getString("ClientGUI.errorSavingFileGifMessage", finalGifFile.toString(), tempGifFile.toString()));
-                    }
-                } catch (Exception ex) {
-                    logger.error(ex, "saveGifGameSummary");
-                    doAlertDialog(Messages.getString("ClientGUI.errorSavingFile"),
-                        Messages.getString("ClientGUI.errorSavingFileGifMessage", finalGifFile.toString(), tempGifFile.toString()));
-                }
-            });
-        }
-    }
 
     protected void saveVictoryList() {
         String filename = client.getLocalPlayer().getName();
@@ -2545,23 +2479,6 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
                     saveVictoryList();
                 }
             }
-
-            if (GUIP.getGifGameSummaryMinimap()) {
-                // Ask if you want to persist the final unit list from a battle encounter
-                if (doYesNoDialog(Messages.getString("ClientGUI.SaveGifDialog.title"),
-                    Messages.getString("ClientGUI.SaveGifDialog.message"))) {
-                    saveGifGameSummary();
-                } else {
-                    String gameUuid = client.getGame().getUUIDString();
-                    File tempGifFile = new File(gameSummaryImagesMMDir(), gameUuid + CG_FILEEXTENTIONGIF);
-                    if (tempGifFile.delete()) {
-                        logger.info("Deleted temporary game summary GIF {}", tempGifFile);
-                    } else {
-                        logger.error("Failed to delete temporary game summary GIF {}", tempGifFile);
-                    }
-                }
-            }
-
 
             // save all destroyed units in a separate "salvage MUL"
             ArrayList<Entity> destroyed = new ArrayList<>();

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -48,8 +48,6 @@ import javax.swing.SwingUtilities;
 
 import megamek.MMConstants;
 import megamek.client.Client;
-import megamek.client.CloseClientListener;
-import megamek.client.IClient;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
 import megamek.client.event.BoardViewListenerAdapter;
@@ -315,7 +313,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
                         dir.mkdirs();
                     }
                     File imgFile = new File(dir, "round_" + game.getRoundCount() + "_" + e.getOldPhase().ordinal() + "_"
-                        + e.getOldPhase() + ".png");
+                          + e.getOldPhase() + ".png");
 
                     try {
                         BufferedImage image = getMinimapImage(game, bv, GAME_SUMMARY_ZOOM, clientGui, null, movePathLines);
@@ -332,14 +330,16 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
                     } catch (Exception ex) {
                         logger.error(ex, "Error saving game summary image.");
                     }
-                    if (e.getNewPhase().isVictory() && (gifWriterThread != null) && gifWriterThread.isAlive()) {
-                        try {
-                            gifWriterThread.stopThread();
-                        } catch (Exception ex) {
-                            logger.error(ex, "Error closing gif writer.");
-                        }
+                }
+
+                if (e.getNewPhase().isVictory() && (gifWriterThread != null) && gifWriterThread.isAlive()) {
+                    try {
+                        gifWriterThread.stopThread();
+                    } catch (Exception ex) {
+                        logger.error(ex, "Error closing gif writer.");
                     }
                 }
+
                 // We clear the move path lines locally, since the game does not currently hold this information until the end of the turn
                 if (e.getNewPhase().isDeployment() || e.getNewPhase().isLounge() || e.getNewPhase().isVictory()) {
                     movePathLines.clear();

--- a/megamek/src/megamek/utilities/GifWriter.java
+++ b/megamek/src/megamek/utilities/GifWriter.java
@@ -177,6 +177,14 @@ public class GifWriter {
         return isLive;
     }
 
+    public boolean delete() {
+        return outputFile.delete();
+    }
+
+    public File getOutputFile() {
+        return outputFile;
+    }
+
     public static void main(String[] args) throws Exception {
         GifWriter.createGifFromGameSummary(args[0]);
     }


### PR DESCRIPTION
# What it does?

Makes Gif Writer finish the image when the victory phase is arrived at.

Also moves the dave dialog inside the gif writer thread, I know it is not the "bestest or correctest" place to leave it, but this deals with the problem where it is running in a separate thread inside another component that we don't have direct access to it, so it may be weird to do it this way, but it is reasonable given that this thread was purpose built for this function. So it is actually working as intended here.