### PR TITLE
Fixes #6585 - Planted Field Blocking WiGE movement.

### DIFF
--- a/megamek/src/megamek/common/MoveStep.java
+++ b/megamek/src/megamek/common/MoveStep.java
@@ -3763,6 +3763,11 @@ public class MoveStep implements Serializable {
                     return false;
                 }
             } else if (elevation <= (destHex.ceiling() - destHex.getLevel())) {
+                // WiGE are not prohibited from flying over planted fields.
+                if ((entity.getMovementMode() == EntityMovementMode.WIGE) && destHex.containsTerrain(Terrains.FIELDS)) {
+                    return true;
+                }
+
                 // VTOLs and WiGEs can fly through woods and jungle below the level of the
                 // treetops on a road.
                 if (destHex.containsTerrain(Terrains.WOODS) || destHex.containsTerrain(Terrains.JUNGLE)) {


### PR DESCRIPTION
Fixes #6585 - Planted Field Blocking WiGE movement.

Planted fields are not a blocking terrain for WiGE movement modes.  