### PR TITLE
Fix for #6682, #6683, also terrain blast over-applying

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -52,6 +52,7 @@ import megamek.client.ui.swing.widget.PicMap;
 import megamek.client.ui.swing.widget.SkinXMLHandler;
 import megamek.client.ui.swing.widget.UnitDisplaySkinSpecification;
 import megamek.common.*;
+import megamek.common.AmmoType.Munitions;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.WeaponSortOrder;
 import megamek.common.equipment.AmmoMounted;
@@ -61,6 +62,7 @@ import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.weapons.AreaEffectHelper;
+import megamek.common.weapons.AreaEffectHelper.DamageFalloff;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.gaussrifles.HAGWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -1854,22 +1856,29 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         } else if (wtype.getDamage() == WeaponType.DAMAGE_ARTILLERY) {
             StringBuilder damage = new StringBuilder();
             int artyDamage = wtype.getRackSize();
-            damage.append(artyDamage);
             int falloff = 10;
+            boolean fuelAirExplosive = false;
             boolean specialArrowIV = false;
             if ((mounted.getLinked() != null) && (mounted.getLinked().getType() instanceof AmmoType)) {
                 AmmoType ammoType = (AmmoType) mounted.getLinked().getType();
+                fuelAirExplosive = ammoType.getMunitionType().contains(Munitions.M_FAE);
                 specialArrowIV = (ammoType.is(AmmoType.T_ARROW_IV)
                         && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ADA)
                                 || ammoType.getMunitionType().contains(AmmoType.Munitions.M_HOMING)));
                 int attackingBA = (entity instanceof BattleArmor) ? ((BattleArmor) entity).getShootingStrength() : -1;
-                falloff = AreaEffectHelper.calculateDamageFallOff(ammoType, attackingBA, false).falloff;
+                DamageFalloff damageFalloff = AreaEffectHelper.calculateDamageFallOff(ammoType, attackingBA, false);
+                artyDamage = damageFalloff.damage;
+                falloff = damageFalloff.falloff;
             }
+            damage.append(artyDamage);
             if (!specialArrowIV) {
                 artyDamage -= falloff;
                 while ((artyDamage > 0) && (falloff > 0)) {
                     damage.append('/').append(artyDamage);
                     artyDamage -= falloff;
+                }
+                if (fuelAirExplosive) {
+                    damage.append("/5");
                 }
             }
             wDamR.setText(damage.toString());

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -643,6 +643,13 @@ public class AreaEffectHelper {
             radius = (int)(Math.ceil(1.0 * damage / falloff) - 1);
             // Fuel-Air munitions get special radius
             if (ammo.getMunitionType().contains(Munitions.M_FAE)) {
+                damage = switch(ammo.getAmmoType()) {
+                    case AmmoType.T_LONG_TOM, AmmoType.T_LONG_TOM_CANNON, AmmoType.T_LONG_TOM_PRIM -> 30;
+                    case AmmoType.T_SNIPER, AmmoType.T_SNIPER_CANNON -> 20;
+                    case AmmoType.T_THUMPER, AmmoType.T_THUMPER_CANNON -> 10;
+                    case AmmoType.T_ARROW_IV, AmmoType.T_ARROWIV_PROTO -> 20;
+                    default -> 0; // Should not happen...
+                };
                 radius = getFuelAirBlastRadiusIndex(ammo.getInternalName());
             }
         }

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -188,13 +188,21 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                 // Currently Artillery Cannons _can_ make Flak attacks using FAE munitions
                 // If this is an ASF Flak attack we know we hit an entity by itself in the air,
                 // so just hit it for full damage.
