### PR TITLE
Fix #6301: phases are not skipped by /victory even with phase skipping enabled

### DIFF
--- a/megamek/src/megamek/server/commands/VictoryCommand.java
+++ b/megamek/src/megamek/server/commands/VictoryCommand.java
@@ -14,6 +14,7 @@
 package megamek.server.commands;
 
 import megamek.common.Player;
+import megamek.common.options.OptionsConstants;
 import megamek.server.Server;
 import megamek.server.totalwarfare.TWGameManager;
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -1360,6 +1360,8 @@ public class TWGameManager extends AbstractGameManager {
      * round.
      */
     public void forceVictory(Player victor, boolean endImmediately, boolean ignorePlayerVotes) {
+        // endImmediately if passed true, or if game option set
+        endImmediately |= game.getOptions().booleanOption(OptionsConstants.VICTORY_SKIP_FORCED_VICTORY);
         game.setEndImmediately(endImmediately);
         game.setIgnorePlayerDefeatVotes(ignorePlayerVotes);
         game.setForceVictory(true);
@@ -2152,6 +2154,9 @@ public class TWGameManager extends AbstractGameManager {
     private void changeToNextTurn(int prevPlayerId) {
         boolean minefieldPhase = game.getPhase().isDeployMinefields();
         boolean artyPhase = game.getPhase().isSetArtilleryAutohitHexes();
+        if (isPlayerForcedVictory()) {
+            setIneligible(game.getPhase());
+        }
 
         GameTurn nextTurn = null;
         Entity nextEntity = null;
@@ -3050,6 +3055,7 @@ public class TWGameManager extends AbstractGameManager {
 
         if (isPlayerForcedVictory()) {
             assistants.addAll(game.getEntitiesVector());
+            game.setTurnVector(new ArrayList<>());
         } else {
             for (Entity entity : game.getEntitiesVector()) {
                 if (entity.isEligibleFor(phase)) {


### PR DESCRIPTION
Adds immediate check to skip all turns and remaining phases _if_ user has "skip all phases when forced victory occurs" enabled, types `/victory`, and gets all other players to accept defeat.

Note:
1. There may be a race condition between registering the forced victory state and bot clients returning their /defeat packets; I'm not sure if there is a good solution for this, but the following note makes it less of an issue.
2. Because of the way the `/victory` command works, we _should_ get all the triggers for a forced victory set prior to actually checking it and clearing the remaining turns because...
3. Actually checking for forced victory and clearing all remaining phases and turns requires a trigger of some kind, which in our case will be ending one unit's turn.

Testing:
- Ran all 3 projects' unit tests
- Tested `/victory` command in multiple phases and with both settings of the "skip all phases" option.

Close #6301 