### PR TITLE
[Issue 6671] Fix incorrect unit valuations due to negative part costs

### DIFF
--- a/megamek/src/megamek/common/cost/AeroCostCalculator.java
+++ b/megamek/src/megamek/common/cost/AeroCostCalculator.java
@@ -32,7 +32,7 @@ public class AeroCostCalculator {
         costs[idx++] = 200000;
         costs[idx++] = 50000;
         costs[idx++] = 2000 * aero.getWeight();
-        costs[idx++] = 50000 * Math.max(aero.getSI(), 0);
+        costs[idx++] = 50000 * aero.getSI();
         costs[idx++] = 25000 + 10 * aero.getWeight();
 
         // Engine
@@ -58,7 +58,12 @@ public class AeroCostCalculator {
         int sinkCost = 2000 + (4000 * aero.getHeatType());
         costs[idx++] = sinkCost * aero.getHeatSinks();
 
+        // Weapons and equipment
         costs[idx++] = CostCalculator.getWeaponsAndEquipmentCost(aero, ignoreAmmo);
+
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
+
         costs[idx] = -aero.getPriceMultiplier();
         double cost = CostCalculator.calculateCost(costs);
         String[] systemNames = { "Cockpit", "Life Support", "Sensors", "Structure", "Flight Systems", "Engine",

--- a/megamek/src/megamek/common/cost/AeroCostCalculator.java
+++ b/megamek/src/megamek/common/cost/AeroCostCalculator.java
@@ -32,7 +32,7 @@ public class AeroCostCalculator {
         costs[idx++] = 200000;
         costs[idx++] = 50000;
         costs[idx++] = 2000 * aero.getWeight();
-        costs[idx++] = 50000 * aero.getSI();
+        costs[idx++] = 50000 * Math.max(aero.getSI(), 0);
         costs[idx++] = 25000 + 10 * aero.getWeight();
 
         // Engine

--- a/megamek/src/megamek/common/cost/BattleArmorCostCalculator.java
+++ b/megamek/src/megamek/common/cost/BattleArmorCostCalculator.java
@@ -76,6 +76,9 @@ public class BattleArmorCostCalculator {
 
         costs[idx++] = (baseArmorCost * battleArmor.getOArmor(BattleArmor.LOC_TROOPER_1));
 
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
+
         // training cost and clan mod
         if (includeTrainingAndClan) {
             if (battleArmor.isClan()) {
@@ -89,14 +92,10 @@ public class BattleArmorCostCalculator {
 
         // TODO : we do not track the modular weapons mount for 1000 C-bills in the unit
         // files
-        costs[idx++] = CostCalculator.getWeaponsAndEquipmentCost(battleArmor, ignoreAmmo);
-        costs[idx++] = -battleArmor.getSquadSize();
+        costs[idx++] = Math.max(0, CostCalculator.getWeaponsAndEquipmentCost(battleArmor, ignoreAmmo));
+        costs[idx] = -battleArmor.getSquadSize();
 
-        double cost = 0; // calculate the total
-        for (int x = 0; x < idx; x++) {
-            cost += costs[x];
-        }
-
+        double cost = CostCalculator.calculateCost(costs);
         String[] systemNames = { "Chassis", "Jumping/VTOL/UMU", "Ground Movement", "Manipulators", "Armor",
                 "Clan Structure Multiplier", "Training", "Equipment", "Troopers" };
         CostCalculator.fillInReport(costReport, battleArmor, ignoreAmmo, systemNames, 7, cost, costs);

--- a/megamek/src/megamek/common/cost/BattleArmorCostCalculator.java
+++ b/megamek/src/megamek/common/cost/BattleArmorCostCalculator.java
@@ -94,11 +94,7 @@ public class BattleArmorCostCalculator {
 
         double cost = 0; // calculate the total
         for (int x = 0; x < idx; x++) {
-            if (costs[x] < 0) {
-                cost *= -costs[x];
-            } else {
-                cost += costs[x];
-            }
+            cost += costs[x];
         }
 
         String[] systemNames = { "Chassis", "Jumping/VTOL/UMU", "Ground Movement", "Manipulators", "Armor",

--- a/megamek/src/megamek/common/cost/ConvFighterCostCalculator.java
+++ b/megamek/src/megamek/common/cost/ConvFighterCostCalculator.java
@@ -42,7 +42,7 @@ public class ConvFighterCostCalculator {
         }
 
         // Structure and Additional flight systems
-        costs[idx++] = 4000 * Math.max(fighter.getSI(), 0);
+        costs[idx++] = 4000 * fighter.getSI();
         costs[idx++] = 25000 + 10 * fighter.getWeight();
 
         // Engine
@@ -72,6 +72,9 @@ public class ConvFighterCostCalculator {
 
         // Power amplifiers
         costs[idx++] = 20000 * fighter.getPowerAmplifierWeight();
+
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
 
         costs[idx] = -fighter.getPriceMultiplier();
         double cost = CostCalculator.calculateCost(costs);

--- a/megamek/src/megamek/common/cost/ConvFighterCostCalculator.java
+++ b/megamek/src/megamek/common/cost/ConvFighterCostCalculator.java
@@ -42,7 +42,7 @@ public class ConvFighterCostCalculator {
         }
 
         // Structure and Additional flight systems
-        costs[idx++] = 4000 * fighter.getSI();
+        costs[idx++] = 4000 * Math.max(fighter.getSI(), 0);
         costs[idx++] = 25000 + 10 * fighter.getWeight();
 
         // Engine

--- a/megamek/src/megamek/common/cost/CostCalculator.java
+++ b/megamek/src/megamek/common/cost/CostCalculator.java
@@ -42,11 +42,7 @@ public class CostCalculator {
     static double calculateCost(double[] costs) {
         double cost = 0;
         for (double v : costs) {
-            if (v < 0) {
-                cost *= -v;
-            } else {
-                cost += v;
-            }
+            cost += v;
         }
         return cost;
     }

--- a/megamek/src/megamek/common/cost/CostCalculator.java
+++ b/megamek/src/megamek/common/cost/CostCalculator.java
@@ -31,6 +31,20 @@ import java.util.Map;
 
 public class CostCalculator {
 
+
+    /**
+     * Replaces all negative costs in the array with 0. Should only be used for additive costs
+     * in order to avoid them being mistaken for cost multipliers and breaking cost calculations.
+     *
+     * @param costs An array of cost values - no multiplier values!
+     */
+    static void removeNegativeAdditiveCosts(double[] costs) {
+        for (int i = 0; i < costs.length; i++) {
+            // Modifies the original array
+            costs[i] = Math.max(0, costs[i]);
+        }
+    }
+
     /**
      * Specialized method to calculate the total cost based on the given costs array. Stepping
      * through the array, positive values will be added to the previous total while a negative value
@@ -42,7 +56,11 @@ public class CostCalculator {
     static double calculateCost(double[] costs) {
         double cost = 0;
         for (double v : costs) {
-            cost += v;
+            if (v < 0) {
+                cost *= -v;
+            } else {
+                cost += v;
+            }
         }
         return cost;
     }

--- a/megamek/src/megamek/common/cost/DropShipCostCalculator.java
+++ b/megamek/src/megamek/common/cost/DropShipCostCalculator.java
@@ -52,6 +52,9 @@ public class DropShipCostCalculator {
         // Life Boats and Escape Pods
         costs[idx++] += 5000 * (dropShip.getLifeBoats() + dropShip.getEscapePods());
 
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
+
         costs[idx] = -dropShip.getPriceMultiplier();
         double cost = CostCalculator.calculateCost(costs);
         String[] systemNames = { "Bridge", "Computer", "Life Support", "Sensors", "Fire Control Computer",

--- a/megamek/src/megamek/common/cost/InfantryCostCalculator.java
+++ b/megamek/src/megamek/common/cost/InfantryCostCalculator.java
@@ -90,6 +90,9 @@ public class InfantryCostCalculator {
         // Cost of armor on a per man basis added
         costs[idx++] = armorCost * infantry.getOInternal(0); // OInternal = menStarting
 
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
+
         // Price multiplier includes anti-mek training, motive type, and specializations
         costs[idx++] = -infantry.getPriceMultiplier();
 

--- a/megamek/src/megamek/common/cost/ProtoMekCostCalculator.java
+++ b/megamek/src/megamek/common/cost/ProtoMekCostCalculator.java
@@ -84,7 +84,12 @@ public class ProtoMekCostCalculator {
         // Armor is linear on the armor value of the ProtoMek
         costs[idx++] = protoMek.getTotalArmor() * ArmorType.forEntity(protoMek).getCost();
 
+        // Weapons and equipment
         costs[idx++] = CostCalculator.getWeaponsAndEquipmentCost(protoMek, ignoreAmmo);
+
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
+
         costs[idx] = -protoMek.getPriceMultiplier();
         double cost = CostCalculator.calculateCost(costs);
         String[] systemNames = { "Cockpit", "Life Support", "Sensors", "Musculature", "Structure", "Arm Actuators",

--- a/megamek/src/megamek/common/cost/SmallCraftCostCalculator.java
+++ b/megamek/src/megamek/common/cost/SmallCraftCostCalculator.java
@@ -28,6 +28,10 @@ public class SmallCraftCostCalculator {
     public static double calculateCost(SmallCraft smallCraft, CalculationReport costReport, boolean ignoreAmmo) {
         double[] costs = new double[16];
         int idx = addBaseCosts(costs, smallCraft, ignoreAmmo);
+
+        // For all additive costs - replace negatives with 0 to separate from multipliers
+        CostCalculator.removeNegativeAdditiveCosts(costs);
+
         costs[idx] = -smallCraft.getPriceMultiplier();
         double cost = CostCalculator.calculateCost(costs);
         String[] systemNames = { "Bridge", "Computer", "Life Support", "Sensors", "Fire Control Computer",


### PR DESCRIPTION
Fixes #6671 

Currently we allow part costs to be negative, and in some unit cost calculation methods for aero units there was a supposed typo that multiplied the final unit cost by the part's cost if it was negative - wildly inflating the final valuations. In this specific case, it was driven by negative SI.

I have brought the aero cost calculation logic in line with all other methods, and put a safeguard treating negative SI as zero. However, we should probably decide what to do with negative unit part prices in principle.