### PR TITLE
Fix #6650: halved fire control weight for support vees, wrong armor for SOAR VTOL

### DIFF
--- a/megamek/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/SOAR VTOL.blk
+++ b/megamek/data/mekfiles/vehicles/TRO Vehicle Annex/VTOL/SOAR VTOL.blk
@@ -1,4 +1,4 @@
-#Saved from version 0.50.0-SNAPSHOT on 2024-06-29
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-15
 <UnitType>
 SupportVTOL
 </UnitType>
@@ -52,9 +52,13 @@ standardseats:6.0:0:-1::-1:0
 45
 </armor_type>
 
-<armor_tech>
+<armor_tech_rating>
+2
+</armor_tech_rating>
+
+<armor_tech_level>
 1
-</armor_tech>
+</armor_tech_level>
 
 <armor>
 5

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -814,7 +814,8 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public double getWeightControls() {
-        return getWeightFireControl() + getWeightCrewAccommodations();
+        // No need to add Firecontrol weights here; they are included in Misc Equipment
+        return getWeightCrewAccommodations();
     }
 
     @Override


### PR DESCRIPTION
Updates how we calculate Support Vee weight when an FCS is added.
Currently we are double-dipping the weight:
- Once as "Controls",
- Once as Misc Equipment.

I've removed FCS weight from the "Controls" calculation for Support Vees only, as the TRO entries all seem to list their weights with the other Equipment entries.

Also corrects the SOAR VTOL's armor to match its grade, tech, and weight.

Note:
There are a still a number of units failing weight tests by a small amount; these are likely unrelated to FCS weights (as in the case of the SOAR above).

Testing:
- Ran all 3 projects' unit tests.
- Checked several units' weights by hand

Close #6650 