### PR TITLE
Corrected Capitalization in Surnames Data

### DIFF
--- a/megamek/data/names/surnames.csv
+++ b/megamek/data/names/surnames.csv
@@ -24766,8 +24766,8 @@ Ethnic Code,Name,Weight
 5,Zurbrugg,1
 5,Zweig,2
 5,Zylberstein,1
-5,felder,1
-5,rauffenburg,1
+5,Felder,1
+5,Rauffenburg,1
 5,von,1
 6,Aafjes,1
 6,Aalbers,1


### PR DESCRIPTION
- Fixed capitalization for "felder" to "Felder" and "rauffenburg" to "Rauffenburg" in the surnames dataset.
- Brings the file in line with MekHQ