### PR TITLE
Fixes #6700 ArrayIndexOutOfBounds refreshing entity list in ForceView

### DIFF
--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -3183,7 +3183,7 @@ public class ChatLounge extends AbstractPhaseDisplay implements
                 pathObjs[index++] = force;
             }
 
-            pathObjs[index + 1] = game().getEntity(entityId);
+            pathObjs[index] = game().getEntity(entityId);
             return new TreePath(pathObjs);
         } else {
             throw new IllegalArgumentException(Messages.getString("ChatLounge.TreePath.methodRequiresEntityForce"));


### PR DESCRIPTION
@UlyssesSockdrawer  - was able to reproduce this reliably by customizing a unit's pilot in ForceView and hitting the `okay` button.  There are several megamek lobby interactions that can cause this same issue.  In the GUI it throws an ArrayIndexOutOfBounds exception dialog... but it can fail quietly to the logs in other interactions from the lobby as well

Fixes #6700 
Fixes #6575 
Fixes #6574 
Fixes #6573

+Fix 6700: Prevent GUI error when changing attributes in the lobby while in ForceView