### PR TITLE
Fix 6711: Add VTOL and WiGE airborne destruction as unsurviveable

### DIFF
--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -922,6 +922,7 @@
 6370=<span class='warning'>*** <data> (<data>) was trapped in the wreckage. ***</span>
 6375=<span class='warning'>*** <data> (<data>) tried to escape the wreckage, but couldn't. ***</span>
 6376=<span class='warning'>*** <data> (<data>) suffered fatal damage during the crash. ***</span>
+6377=<span class='warning'>*** <data> (<data>) was destroyed in the mid-air explosion. ***</span>
 6380=<data> (<data>) ends its swarm attack.
 6385=<data> (<data>) is freed from its swarm attack.
 6390=<span class='warning'>*** <data> EXPLODES! <data> DAMAGE! ***</span>

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -3248,7 +3248,12 @@ public class Princess extends BotClient {
         Coords pathEndpoint = path.getFinalCoords();
         Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity, pathEndpoint, getGame(), false);
 
-        // if there are no enemies on the board, then we're not launching anything.
+        // Don't launch at high velocity in atmosphere or the fighters will be destroyed!
+        if (path.getFinalVelocity() > 2 && !game.getBoard().inSpace()) {
+            return;
+        }
+
+            // if there are no enemies on the board, then we're not launching anything.
         if ((null == closestEnemy) || (closestEnemy.getTargetType() != Targetable.TYPE_ENTITY)) {
             return;
         }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -24774,11 +24774,13 @@ public class TWGameManager extends AbstractGameManager {
      */
     protected void destroyTransportedUnits(Entity entity, int condition, boolean survivable, Vector<Report> vDesc) {
         Report r;
+        int messageId = 6375;
 
         // We'll need this later...
         Aero ship = null;
         if (entity.isLargeCraft()) {
             ship = (Aero) entity;
+            messageId = 6377;
         }
 
         // Regardless of what was passed in, units loaded onto vehicles not on the
@@ -24896,7 +24898,7 @@ public class TWGameManager extends AbstractGameManager {
                 if (!survivable || !survived
                     // Don't unload from ejecting spacecraft. The crews aren't in their units...
                     || (ship != null && ship.isEjecting())) {
-                    destroyCarriedUnit(entity, other, condition, 6370, vDesc);
+                    destroyCarriedUnit(entity, other, condition, messageId, vDesc);
                 } else {
                     // Handle all _possibly_ survivable destruction:
                     // 1. BAs mounting an Omni / Mechanized mounting anything (TW pg 227):

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -24781,12 +24781,12 @@ public class TWGameManager extends AbstractGameManager {
             ship = (Aero) entity;
         }
 
-        // Regardless of what was passed in, units loaded onto ships not on the
+        // Regardless of what was passed in, units loaded onto vehicles not on the
         // ground are destroyed.
         // Units in an Aerospace unit destroyed in a crash are also destroyed.
         // Units in an Aerospace unit that is already on the ground usually survive if
         // they can evacuate the wreck.
-        if (entity.isAirborne()) {
+        if (entity.isAirborne() || entity.isAirborneVTOLorWIGE()) {
             survivable = false;
         }
 
@@ -24856,28 +24856,33 @@ public class TWGameManager extends AbstractGameManager {
                 }
                 // Can the other unit survive?
                 boolean survived = false;
+                // Assumes infantry; other units take no damage or are damaged via other means
                 // Riding a tank/VTOL
-                if (entity instanceof Tank) {
-                    if (entity.getMovementMode().isNaval()
-                        || entity.getMovementMode().isHydrofoil()) {
-                        if (other.getMovementMode().isUMUInfantry()) {
+                if (other.isInfantry()) {
+                    if (entity instanceof Tank) {
+                        if (entity.getMovementMode().isNaval()
+                              || entity.getMovementMode().isHydrofoil()) {
+                            if (other.getMovementMode().isUMUInfantry()) {
+                                survived = Compute.d6() <= 3;
+                            } else if (other.getMovementMode().isJumpInfantry()) {
+                                survived = Compute.d6() == 1;
+                            } else if (other.getMovementMode().isVTOL()) {
+                                survived = Compute.d6() <= 2;
+                            }
+                        } else if (entity.getMovementMode().isSubmarine()) {
+                            if (other.getMovementMode().isUMUInfantry()) {
+                                survived = Compute.d6() == 1;
+                            }
+                        } else if (entity instanceof VTOL || entity.getMovementMode().isWiGE()) {
                             survived = Compute.d6() <= 3;
-                        } else if (other.getMovementMode().isJumpInfantry()) {
-                            survived = Compute.d6() == 1;
-                        } else if (other.getMovementMode().isVTOL()) {
-                            survived = Compute.d6() <= 2;
+                        } else {
+                            survived = Compute.d6() <= 4;
                         }
-                    } else if (entity.getMovementMode().isSubmarine()) {
-                        if (other.getMovementMode().isUMUInfantry()) {
-                            survived = Compute.d6() == 1;
+                    } else if (entity instanceof Mek) {
+                        // mechanized BA can escape on a roll of 1 or 2
+                        if (externalUnits.contains(other)) {
+                            survived = Compute.d6() < 3;
                         }
-                    } else {
-                        survived = Compute.d6() <= 4;
-                    }
-                } else if (entity instanceof Mek) {
-                    // mechanized BA can escape on a roll of 1 or 2
-                    if (externalUnits.contains(other)) {
-                        survived = Compute.d6() < 3;
                     }
                 }
 

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -24857,11 +24857,12 @@ public class TWGameManager extends AbstractGameManager {
                 // Can the other unit survive?
                 boolean survived = false;
                 // Assumes infantry; other units take no damage or are damaged via other means
-                // Riding a tank/VTOL
                 if (other.isInfantry()) {
+                    // Riding a tank/VTOL/other vehicle
                     if (entity instanceof Tank) {
                         if (entity.getMovementMode().isNaval()
                               || entity.getMovementMode().isHydrofoil()) {
+                            // Naval vessel
                             if (other.getMovementMode().isUMUInfantry()) {
                                 survived = Compute.d6() <= 3;
                             } else if (other.getMovementMode().isJumpInfantry()) {
@@ -24870,12 +24871,15 @@ public class TWGameManager extends AbstractGameManager {
                                 survived = Compute.d6() <= 2;
                             }
                         } else if (entity.getMovementMode().isSubmarine()) {
+                            // Submarine
                             if (other.getMovementMode().isUMUInfantry()) {
                                 survived = Compute.d6() == 1;
                             }
                         } else if (entity instanceof VTOL || entity.getMovementMode().isWiGE()) {
+                            // Non-airborne VTOL / WiGE
                             survived = Compute.d6() <= 3;
                         } else {
+                            // All others
                             survived = Compute.d6() <= 4;
                         }
                     } else if (entity instanceof Mek) {
@@ -24883,10 +24887,13 @@ public class TWGameManager extends AbstractGameManager {
                         if (externalUnits.contains(other)) {
                             survived = Compute.d6() < 3;
                         }
+                    } else if (entity.isAero()) {
+                        // Infantry in a destroyed Aerospace unit have only 1/6 chance to escape
+                        survived = Compute.d6() == 1;
                     }
                 }
 
-                if (!survivable || (externalUnits.contains(other) && !survived)
+                if (!survivable || !survived
                     // Don't unload from ejecting spacecraft. The crews aren't in their units...
                     || (ship != null && ship.isEjecting())) {
                     destroyCarriedUnit(entity, other, condition, 6370, vDesc);


### PR DESCRIPTION
Also explicitly check for infantry survival when carrier destroyed otherwise.

Previously we assumed that the destruction checks for a carried unit would only apply to Infantry, as they were the most likely to be carried by a destroyed unit.
We also assumed that any Tank-derived unit was being destroyed on the ground; in fact we need to check if the unit was destroyed in the air first.

This PR adds an explicit check for Infantry vs other carried unit types, which should only be destroyed in specific circumstances handled elsewhere (or by the existing Airborne) check.
It also adds the missing destruction checks for infantry units per TW pg. 223.

Testing:
- Ran all 3 projects' unit tests.
- Tested with loaded units in a variety of situations.

Close: #6711 

