### PR TITLE
Add is on board flag to hex

### DIFF
--- a/megamek/src/megamek/ai/optimizer/UtilityPathRankerCostFunction.java
+++ b/megamek/src/megamek/ai/optimizer/UtilityPathRankerCostFunction.java
@@ -317,7 +317,7 @@ public record UtilityPathRankerCostFunction(CardinalEdge homeEdge, CostFunctionS
             for (int y = 0; y < board.getHeight(); y++) {
                 idx = y * board.getWidth() + x;
                 Hex hex = board.getHex(x, y);
-                if (hex != null) {
+                if (hex.isOnBoard()) {
                     level = hex.floor();
                     temp = hex.terrainLevel(Terrains.BUILDING);
                     if (temp != Terrain.LEVEL_NONE) {
@@ -1057,7 +1057,7 @@ public record UtilityPathRankerCostFunction(CardinalEdge homeEdge, CostFunctionS
                     var yMidPoint = (startY + endY) / 2;
                     for (var coords : new Coords(xMidPoint, yMidPoint).allAtDistanceOrLess(3)) {
                         var hex = board.getHex(coords);
-                        if (hex == null || hex.isClearHex() && hasNoHazards(hex)) {
+                        if (hex.isOffBoard() || hex.isClearHex() && hasNoHazards(hex)) {
                             addStrategicGoal(coords);
                             break;
                         }

--- a/megamek/src/megamek/client/bot/RandomMinefieldDeploymentPlanner.java
+++ b/megamek/src/megamek/client/bot/RandomMinefieldDeploymentPlanner.java
@@ -60,7 +60,7 @@ public class RandomMinefieldDeploymentPlanner implements MinefieldDeploymentPlan
             Coords coords = new Coords(Compute.randomInt(board.getWidth()),
                   Compute.randomInt(board.getHeight()));
             Hex hex = board.getHex(coords);
-            if ((hex != null)
+            if ((hex.isOnBoard())
                   && !hex.hasDepth1WaterOrDeeper()
                   && (hex.hasPavementOrRoad() || hex.hasVegetation()
                   || (hex.isClearHex() && (maxTries < numberOfCoords * 10))))

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1140,7 +1140,7 @@ public class FireControl {
             ) {
                 Hex hex = game.getBoard().getHex(target.getPosition());
                 // If somehow we get an off-board hex, it's impossible to hit.
-                if (hex == null) {
+                if (hex.isOffBoard()) {
                     return new ToHitData(TH_NULL_POSITION);
                 }
                 if (Compute.allEnemiesOutsideBlast(target, shooter, firingAmmo.getType(), false, false, false, game)) {
@@ -2015,7 +2015,7 @@ public class FireControl {
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
             Entity entity = (Entity) target;
             Hex hex = game.getBoard().getHex(entity.getPosition());
-            hexToBomb.setTargetLevel((hex != null) ? hex.getLevel() : 0);
+            hexToBomb.setTargetLevel(hex.isOnBoard() ? hex.getLevel() : 0);
 
             if (entity.isAirborne()) {
                 return diveBombPlan;
@@ -2023,7 +2023,7 @@ public class FireControl {
             if (entity.isAirborneVTOLorWIGE()) {
                 // If VTOL / WiGE movement and flying, can only be hit if over water
                 // or buildings, and only if within a specific level range
-                if (hex == null || !hex.containsAnyTerrainOf(Terrains.BLDG_ELEV, Terrains.WATER)) {
+                if (hex.isOffBoard() || !hex.containsAnyTerrainOf(Terrains.BLDG_ELEV, Terrains.WATER)) {
                     return diveBombPlan;
                 }
                 hexToBomb.setTargetLevel(hex.getLevel() + entity.getElevation());
@@ -2031,7 +2031,7 @@ public class FireControl {
             // Submarine units can be bombed, but bombs impact the water surface and transfers 1 to 2
             // levels of depth downward.
             if (entity.getMovementMode().isSubmarine()) {
-                if (hex == null || !hex.containsAnyTerrainOf(Terrains.WATER)) {
+                if (hex.isOffBoard() || !hex.containsAnyTerrainOf(Terrains.WATER)) {
                     return diveBombPlan;
                 }
                 if (entity.getElevation() < -2) {

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -433,7 +433,7 @@ public class PathEnumerator {
         boolean needsAdjust = false;
         for (Coords c : path.getCoordsSet()) {
             Hex hex = getGame().getBoard().getHex(c);
-            if ((hex != null) && hex.containsTerrain(Terrains.BRIDGE)) {
+            if (hex.isOnBoard() && hex.containsTerrain(Terrains.BRIDGE)) {
                 if (getGame().getBoard().getBuildingAt(c).getCurrentCF(c) >= path.getEntity().getWeight()) {
                     needsAdjust = true;
                     break;

--- a/megamek/src/megamek/client/bot/princess/SwarmContext.java
+++ b/megamek/src/megamek/client/bot/princess/SwarmContext.java
@@ -204,7 +204,7 @@ public class SwarmContext {
                 var yMidPoint = (startY + endY) / 2;
                 for (var coords : new Coords(xMidPoint, yMidPoint).allAtDistanceOrLess(3)) {
                     var hex = board.getHex(coords);
-                    if (hex == null || hex.isClearHex() && hasNoHazards(hex)) {
+                    if (hex.isOffBoard() || hex.isClearHex() && hasNoHazards(hex)) {
                         addStrategicGoal(coords);
                         break;
                     }

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -672,7 +672,7 @@ public class WeaponFireInfo {
                 ? ((Entity) target).getElevation()
                 : ((HexTarget) target).getTargetLevel();
 
-            if (hex != null && hex.containsAnyTerrainOf(Terrains.WATER, Terrains.BLDG_ELEV)) {
+            if (hex.isOnBoard() && hex.containsAnyTerrainOf(Terrains.WATER, Terrains.BLDG_ELEV)) {
                 if ((hex.ceiling() + 2 ) < (hex.getLevel() + targetLevel)) {
                     return new ToHitData(FireControl.TH_NO_TARGETS_IN_BLAST);
                 }
@@ -776,7 +776,7 @@ public class WeaponFireInfo {
                     Coords coords = entry.getValue();
                     Hex hex = game.getBoard().getHex(coords);
                     // Currently, bombs off board are not supported.
-                    if (hex == null) {
+                    if (hex.isOffBoard()) {
                         continue;
                     }
                     // Record collateral damage to buildings

--- a/megamek/src/megamek/client/commands/LookCommand.java
+++ b/megamek/src/megamek/client/commands/LookCommand.java
@@ -45,7 +45,7 @@ public class LookCommand extends ClientCommand {
         Coords pos = getClientGUI().getCurrentHex();
         Hex hex = getClient().getGame().getBoard().getHex(pos);
         String str;
-        if (hex != null) {
+        if (hex.isOnBoard()) {
             str = "Looking around hex (" + (pos.getX() + 1) + ", "
                     + (pos.getY() + 1) + ")\n";
             for (String dir : directions) {
@@ -53,7 +53,7 @@ public class LookCommand extends ClientCommand {
                 str += "To the " + dir  + " (" + (coord.getX() + 1) + ", "
                         + (coord.getY() + 1) + "): ";
                 hex = getClient().getGame().getBoard().getHex(coord);
-                if (hex != null) {
+                if (hex.isOnBoard()) {
                     str += hex.toString();
                 } else {
                     str += "off map.\n";

--- a/megamek/src/megamek/client/commands/ShowTileCommand.java
+++ b/megamek/src/megamek/client/commands/ShowTileCommand.java
@@ -81,7 +81,7 @@ public class ShowTileCommand extends ClientCommand {
             do {
                 hex = getClient().getGame().getBoard().getHex(coord);
                 getClientGUI().setCurrentHex(hex);
-                if (hex != null) {
+                if (hex.isOnBoard()) {
                     str = "Details for hex (" + (coord.getX() + 1) + ", "
                           + (coord.getY() + 1) + ") : " + hex;
 

--- a/megamek/src/megamek/client/ui/swing/BoardEditor.java
+++ b/megamek/src/megamek/client/ui/swing/BoardEditor.java
@@ -1234,7 +1234,7 @@ public class BoardEditor extends JPanel implements ItemListener, ListSelectionLi
     }
 
     private void repaintWorkingHex() {
-        if (curHex != null) {
+        if (curHex.isOnBoard()) {
             TilesetManager tm = bv.getTilesetManager();
             tm.clearHex(curHex);
         }
@@ -2360,7 +2360,7 @@ public class BoardEditor extends JPanel implements ItemListener, ListSelectionLi
         @Override
         public void paintComponent(Graphics g) {
             super.paintComponent(g);
-            if (curHex != null) {
+            if (curHex.isOnBoard()) {
                 // draw the terrain images
                 TilesetManager tm = bv.getTilesetManager();
                 g.drawImage(tm.baseFor(curHex), 0, 0, HexTileset.HEX_W, HexTileset.HEX_H, this);
@@ -2455,7 +2455,7 @@ public class BoardEditor extends JPanel implements ItemListener, ListSelectionLi
             try {
                 String clipboardString = (String) contents.getTransferData(DataFlavor.stringFlavor);
                 Hex pastedHex = Hex.parseClipboardString(clipboardString);
-                if (pastedHex != null) {
+                if (pastedHex.isOnBoard()) {
                     setCurrentHex(pastedHex);
                 }
             } catch (Exception ex) {

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -3289,7 +3289,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
      * Set the Current Hex, used by client commands for the visually impaired
      */
     public void setCurrentHex(Hex hex) {
-        if (hex != null) {
+        if (hex.isOnBoard()) {
             currentHex = hex.getCoords();
         }
     }

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -1497,7 +1497,7 @@ public class MapMenu extends JPopupMenu {
 
         Hex h = board.getHex(coords);
         // If the hex is null, we're done here
-        if (h == null) {
+        if (h.isOffBoard()) {
             return menu;
         }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardEditorTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardEditorTooltip.java
@@ -68,7 +68,7 @@ public class BoardEditorTooltip implements BoardViewTooltipProvider {
             return null;
         }
         Hex hex = game.getBoard().getHex(coords);
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return "Error: No hex found at " + coords;
         }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -1309,7 +1309,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                     // Draw hexes that are legal at a higher deployment elevation
                     Hex hex = board.getHex(c);
                     // Default to Elevation 1 if ceiling + 1 <= 0.
-                    int maxHeight = (isWiGE) ? 1 : (hex != null) ? Math.max(hex.ceiling() + 1, 1) : 1;
+                    int maxHeight = (isWiGE) ? 1 : hex.isOnBoard() ? Math.max(hex.ceiling() + 1, 1) : 1;
                     if (board.isLegalDeployment(c, en_Deployer) &&
                         !en_Deployer.isLocationProhibited(c, maxHeight)) {
                         drawHexBorder(g, getHexLocation(c), Color.cyan);
@@ -1816,7 +1816,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                         // to get correct occlusion; drawX may be any int though
                         Coords c = new Coords(x + drawX / 2 * 2, y + drawY);
                         Hex hex = board.getHex(c);
-                        if ((hex != null)) {
+                        if (hex.isOnBoard()) {
                             drawHex(c, g, saveBoardImage);
                             drawOrthograph(c, g);
                             drawHexSpritesForHex(c, g, behindTerrainHexSprites);
@@ -1832,7 +1832,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                 for (int x = 0; x < drawWidth; x++) {
                     Coords c = new Coords(x + drawX, y + drawY);
                     Hex hex = board.getHex(c);
-                    if (hex != null) {
+                    if (hex.isOnBoard()) {
                         if (!saveBoardImage) {
                             if (GUIP.getShowWrecks()) {
                                 drawIsometricWreckSpritesForHex(c, g, isometricWreckSprites);
@@ -1871,7 +1871,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         }
 
         final Hex hex = game.getBoard().getHex(c);
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return;
         }
         final Point hexLoc = getHexLocation(c);
@@ -1920,7 +1920,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             int largestLevelDiff = 0;
             for (int dir : allDirections) {
                 Hex adjHex = game.getBoard().getHexInDir(c, dir);
-                if (adjHex == null) {
+                if (adjHex.isOffBoard()) {
                     continue;
                 }
                 int levelDiff = Math.abs(level - adjHex.getLevel());
@@ -2415,7 +2415,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
             // Determine the depth of the edge that needs to be drawn.
             int height = elev;
             Hex southHex = game.getBoard().getHexInDir(c, 3);
-            if ((dir != 3) && (southHex != null) && (elev > southHex.getLevel())) {
+            if ((dir != 3) && southHex.isOnBoard() && (elev > southHex.getLevel())) {
                 height = elev - southHex.getLevel();
             }
             int scaledHeight = (int) (HEX_ELEV * scale * height);
@@ -2491,9 +2491,9 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
     private boolean drawElevationLine(Coords src, int direction) {
         final Hex srcHex = game.getBoard().getHex(src);
         final Hex destHex = game.getBoard().getHexInDir(src, direction);
-        if ((destHex == null) && (srcHex.getLevel() != 0)) {
+        if (destHex.isOffBoard() && (srcHex.getLevel() != 0)) {
             return true;
-        } else if (destHex == null) {
+        } else if (destHex.isOffBoard()) {
             return false;
         } else if (srcHex.getLevel() != destHex.getLevel()) {
             return true;
@@ -2554,7 +2554,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         final Hex destHex = game.getBoard().getHexInDir(src, direction);
 
         // When at the board edge, create a shadow in hexes of level < 0
-        if (destHex == null) {
+        if (destHex.isOffBoard()) {
             if (srcHex.getLevel() >= 0) {
                 return null;
             }
@@ -2583,7 +2583,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         final Hex srcHex = game.getBoard().getHex(src);
         final Hex destHex = game.getBoard().getHexInDir(src, direction);
 
-        if (destHex == null) {
+        if (destHex.isOffBoard()) {
             return null;
         }
 
@@ -2615,7 +2615,7 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
         float elevationAdjust = 0.0f;
 
         Hex hex = game.getBoard().getHex(x, y);
-        if ((hex != null) && useIsometric() && !ignoreElevation) {
+        if (hex.isOnBoard() && useIsometric() && !ignoreElevation) {
             elevationAdjust = hex.getLevel() * HEX_ELEV * scale * -1.0f;
         }
         int ypos = (y * (int) (HEX_H * scale))

--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -367,13 +367,13 @@ public class FovHighlightingAndDarkening {
         GUIPreferences guip = GUIPreferences.getInstance();
         Board board = this.boardView1.game.getBoard();
         Hex srcHex = board.getHex(src);
-        if (srcHex == null) {
-            logger.error("Cannot process line of sight effects with a null source hex.");
+        if (srcHex.isOffBoard()) {
+            logger.error("Cannot process line of sight effects with a hex outside the board.");
             return null;
         }
         Hex dstHex = board.getHex(dest);
-        if (dstHex == null) {
-            logger.error("Cannot process line of sight effects with a null destination hex.");
+        if (dstHex.isOffBoard()) {
+            logger.error("Cannot process line of sight effects with a hex outside the board.");
             return null;
         }
 

--- a/megamek/src/megamek/client/ui/swing/boardview/TWBoardViewTooltip.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TWBoardViewTooltip.java
@@ -72,7 +72,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
         String result = "";
 
         // Hex Terrain
-        if (GUIP.getShowMapHexPopup() && (mhex != null)) {
+        if (GUIP.getShowMapHexPopup() && (mhex.isOnBoard())) {
             StringBuffer sbTerrain = new StringBuffer();
             appendTerrainTooltip(sbTerrain, mhex, GUIP);
             String sTerrain = sbTerrain.toString();
@@ -140,7 +140,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
 
         // Show the player(s) that may deploy here
         // in the artillery autohit designation phase
-        if (game.getPhase().isSetArtilleryAutohitHexes() && (mhex != null)) {
+        if (game.getPhase().isSetArtilleryAutohitHexes() && (mhex.isOnBoard())) {
             result += HexTooltip.getAttilleryHit(GUIP, game, coords);
         }
 
@@ -345,8 +345,8 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
     /**
      * Appends HTML describing the terrain of a given hex
      */
-    public void appendTerrainTooltip(StringBuffer txt, @Nullable Hex mhex, GUIPreferences GUIP) {
-        if (mhex == null) {
+    public void appendTerrainTooltip(StringBuffer txt, Hex mhex, GUIPreferences GUIP) {
+        if (mhex.isOffBoard()) {
             return;
         }
 
@@ -356,8 +356,8 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
     /**
      * Appends HTML describing the buildings and minefields in a given hex
      */
-    public void appendBuildingsTooltip(StringBuffer txt, @Nullable Hex mhex) {
-        if ((mhex != null) && (clientGui != null)) {
+    public void appendBuildingsTooltip(StringBuffer txt, Hex mhex) {
+        if ((mhex.isOnBoard()) && (clientGui != null)) {
             String result = HexTooltip.getHexTip(mhex, clientGui.getClient(), GUIP);
             txt.append(result);
         }

--- a/megamek/src/megamek/client/ui/swing/boardview/TerrainShadowHelper.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/TerrainShadowHelper.java
@@ -185,7 +185,7 @@ class TerrainShadowHelper {
                     surrounded = false;
                 } else {
                     Hex nhex = board.getHex(c.translated(dir));
-                    if (nhex != null) {
+                    if (nhex.isOnBoard()) {
                         int lv = nhex.getLevel();
                         if (lv < level) {
                             surrounded = false;

--- a/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
+++ b/megamek/src/megamek/client/ui/swing/minimap/Minimap.java
@@ -694,7 +694,7 @@ public final class Minimap extends JPanel implements IPreferenceChangeListener {
             for (int j = 0; j < board.getWidth(); j++) {
                 for (int k = 0; k < board.getHeight(); k++) {
                     Hex h = board.getHex(j, k);
-                    if (h == null) {
+                    if (h.isOffBoard()) {
                         continue;
                     }
                     if (dirtyMap || dirty[j / 10][k / 10]) {

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -162,7 +162,7 @@ public class SummaryPanel extends PicMap {
 
             Hex mhex = entity.getGame().getBoard().getHex(entity.getPosition());
 
-            if (mhex != null) {
+            if (mhex.isOnBoard()) {
                 String terrainTip = HexTooltip.getTerrainTip(mhex, GUIP, entity.getGame());
                 String attr = String.format("FACE=Dialog BGCOLOR=%s", UIUtil.toColorHexString(GUIP.getUnitToolTipTerrainBGColor()));
                 col = UIUtil.tag("TD", attr, terrainTip);

--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -1120,7 +1120,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         Coords position = entity.getPosition();
         if (!en.isOffBoard() && (position != null)) {
             Hex hex = game.getBoard().getHex(position);
-            if (hex != null) {
+            if (hex.isOnBoard()) {
                 if (hex.containsTerrain(Terrains.FIRE)
                         && (hex.getFireTurn() > 0)) {
                     // standing in fire

--- a/megamek/src/megamek/client/ui/swing/util/EntityWreckHelper.java
+++ b/megamek/src/megamek/client/ui/swing/util/EntityWreckHelper.java
@@ -20,7 +20,7 @@ import megamek.common.*;
 /**
  * This class handles logic for displaying various kinds of damage and
  * destruction decals
- * 
+ *
  * @author NickAragua
  *
  */
@@ -132,7 +132,7 @@ public class EntityWreckHelper {
      */
     public static boolean entityOnBridge(Entity entity) {
         Hex hex = entity.getGame().getBoard().getHex(entity.getPosition());
-        if (hex != null) {
+        if (hex.isOnBoard()) {
             boolean hexHasBridge = hex.containsTerrain(Terrains.BRIDGE_CF);
 
             if (hexHasBridge && entity.getElevation() >= hex.ceiling()) {

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -230,7 +230,7 @@ public class Board implements Serializable {
         int index = 0;
         for (int h = 0; h < height; h++) {
             for (int w = 0; w < width; w++) {
-                data[index++] = new Hex(0, "sky:1", "", new Coords(w, h));
+                data[index++] = new Hex(0, "sky:1", "", new Coords(w, h), true);
             }
         }
         Board result = new Board(width, height, data);
@@ -250,7 +250,7 @@ public class Board implements Serializable {
         int index = 0;
         for (int h = 0; h < height; h++) {
             for (int w = 0; w < width; w++) {
-                data[index++] = new Hex(0, "space:1", "", new Coords(w, h));
+                data[index++] = new Hex(0, "space:1", "", new Coords(w, h), true);
             }
         }
         Board result = new Board(width, height, data);
@@ -303,10 +303,10 @@ public class Board implements Serializable {
      *
      * @param x the x Coords.
      * @param y the y Coords.
-     * @return the Hex, if this Board contains the (x, y) location; null otherwise.
+     * @return the Hex, if this Board contains the (x, y) location; A clean, plain hex at level 0 marked as off board otherwise.
      */
-    public @Nullable Hex getHex(final int x, final int y) {
-        return contains(x, y) ? data[(y * width) + x] : null;
+    public Hex getHex(final int x, final int y) {
+        return contains(x, y) ? data[(y * width) + x] : new Hex(0, false);
     }
 
     /**
@@ -350,7 +350,7 @@ public class Board implements Serializable {
             for (int x = 0; x < width; x++) {
                 // Does this hex contain a building?
                 Hex curHex = getHex(x, y);
-                if ((curHex != null) && (curHex.containsTerrain(Terrains.BUILDING))) {
+                if (curHex.isOnBoard() && (curHex.containsTerrain(Terrains.BUILDING))) {
                     // Yup, but is it a repeat?
                     Coords coords = new Coords(x, y);
                     if (!bldgByCoords.containsKey(coords)) {
@@ -379,7 +379,7 @@ public class Board implements Serializable {
                     }
                 }
 
-                if ((curHex != null) && (curHex.containsTerrain(Terrains.FUEL_TANK))) {
+                if (curHex.isOnBoard() && (curHex.containsTerrain(Terrains.FUEL_TANK))) {
                     // Yup, but is it a repeat?
                     Coords coords = new Coords(x, y);
                     if (!bldgByCoords.containsKey(coords)) {
@@ -406,7 +406,7 @@ public class Board implements Serializable {
                     }
                 }
 
-                if ((curHex != null) && curHex.containsTerrain(Terrains.BRIDGE)) {
+                if (curHex.isOnBoard() && curHex.containsTerrain(Terrains.BRIDGE)) {
                     // Yup, but is it a repeat?
                     Coords coords = new Coords(x, y);
                     if (!bldgByCoords.containsKey(coords)) {
@@ -475,7 +475,7 @@ public class Board implements Serializable {
     private void initializeHex(int x, int y, boolean event) {
         Hex hex = getHex(x, y);
 
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return;
         }
 
@@ -1070,7 +1070,7 @@ public class Board implements Serializable {
                     }
                     int elevation = Integer.parseInt(args[1]);
                     // The coordinates in the .board file are ignored!
-                    nd[index] = new Hex(elevation, args[2], args[3], new Coords(index % nw, index / nw));
+                    nd[index] = new Hex(elevation, args[2], args[3], new Coords(index % nw, index / nw), true);
                     index++;
                 } else if ((st.ttype == StreamTokenizer.TT_WORD) && st.sval.equalsIgnoreCase("description")) {
                     st.nextToken();
@@ -1148,11 +1148,11 @@ public class Board implements Serializable {
         for (int x = 0; x < width; x++) {
             for (int y = 0; y < height; y++) {
                 Hex hex = data[(y * width) + x];
-                if (hex == null) {
+                if (hex.isOffBoard()) {
                     if (errors != null) {
-                        errors.add("Null hex for coordinates " + x + "; " + y + ". Breaking off validity check.");
+                        errors.add("Hex coordinates " + x + "; " + y + " are off the board. Breaking off validity check.");
                     }
-                    // A null hex must never happen. No need to process the rest of the board.
+                    // An off board hex must never happen. No need to process the rest of the board.
                     return false;
                 }
                 List<String> hexErrors = new ArrayList<>();
@@ -1164,7 +1164,7 @@ public class Board implements Serializable {
                 if (hex.containsTerrain(Terrains.BUILDING) && hex.getTerrain(Terrains.BUILDING).hasExitsSpecified()) {
                     for (int dir = 0; dir < 6; dir++) {
                         Hex adjHex = getHexInDir(x, y, dir);
-                        if ((adjHex != null)
+                        if ((adjHex.isOnBoard())
                                 && adjHex.containsTerrain(Terrains.BUILDING)
                                 && hex.containsTerrainExit(Terrains.BUILDING, dir)) {
                             if (adjHex.getTerrain(Terrains.BUILDING).getLevel() != hex.getTerrain(Terrains.BUILDING)

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -303,10 +303,10 @@ public class Board implements Serializable {
      *
      * @param x the x Coords.
      * @param y the y Coords.
-     * @return the Hex, if this Board contains the (x, y) location; A clean, plain hex at level 0 marked as off board otherwise.
+     * @return the Hex, if this Board contains the (x, y) location; A clean, plain hex at level 0 and the coords, marked as off board otherwise.
      */
     public Hex getHex(final int x, final int y) {
-        return contains(x, y) ? data[(y * width) + x] : new Hex(0, false);
+        return contains(x, y) ? data[(y * width) + x] : new Hex(0, new Coords(x, y) , false);
     }
 
     /**

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -84,7 +84,7 @@ public class BulldozerMovePath extends MovePath {
     public MovePath addStep(final MoveStepType type) {
         BulldozerMovePath mp = (BulldozerMovePath) super.addStep(type);
         Hex hex = mp.getGame().getBoard().getHex(mp.getFinalCoords());
-        int hexWaterDepth = ((hex != null) && hex.containsTerrain(Terrains.WATER)) ? hex.depth() : Integer.MIN_VALUE;
+        int hexWaterDepth = (hex.isOnBoard() && hex.containsTerrain(Terrains.WATER)) ? hex.depth() : Integer.MIN_VALUE;
 
         if (!mp.isMoveLegal() && !mp.isJumping()) {
             // here, we will check if the step is illegal because the unit in question
@@ -117,7 +117,7 @@ public class BulldozerMovePath extends MovePath {
             // water)
             // then we are impeding future jump movement and should add an extra cost to
             // this step
-            if ((hex != null) && !hex.containsTerrain(Terrains.BRIDGE)) {
+            if (hex.isOnBoard() && !hex.containsTerrain(Terrains.BRIDGE)) {
                 // special case - mek jumping into depth 1 water might not be all that bad, jump
                 // mp cost wise
                 if (hexWaterDepth == 1) {
@@ -191,7 +191,7 @@ public class BulldozerMovePath extends MovePath {
         Hex destHex = board.getHex(finalCoords);
         int levelingCost = CANNOT_LEVEL;
 
-        if (destHex == null) {
+        if (destHex.isOffBoard()) {
             return levelingCost;
         }
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -983,7 +983,7 @@ public class Compute {
         Hex secondHex = game.getBoard().getHex(second);
         Entity entity = game.getEntity(entityId);
 
-        if ((firstHex == null) || (secondHex == null)) {
+        if ((firstHex.isOffBoard()) || (secondHex.isOffBoard())) {
             // leave it, will be handled
         } else if (entity.elevationOccupied(firstHex) > entity
                 .elevationOccupied(secondHex)) {
@@ -1247,7 +1247,7 @@ public class Compute {
         boolean targetUnderwater = false;
         boolean weaponUnderwater = (ae.getLocationStatus(weapon.getLocation()) == ILocationExposureStatus.WET);
         if ((target.getTargetType() == Targetable.TYPE_ENTITY)
-                && (targHex != null) && targHex.containsTerrain(Terrains.WATER)
+                && targHex.isOnBoard() && targHex.containsTerrain(Terrains.WATER)
                 && (targBottom < 0)) {
 
             if (targTop >= 0) {
@@ -1274,7 +1274,7 @@ public class Compute {
         }
 
         // allow ice to be cleared from below
-        if ((targHex != null) && targHex.containsTerrain(Terrains.WATER)
+        if (targHex.isOnBoard() && targHex.containsTerrain(Terrains.WATER)
                 && (target.getTargetType() == Targetable.TYPE_HEX_CLEAR)) {
             targetInPartialWater = true;
         }
@@ -2831,7 +2831,7 @@ public class Compute {
         ToHitData toHit = new ToHitData();
 
         // space screens; bonus depends on number (level)
-        if ((hex != null) && (hex.terrainLevel(Terrains.SCREEN) > 0)) {
+        if (hex.isOnBoard() && (hex.terrainLevel(Terrains.SCREEN) > 0)) {
             toHit.addModifier(hex.terrainLevel(Terrains.SCREEN) + 1,
                     "attacker in screen(s)");
         }
@@ -2873,7 +2873,7 @@ public class Compute {
         Hex hex = game.getBoard().getHex(t.getPosition());
         if (t.getTargetType() == Targetable.TYPE_ENTITY) {
             entityTarget = (Entity) t;
-            if (hex == null) {
+            if (hex.isOffBoard()) {
                 entityTarget.setPosition(game.getEntity(entityTarget.getId())
                         .getPosition());
                 hex = game.getBoard().getHex(
@@ -2882,7 +2882,7 @@ public class Compute {
         }
 
         // if the hex doesn't exist, it's unlikely to have terrain modifiers
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return toHit;
         }
 
@@ -5674,7 +5674,7 @@ public class Compute {
         int metalContent = 0;
         for (Coords c : coords) {
             Hex hex = board.getHex(c);
-            if (hex != null && hex.containsTerrain(Terrains.METAL_CONTENT)) {
+            if (hex.isOnBoard() && hex.containsTerrain(Terrains.METAL_CONTENT)) {
                 metalContent += hex.terrainLevel(Terrains.METAL_CONTENT);
             }
         }
@@ -6475,7 +6475,7 @@ public class Compute {
         // Get the Hex at those coordinates.
         final Hex curHex = game.getBoard().getHex(coords);
 
-        if (curHex == null) {
+        if (curHex.isOffBoard()) {
             // probably off board artillery or reinforcement
             return false;
         }
@@ -7959,7 +7959,7 @@ public class Compute {
         // are too deep or too high for _any_ blast damage to reach.
 
         Hex hex = game.getBoard().getHex(position);
-        final boolean causeAEBlast = hex != null && hex.containsAnyTerrainOf(Terrains.BLDG_ELEV, Terrains.WATER);
+        final boolean causeAEBlast = hex.isOnBoard() && hex.containsAnyTerrainOf(Terrains.BLDG_ELEV, Terrains.WATER);
         final int baseHeight;
         final int ceiling;
         if (flak) {
@@ -7969,8 +7969,8 @@ public class Compute {
                 ceiling = baseHeight = target.getElevation();
             }
         } else {
-            baseHeight = (hex != null) ? hex.getLevel() : 0;
-            ceiling = (hex != null) ? hex.ceiling() : baseHeight;
+            baseHeight = hex.isOnBoard() ? hex.getLevel() : 0;
+            ceiling = hex.isOnBoard() ? hex.ceiling() : baseHeight;
         }
 
         // Get radius, base damage

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -190,7 +190,7 @@ public class Dropship extends SmallCraft {
             Coords secondaryCoord = c.translated(dir);
             Hex secondaryHex = game.getBoard().getHex(secondaryCoord);
             boolean occupied = game.getEntities(secondaryCoord).hasNext();
-            if (secondaryHex == null) {
+            if (secondaryHex.isOffBoard()) {
                 // Don't allow landed dropships to hang off the board
                 isProhibited = true;
             } else {
@@ -247,7 +247,7 @@ public class Dropship extends SmallCraft {
         int secondElev = centralElev;
         Hex currHex = game.getBoard().getHex(c.translated(5));
         // Ensure we aren't trying to deploy off the board
-        if (currHex == null) {
+        if (currHex.isOffBoard()) {
             return true;
         }
         for (int dir = 0; dir < 6; dir++) {
@@ -256,7 +256,7 @@ public class Dropship extends SmallCraft {
             }
             Hex nextHex = game.getBoard().getHex(c.translated(dir));
             // Ensure we aren't trying to deploy off the board
-            if (nextHex == null) {
+            if (nextHex.isOffBoard()) {
                 return true;
             }
             if ((currHex.getLevel() != centralElev) && (currHex.getLevel() == nextHex.getLevel())) {
@@ -492,7 +492,7 @@ public class Dropship extends SmallCraft {
         // A grounded dropship with the center hex in level 1 water is immobile.
         if ((game != null) && !game.getBoard().inSpace() && !isAirborne()) {
             Hex hex = game.getBoard().getHex(getPosition());
-            if ((hex != null) && (hex.containsTerrain(Terrains.WATER, 1) && !hex.containsTerrain(Terrains.ICE))) {
+            if (hex.isOnBoard() && (hex.containsTerrain(Terrains.WATER, 1) && !hex.containsTerrain(Terrains.ICE))) {
                 return 0;
             }
         }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3275,7 +3275,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public int elevationOccupied(Hex hex, int elevation) {
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return 0;
         }
         if ((movementMode == EntityMovementMode.VTOL)
@@ -7790,12 +7790,12 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             addPilotingModifierForTerrain(roll, lastPos);
         }
 
-        boolean prevStepPavement = (prevStep != null) ? prevStep.isPavementStep() : ((prevHex != null) && prevHex.hasPavement());
+        boolean prevStepPavement = (prevStep != null) ? prevStep.isPavementStep() : (prevHex.isOnBoard() && prevHex.hasPavement());
         PlanetaryConditions conditions = game.getPlanetaryConditions();
         boolean affectedByIce = !movementMode.isHoverOrWiGE() || conditions.getWind().isStrongerThan(Wind.STRONG_GALE);
         boolean runOrSprint = (overallMoveType == EntityMovementType.MOVE_RUN) || (overallMoveType == EntityMovementType.MOVE_SPRINT);
-        boolean unitTouchesIce = (prevHex != null) && prevHex.containsTerrain(Terrains.ICE) && (currStep.getElevation() == 0);
-        boolean unitTouchesBlackIce = (prevHex != null) && prevHex.containsTerrain(Terrains.BLACK_ICE)
+        boolean unitTouchesIce = prevHex.isOnBoard() && prevHex.containsTerrain(Terrains.ICE) && (currStep.getElevation() == 0);
+        boolean unitTouchesBlackIce = prevHex.isOnBoard() && prevHex.containsTerrain(Terrains.BLACK_ICE)
             && (((currStep.getElevation() == 0) && prevHex.containsAnyTerrainOf(Terrains.ROAD, Terrains.PAVEMENT))
             || (prevHex.containsTerrain(Terrains.BRIDGE_ELEV) && (currStep.getElevation() == prevHex.terrainLevel(Terrains.BRIDGE_ELEV))));
         boolean isMoveAndTurn = (prevFacing != curFacing) && !Objects.equals(curPos, lastPos);
@@ -8022,7 +8022,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
             rv += 4;
         }
         // check previous hex for building
-        if (prevHex != null) {
+        if (prevHex.isOnBoard()) {
             int prevEl = getElevation();
             if (prevStep != null) {
                 prevEl = prevStep.getElevation();
@@ -10058,7 +10058,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
                 && hasWorkingMisc(MiscType.F_TOOLS,
                         MiscType.S_DEMOLITION_CHARGE)) {
             Hex hex = game.getBoard().getHex(getPosition());
-            if (hex == null) {
+            if (hex.isOffBoard()) {
                 return false;
             }
             return hex.containsTerrain(Terrains.BUILDING);
@@ -11061,7 +11061,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         if ((fa % 30) == 0) {
             Hex srcHex = game.getBoard().getHex(src);
             Hex curHex = game.getBoard().getHex(getPosition());
-            if ((srcHex != null) && (curHex != null)) {
+            if (srcHex.isOnBoard() && curHex.isOnBoard()) {
                 LosEffects.AttackInfo ai = LosEffects.buildAttackInfo(src,
                         getPosition(), 1, getElevation(), srcHex.floor(),
                         curHex.floor());
@@ -11544,7 +11544,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         PilotingRollData roll = getBasePilotingRoll(overallMoveType);
 
         if ((moveType != EntityMovementType.MOVE_JUMP)
-                && (prevHex != null)
+                && prevHex.isOnBoard()
                 && (distance > 1)
                 && ((overallMoveType == EntityMovementType.MOVE_RUN)
                         || (overallMoveType == EntityMovementType.MOVE_VTOL_RUN)

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -888,7 +888,6 @@ public class Hex implements Serializable {
                 .filter(t -> !Terrains.AUTOMATIC.contains(t))
                 .mapToObj(t -> getTerrain(t).toString()).collect(Collectors.toList());
         hexString.append(String.join(";", terrains));
-
         return hexString.toString();
     }
 

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -915,7 +915,6 @@ public class Hex implements Serializable {
         String theme = "";
         int hexLevel = 0;
         String terrainString = "";
-        boolean isOnBoard = true;
         String[] tokens = clipboardString.split("///");
         for (String token : tokens) {
             String[] infos = token.split("###");

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -63,6 +63,14 @@ public class Hex implements Serializable {
     }
 
     /**
+     * Constructs a clean plain hex at the specified level and coordinates which may be marked on or off the board
+     */
+    public Hex(int level, Coords coords, boolean isOnBoard) {
+        this(level, new Terrain[Terrains.SIZE], null, coords, isOnBoard);
+    }
+
+
+    /**
      * Constructs a Hex with all parameters.
      */
     public Hex(int level, Terrain[] terrains, String theme, Coords c, boolean isOnBoard) {

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -33,6 +33,7 @@ public class Hex implements Serializable {
     private String theme;
     private String originalTheme;
     private int fireTurn;
+    private final boolean isOnBoard;
     //endregion Variable Declarations
 
     //region Constructors
@@ -47,19 +48,27 @@ public class Hex implements Serializable {
      * Constructs a clean, plain hex at specified level.
      */
     public Hex(int level) {
-        this(level, new Terrain[Terrains.SIZE], null, new Coords(0, 0));
+        this(level, new Terrain[Terrains.SIZE], null, new Coords(0, 0), true);
     }
 
     public Hex(int level, Terrain[] terrains, String theme) {
-        this(level, terrains, theme, new Coords(0, 0));
+        this(level, terrains, theme, new Coords(0, 0), true);
+    }
+
+    /**
+     * Constructs a clean, plain hex at the specified level which may be marked on or off the board
+     */
+    public Hex(int level, boolean isOnBoard) {
+        this(level, new Terrain[Terrains.SIZE], null, new Coords(0, 0), isOnBoard);
     }
 
     /**
      * Constructs a Hex with all parameters.
      */
-    public Hex(int level, Terrain[] terrains, String theme, Coords c) {
+    public Hex(int level, Terrain[] terrains, String theme, Coords c, boolean isOnBoard) {
         this.level = level;
         coords = c;
+        this.isOnBoard = isOnBoard;
         for (final Terrain t : terrains) {
             if (t != null) {
                 this.terrains.put(t.getType(), t);
@@ -75,14 +84,14 @@ public class Hex implements Serializable {
     }
 
     public Hex(int level, String terrain, String theme) {
-        this(level, terrain, theme, new Coords(0, 0));
+        this(level, terrain, theme, new Coords(0, 0),true);
     }
 
     /**
      * Constructs a Hex from a combined string terrains format
      */
-    public Hex(int level, String terrain, String theme, Coords c) {
-        this(level, new Terrain[Terrains.SIZE], theme, c);
+    public Hex(int level, String terrain, String theme, Coords c, boolean isOnBoard) {
+        this(level, new Terrain[Terrains.SIZE], theme, c, isOnBoard);
         for (StringTokenizer st = new StringTokenizer(terrain, ";", false); st.hasMoreTokens();) {
             addTerrain(new Terrain(st.nextToken()));
         }
@@ -180,7 +189,7 @@ public class Hex implements Serializable {
                 continue;
             }
 
-            if (other != null) {
+            if (other.isOnBoard()) {
                 oTerr = other.getTerrain(i);
             } else {
                 oTerr = null;
@@ -189,20 +198,20 @@ public class Hex implements Serializable {
             cTerr.setExit(direction, cTerr.exitsTo(oTerr));
 
             // Water gets a special treatment: Water at the board edge
-            // (hex == null) should usually look like ocean and
+            // (hex.isOffBoard()) should usually look like ocean and
             // therefore always gets connection to outside the board
-            if ((cTerr.getType() == Terrains.WATER) && (other == null)) {
+            if ((cTerr.getType() == Terrains.WATER) && (other.isOffBoard())) {
                 cTerr.setExit(direction, true);
             }
 
             // Roads exit into pavement, too.
-            if ((other != null) && roadsAutoExit && (cTerr.getType() == Terrains.ROAD)
+            if ((other.isOffBoard()) && roadsAutoExit && (cTerr.getType() == Terrains.ROAD)
                     && other.containsTerrain(Terrains.PAVEMENT)) {
                 cTerr.setExit(direction, true);
             }
 
             // buildings must have the same building class
-            if ((other != null) && (cTerr.getType() == Terrains.BUILDING)
+            if ((other.isOnBoard()) && (cTerr.getType() == Terrains.BUILDING)
                     && (terrainLevel(Terrains.BLDG_CLASS) != other.terrainLevel(Terrains.BLDG_CLASS))) {
                 cTerr.setExit(direction, false);
             }
@@ -563,7 +572,7 @@ public class Hex implements Serializable {
         for (Integer i : terrains.keySet()) {
             tcopy[i] = new Terrain(terrains.get(i));
         }
-        return new Hex(level, tcopy, theme, coords);
+        return new Hex(level, tcopy, theme, coords, isOnBoard);
     }
 
     /**
@@ -694,6 +703,20 @@ public class Hex implements Serializable {
      */
     public void setCoords(Coords c) {
         coords = c;
+    }
+
+    /**
+     * @return if this hex is on the board.
+     */
+    public boolean isOnBoard() {
+        return isOnBoard;
+    }
+
+    /**
+     * @return if this hex is off the board.
+     */
+    public boolean isOffBoard() {
+        return !isOnBoard;
     }
 
     /**
@@ -865,6 +888,7 @@ public class Hex implements Serializable {
                 .filter(t -> !Terrains.AUTOMATIC.contains(t))
                 .mapToObj(t -> getTerrain(t).toString()).collect(Collectors.toList());
         hexString.append(String.join(";", terrains));
+
         return hexString.toString();
     }
 
@@ -884,6 +908,7 @@ public class Hex implements Serializable {
         String theme = "";
         int hexLevel = 0;
         String terrainString = "";
+        boolean isOnBoard = true;
         String[] tokens = clipboardString.split("///");
         for (String token : tokens) {
             String[] infos = token.split("###");
@@ -908,6 +933,6 @@ public class Hex implements Serializable {
                     break;
             }
         }
-        return new Hex(hexLevel, terrainString, theme, new Coords(0, 0));
+        return new Hex(hexLevel, terrainString, theme, new Coords(0, 0), true);
     }
 }

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -404,7 +404,7 @@ public interface IAero {
             for (int dir = 0; dir < 6; dir++) {
                 Coords adj = currPos.translated(dir);
                 adjHex = ((Entity) this).getGame().getBoard().getHex(adj);
-                if (!positions.contains(adj) && (adjHex != null) && adjHex.getLevel() <= hex.getLevel()) {
+                if (!positions.contains(adj) && adjHex.isOnBoard() && adjHex.getLevel() <= hex.getLevel()) {
                     allAdjacentHigher = false;
                     break;
                 }
@@ -515,7 +515,7 @@ public interface IAero {
         boolean clear = false;
         for (Coords pos : landingPositions) {
             Hex hex = ((Entity) this).getGame().getBoard().getHex(pos);
-            if (hex == null) {
+            if (hex.isOffBoard()) {
                 continue;
             }
             if (hex.hasPavementOrRoad()) {

--- a/megamek/src/megamek/common/LargeSupportTank.java
+++ b/megamek/src/megamek/common/LargeSupportTank.java
@@ -210,7 +210,7 @@ public class LargeSupportTank extends SupportTank {
         if ((fa % 30) == 0) {
             Hex srcHex = game.getBoard().getHex(src);
             Hex curHex = game.getBoard().getHex(getPosition());
-            if ((srcHex != null) && (curHex != null)) {
+            if (srcHex.isOnBoard() && curHex.isOnBoard()) {
                 LosEffects.AttackInfo ai = LosEffects.buildAttackInfo(src,
                         getPosition(), 1, getElevation(), srcHex.floor(),
                         curHex.floor());

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -478,7 +478,7 @@ public class LosEffects {
 
         final Hex attackerHex = game.getBoard().getHex(attackerPosition);
         final Hex targetHex = game.getBoard().getHex(targetPosition);
-        if ((attackerHex == null) || (targetHex == null)) {
+        if (attackerHex.isOffBoard() || targetHex.isOffBoard()) {
             LosEffects los = new LosEffects();
             los.blocked = true; // TODO: come up with a better "impossible"
             los.hasLoS = false;
@@ -612,7 +612,7 @@ public class LosEffects {
 
         final Hex attackerHex = game.getBoard().getHex(attackerPosition);
         final Hex targetHex = game.getBoard().getHex(targetPosition);
-        if ((attackerHex == null) || (targetHex == null)) {
+        if (attackerHex.isOffBoard() || targetHex.isOffBoard()) {
             LosEffects los = new LosEffects();
             los.blocked = true; // TODO: come up with a better "impossible"
             los.hasLoS = false;

--- a/megamek/src/megamek/common/Mek.java
+++ b/megamek/src/megamek/common/Mek.java
@@ -4173,7 +4173,7 @@ public abstract class Mek extends Entity {
     @Override
     public boolean isLocationProhibited(Coords c, int currElevation) {
         Hex hex = game.getBoard().getHex(c);
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return false;
         }
         if (hex.containsTerrain(Terrains.IMPASSABLE)) {

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -451,7 +451,7 @@ public class MovePath implements Cloneable, Serializable {
         // jumping into heavy woods is danger
         if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_PSR_JUMP_HEAVY_WOODS)) {
             Hex hex = game.getBoard().getHex(step.getPosition());
-            if ((hex != null) && isJumping() && step.isEndPos(this)) {
+            if (hex.isOnBoard() && isJumping() && step.isEndPos(this)) {
                 PilotingRollData psr = entity.checkLandingInHeavyWoods(step.getMovementType(false), hex);
                 if (psr.getValue() != PilotingRollData.CHECK_FALSE) {
                     step.setDanger(true);

--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3244,7 +3244,7 @@ public class MoveStep implements Serializable {
         final Coords dest = getPosition();
         final Hex destHex = game.getBoard().getHex(dest);
         final Entity entity = getEntity();
-        if (destHex == null) {
+        if (destHex.isOffBoard()) {
             return false;
         }
         if (null == dest) {

--- a/megamek/src/megamek/common/SuperHeavyTank.java
+++ b/megamek/src/megamek/common/SuperHeavyTank.java
@@ -289,7 +289,7 @@ public class SuperHeavyTank extends Tank {
         if ((fa % 30) == 0) {
             Hex srcHex = game.getBoard().getHex(src);
             Hex curHex = game.getBoard().getHex(getPosition());
-            if ((srcHex != null) && (curHex != null)) {
+            if (srcHex.isOnBoard() && curHex.isOnBoard()) {
                 LosEffects.AttackInfo ai = LosEffects.buildAttackInfo(src, getPosition(),
                         1, getElevation(), srcHex.floor(), curHex.floor());
                 ArrayList<Coords> in = Coords.intervening(ai.attackPos, ai.targetPos,

--- a/megamek/src/megamek/common/actions/BAVibroClawAttackAction.java
+++ b/megamek/src/megamek/common/actions/BAVibroClawAttackAction.java
@@ -79,7 +79,7 @@ public class BAVibroClawAttackAction extends AbstractAttackAction {
 
         final Hex attHex = game.getBoard().getHex(ae.getPosition());
         final Hex targHex = game.getBoard().getHex(target.getPosition());
-        if ((attHex == null) || (targHex == null)) {
+        if ((attHex.isOffBoard()) || (targHex.isOffBoard())) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "off board");
         }
 

--- a/megamek/src/megamek/common/actions/ProtoMekPhysicalAttackAction.java
+++ b/megamek/src/megamek/common/actions/ProtoMekPhysicalAttackAction.java
@@ -111,7 +111,7 @@ public class ProtoMekPhysicalAttackAction extends AbstractAttackAction {
 
         final Hex attHex = game.getBoard().getHex(ae.getPosition());
         final Hex targHex = game.getBoard().getHex(target.getPosition());
-        if ((attHex == null) || (targHex == null)) {
+        if (attHex.isOffBoard() || targHex.isOffBoard()) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "off board");
         }
         final int attackerElevation = ae.getElevation() + attHex.getLevel();

--- a/megamek/src/megamek/common/actions/PushAttackAction.java
+++ b/megamek/src/megamek/common/actions/PushAttackAction.java
@@ -92,10 +92,10 @@ public class PushAttackAction extends DisplacementAttackAction {
         Hex attHex = game.getBoard().getHex(ae.getPosition());
         Hex targHex = game.getBoard().getHex(te.getPosition());
 
-        if (attHex == null) {
+        if (attHex.isOffBoard()) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "Entity #" + ae.getId() + " does not know its position.");
         }
-        if (targHex == null) {
+        if (targHex.isOffBoard()) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "Entity #" + te.getId() + " does not know its position.");
         }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -550,7 +550,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if (te == null) {
             Hex hex = game.getBoard().getHex(target.getPosition());
 
-            targEl = hex == null ? 0 : -hex.depth();
+            targEl = hex.isOffBoard() ? 0 : -hex.depth();
         } else {
             targEl = te.relHeight();
         }
@@ -4572,8 +4572,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Target's hex
         Hex targHex = game.getBoard().getHex(target.getPosition());
 
-        boolean targetHexContainsWater = targHex != null && targHex.containsTerrain(Terrains.WATER);
-        boolean targetHexContainsFortified = targHex != null && targHex.containsTerrain(Terrains.FORTIFIED);
+        boolean targetHexContainsWater = targHex.isOnBoard() && targHex.containsTerrain(Terrains.WATER);
+        boolean targetHexContainsFortified = targHex.isOnBoard() && targHex.containsTerrain(Terrains.FORTIFIED);
 
         Entity te = null;
         if (ttype == Targetable.TYPE_ENTITY) {
@@ -4803,7 +4803,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         Entity targetEntity = (Entity) target;
 
         Hex targetHex = targetEntity.getGame().getBoard().getHex(target.getPosition());
-        if (targetHex == null) {
+        if (targetHex.isOffBoard()) {
             return false;
         }
 

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -312,7 +312,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         // move? Currently not, but if we did, this is probably where this logic would
         // go.
         return path.getCachedEntityState().getNumBreachedLegs() > 0 &&
-                hex != null &&
+                hex.isOnBoard() &&
                 hex.terrainLevel(Terrains.WATER) > 0;
     }
 

--- a/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/InfantryPathFinder.java
@@ -172,7 +172,7 @@ public class InfantryPathFinder {
             // if we're definitely going to collapse a bridge we're stepping on let's just
             // stop right here. we're walking *through* buildings, so collapsing them isn't
             // going to be a problem
-            if (destinationHex == null ||
+            if (destinationHex.isOffBoard() ||
                     destinationHex.containsTerrain(Terrains.BRIDGE_CF) &&
                             (destinationHex.getTerrain(Terrains.BRIDGE_CF).getLevel() < startingPath.getEntity()
                                     .getWeight())) {

--- a/megamek/src/megamek/common/pathfinder/PathDecorator.java
+++ b/megamek/src/megamek/common/pathfinder/PathDecorator.java
@@ -35,10 +35,10 @@ import megamek.common.pathfinder.LongestPathFinder.MovePathMinefieldAvoidanceMin
  * @author NickAragua
  */
 public class PathDecorator {
-    
+
     public static Set<MovePath> decoratePath(BulldozerMovePath source) {
         Set<MovePath> result = new HashSet<>();
-        
+
         // paths that aren't on the ground require separate and special logic
         if (source.isJumping()) {
             result.addAll(decorateJumpPath(source));
@@ -49,51 +49,51 @@ public class PathDecorator {
         } else {
             result.addAll(decorateGroundPath(source));
         }
-        
+
         return result;
     }
-    
+
     /**
      * Takes a given (jumping) path and returns a list of child paths that lead up to max jump MP or
      * max jump MP without gravity.
      */
     public static Set<MovePath> decorateJumpPath(BulldozerMovePath source) {
         Set<MovePath> retVal = new HashSet<>();
-        
+
         MovePath clippedSource = source.clone();
         clippedSource.clipToPossible();
-        
+
         // jumping move paths are pretty easy to clip
         // there are two interesting MP amounts - current jump MP and jump MP without "bonus" for low gravity.
         Set<Integer> desiredMPs = new HashSet<>();
         desiredMPs.add(source.getCachedEntityState().getJumpMP());
         desiredMPs.add(source.getCachedEntityState().getJumpMPNoGravity());
-        
+
         for (int desiredMP : desiredMPs) {
             List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
             retVal.addAll(clippedPaths);
         }
-        
+
         // if there is a bad guy in the last step, clip to one step short and see if we can't get around.
         if ((clippedSource.getLastStep() != null) &&
             clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
             clippedSource.removeLastStep();
-            
+
             for (int desiredMP : desiredMPs) {
                 List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
                 retVal.addAll(clippedPaths);
             }
         }
-        
+
         return retVal;
     }
-    
+
     /**
      * Takes the given path and returns a list of child paths that go up to walk/run/run+masc/sprint/sprint+masc MP usage.
      */
     public static Set<MovePath> decorateGroundPath(BulldozerMovePath source) {
         Set<MovePath> retVal = new HashSet<>();
-     
+
         // we want to generate the following paths and decorations:
         // a "walking" path
         // a "running" path
@@ -101,10 +101,10 @@ public class PathDecorator {
         // a "sprinting" path
         // a "sprint with masc" path
         // decorations are movement possibilities that "fill up" any remaining MP with turns and unrelated moves
-        
+
         MovePath clippedSource = source.clone();
         clippedSource.clipToPossible();
-        
+
         Set<Integer> desiredMPs = new HashSet<>();
         desiredMPs.add(source.getCachedEntityState().getSprintMP());
         desiredMPs.add(source.getCachedEntityState().getSprintMPwithoutMASC());
@@ -117,21 +117,21 @@ public class PathDecorator {
             List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
             retVal.addAll(clippedPaths);
         }
-        
+
         // if there is a bad guy in the last step, clip to one step short and see if we can't get around.
         if ((clippedSource.getLastStep() != null) &&
             clippedSource.getGame().getFirstEnemyEntity(clippedSource.getLastStep().getPosition(), clippedSource.getEntity()) != null) {
             clippedSource.removeLastStep();
-            
+
             for (int desiredMP : desiredMPs) {
                 List<MovePath> clippedPaths = clipToDesiredMP(clippedSource, desiredMP);
                 retVal.addAll(clippedPaths);
             }
         }
-        
+
         return retVal;
     }
-    
+
     /**
      * Clips the given path until it only uses the desired MP or less.
      */
@@ -142,7 +142,7 @@ public class PathDecorator {
         }
         return generatePossiblePaths(newPath, desiredMP);
     }
-    
+
     /**
      * Uses the LongestPathFinder to generate all paths possible from a starting path,
      * up to the desired MP
@@ -155,9 +155,9 @@ public class PathDecorator {
         lpf.run(source);
         return new ArrayList<>(lpf.getLongestComputedPaths());
     }
-    
+
     /**
-     * For units using VTOL movement, add "UP" steps to the end of the MovePath source 
+     * For units using VTOL movement, add "UP" steps to the end of the MovePath source
      * so that a forward movement can pass over intervening terrain
      */
     public static void AdjustElevationForForwardMovement(MovePath source) {
@@ -165,29 +165,29 @@ public class PathDecorator {
         if (source.getEntity().getMovementMode() != EntityMovementMode.VTOL) {
             return;
         }
-        
+
         // get the hex that is in the direction we're facing
         Coords destinationCoords = source.getFinalCoords().translated(source.getFinalFacing());
         Hex destHex = source.getGame().getBoard().getHex(destinationCoords);
-        if (destHex == null) {
+        if (destHex.isOffBoard()) {
             return;
         }
-        
+
         // If the unit cannot go up in it's current hex, nothing can be done
         int entityElevation = source.getFinalElevation();
         boolean canGoUp = source.getEntity().canGoUp(entityElevation, source.getFinalCoords());
         if (!canGoUp) {
             return;
         }
-        
+
         Hex srcHex = source.getGame().getBoard().getHex(source.getFinalCoords());
-        int absHeight = srcHex.getLevel() + entityElevation;  
+        int absHeight = srcHex.getLevel() + entityElevation;
         int destElevation = absHeight - destHex.getLevel();
         int safeElevation = destHex.maxTerrainFeatureElevation(false);
-        
-        // Add as many UP steps as MP will allow, until able to move forward 
+
+        // Add as many UP steps as MP will allow, until able to move forward
         while (destElevation <= safeElevation) {
-            // Do not go up if the unit can go forward before rising above the 
+            // Do not go up if the unit can go forward before rising above the
             // maximum terrain elevation, e.g. under a bridge
             // VTOLs shouldn't land in this way, however.
             boolean noLanding = (destElevation >= 1);
@@ -199,7 +199,7 @@ public class PathDecorator {
             }
             if (source.getEntity().isElevationValid(destElevation, destHex) && noLanding) {
                 return;
-            }   
+            }
 
             source.addStep(MoveStepType.UP);
 
@@ -207,7 +207,7 @@ public class PathDecorator {
                 source.removeLastStep();
                 return;
             }
-            
+
             destElevation++;
         }
     }

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -400,16 +400,16 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
             return 0;
         }
         Hex currHex = board.getHex(mp.getFinalCoords());
-        if (currHex == null) {
-            logger.debug("getLevelDiff: currHex was null!" +
+        if (currHex.isOffBoard()) {
+            logger.debug("getLevelDiff: currHex is off the board!" +
                     "\nStart: " + mp.getStartCoords() +
                     "\ncurrHex:  " + mp.getFinalCoords() +
                     "\nPath: " + mp);
             return 0;
         }
         Hex destHex = board.getHex(dest);
-        if (destHex == null) {
-            logger.debug("getLevelDiff: destHex was null!" +
+        if (destHex.isOffBoard()) {
+            logger.debug("getLevelDiff: destHex is off the board!" +
                     "\nStart: " + mp.getStartCoords() +
                     "\ndestHex: " + dest +
                     "\nPath: " + mp);

--- a/megamek/src/megamek/common/planetaryconditions/IlluminationLevel.java
+++ b/megamek/src/megamek/common/planetaryconditions/IlluminationLevel.java
@@ -90,7 +90,7 @@ public enum IlluminationLevel {
 
         // Fires can reduce nighttime penalties by up to 2 points.
         final Hex hex = game.getBoard().getHex(coords);
-        if ((hex != null) && hex.containsTerrain(Terrains.FIRE)) {
+        if (hex.isOnBoard() && hex.containsTerrain(Terrains.FIRE)) {
             return IlluminationLevel.FIRE;
         }
 

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -136,9 +136,9 @@ public class BoardUtilities {
         for (int h = 0; h < mapSettings.getBoardHeight(); h++) {
             for (int w = 0; w < mapSettings.getBoardWidth(); w++) {
                 if (mapSettings.getMedium() == MapSettings.MEDIUM_SPACE) {
-                    nb[index++] = new Hex(0, "space:1", mapSettings.getTheme(), new Coords(w, h));
+                    nb[index++] = new Hex(0, "space:1", mapSettings.getTheme(), new Coords(w, h), true);
                 } else {
-                    nb[index++] = new Hex(elevationMap[w][h], "", mapSettings.getTheme(), new Coords(w, h));
+                    nb[index++] = new Hex(elevationMap[w][h], "", mapSettings.getTheme(), new Coords(w, h), true);
                 }
             }
         }
@@ -639,7 +639,7 @@ public class BoardUtilities {
             for (int dir = 0; dir < 6; dir++) {
                 Point loc = reverseHex.get(field);
                 Hex newHex = board.getHexInDir(loc.x, loc.y, dir);
-                if ((newHex != null) && (!alreadyUsed.contains(newHex))
+                if (newHex.isOnBoard() && (!alreadyUsed.contains(newHex))
                         && (!notYetUsed.contains(newHex))
                         && (!unUsed.contains(newHex))) {
                     ((newHex.containsTerrain(terrainType)) ? notYetUsed : unUsed).add(newHex);
@@ -893,7 +893,7 @@ public class BoardUtilities {
         Hex hex;
 
         hex = board.getHexInDir(current.x, current.y, direction);
-        while ((hex != null) && (width-- > 0)) {
+        while (hex.isOnBoard() && (width-- > 0)) {
             hex.removeAllTerrains();
             hex.addTerrain(new Terrain(Terrains.WATER, 1));
             result.add(hex);

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -372,7 +372,7 @@ public class AreaEffectHelper {
         int cluster = 5;
 
         // Check: is entity inside building?
-        if ((bldg != null) && (bldgAbsorbs > 0) && hex.isOnBoard()
+        if ((bldg != null) && (bldgAbsorbs > 0) && hex != null && hex.isOnBoard()
                 && (entity.getElevation() < hex.terrainLevel(Terrains.BLDG_ELEV))) {
             cluster -= bldgAbsorbs;
             // some buildings scale remaining damage that is not absorbed
@@ -457,7 +457,7 @@ public class AreaEffectHelper {
         // Entity/ammo specific damage modifiers
         if (ammo != null) {
             if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
-                if (hex.isOnBoard() && hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
+                if (hex != null && hex.isOnBoard() && hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
                     hits *= 2;
                 }
             }

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -372,7 +372,7 @@ public class AreaEffectHelper {
         int cluster = 5;
 
         // Check: is entity inside building?
-        if ((bldg != null) && (bldgAbsorbs > 0) && hex != null
+        if ((bldg != null) && (bldgAbsorbs > 0) && hex.isOnBoard()
                 && (entity.getElevation() < hex.terrainLevel(Terrains.BLDG_ELEV))) {
             cluster -= bldgAbsorbs;
             // some buildings scale remaining damage that is not absorbed
@@ -457,7 +457,7 @@ public class AreaEffectHelper {
         // Entity/ammo specific damage modifiers
         if (ammo != null) {
             if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
-                if (hex != null && hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
+                if (hex.isOnBoard() && hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
                     hits *= 2;
                 }
             }
@@ -1037,7 +1037,7 @@ public class AreaEffectHelper {
         }
 
         Hex hex = game.getBoard().getHex(center);
-        boolean effectivelyAE = (hex != null && hex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER)));
+        boolean effectivelyAE = (hex.isOnBoard() && hex.containsAnyTerrainOf(Set.of(Terrains.BUILDING, Terrains.WATER)));
         // 1. Handle Artillery-specific blast column (N levels up from _any_ hit where N
         // is base damage / 10 for most artillery, damage / 25 for Cruise Missiles)
         // Note that this falloff is separate from horizontal blast falloff, above.

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -323,7 +323,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
 
         if (atype.getMunitionType().contains(Munitions.M_FAE)) {
             Hex finalHex = game.getBoard().getHex(finalPos);
-            altitude = (finalHex != null) ? finalHex.getLevel() : altitude;
+            altitude = finalHex.isOnBoard() ? finalHex.getLevel() : altitude;
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     AreaEffectHelper.processFuelAirDamage(
                             finalPos, altitude, atype, aaa.getEntity(game), vPhaseReport, gameManager));

--- a/megamek/src/megamek/common/weapons/MekMortarAirburstHandler.java
+++ b/megamek/src/megamek/common/weapons/MekMortarAirburstHandler.java
@@ -137,7 +137,7 @@ public class MekMortarAirburstHandler extends AmmoWeaponHandler {
         // Damage Terrain if applicable
         Hex h = game.getBoard().getHex(targetPos);
         newReports = new Vector<>();
-        if ((h != null) && h.hasTerrainFactor()) {
+        if (h.isOnBoard() && h.hasTerrainFactor()) {
             r = new Report(3384);
             r.indent(2);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/MissileMineClearanceHandler.java
+++ b/megamek/src/megamek/common/weapons/MissileMineClearanceHandler.java
@@ -173,7 +173,7 @@ public class MissileMineClearanceHandler extends AmmoWeaponHandler {
         // Damage Terrain if applicable
         Hex h = game.getBoard().getHex(targetPos);
         newReports = new Vector<>();
-        if ((h != null) && h.hasTerrainFactor()) {
+        if (h.isOnBoard() && h.hasTerrainFactor()) {
             r = new Report(3384);
             r.indent(2);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/WeaponHandler.java
@@ -1640,7 +1640,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
      * Worker function - does the entity gain partial cover from shallow water?
      */
     protected boolean unitGainsPartialCoverFromWater(Hex targetHex, Entity entityTarget) {
-        return (targetHex != null) &&
+        return (targetHex.isOnBoard()) &&
                 targetHex.containsTerrain(Terrains.WATER) &&
                 (entityTarget.relHeight() == targetHex.getLevel());
     }
@@ -1654,7 +1654,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         // be tall enough for it to make a difference,
         // target "feet" are below the "ceiling"
         // target "head" is above the "ceiling"
-        return (targetHex != null) &&
+        return (targetHex.isOnBoard()) &&
                 (entityTarget.getHeight() > 0) &&
                 (entityTarget.getElevation() < targetHex.ceiling()) &&
                 (entityTarget.relHeight() >= targetHex.ceiling());

--- a/megamek/src/megamek/server/FireProcessor.java
+++ b/megamek/src/megamek/server/FireProcessor.java
@@ -243,7 +243,7 @@ public class FireProcessor extends DynamicTerrainProcessor {
         // unless a higher hex intervenes
         Hex nextHex = game.getBoard().getHex(nextCoords);
         Hex jumpHex = game.getBoard().getHex(nextCoords.translated(windDir.ordinal()));
-        if ((nextHex != null) && (jumpHex != null) && !(nextHex.containsTerrain(Terrains.FIRE))
+        if (nextHex.isOnBoard() && jumpHex.isOnBoard() && !(nextHex.containsTerrain(Terrains.FIRE))
                 && ((curHeight >= nextHex.ceiling()) || (jumpHex.ceiling() >= nextHex.ceiling()))) {
             // we've already gone one step in the wind direction, now go another
             directroll.addModifier(3, "crossing non-burning hex");
@@ -269,7 +269,7 @@ public class FireProcessor extends DynamicTerrainProcessor {
     public void spreadFire(final Coords origin, final Coords coords, final TargetRoll roll,
             final int height) {
         Hex hex = game.getBoard().getHex(coords);
-        if ((hex == null) || (Math.abs(hex.ceiling() - height) > 4)) {
+        if ((hex.isOffBoard()) || (Math.abs(hex.ceiling() - height) > 4)) {
             // Don't attempt to spread fire off the board or for large differences in height
             return;
         }
@@ -348,7 +348,7 @@ public class FireProcessor extends DynamicTerrainProcessor {
         for (SmokeCloud cloud : game.getSmokeCloudList()) {
             for (Coords coords : cloud.getCoordsList()) {
                 Hex smokeHex = gameManager.getGame().getBoard().getHex(coords);
-                if (smokeHex != null) {
+                if (smokeHex.isOnBoard()) {
                     if (smokeHex.containsTerrain(Terrains.SMOKE)) {
                         if (smokeHex.terrainLevel(Terrains.SMOKE) == SmokeCloud.SMOKE_LIGHT) {
                             smokeHex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_HEAVY));

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -60,7 +60,7 @@ public class ServerHelper {
                 te_hex = game.getBoard().getHex(te.getPosition());
             }
 
-            if ((te_hex != null) && !te_hex.containsTerrain(Terrains.WOODS) && !te_hex.containsTerrain(Terrains.JUNGLE)
+            if (te_hex.isOnBoard() && !te_hex.containsTerrain(Terrains.WOODS) && !te_hex.containsTerrain(Terrains.JUNGLE)
                     && !te_hex.containsTerrain(Terrains.ROUGH) && !te_hex.containsTerrain(Terrains.RUBBLE)
                     && !te_hex.containsTerrain(Terrains.SWAMP) && !te_hex.containsTerrain(Terrains.BUILDING)
                     && !te_hex.containsTerrain(Terrains.FUEL_TANK) && !te_hex.containsTerrain(Terrains.FORTIFIED)

--- a/megamek/src/megamek/server/commands/ShowTileCommand.java
+++ b/megamek/src/megamek/server/commands/ShowTileCommand.java
@@ -31,7 +31,7 @@ import megamek.server.totalwarfare.TWGameManager;
  * This command exists to print tile information to the chat window and is
  * primarily intended for
  * visually impaired users.
- * 
+ *
  * @author dirk
  */
 public class ShowTileCommand extends ServerCommand {
@@ -59,7 +59,7 @@ public class ShowTileCommand extends ServerCommand {
 
             do {
                 hex = gameManager.getGame().getBoard().getHex(coord);
-                if (hex != null) {
+                if (hex.isOnBoard()) {
                     str = "Details for hex (" + (coord.getX() + 1) + ", "
                             + (coord.getY() + 1) + ") : " + hex;
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -3267,10 +3267,10 @@ public class TWGameManager extends AbstractGameManager {
         unit.setSecondaryFacing(facing);
 
         Hex hex = game.getBoard().getHex(pos);
-        boolean isBridge = (hex != null)
+        boolean isBridge = (hex.isOnBoard())
                 && hex.containsTerrain(Terrains.PAVEMENT);
 
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             unit.setElevation(elevation);
         } else if (unloader.getMovementMode() == EntityMovementMode.VTOL) {
             if (unit.getMovementMode() == EntityMovementMode.VTOL) {
@@ -3768,7 +3768,7 @@ public class TWGameManager extends AbstractGameManager {
         if (altitude == 1) {
             Hex hex = getGame().getBoard().getHex(curPos);
             int elevation = 0;
-            if (hex != null) {
+            if (hex.isOnBoard()) {
                 elevation = (hex.getTerrain(Terrains.BLDG_ELEV) != null) ? hex.maxTerrainFeatureElevation(false) : 0;
             }
             EntityMovementMode moveMode = drop.getMovementMode();
@@ -6490,7 +6490,7 @@ public class TWGameManager extends AbstractGameManager {
         vPhaseReport.add(r);
         createSmoke(coords, SmokeCloud.SMOKE_HEAVY, 3);
         Hex hex = game.getBoard().getHex(coords);
-        if (hex != null) {
+        if (hex.isOnBoard()) {
             hex.addTerrain(new Terrain(Terrains.SMOKE, SmokeCloud.SMOKE_HEAVY));
             sendChangedHex(coords);
             for (int dir = 0; dir <= 5; dir++) {
@@ -6795,7 +6795,7 @@ public class TWGameManager extends AbstractGameManager {
             case Targetable.TYPE_BLDG_IGNITE:
                 // Report that damage applied to terrain, if there's TF to damage
                 Hex h = game.getBoard().getHex(t.getPosition());
-                if ((h != null) && h.hasTerrainFactor()) {
+                if (h.isOnBoard() && h.hasTerrainFactor()) {
                     r = new Report(3384);
                     r.indent(2);
                     r.subject = attId;
@@ -8069,7 +8069,7 @@ public class TWGameManager extends AbstractGameManager {
         Vector<Report> vPhaseReport = new Vector<>();
         PlanetaryConditions conditions = game.getPlanetaryConditions();
         boolean aeroSpaceborne = (entity.getEntityType() & Entity.ETYPE_AERO) == 0 && entity.isSpaceborne();
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return vPhaseReport;
         }
         if ((hex.terrainLevel(Terrains.WATER) > 0) && !isJump
@@ -8904,7 +8904,7 @@ public class TWGameManager extends AbstractGameManager {
         final int direction = src.direction(dest);
 
         // Handle null hexes.
-        if ((srcHex == null) || (destHex == null)) {
+        if (srcHex.isOffBoard() || destHex.isOffBoard()) {
             logger.error("Can not displace " + entity.getShortName()
                     + " from " + src + " to " + dest + ".");
             return displacementReport;
@@ -11061,7 +11061,7 @@ public class TWGameManager extends AbstractGameManager {
         Report r;
 
         // Ignore bad coordinates.
-        if (hex == null) {
+        if (hex.isOffBoard()) {
             return false;
         }
 
@@ -11194,7 +11194,7 @@ public class TWGameManager extends AbstractGameManager {
     public Vector<Report> tryClearHex(Coords c, int nDamage, int entityId) {
         Vector<Report> vPhaseReport = new Vector<>();
         Hex h = game.getBoard().getHex(c);
-        if (h == null) {
+        if (h.isOffBoard()) {
             return vPhaseReport;
         }
         Terrain woods = h.getTerrain(Terrains.WOODS);
@@ -15316,7 +15316,7 @@ public class TWGameManager extends AbstractGameManager {
                 }
             }
 
-            if (entity.tracksHeat() && (entityHex != null) && entityHex.containsTerrain(Terrains.FIRE)
+            if (entity.tracksHeat() && entityHex.isOnBoard() && entityHex.containsTerrain(Terrains.FIRE)
                     && (entityHex.getFireTurn() > 0)
                     && (entity.getElevation() <= 1) && (entity.getAltitude() == 0)) {
                 int heatToAdd = 5;
@@ -15445,7 +15445,7 @@ public class TWGameManager extends AbstractGameManager {
 
             // Add +5 Heat if the hex you're in is on fire
             // and was on fire for the full round.
-            if (entityHex != null) {
+            if (entityHex.isOnBoard()) {
                 int magma = entityHex.terrainLevel(Terrains.MAGMA);
                 if ((magma > 0) && (entity.getElevation() == 0)) {
                     int heatToAdd = 5 * magma;
@@ -20369,7 +20369,7 @@ public class TWGameManager extends AbstractGameManager {
         int maxDist = damages.length;
         Hex hex = game.getBoard().getHex(position);
         // Center hex starts on fire for engine explosions
-        if (engineExplosion && (hex != null) && !hex.containsTerrain(Terrains.FIRE)) {
+        if (engineExplosion && hex.isOnBoard() && !hex.containsTerrain(Terrains.FIRE)) {
             r = new Report(5136);
             r.indent(2);
             r.type = Report.PUBLIC;
@@ -20382,7 +20382,7 @@ public class TWGameManager extends AbstractGameManager {
             }
             vDesc.addAll(reports);
         }
-        if ((hex != null) && hex.hasTerrainFactor()) {
+        if (hex.isOnBoard() && hex.hasTerrainFactor()) {
             r = new Report(3384);
             r.indent(2);
             r.type = Report.PUBLIC;
@@ -20401,7 +20401,7 @@ public class TWGameManager extends AbstractGameManager {
             List<Coords> coords = position.allAtDistance(dist);
             for (Coords c : coords) {
                 hex = game.getBoard().getHex(c);
-                if ((hex != null) && hex.hasTerrainFactor()) {
+                if (hex.isOnBoard() && hex.hasTerrainFactor()) {
                     r = new Report(3384);
                     r.indent(2);
                     r.type = Report.PUBLIC;
@@ -20619,7 +20619,7 @@ public class TWGameManager extends AbstractGameManager {
         Hex shelteringHex = game.getBoard().getHex(shelteringCoords);
 
         // This is an error condition. It really shouldn't ever happen.
-        if (shelteringHex == null) {
+        if (shelteringHex.isOffBoard()) {
             return false;
         }
 
@@ -24684,7 +24684,7 @@ public class TWGameManager extends AbstractGameManager {
         Coords curPos = entity.getPosition();
         Hex entityHex = game.getBoard().getHex(curPos);
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BATTLE_WRECK)
-                && (entityHex != null) && game.getBoard().onGround()
+                && entityHex.isOnBoard() && game.getBoard().onGround()
                 && !entityHex.containsTerrain(Terrains.ULTRA_SUBLEVEL)
                 && !((entity instanceof Infantry) || (entity instanceof ProtoMek))) {
             // large support vees will create ultra rough, otherwise rough
@@ -25820,7 +25820,7 @@ public class TWGameManager extends AbstractGameManager {
         for (Coords smokeCoords : coords) {
             Hex smokeHex = game.getBoard().getHex(smokeCoords);
             Report r;
-            if (smokeHex == null) {
+            if (smokeHex.isOffBoard()) {
                 continue;
             }
             // Have to check if it's inferno smoke or from a heavy/hardened
@@ -30324,7 +30324,7 @@ public class TWGameManager extends AbstractGameManager {
         // Terrain modifiers should only apply if the unit is on the ground...
         // TO:AR 6th ed p165
         if (!entity.isSpaceborne() && !entity.isAirborne()) {
-            if (targetHex != null) {
+            if (targetHex.isOnBoard()) {
                 if ((targetHex.terrainLevel(Terrains.WATER) > 0)
                         && !targetHex.containsTerrain(Terrains.ICE)) {
                     rollTarget.addModifier(-1, "landing in water");
@@ -31445,19 +31445,19 @@ public class TWGameManager extends AbstractGameManager {
                 BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_LARGE);
         Building bldg = game.getBoard().getBuildingAt(coords);
         Hex hex = game.getBoard().getHex(coords);
-        int effectiveLevel = (hex != null) ? hex.getLevel() : 0;
+        int effectiveLevel = hex.isOnBoard() ? hex.getLevel() : 0;
 
         Report r;
 
         // We only process _some_ of the normal damage when a hex is off-board
-        if (hex != null) {
+        if (hex.isOnBoard()) {
 
             // Non-flak artillery damages terrain
             // TODO: account for altitude vs: terrain height
             if (!flak) {
                 // Report that damage applied to terrain, if there's TF to damage
                 Hex h = game.getBoard().getHex(coords);
-                if ((h != null) && h.hasTerrainFactor()) {
+                if (h.isOnBoard() && h.hasTerrainFactor()) {
                     r = new Report(3384);
                     r.indent(2);
                     r.subject = subjectId;
@@ -31666,7 +31666,7 @@ public class TWGameManager extends AbstractGameManager {
         // Pretend we know what level the user was aiming at.
         // TODO: remove once we can pass targetLevel info between client and server
         int targetLevel = 0;
-        if (hex != null) {
+        if (hex.isOnBoard()) {
             targetLevel = hex.getLevel();
             if (hex.getTerrain(Terrains.BLDG_ELEV) != null) {
                 // Get an entity that's near or below the ceiling level
@@ -31971,7 +31971,7 @@ public class TWGameManager extends AbstractGameManager {
     public void removeSmokeTerrain(SmokeCloud cloud) {
         for (Coords coords : cloud.getCoordsList()) {
             Hex hex = game.getBoard().getHex(coords);
-            if ((hex != null) && hex.containsTerrain(Terrains.SMOKE)) {
+            if (hex.isOnBoard() && hex.containsTerrain(Terrains.SMOKE)) {
                 hex.removeTerrain(Terrains.SMOKE);
                 sendChangedHex(coords);
             }

--- a/megamek/unittests/megamek/common/ComputeArtilleryTest.java
+++ b/megamek/unittests/megamek/common/ComputeArtilleryTest.java
@@ -21,6 +21,7 @@ package megamek.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -82,7 +83,9 @@ class ComputeArtilleryTest {
     @Test
     void testComplexCalculateLead() {
         // Mock the board
+        Hex mockHex = mock(Hex.class);
         Board mockBoard = mock(Board.class);
+        when(mockBoard.getHex(any())).thenReturn(mockHex);
         Game mockGame = mock(Game.class);
         when(mockGame.getBoard()).thenReturn(mockBoard);
 

--- a/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
+++ b/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
@@ -48,6 +48,7 @@ public class WeaponAttackActionToHitTest {
     GameOptions mockOptions;
     PlanetaryConditions mockPlanetaryConditions;
 
+    Hex mockHex;
     Board mockBoard;
     Game mockGame;
     LosEffects mockLos;
@@ -73,9 +74,14 @@ public class WeaponAttackActionToHitTest {
         when(mockPlayer.isEnemyOf(mockEnemy)).thenReturn(true);
         when(mockEnemy.isEnemyOf(mockPlayer)).thenReturn(true);
 
+        //Mock a Hex
+        mockHex = mock(Hex.class);
+
         // Mock the board
         mockBoard = mock(Board.class);
         when(mockBoard.inSpace()).thenReturn(false);
+        when(mockBoard.getHex(anyInt(), anyInt())).thenReturn(mockHex);
+        when(mockBoard.getHex(any(Coords.class))).thenReturn(mockHex);
 
         // Mock Options
         mockOptions = mock(GameOptions.class);

--- a/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -112,6 +113,11 @@ class AreaEffectHelperTest {
     void testShapeBlastR2ArtilleryAttackOnBoardNoAETerrainLevel0() {
         game.setBoard(new Board(16,17));
         Coords centerPoint = new Coords(7,7);
+        ArrayList<Coords> areaOfEffectHexCoords = centerPoint.allAtDistanceOrLess(1);
+        areaOfEffectHexCoords.forEach(coords -> {
+            Hex adjacentHex = new Hex(0);
+            game.getBoard().setHex(coords, adjacentHex);
+        });
         AmmoType ammo = mockLTAmmoType;
         DamageFalloff falloff = calculateDamageFallOff(ammo, 0, false);
         HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
@@ -126,6 +132,11 @@ class AreaEffectHelperTest {
     void testShapeBlastR1ArtilleryAttackOnBoardNoAETerrainLevel0() {
         game.setBoard(new Board(16,17));
         Coords centerPoint = new Coords(7,7);
+        ArrayList<Coords> areaOfEffectHexCoords = centerPoint.allAtDistanceOrLess(1);
+        areaOfEffectHexCoords.forEach(coords -> {
+            Hex adjacentHex = new Hex(0);
+            game.getBoard().setHex(coords, adjacentHex);
+        });
         HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
             mockSniperAmmoType,
             centerPoint, 0, true, false, false, game, false
@@ -139,6 +150,11 @@ class AreaEffectHelperTest {
     void testShapeBlastR1ArtilleryAttackOnBoardNoAETerrainLevel2Flak() {
         game.setBoard(new Board(16,17));
         Coords centerPoint = new Coords(7,7);
+        ArrayList<Coords> areaOfEffectHexCoords = centerPoint.allAtDistanceOrLess(1);
+        areaOfEffectHexCoords.forEach(coords -> {
+            Hex adjacentHex = new Hex(0);
+            game.getBoard().setHex(coords, adjacentHex);
+        });
         int height = 2;
         HashMap<Map.Entry<Integer, Coords>, Integer> shape = AreaEffectHelper.shapeBlast(
             mockSniperAmmoType,
@@ -159,6 +175,15 @@ class AreaEffectHelperTest {
         int expectedHalfDamage = (int) Math.ceil(mockBombHEAmmoType.getDamagePerShot() / 2.0);
         game.setBoard(new Board(16,17));
         Coords centerPoint = new Coords(7,7);
+        // The radial hexes have to be set first so they are not null when the centerPoint
+        // hex is added.  It has exitable terrain and attempts to update the adjacent hexes
+        ArrayList<Coords> areaOfEffectHexCoords = centerPoint.allAtDistanceOrLess(1);
+        areaOfEffectHexCoords.forEach(coords -> {
+            if (!coords.equals(centerPoint)) {
+                Hex adjacentHex = new Hex(0);
+                game.getBoard().setHex(coords, adjacentHex);
+            }
+        });
         Hex hex = new Hex(0);
         hex.addTerrain(new Terrain(Terrains.BUILDING, height, true, 63));
         game.getBoard().setHex(centerPoint, hex);
@@ -182,6 +207,15 @@ class AreaEffectHelperTest {
         int expectedHalfDamage = (int) Math.ceil(mockBombFAEAmmoType.getDamagePerShot() / 2.0);
         game.setBoard(new Board(16,17));
         Coords centerPoint = new Coords(7,7);
+        // The radial hexes have to be set first so they are not null when the centerPoint
+        // hex is added.  It has exitable terrain and attempts to update the adjacent hexes
+        ArrayList<Coords> areaOfEffectHexCoords = centerPoint.allAtDistanceOrLess(2);
+        areaOfEffectHexCoords.forEach(coords -> {
+            if (!coords.equals(centerPoint)) {
+                Hex adjacentHex = new Hex(0);
+                game.getBoard().setHex(coords, adjacentHex);
+            }
+        });
         Hex hex = new Hex(0);
         hex.addTerrain(new Terrain(Terrains.BUILDING, height, true, 63));
         game.getBoard().setHex(centerPoint, hex);


### PR DESCRIPTION
Implements #6564 

The core change here is to implement an isOnBoard flag in the Hex class, and then update the Board class to always return a Hex object from the getHex method instead of a null.  The returned Hex will have isOnBoard set to false if the coordinates are outside the board. Two new methods were added to Hex to facilitate checking if the hex is on board or off board.

A secondary change is to update all the places in the code a null check happens. Null checks in either direction equals or not equals were updated to use the new isOffBoard and isOnBoard (respectively) methods.