+                int height = target.getElevation();
+                if (target instanceof HexTarget) {
+                    Board board = game.getBoard();
+                    if (board.contains(targetPos)) {
+                        height = board.getHex(targetPos).getLevel();
+                    }
+                }
+
                 if (asfFlak) {
                     AreaEffectHelper.artilleryDamageEntity((Entity) target, ammoType.getRackSize(), null,
-                            0, false, asfFlak, isFlak, target.getElevation(),
-                            targetPos, atype, targetPos, false, ae, null, target.getElevation(),
+                            0, false, asfFlak, isFlak, height,
+                            targetPos, atype, targetPos, false, ae, null, getAttackerId(),
                             vPhaseReport, gameManager);
                 } else {
-                    AreaEffectHelper.processFuelAirDamage(targetPos, target.getElevation(),
+                    AreaEffectHelper.processFuelAirDamage(targetPos, height,
                             ammoType, ae, vPhaseReport, gameManager);
                 }
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31772,7 +31772,7 @@ public class TWGameManager extends AbstractGameManager {
             Vector<Report> vPhaseReport, boolean asfFlak,
             Vector<Integer> alreadyHit, boolean variableDamage, DamageFalloff falloff) {
 
-        // Values used later (TODO: include FAE munition here)
+        // Values used later
         boolean isFuelAirBomb = ammo != null && ( ammo.getMunitionType().contains(Munitions.M_FAE)
               || (BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_SMALL
                       || BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_LARGE));

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31789,7 +31789,7 @@ public class TWGameManager extends AbstractGameManager {
             if (!flak) {
                 // Report that damage applied to terrain, if there's TF to damage
                 Hex h = game.getBoard().getHex(coords);
-                if ((h != null) && h.hasTerrainFactor()) {
+                if ((h != null) && h.hasTerrainFactor() && h.hasTerrainFactor() && (altitude == h.getLevel())) {
                     r = new Report(3384);
                     r.indent(2);
                     r.subject = subjectId;

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31786,11 +31786,10 @@ public class TWGameManager extends AbstractGameManager {
         if (hex != null) {
 
             // Non-flak artillery damages terrain
-            // TODO: account for altitude vs: terrain height
             if (!flak) {
                 // Report that damage applied to terrain, if there's TF to damage
                 Hex h = game.getBoard().getHex(coords);
-                if ((h != null) && h.hasTerrainFactor() && h.hasTerrainFactor() && (altitude == h.getLevel())) {
+                if ((h != null) && h.hasTerrainFactor() && (altitude == h.getLevel())) {
                     r = new Report(3384);
                     r.indent(2);
                     r.subject = subjectId;
@@ -31806,7 +31805,6 @@ public class TWGameManager extends AbstractGameManager {
                 vPhaseReport.addAll(newReports);
             }
 
-            // TODO: account for altitude vs: terrain height
             // Buildings do _not_ shield housed units from artillery damage!
             if ((bldg != null)
                     && !(flak && (((altitude > hex.terrainLevel(Terrains.BLDG_ELEV))

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -32,6 +32,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.swing.GUIPreferences;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.common.*;
+import megamek.common.AmmoType.Munitions;
 import megamek.common.Building.DemolitionCharge;
 import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.*;
@@ -31771,10 +31772,10 @@ public class TWGameManager extends AbstractGameManager {
             Vector<Report> vPhaseReport, boolean asfFlak,
             Vector<Integer> alreadyHit, boolean variableDamage, DamageFalloff falloff) {
 
-        // Values used later
-        boolean isFuelAirBomb = ammo != null &&
-                (BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_SMALL ||
-                        BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_LARGE);
+        // Values used later (TODO: include FAE munition here)
+        boolean isFuelAirBomb = ammo != null && ( ammo.getMunitionType().contains(Munitions.M_FAE)
+              || (BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_SMALL
+                      || BombType.getBombTypeFromInternalName(ammo.getInternalName()) == BombType.B_FAE_LARGE));
         Building bldg = game.getBoard().getBuildingAt(coords);
         Hex hex = game.getBoard().getHex(coords);
         int effectiveLevel = (hex != null) ? hex.getLevel() : 0;


### PR DESCRIPTION
Fixes four issues with FAE munitions using the updated blast shaping code:
1. FAE explosion handling was not taking the underlying hex's level into account when creating the blast
2. FAE cannon damage was not getting set correctly
3. FAE munitions' blast damage profile was not correctly represented in the target display, using incorrect damage and falloff values.
4. Blasts were doing extra damage to the terrain factor of each hex due to ignoring the blast height anyways

This fix adds FAE artillery damage profiles to the target display, correctly generates FAE munition blast damage and blast shapes, and correctly passes the target hex elevation to the blast handling code.
Additionally, the new 3D blast shapes will only damage terrain factor for hexes whose surfaces intersect with the blast shape; hexes above or below the blast will not be affected (just like units).
Buildings will still take damage for every level that is within the blast shape, however.

NOTE: we do not have blast shadowing (buildings and hexes blocking/partially absorbing blast damage) implemented yet.  This is a non-trivial feature and will not be ready in time for the next release.
So players will see blasts going "through" intervening terrain or buildings in some cases.

Close #6682 
Close #6683 