### PR TITLE
Simplify Hex class to handle on board check

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/SummaryPanel.java
@@ -162,7 +162,7 @@ public class SummaryPanel extends PicMap {
 
             Hex mhex = entity.getGame().getBoard().getHex(entity.getPosition());
 
-            if (mhex.isOnBoard()) {
+            if (mhex != null) {
                 String terrainTip = HexTooltip.getTerrainTip(mhex, GUIP, entity.getGame());
                 String attr = String.format("FACE=Dialog BGCOLOR=%s", UIUtil.toColorHexString(GUIP.getUnitToolTipTerrainBGColor()));
                 col = UIUtil.tag("TD", attr, terrainTip);

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -139,6 +139,8 @@ public class Board implements Serializable {
      */
     private final Map<Integer, HexArea> areas = new HashMap<>();
 
+    private static final OffBoardHex offBoardHex = new OffBoardHex();
+
     // endregion Variable Declarations
 
     // region Constructors
@@ -230,7 +232,7 @@ public class Board implements Serializable {
         int index = 0;
         for (int h = 0; h < height; h++) {
             for (int w = 0; w < width; w++) {
-                data[index++] = new Hex(0, "sky:1", "", new Coords(w, h), true);
+                data[index++] = new Hex(0, "sky:1", "", new Coords(w, h));
             }
         }
         Board result = new Board(width, height, data);
@@ -250,7 +252,7 @@ public class Board implements Serializable {
         int index = 0;
         for (int h = 0; h < height; h++) {
             for (int w = 0; w < width; w++) {
-                data[index++] = new Hex(0, "space:1", "", new Coords(w, h), true);
+                data[index++] = new Hex(0, "space:1", "", new Coords(w, h));
             }
         }
         Board result = new Board(width, height, data);
@@ -303,10 +305,10 @@ public class Board implements Serializable {
      *
      * @param x the x Coords.
      * @param y the y Coords.
-     * @return the Hex, if this Board contains the (x, y) location; A clean, plain hex at level 0 and the coords, marked as off board otherwise.
+     * @return the Hex, if this Board contains the (x, y) location; A clean, plain hex at level 0 and the coords, lomarked as off board otherwise.
      */
     public Hex getHex(final int x, final int y) {
-        return contains(x, y) ? data[(y * width) + x] : new Hex(0, new Coords(x, y) , false);
+        return contains(x, y) ? data[(y * width) + x] : offBoardHex;
     }
 
     /**
@@ -1070,7 +1072,7 @@ public class Board implements Serializable {
                     }
                     int elevation = Integer.parseInt(args[1]);
                     // The coordinates in the .board file are ignored!
-                    nd[index] = new Hex(elevation, args[2], args[3], new Coords(index % nw, index / nw), true);
+                    nd[index] = new Hex(elevation, args[2], args[3], new Coords(index % nw, index / nw));
                     index++;
                 } else if ((st.ttype == StreamTokenizer.TT_WORD) && st.sval.equalsIgnoreCase("description")) {
                     st.nextToken();

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -33,7 +33,6 @@ public class Hex implements Serializable {
     private String theme;
     private String originalTheme;
     private int fireTurn;
-    private final boolean isOnBoard;
     //endregion Variable Declarations
 
     //region Constructors
@@ -48,35 +47,19 @@ public class Hex implements Serializable {
      * Constructs a clean, plain hex at specified level.
      */
     public Hex(int level) {
-        this(level, new Terrain[Terrains.SIZE], null, new Coords(0, 0), true);
+        this(level, new Terrain[Terrains.SIZE], null, new Coords(0, 0));
     }
 
     public Hex(int level, Terrain[] terrains, String theme) {
-        this(level, terrains, theme, new Coords(0, 0), true);
+        this(level, terrains, theme, new Coords(0, 0));
     }
-
-    /**
-     * Constructs a clean, plain hex at the specified level which may be marked on or off the board
-     */
-    public Hex(int level, boolean isOnBoard) {
-        this(level, new Terrain[Terrains.SIZE], null, new Coords(0, 0), isOnBoard);
-    }
-
-    /**
-     * Constructs a clean plain hex at the specified level and coordinates which may be marked on or off the board
-     */
-    public Hex(int level, Coords coords, boolean isOnBoard) {
-        this(level, new Terrain[Terrains.SIZE], null, coords, isOnBoard);
-    }
-
 
     /**
      * Constructs a Hex with all parameters.
      */
-    public Hex(int level, Terrain[] terrains, String theme, Coords c, boolean isOnBoard) {
+    public Hex(int level, Terrain[] terrains, String theme, Coords c) {
         this.level = level;
         coords = c;
-        this.isOnBoard = isOnBoard;
         for (final Terrain t : terrains) {
             if (t != null) {
                 this.terrains.put(t.getType(), t);
@@ -92,14 +75,14 @@ public class Hex implements Serializable {
     }
 
     public Hex(int level, String terrain, String theme) {
-        this(level, terrain, theme, new Coords(0, 0),true);
+        this(level, terrain, theme, new Coords(0, 0));
     }
 
     /**
      * Constructs a Hex from a combined string terrains format
      */
-    public Hex(int level, String terrain, String theme, Coords c, boolean isOnBoard) {
-        this(level, new Terrain[Terrains.SIZE], theme, c, isOnBoard);
+    public Hex(int level, String terrain, String theme, Coords c) {
+        this(level, new Terrain[Terrains.SIZE], theme, c);
         for (StringTokenizer st = new StringTokenizer(terrain, ";", false); st.hasMoreTokens();) {
             addTerrain(new Terrain(st.nextToken()));
         }
@@ -580,7 +563,7 @@ public class Hex implements Serializable {
         for (Integer i : terrains.keySet()) {
             tcopy[i] = new Terrain(terrains.get(i));
         }
-        return new Hex(level, tcopy, theme, coords, isOnBoard);
+        return new Hex(level, tcopy, theme, coords);
     }
 
     /**
@@ -717,14 +700,14 @@ public class Hex implements Serializable {
      * @return if this hex is on the board.
      */
     public boolean isOnBoard() {
-        return isOnBoard;
+        return true;
     }
 
     /**
      * @return if this hex is off the board.
      */
     public boolean isOffBoard() {
-        return !isOnBoard;
+        return false;
     }
 
     /**
@@ -939,6 +922,6 @@ public class Hex implements Serializable {
                     break;
             }
         }
-        return new Hex(hexLevel, terrainString, theme, new Coords(0, 0), true);
+        return new Hex(hexLevel, terrainString, theme, new Coords(0, 0));
     }
 }

--- a/megamek/src/megamek/common/OffBoardHex.java
+++ b/megamek/src/megamek/common/OffBoardHex.java
@@ -1,0 +1,18 @@
+package megamek.common;
+
+public class OffBoardHex extends Hex {
+
+    OffBoardHex() {
+        super();
+    }
+
+    @Override
+    public boolean isOnBoard() {
+        return false;
+    }
+
+    @Override
+    public boolean isOffBoard() {
+        return true;
+    }
+}

--- a/megamek/src/megamek/common/OffBoardHex.java
+++ b/megamek/src/megamek/common/OffBoardHex.java
@@ -2,10 +2,6 @@ package megamek.common;
 
 public class OffBoardHex extends Hex {
 
-    OffBoardHex() {
-        super();
-    }
-
     @Override
     public boolean isOnBoard() {
         return false;

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -136,9 +136,9 @@ public class BoardUtilities {
         for (int h = 0; h < mapSettings.getBoardHeight(); h++) {
             for (int w = 0; w < mapSettings.getBoardWidth(); w++) {
                 if (mapSettings.getMedium() == MapSettings.MEDIUM_SPACE) {
-                    nb[index++] = new Hex(0, "space:1", mapSettings.getTheme(), new Coords(w, h), true);
+                    nb[index++] = new Hex(0, "space:1", mapSettings.getTheme(), new Coords(w, h));
                 } else {
-                    nb[index++] = new Hex(elevationMap[w][h], "", mapSettings.getTheme(), new Coords(w, h), true);
+                    nb[index++] = new Hex(elevationMap[w][h], "", mapSettings.getTheme(), new Coords(w, h));
                 }
             }
         }

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -26,7 +26,6 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import megamek.common.Coords;
-import megamek.common.Hex;
 import megamek.common.EntityFluff;
 import megamek.common.net.marshalling.SanityInputFilter;
 import megamek.common.options.AbstractOptions;

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -26,6 +26,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import megamek.common.Coords;
+import megamek.common.Hex;
 import megamek.common.EntityFluff;
 import megamek.common.net.marshalling.SanityInputFilter;
 import megamek.common.options.AbstractOptions;


### PR DESCRIPTION
Refactor the isOnBoard approach to fix the load save serialization issue:
 * Remove the isOnBoard flag from Hex class.
 * Hex.isOnBoard() always returns true, Hex.isOffBoard() always returns false
 * Create OffBoardHex class to extend Hex, this object is returned whenver Board.getHex() is given coords not on the board.
 * OffBoardHex.isOnBoard() always returns false, OffBoardHex.isOffBoard() always returns true.

Also fixes #6686 by restoring the specific null check for the hex of an undeployed mek.