### PR TITLE
Better indicate effect of RISC ECS

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4947,7 +4947,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         // RISC ECS
         for (MiscMounted m : getMisc()) {
             if (m.getType().hasFlag(MiscType.F_EMERGENCY_COOLANT_SYSTEM)) {
-                sb.append(", +MoS with RISC ECS");
+                sb.append(", ").append(capacity + 6).append("+MoS with RISC ECS");
             }
         }
 


### PR DESCRIPTION
Adds the +6 heat sinking from RISC ECS to heat readouts. Compare the heat profiles of these two sheets:

![image](https://github.com/user-attachments/assets/c3192894-d534-4569-8133-2f7e857879ef)
![image](https://github.com/user-attachments/assets/249fe9d4-6a4c-4e7b-81da-4a43ab410c3d)

Official sheets don't include the heat profile so I don't think this needs CGL approval. 