### PR TITLE
Added 694 Brand New Callsigns

### DIFF
--- a/megamek/data/names/callsigns.csv
+++ b/megamek/data/names/callsigns.csv
@@ -1,10 +1,15 @@
 ﻿Callsign,Weight
 Aardvark,1
 Aardwolf,1
+Abductor,1
 Able,1
 Abnormal,1
+Abomination,1
+Abraxas,1
+Abs,1
 Abscess,1
 Absence,1
+Absolute Zero,1
 Abyss,1
 Academic,1
 Accountant,1
@@ -19,15 +24,20 @@ Active,1
 Actuator,1
 Adagio,1
 Adarna,1
+Adder,1
 Admiral,1
 Adonis,1
 Aegis,1
+Aeneas,1
 Aerial,1
+Aerie,1
 Aero,1
 Aether,1
 Aethon,1
+Afro,1
 Afterburner,1
 Aftermath,1
+Aftershock,1
 Agate,1
 Agent,1
 Agile,1
@@ -37,6 +47,7 @@ Ahab,1
 Ahuizotl,1
 Aikido,1
 Aimless,1
+Air Raid,1
 Airborne,1
 Airburst,1
 Airfang,1
@@ -45,6 +56,7 @@ Airhorn,1
 Airlift,1
 Airtight,1
 Airwave,1
+Ajax,1
 Albatross,1
 Albion,1
 Alchemist,1
@@ -53,30 +65,36 @@ Alexander,1
 Algorithm,1
 Alias,1
 Alien,1
+All Thumbs,1
 Allegiance,1
 Alleycat,1
 Alloy,1
 Alpha,1
-Alpha Strike, 1,1
+Alpha Strike,1
 Alphabet,1
+Alphabet Soup,1
 Alpine,1
 Altar,1
 Alter,1
 Amarok,1
 Amaterasu,1
 Amazon,1
+Amazonian,1
 Ambassador,1
 Amber,1
 Amberglow,1
 Ambrosia,1
 Ambush,1
+Ame-no-Ohabari,1
 Amethyst,1
 Ammo,1
 Ammut,1
 Amore,1
 Amphibian,1
+Amphitrite,1
 Amulet,1
 Anansi,1
+Anastasia,1
 Anchor,1
 Anchor Shot,1
 Android,1
@@ -88,6 +106,7 @@ Angry,1
 Angst,1
 Angus,1
 Animal,1
+Ankh,1
 Antares,1
 Anteater,1
 Anthem,1
@@ -106,6 +125,7 @@ Apocalypse,1
 Apollo,1
 Apparition,1
 Apple,1
+Apple Pie,1
 Applejack,1
 Applesauce,1
 Apricot,1
@@ -120,6 +140,7 @@ Arcana,1
 Arcane,1
 Arcanum,1
 Archer,1
+Archimedes,1
 Architect,1
 Archive,1
 Arclight,1
@@ -131,6 +152,7 @@ Argo,1
 Argonaut,1
 Argus,1
 Aria,1
+Ariel,1
 Aristocrat,1
 Aristotle,1
 Ark,1
@@ -142,10 +164,12 @@ Armbar,1
 Armor,1
 Armor Bear,1
 Armory,1
+Arms,1
 Army,1
 Array,1
 Arrow,1
 Arsenal,1
+Arson,1
 Artemis,1
 Artifact,1
 Ascent,1
@@ -155,6 +179,7 @@ Ash,1
 Ashen,1
 Ashfall,1
 Ashtray,1
+Asi,1
 Aspen,1
 Asphalt,1
 Assassin,1
@@ -179,11 +204,13 @@ Aurora,1
 Austin,1
 Auto,1
 Autocannon,1
+Autumn,1
 Avalanche,1
 Avalon,1
 Avast,1
 Avenger,1
 Avenging Angel,1
+Aviator,1
 Avril,1
 Awakening,1
 AWOL,1
@@ -215,6 +242,7 @@ Backtrack,1
 Bacon,1
 Baconator,1
 Badger,1
+Bae,1
 Bagel,1
 Bagman,1
 Bagpipe,1
@@ -231,7 +259,9 @@ Ballerina,1
 Ballistic,1
 Bam Bam,1
 Bambi,1
+Bamboo,1
 Banana,1
+Bananas,1
 Band,1
 Band-Aid,1
 Bandit,1
@@ -241,18 +271,21 @@ Bandwagon,1
 Bandwidth,1
 Bane,1
 Bang,1
+Bangles,1
 Banhammer,1
 Banjo,1
 Bank,1
 Banshee,1
 Banter,1
 Banzai,1
+Barb,1
 Barbarian,1
 Barbecue,1
 Barbell,1
 Barbican,1
 Barbie,1
 Bardiche,1
+Bare Foot,1
 Barf,1
 Bark,1
 Barley,1
@@ -261,7 +294,7 @@ Barn Owl,1
 Barnacle,1
 Barnet,1
 Baron,1
-Barracade,1
+Barricade,1
 Barracuda,1
 Barrage,1
 Barrel,1
@@ -286,6 +319,7 @@ Batangas,1
 Batfish,1
 Baton,1
 Battalion,1
+Battery,1
 Battleborn,1
 Battleclad,1
 Battlecry,1
@@ -297,6 +331,7 @@ Bayonet,1
 Bayot,1
 Bazaar,1
 Bazooka,1
+BBQ,1
 Beach,1
 Beachball,1
 Beachhead,1
@@ -306,18 +341,26 @@ Beak,1
 Beaker,1
 Beans,1
 Bear,1
+Bear Trap,1
 Beast,1
 Beat,1
 Beatbox,1
 Beauty,1
 Beaver,1
+Bedrock,1
 Bee Sting,1
 Beef,1
+Beefcake,1
 Beefeater,1
 Beehive,1
+Beethoven,1
 Beetle,1
+Beetlejuice,1
 Behemoth,1
+Belch,1
 Bell,1
+Belladonna,1
+Belle,1
 Bellerophon,1
 Bellows,1
 Belly Flop,1
@@ -328,12 +371,20 @@ Bengal,1
 Beowulf,1
 Berry,1
 Berserk,1
+Berserker,1
 Beta,1
+Betsy,1
 Beyond,1
 Bicep,1
+Bickers,1
 Bifrost,1
 Big Al,1
+Big Ben,1
+Big Bird,1
 Big Dog,1
+Big Gulp,1
+Big Mac,1
+Big McLargeHuge,1
 Big Rig,1
 Big Texas,1
 Big Ticket,1
@@ -349,20 +400,24 @@ Binary,1
 Binder,1
 Bindle,1
 Bingo,1
+Biohazard,1
 Birch,1
 Bird,1
 Birdbrain,1
 Birdhand,1
 Birdie,1
 Birdstrike,1
+Birdy,1
 Biscotti,1
 Biscuit,1
 Biscuit Bandit,1
 Bishop,1
 Bison,1
 Bittersweet,1
+Bjorn,1
 Black,1
 Black Sheep,1
+Blackbeard,1
 Blackberry,1
 Blackbird,1
 Blackdog,1
@@ -375,6 +430,7 @@ Blackthorn,1
 Blackwater,1
 Blade,1
 Bladestorm,1
+Blargh,1
 Blaster,1
 Blazar,1
 Blaze,1
@@ -382,24 +438,30 @@ Blazer,1
 Bleak,1
 Blender,1
 Blight,1
+Blimp,1
 Blind,1
 Blindside,1
 Blindspot,1
 Blink,1
 Blip,1
+Blipper,1
 Bliss,1
 Blister,1
 Blitz,1
 Blitzkrieg,1
 Blizzard,1
+Blob,1
 Blobfish,1
 Blockade,1
 Blocker,1
+Blockhead,1
 Blond,1
 Blondie,1
 Blood,1
+Bloodwing,1
 Bloodfang,1
 Bloodhound,1
+Bloodlust,1
 Bloodname,1
 Bloodrider,1
 Bloodstone,1
@@ -409,6 +471,7 @@ Blot,1
 Blowfly,1
 Blowpipe,1
 Blowtorch,1
+Blubber,1
 Bludgeon,1
 Blue,1
 Bluebird,1
@@ -419,6 +482,7 @@ Bluff,1
 Blunder,1
 Blur,1
 Blush,1
+Bo Peep,1
 Boa,1
 Boar,1
 Boarstrike,1
@@ -426,7 +490,10 @@ Bobbin,1
 Bobcat,1
 Bobsled,1
 Bobtail,1
+Body Bag,1
+Bofu,1
 Bogey,1
+Boggart,1
 Bolo,1
 Bolt,1
 Bomber,1
@@ -437,9 +504,14 @@ Bonecrusher,1
 Boneless,1
 Bones,1
 Boneyard,1
+Bongo Drums,1
 Bonnie,1
+Bonsai,1
+Boo,1
 Boo-Boo,1
 Booger,1
+Boogers,1
+Boogeyman,1
 Book,1
 Booker,1
 Bookie,1
@@ -456,6 +528,7 @@ Booster,1
 Boot,1
 Bootcamp,1
 Bootleg,1
+Borealis,1
 Boss,1
 Botanical,1
 Bottlecap,1
@@ -463,34 +536,44 @@ Boudica,1
 Boulder,1
 Bouncer,1
 Bounty,1
+Bouquet,1
 Bowline,1
 Boxcar,1
 Boxer,1
 Boysenberry,1
 Bozo,1
 Braid,1
+Brain Freeze,1
 Brainiac,1
 Brains,1
+Brainwash,1
 Brainy,1
+Brakes,1
 Bramble,1
 Brandy,1
 Branth,1
 Brass,1
+Brat,1
 Brave,1
+Braveheart,1
 Bravery,1
 Bravo,1
 Brawl,1
 Brawler,1
 Brawny,1
+Breadbox,1
+Breakdance,1
 Breakdown,1
 Breaker,1
 Breakfall,1
+Breakfast,1
 Breakwater,1
 Breeze,1
 Brew,1
 Brewer,1
 Briar,1
 Brick,1
+Brick House,1
 Brickwall,1
 Brickyard,1
 Brig,1
@@ -509,9 +592,13 @@ Brood,1
 Broody,1
 Brook,1
 Broom,1
+Bruce,1
+Bruiser,1
+Brussels Sprout,1
 Brute,1
 Brutus,1
 Bub,1
+Bubblegum,1
 Bubbles,1
 Bubblewrap,1
 Buccaneer,1
@@ -521,27 +608,32 @@ Buckeye,1
 Buckshot,1
 Buckskin,1
 Bucky,1
+Bud,1
 Buddha,1
 Buddy,1
 Buff,1
 Buffalo,1
 Buffoon,1
 Bug,1
+Bug Zapper,1
 Bugbear,1
 Buggy,1
 Bugs,1
 Bugspray,1
 Bugsy,1
 Builder,1
+Bulb,1
 Bulkhead,1
 Bull,1
 Bulldog,1
+Bulldozer,1
 Bullet,1
 Bulletproof,1
 Bullfrog,1
 Bullion,1
 Bullseye,1
 Bulwark,1
+Bum Rush,1
 Bumble,1
 Bumblebee,1
 Bumper,1
@@ -549,17 +641,21 @@ Bunker,1
 Bunny,1
 Buns,1
 Bunyip,1
+Buoy,1
 Buraq,1
 Burger,1
 Burglar,1
 Burlap,1
+Burlesque,1
 Burn,1
 Burner,1
 Burnout,1
 Burst,1
 Bus Stop,1
+Bush,1
 Bushel,1
 Bushido,1
+Bushwacker,1
 Buster,1
 Bustle,1
 Busybee,1
@@ -569,17 +665,21 @@ Butcher,1
 Butler,1
 Buttercup,1
 Button,1
+Buttons,1
 Buzz,1
+Buzz Kill,1
 Buzzard,1
 Buzzkill,1
 Buzzsaw,1
 Byte,1
 C-Bill,1
 Cabal,1
+Cabaret,1
 Cabbage,1
 Cabin,1
 Cable,1
 Caboose,1
+Cacoon,1
 Cactus,1
 Caddy,1
 Cadence,1
@@ -589,6 +689,7 @@ Cage,1
 Cait Sidhe,1
 Cajun,1
 Cake,1
+Caladbolg,1
 Caladrius,1
 Calamari,1
 Calamity,1
@@ -605,6 +706,7 @@ Camel,1
 Camelot,1
 Camelthorn,1
 Cameo,1
+Cameron,1
 Camouflage,1
 Camper,1
 Campfire,1
@@ -626,18 +728,22 @@ Capella,1
 Capital,1
 Capo,1
 Capoeira,1
+Cappuccino,1
 Capricorn,1
 Capstone,1
 Captain,1
-Caracel,1
+Car Bomb,1
+Caracal,1
 Carafe,1
 Carat,1
 Caravan,1
 Caravel,1
 Carbon,1
 Carcass,1
+Carousel,1
 Cardboard,1
 Cardinal,1
+Carebear,1
 Cargo,1
 Carnage,1
 Carnie,1
@@ -678,6 +784,7 @@ Cauldron,1
 Causeway,1
 Cavalier,1
 Caveman,1
+Cavity,1
 Cayenne,1
 Celery,1
 Celeste,1
@@ -688,6 +795,8 @@ Centauri,1
 Center,1
 Centurion,1
 Cerberus,1
+Cerebro,1
+Cerebus,1
 Cermak,1
 Cerulean,1
 Cesspool,1
@@ -699,6 +808,7 @@ Chalkline,1
 Challenger,1
 Chamberlain,1
 Chameleon,1
+Chamomile,1
 Champagne,1
 Champion,1
 Chancellor,1
@@ -724,14 +834,17 @@ Chatterbox,1
 Checkbox,1
 Checkerboard,1
 Checkers,1
+Checklist,1
 Checkmate,1
 Checkpoint,1
 Cheddar,1
+Cheeky,1
 Cheese,1
 Cheeseburger,1
 Cheetah,1
 Cherry,1
 Cherry Bomb,1
+Chester,1
 Chestnut,1
 Chick,1
 Chicken,1
@@ -745,29 +858,38 @@ Chillbox,1
 Chiller,1
 Chime,1
 Chimera,1
+Chimichanga,1
 Chimney,1
 Chinook,1
 Chinstrap,1
+Chip,1
 Chipmunk,1
 Chips,1
 Chipset,1
 Chiron,1
 Chisel,1
 Chivalry,1
+Chive,1
 Chocolate,1
 Chokehold,1
 Chomper,1
+Chonk,1
 Chopper,1
 Chopstick,1
 Chorus,1
 Chosen,1
+Chosen One,1
 Chowder,1
 Chrome,1
 Chrome Dog,1
+Chrome Dome,1
 Chrono,1
+Chrysalis,1
+Chrysaor,1
 Chuck,1
 Chuckles,1
 Chuckwagon,1
+Chucky,1
 Chum,1
 Chupacabra,1
 Church,1
@@ -776,6 +898,7 @@ Cicerone,1
 Cider,1
 Cinder,1
 Cinderella,1
+Cinnamon,1
 Cipher,1
 Circe,1
 Circuit,1
@@ -784,16 +907,22 @@ Citrine,1
 Citrus,1
 City,1
 Citylight,1
+Claiomh Solais,1
 Clairvoyant,1
 Clam,1
 Clamp,1
 Clandestine,1
 Clanky,1
+Clarent,1
 Clarity,1
 Clash,1
 Classic,1
 Claw,1
+Clawfoot,1
+Claws,1
+Clay,1
 Claymore,1
+Clayton,1
 Clem,1
 Cleopatra,1
 Cleric,1
@@ -805,6 +934,8 @@ Clipper,1
 Cloak,1
 Cloakfang,1
 Clobber,1
+Clogs,1
+Clone,1
 Close Shave,1
 Closer,1
 Cloud,1
@@ -822,6 +953,7 @@ Coach,1
 Coast,1
 Coastguard,1
 Cobalt,1
+Cobbler,1
 Cobra,1
 Cobweb,1
 Cockatrice,1
@@ -855,13 +987,20 @@ Comet,1
 Command,1
 Commando,1
 Commlink,1
+Commodore,1
 Compass,1
 Conan,1
 Conceal,1
+Conch,1
 Conclave,1
 Concrete,1
+Concussion,1
 Condor,1
+Conductor,1
+Conehead,1
 Confessor,1
+Confetti,1
+Confucius,1
 Conjure,1
 Conman,1
 Conqueror,1
@@ -869,9 +1008,12 @@ Conquistador,1
 Consigliere,1
 Console,1
 Constable,1
+Constipation,1
 Contact,1
+Contagion,1
 Contraband,1
 Control,1
+Conventions,1
 Conveyor,1
 Convict,1
 Convoy,1
@@ -879,10 +1021,13 @@ Cooker,1
 Cookie,1
 Cookies,1
 Cool Hand,1
+Coolant,1
 Cooler,1
+Cooper,1
 Copper,1
 Copperhead,1
 Coppertop,1
+Copycat,1
 Coral,1
 Cordon,1
 Core,1
@@ -894,11 +1039,16 @@ Cornflower,1
 Corona,1
 Coronet,1
 Coronis,1
+Corpse,1
+Corpse Flower,1
 Corruption,1
 Corsair,1
+Cortain,1
 Cosmic,1
 Cosmo,1
 Cosmos,1
+Cotton,1
+Cotton Candy,1
 Cougar,1
 Count,1
 Countdown,1
@@ -911,11 +1061,13 @@ Courtier,1
 Cover,1
 Covert,1
 Cow,1
+Coward,1
 Cowboy,1
 Coyote,1
 Crab,1
 Crabshack,1
 Cracked,1
+Crackers,1
 Crackle,1
 Crackpot,1
 Crackshot,1
@@ -926,6 +1078,7 @@ Crane,1
 Crank,1
 Crankcase,1
 Crash,1
+Crash Test Dummy,1
 Crashdown,1
 Crashsite,1
 Crate,1
@@ -934,8 +1087,10 @@ Craven,1
 Crawfish,1
 Crawl,1
 Crawler,1
+Crayfish,1
 Crayon,1
 Crazy Quilt,1
+Cream,1
 Cream Puff,1
 Creator,1
 Creep,1
@@ -945,13 +1100,17 @@ Crepe,1
 Crescendo,1
 Crescent,1
 Crest,1
+Cretaceous,1
 Cricket,1
+Crikey,1
+Criminal,1
 Crimson,1
 Crispy,1
 Critical,1
 Critter,1
 Croc,1
 Crocale,1
+Crocea Mors,1
 Cromwell,1
 Crook,1
 Cross,1
@@ -975,6 +1134,7 @@ Crunch,1
 Cruncher,1
 Crusader,1
 Crusher,1
+Crusty,1
 Crybaby,1
 Cryo,1
 Cryptic,1
@@ -990,10 +1150,12 @@ Cupcake,1
 Cure,1
 Curly,1
 Current,1
+Curtana,1
 Curve,1
 Cushion,1
 Custard,1
 Custer,1
+Cutie,1
 Cutlass,1
 Cutline,1
 Cutter,1
@@ -1015,6 +1177,7 @@ Daedalus,1
 Daemon,1
 Dagger,1
 Daily,1
+Dainsleif,1
 Dairy,1
 Daisy,1
 Daito,1
@@ -1027,6 +1190,8 @@ Dancer,1
 Dandelion,1
 Dandy,1
 Danger,1
+Danger Noodle,1
+Dante,1
 Daphne,1
 Dare,1
 Daredevil,1
@@ -1038,8 +1203,10 @@ Darken,1
 Darkfang,1
 Darklight,1
 Darkness,1
+Darkside,1
 Darkstar,1
 Dart,1
+Darwin,1
 Dash,1
 Dashcam,1
 Data,1
@@ -1050,6 +1217,7 @@ Dawnfire,1
 Dawnveil,1
 Daylight,1
 Dazzle,1
+Dazzler,1
 Deacon,1
 Dead End,1
 Deadbolt,1
@@ -1061,9 +1229,11 @@ Deadshot,1
 Deadwood,1
 Dealbreaker,1
 Dealer,1
+Dear John,1
 Death,1
 Death Angel,1
 Deathdealer,1
+Deathscythe Murderkill,1
 Deathspire,1
 Deathstalker,1
 Deathstroke,1
@@ -1071,6 +1241,7 @@ Debonair,1
 Debug,1
 Decay,1
 Deceiver,1
+Decibel,1
 Decker,1
 Deckhand,1
 Decoy,1
@@ -1087,26 +1258,32 @@ Defiant,1
 Defrag,1
 Defrost,1
 Dehydrate,1
+Deimos,1
 Dekker,1
+Delphi,1
 Delta,1
 Deluxe,1
 Demeter,1
 Demo,1
 Demoman,1
 Demon,1
+Demonspawn,1
 Dempsey,1
 Denial,1
 Depth,1
 Depth Charge,1
 Deputy,1
 Derby,1
+Derpy,1
 Desert,1
 Desolate,1
 Desperado,1
 Destiny,1
 Destroyer,1
+Detective,1
 Detonator,1
 Detour,1
+Detritus,1
 Detroit,1
 Deuce,1
 Devil,1
@@ -1116,6 +1293,7 @@ Dexter,1
 Diablo,1
 Dialtone,1
 Diamond,1
+Dian Wei,1
 Dice,1
 Diesel,1
 Digger,1
@@ -1127,6 +1305,7 @@ Dingo,1
 Dino,1
 Dionysus,1
 Dipper,1
+Dippler,1
 Dipstick,1
 Direwolf,1
 Dirge,1
@@ -1135,6 +1314,7 @@ Dirt,1
 Dirtnap,1
 Disarm,1
 Disco,1
+Disco Fever,1
 Discord,1
 Discreet,1
 Disease,1
@@ -1143,6 +1323,7 @@ Dispenser,1
 Distemper,1
 Ditch,1
 Ditchdigger,1
+Ditzy,1
 Diva,1
 Dive,1
 Diver,1
@@ -1153,9 +1334,11 @@ Dixie,1
 Dizzy,1
 DJ,1
 Djinn,1
+DNA,1
 Doc,1
 Dockhand,1
 Dockside,1
+Doctor,1
 Doctrine,1
 Dodger,1
 Dog,1
@@ -1163,21 +1346,26 @@ Dog Ear,1
 Doghouse,1
 Dogma,1
 Dojang,1
+Dojigiri,1
 Dojo,1
+Dollop,1
 Dolphin,1
 Domain,1
+Dome,1
 Dominion,1
 Domino,1
 Doodle,1
 Doofus,1
 Doom,1
 Doomsday,1
+Doorbell,1
 Doormat,1
 Doorway,1
 Dopey,1
 Double,1
 Doubledown,1
 Doubleshot,1
+Doug,1
 Doughball,1
 Doughboy,1
 Dove,1
@@ -1188,6 +1376,7 @@ Downtown,1
 Dozer,1
 Dozey,1
 Draco,1
+Dracula,1
 Draft,1
 Drag Strip,1
 Dragnet,1
@@ -1209,6 +1398,7 @@ Dreamer,1
 Dreamland,1
 Dreamstalker,1
 Dreamstrike,1
+Dreidel,1
 Drencher,1
 Drift,1
 Driftcore,1
@@ -1228,6 +1418,8 @@ Dropkick,1
 Dropout,1
 Dropship,1
 Drought,1
+Drumstick,1
+Dry Ice,1
 Dryad,1
 Duchess,1
 Duck,1
@@ -1235,10 +1427,12 @@ Duckie,1
 Dude,1
 Duke,1
 Dumbbell,1
+Dumbell,1
 Dumpling,1
 Dumpster,1
 Dune,1
 Dune Rat,1
+Durandal,1
 Dusk,1
 Dust,1
 Dust Devil,1
@@ -1251,11 +1445,16 @@ Dutch,1
 Dynamite,1
 Dynamo,1
 Dynasty,1
+Dynomite,1
+Dyrnwyn,1
 Eagle,1
 Eagle Eye,1
+Earbuds,1
 Earl,1
 Ears,1
 Earthquake,1
+East,1
+Easter,1
 Eastwood,1
 Easy,1
 Echelon,1
@@ -1263,14 +1462,18 @@ Echidna,1
 Echo,1
 Echoflare,1
 Eclipse,1
+Ectoplasm,1
 Eden,1
 Edge,1
 Eggroll,1
 Ego,1
 Eidolon,1
 Eight-Ball,1
+Einstein,1
 Elation,1
 Elbow,1
+Elbows,1
+Elder,1
 Electra,1
 Elemental,1
 Elevator,1
@@ -1284,6 +1487,7 @@ Emberhound,1
 Emerald,1
 Emissary,1
 Emitter,1
+Emo,1
 Emperor,1
 Empire,1
 Empress,1
@@ -1294,12 +1498,14 @@ Enchanter,1
 Encrypt,1
 Encyclopedia,1
 Endurance,1
+Energizer,1
 Energy,1
 Enforcer,1
 Engage,1
 Engine,1
 Enigma,1
 Entry,1
+Envelope,1
 Eon,1
 Eos,1
 Epic,1
@@ -1318,7 +1524,7 @@ Eskrima,1
 Espresso,1
 Essence,1
 Esteem,1
-et,1
+ET,1
 Eternal,1
 Eternity,1
 Ethereal,1
@@ -1329,6 +1535,7 @@ Eurydice,1
 Evac,1
 Evader,1
 Eventide,1
+Everest,1
 Evergreen,1
 Evil,1
 Evil Eye,1
@@ -1343,14 +1550,20 @@ Explorer,1
 Express,1
 Expresso,1
 Exquisite,1
+Extra Large,1
 Extractor,1
+Eye Guy,1
 Eyeball,1
 Fabulous,1
+Facade,1
 Face,1
+Facepalm,1
+Faceplant,1
 Faction,1
 Fade,1
 Faerie,1
 Fafnir,1
+Fahrenheit,1
 Fair Weather,1
 Faith,1
 Faker,1
@@ -1359,6 +1572,7 @@ Falcon,1
 Falconer,1
 Falconheart,1
 Falconry,1
+Falling Plate,1
 Fallout,1
 Fame,1
 Fang,1
@@ -1375,6 +1589,7 @@ Fauchard,1
 Fawn,1
 Fearless,1
 Feather,1
+Featherweight,1
 Feedback,1
 Feint,1
 Feldspar,1
@@ -1388,7 +1603,9 @@ Feral,1
 Fern,1
 Ferret,1
 Fester,1
+Fetus,1
 Fever Dream,1
+Fey,1
 Fez,1
 Fiber,1
 Fiction,1
@@ -1403,8 +1620,10 @@ Figurehead,1
 Finder,1
 Fine-line,1
 Fingers,1
+Finn,1
 Fire,1
 Fire Cat,1
+Firearm,1
 Fireball,1
 Firebird,1
 Firebrand,1
@@ -1422,9 +1641,13 @@ Firewall,1
 Firewing,1
 Firewolf,1
 Firewood,1
+Fireworks,1
+First Aid,1
 Fish,1
 Fisher,1
 Fisherman,1
+Fish Sticks,1
+Fisticuffs,1
 Fix-It,1
 Fixer,1
 Fizz,1
@@ -1432,12 +1655,14 @@ Fizzle,1
 Fjord,1
 Flag,1
 Flak,1
+Flamberge,1
 Flame,1
 Flamingo,1
 Flange,1
 Flank,1
 Flanker,1
 Flapjack,1
+Flapper,1
 Flare,1
 Flaregun,1
 Flash,1
@@ -1454,24 +1679,31 @@ Flay,1
 Flea,1
 Flechette,1
 Flesh,1
+Fleur,1
 Flex,1
 Flicker,1
 Flight,1
 Flim-Flam,1
+Flinchy,1
 Flint,1
 Flintlock,1
 Flip,1
+Flip Flops,1
 Flipflop,1
 Flipper,1
 Flood,1
+Flora,1
 Flotsam,1
 Flounder,1
+Flower,1
 Floyd,1
 Fluffy,1
 Fluke,1
 Flume,1
 Flurry,1
+Flutter,1
 Flux,1
+Fly Trap,1
 Flyboy,1
 Flycatcher,1
 Flynn,1
@@ -1482,8 +1714,10 @@ Fogbank,1
 Foggy,1
 Foghorn,1
 Folio,1
+Food Fight,1
 Footloose,1
 Forager,1
+Forbidden,1
 Force,1
 Forest,1
 Forge,1
@@ -1492,10 +1726,12 @@ Formation,1
 Fortitude,1
 Fortress,1
 Fortune,1
+Fortune Cookie,1
 Forward,1
 Fossil,1
 Foul,1
 Fountain,1
+Four Eyes,1
 Fox,1
 Foxglove,1
 Foxhole,1
@@ -1504,8 +1740,11 @@ Foxy,1
 Fracas,1
 Fractal,1
 Frag,1
+Frankenstein,1
 Freak,1
 Freakshow,1
+Freckles,1
+Fred,1
 Frederick,1
 Free Throw,1
 Freebie,1
@@ -1513,6 +1752,7 @@ Freebirth,1
 Freebooter,1
 Freedom,1
 Freefall,1
+Freeloader,1
 Freeway,1
 Freezer,1
 Freight,1
@@ -1527,6 +1767,7 @@ Friday,1
 Fridge,1
 Friendly,1
 Frigate,1
+Frisky,1
 Frog,1
 Froggy,1
 Frolic,1
@@ -1537,7 +1778,9 @@ Frostbite,1
 Frostfang,1
 Frostfire,1
 Frosty,1
+Fruit Punch,1
 Fudge,1
+Fujin,1
 Fumble,1
 Fungus,1
 Funky,1
@@ -1577,6 +1820,7 @@ Gangster,1
 Ganymede,1
 Garbage,1
 Gargoyle,1
+Garlic,1
 Garm,1
 Garnet,1
 Garrison,1
@@ -1586,6 +1830,7 @@ Gasket,1
 Gaslight,1
 Gaspipe,1
 Gassy,1
+Gate Crasher,1
 Gateway,1
 Gator,1
 Gatsby,1
@@ -1602,6 +1847,7 @@ Geezer,1
 Gemini,1
 Gemstone,1
 Genbu,1
+General,1
 Generator,1
 Genesis,1
 Geneva,1
@@ -1610,6 +1856,7 @@ Genitor,1
 Gentry,1
 Geode,1
 Geoduck,1
+Geranium,1
 Gerbil,1
 Geronimo,1
 Geryon,1
@@ -1653,29 +1900,39 @@ Glissade,1
 Glitch,1
 Glitter,1
 Global,1
+Gloomy,1
 Glory,1
 Gloryhog,1
+Glover,1
 Glow,1
+Glowbug,1
 Glyde,1
 Glyph,1
 Gnarly,1
 Gnaw,1
 Goat,1
 Goblin,1
+Gobstopper,1
 Godan,1
 Godiva,1
+Godless,1
+Godric,1
 Goggles,1
 Goji,1
 Gold,1
+Gold Digger,1
 Gold Leaf,1
+Golden,1
 Goldenrod,1
 Goldfinch,1
 Goldfish,1
 Goldhorn,1
+Goldilocks,1
 Golem,1
 Goliath,1
 Gomer,1
 Gong,1
+Gongjin,1
 Gonzo,1
 Goober,1
 Goody,1
@@ -1683,18 +1940,22 @@ Goofy,1
 Goose,1
 Goosefoot,1
 Gopher,1
+Gore,1
 Gorgon,1
 Gorilla,1
 Gourmand,1
 Grace,1
 Graceland,1
 Grackle,1
+Gram,1
 Grand,1
 Grand Slam,1
 Grandeur,1
 Grandmaster,1
 Grandpa,1
 Granite,1
+Granny,1
+Grapple,1
 Grappler,1
 Grass,1
 Grave,1
@@ -1706,24 +1967,29 @@ Gravytrain,1
 Grayscale,1
 Greaseball,1
 Greasy,1
+Great Wall,1
 Green,1
 Green Light,1
 Greenroom,1
 Gremlin,1
 Grenade,1
 Grendel,1
+Grey Wind,1
 Greyhound,1
 Grid,1
 Gridiron,1
 Gridline,1
 Grief,1
 Griffin,1
+Griffon,1
+Grifter,1
 Grill,1
 Grim,1
 Grime,1
 Grimfang,1
 Grinch,1
 Grinder,1
+Grinner,1
 Grit,1
 Grizzly,1
 Groovy,1
@@ -1732,11 +1998,13 @@ Grounder,1
 Groundhog,1
 Growl,1
 Grub,1
+Grudge,1
 Grump,1
 Grumpy,1
 Grunt,1
 Grunter,1
 Gryphon,1
+Guacamole,1
 Guano,1
 Guard,1
 Guardian,1
@@ -1752,6 +2020,7 @@ Gundog,1
 Gundoll,1
 Gunfire,1
 Gung-Ho,1
+Gungnir,1
 Gunhog,1
 Gunmetal,1
 Gunner,1
@@ -1793,6 +2062,7 @@ Hammerhead,1
 Hammock,1
 Handcuff,1
 Handmaiden,1
+Handsy,1
 Hang-up,1
 Hangar,1
 Hangman,1
@@ -1800,8 +2070,10 @@ Hangnail,1
 Hangover,1
 Hannibal,1
 Happy,1
+Harassment,1
 Harbinger,1
 Harbor,1
+Harbinger,1
 Hard Rock,1
 Hardball,1
 Hardcase,1
@@ -1860,9 +2132,11 @@ Heavy Duty,1
 Heavyweight,1
 Hecate,1
 Hectic,1
+Hector,1
 Hedge,1
 Hedgehog,1
 Hefty,1
+Heifer,1
 Heirloom,1
 Helhound,1
 Helios,1
@@ -1876,8 +2150,10 @@ Hellfire,1
 Hellhound,1
 Hellion,1
 Helm,1
+Helmet,1
 Helo,1
 Hemlock,1
+Hephaestus,1
 Hera,1
 Heracles,1
 Hercules,1
@@ -1898,6 +2174,7 @@ High Roller,1
 High Voltage,1
 Highball,1
 Highbrow,1
+Highness,1
 Highrise,1
 Hightail,1
 Hightide,1
@@ -1906,6 +2183,7 @@ Highwater,1
 Highway,1
 Highwire,1
 Hillbilly,1
+Hindenburg,1
 Hinge,1
 Hippo,1
 Hippogriff,1
@@ -1932,11 +2210,13 @@ Holy,1
 Holy Man,1
 Homunculus,1
 Honey,1
+Honeycomb,1
 Honeydew,1
 Honor,1
 Honor Guard,1
 Hooch,1
 Hood,1
+Hoodlem,1
 Hook,1
 Hooligan,1
 Hoop Snake,1
@@ -1952,26 +2232,32 @@ Horse,1
 Horseman,1
 Horsepower,1
 Horseshoe,1
+Horus,1
 Hose,1
 Hot Damn,1
-Hot Rod,1
+Hot Dog,1
+Hot Head,1
+Hot Sauce,1
 Hotbox,1
-Hotdog,1
 Hothead,1
-Hotrod,1
 Hotshot,1
 Hotspur,1
 Hotwing,1
 Hotwire,1
+Houdini,1
 Hound,1
 Howdy,1
 Howl,1
 Howler,1
+Hrotti,1
+Hubby,1
 Hubcap,1
 Huckleberry,1
 Hudson,1
 Huevos,1
 Huggy,1
+Hula,1
+Hula Hoop,1
 Hulk,1
 Hull,1
 Hum,1
@@ -2006,6 +2292,7 @@ Ice Cube,1
 Iceberg,1
 Icebox,1
 Icebreaker,1
+Iceburg,1
 Icecap,1
 Icefall,1
 Icefisher,1
@@ -2015,6 +2302,7 @@ Icehouse,1
 Iceman,1
 Icepick,1
 Icetea,1
+Ichabod,1
 Icicle,1
 Icon,1
 Idea,1
@@ -2023,12 +2311,14 @@ Idun,1
 Ifrit,1
 Igor,1
 Iguana,1
+Illiad,1
 Illusion,1
 Image,1
 Imp,1
 Impact,1
 Imperator,1
 Imperial,1
+Imposter,1
 Incant,1
 Inch,1
 Incognito,1
@@ -2040,6 +2330,7 @@ Indy,1
 Infernal,1
 Inferno,1
 Infinity,1
+Ingot,1
 Inkblot,1
 Inkwell,1
 Innovation,1
@@ -2059,8 +2350,10 @@ Irish,1
 Iron,1
 Iron Claw,1
 Iron Crane,1
+Iron Giant,1
 Iron Jackal,1
 Iron Lady,1
+Iron Maiden,1
 Iron Man,1
 Iron Will,1
 Ironclad,1
@@ -2075,6 +2368,7 @@ Ironshade,1
 Ironsides,1
 Ironwood,1
 Irony,1
+Irrelevant,1
 Ishtar,1
 Isis,1
 Island,1
@@ -2086,6 +2380,7 @@ Ivory,1
 Ivy,1
 Jab,1
 Jack,1
+Jack O'Lantern,1
 Jackal,1
 Jackalope,1
 Jackdaw,1
@@ -2110,13 +2405,17 @@ Jasmine,1
 Jasper,1
 Java,1
 Javelin,1
+Jawbreaker,1
 Jaws,1
 Jay,1
 Jayhawk,1
 Jazz,1
+Jazz Hands,1
 Jazzman,1
 Jeckyl,1
 Jeet,1
+Jekyll,1
+Jello,1
 Jelly,1
 Jellybean,1
 Jenkins,1
@@ -2125,15 +2424,19 @@ Jester,1
 Jet,1
 Jet Set,1
 Jethro,1
+Jetsam,1
 Jetstream,1
 Jetstrike,1
 Jettison,1
 Jewel,1
+Jewels,1
 Jiangshi,1
 Jib,1
 Jibber,1
+Jiggles,1
 Jiggly,1
 Jigsaw,1
+Jimmy,1
 Jingle,1
 Jinx,1
 Jitter,1
@@ -2159,8 +2462,10 @@ Judo,1
 Juggernaut,1
 Juggler,1
 Juice,1
+Juice Box,1
 Juicy,1
 Jukebox,1
+Juliet,1
 Julius,1
 Jumbo,1
 Jump Jet,1
@@ -2176,20 +2481,26 @@ Junk Yard,1
 Junker,1
 Junkheap,1
 Juno,1
+Jupiter,1
 Jury-Rig,1
 Justicar,1
 Justice,1
+Juzumaru,1
 Jynx,1
 K-9,1
 Kaboom,1
 Kaiju,1
 Kaiser,1
 Kali,1
+Kallista,1
+Kamikaze,1
 Karambit,1
 Karat,1
 Karate,1
+Karen,1
 Karkinos,1
 Karma,1
+Katana,1
 Kato,1
 Kayak,1
 Kazoo,1
@@ -2224,10 +2535,14 @@ Kickflip,1
 Kicksnap,1
 Kickstart,1
 Kid,1
+Kilimanjaro,1
 Killbox,1
 Killer,1
 Killjoy,1
+Kiln,1
 Kilo,1
+Kilobyte,1
+Kiloton,1
 Kilroy,1
 Kindle,1
 Kindling,1
@@ -2260,27 +2575,33 @@ Knox,1
 Knucklehead,1
 Knuckles,1
 Koala,1
-Kobiyashi,1
+Kobayashi,1
 Kodama,1
 Kodiak,1
 Kojak,1
+Komodo,1
 Kong,1
+Kongming,1
 Koschei,1
 Kpinga,1
+Krakatoa,1
 Kraken,1
 Krakenborn,1
 Krampus,1
 Krav,1
 Krieger,1
 Krill,1
+Kronos,1
 Krunch,1
 Kukri,1
 Kumiho,1
 Kunai,1
+Kusanagi-no-Tsurugi,1
 Lab Rat,1
 Lace,1
 Laceleaf,1
 Laddie,1
+Ladle,1
 Lady,1
 Lager,1
 Lagoon,1
@@ -2292,9 +2613,11 @@ Lambchop,1
 Lament,1
 Lamia,1
 Lamp,1
+Lampchop,1
 Lamplight,1
 Lamprey,1
 Lance,1
+Lancelot,1
 Lancer,1
 Land Shark,1
 Lander,1
@@ -2325,9 +2648,13 @@ Leather,1
 Leatherneck,1
 Leech,1
 Lefty,1
+Leg Day,1
 Legacy,1
 Legal,1
+Leg Biter,1
 Legend,1
+Legion,1
+Legs,1
 Lemon,1
 Lemonade,1
 Leonidas,1
@@ -2335,6 +2662,7 @@ Leprechaun,1
 Leshy,1
 Lethal,1
 Letter,1
+Lettuce,1
 Lever,1
 Leviathan,1
 Lexicon,1
@@ -2354,8 +2682,10 @@ Lightning,1
 Lightningbug,1
 Lightspeed,1
 Lightweaver,1
+Lilith,1
 Lily,1
 Lilypad,1
+Limber,1
 Limelight,1
 Limit,1
 Limpet,1
@@ -2372,6 +2702,7 @@ Lionheart,1
 Lionness,1
 Lipstick,1
 Lite,1
+Lithium,1
 Little,1
 Live,1
 Livewire,1
@@ -2395,6 +2726,7 @@ Lodestar,1
 Logarithm,1
 Logjam,1
 Loki,1
+Lollipop,1
 Lone Eagle,1
 Lone Star,1
 Lone Wolf,1
@@ -2405,6 +2737,7 @@ Longbow,1
 Longhorn,1
 Longshadow,1
 Longshot,1
+Loofah,1
 Looking Glass,1
 Lookout,1
 Loom,1
@@ -2415,10 +2748,12 @@ Loophole,1
 Loopy,1
 Loot,1
 Looter,1
+Lorelei,1
 Lostech,1
 Lotus,1
 Loud,1
 Loudmouth,1
+Love Bug,1
 Lowball,1
 Lowrider,1
 Loyal,1
@@ -2435,6 +2770,7 @@ Luminous,1
 Lumpy,1
 Luna,1
 Lunar,1
+Lunatic,1
 Lunchbox,1
 Lungfish,1
 Lurk,1
@@ -2490,6 +2826,9 @@ Mallard,1
 Malware,1
 Mamba,1
 Mammoth,1
+Man o' War,1
+Man Trap,1
+Mana,1
 Mandrake,1
 Mandrill,1
 Mangler,1
@@ -2501,11 +2840,14 @@ Mannequin,1
 Manta,1
 Manticore,1
 Mantis,1
+Mantle,1
 Mantra,1
 Maple,1
+Maracas,1
 Marauder,1
 Marble,1
 Marbles,1
+Mardi Gras,1
 Mariachi,1
 Marine,1
 Mariner,1
@@ -2520,10 +2862,14 @@ Marrow,1
 Mars,1
 Marshal,1
 Marshall,1
+Marshmallow,1
 Martini,1
 Marvel,1
+Marvin,1
+Masamune,1
 Mascot,1
 Mask,1
+Masquerade,1
 Mast,1
 Masterkey,1
 Masterpiece,1
@@ -2540,6 +2886,7 @@ Maximum,1
 Mayhem,1
 Mayo,1
 Meadow,1
+Meadow Breeze,1
 Meadowlark,1
 Meat,1
 Meatball,1
@@ -2548,11 +2895,15 @@ Mechanic,1
 Medallion,1
 Medea,1
 Medic,1
+Medieval,1
 Medipack,1
 Medusa,1
+Meep,1
 Megaflop,1
+Megamind,1
 Megasaur,1
 Megawatt,1
+Mek-Fu,1
 Mekjock,1
 Mekrat,1
 MekWarrior,1
@@ -2562,11 +2913,13 @@ Melon,1
 Meltdown,1
 Memory,1
 Menace,1
+Mengde,1
 Merc,1
 Merchant,1
 Mercury,1
 Mercy,1
 Merlin,1
+Merlot,1
 Merrow,1
 Mesa,1
 Meta,1
@@ -2582,7 +2935,9 @@ Microwave,1
 Midas,1
 Middleman,1
 Midgard,1
+Midnight,1
 Midwinter,1
+Mikazuki,1
 Milestone,1
 Milk,1
 Milkman,1
@@ -2601,28 +2956,38 @@ Mint,1
 Minuteman,1
 Mirage,1
 Mirror,1
+Mischief,1
+Misery,1
+Misfire,1
 Misfit,1
+Miss-A-Lot,1
 Missile,1
 Mist,1
+Mistake,1
 Mistclaw,1
 Mistral,1
 Miter,1
 Mittens,1
 Mixer,1
+Mjolnir,1
 Moai,1
 Mobile,1
+Moby Dick,1
 Moccasin,1
 Mocha,1
 Modem,1
 Module,1
 Moebius,1
 Mohawk,1
+Mojave,1
 Mojo,1
 Mole,1
 Molly,1
 Momentum,1
 Monarch,1
 Money,1
+Money Bags,1
+Money Shot,1
 Mongoose,1
 Mongrel,1
 Monk,1
@@ -2631,6 +2996,8 @@ Monkshood,1
 Monochrome,1
 Monsoon,1
 Monster,1
+Monster Mash,1
+Moo-Moo,1
 Mooch,1
 Moon,1
 Moon Rabbit,1
@@ -2647,6 +3014,8 @@ Moosejaw,1
 Moped,1
 Moral,1
 Moray,1
+Mordred,1
+Morgana,1
 Morning Star,1
 Morningdew,1
 Morpheus,1
@@ -2665,6 +3034,7 @@ Motor Mouth,1
 Motown,1
 Mountain,1
 Mouse,1
+Mouse Trap,1
 Mouth,1
 Mouthwash,1
 Mover,1
@@ -2674,6 +3044,7 @@ Mud Hen,1
 Mudbug,1
 Mudflap,1
 Mudguard,1
+Mudpuppy,1
 Mudslide,1
 Muffin,1
 Muffintop,1
@@ -2684,8 +3055,12 @@ Mullet,1
 Mumble,1
 Mumbles,1
 Mumbo Jumbo,1
+Mummy,1
 Munch,1
+Muncher,1
 Mural,1
+Muramasa,1
+Murderer,1
 Murdock,1
 Murk,1
 Murky,1
@@ -2697,11 +3072,14 @@ Music Box,1
 Musket,1
 Muskrat,1
 Mustang,1
+Mutant,1
 Mutiny,1
 Mutt,1
-Muttonchop,1
+Muttonchops,1
 Muzzle,1
+Mystery,1
 Mystic,1
+Mystify,1
 Mystique,1
 Mythic,1
 Nacho,1
@@ -2717,15 +3095,18 @@ Nanofang,1
 Napalm,1
 Napoleon,1
 Narcissus,1
+Narcolepsy,1
 Nasty,1
 Nautilus,1
 Nav,1
 Navigator,1
 NavPoint,1
 Nebula,1
+Nectar,1
 Needle,1
 Needlenose,1
 Needles,1
+Nefertiti,1
 Nekomata,1
 Nemesis,1
 Nemo,1
@@ -2736,14 +3117,20 @@ Nephilim,1
 Neptune,1
 Nereid,1
 Nest,1
+Nettles,1
 Neuron,1
 Neutron,1
+Nevermore,1
+Newton,1
 Nexus,1
 Nibbler,1
 Nibbles,1
 Nickel,1
+Nickname,1
 Niflheim,1
+Nigel,1
 Night,1
+Night Light,1
 Night Lynx,1
 Night Witch,1
 Nightcap,1
@@ -2756,6 +3143,8 @@ Nightshade,1
 Nightstalker,1
 Nightstick,1
 Nightwatch,1
+Nihongo,1
+Niles,1
 Nimbus,1
 Nine,1
 Ningyo,1
@@ -2763,7 +3152,9 @@ Ninja,1
 Nitro,1
 Nixie,1
 Noble,1
+Nocturne,1
 Node,1
+Noggin,1
 Noir,1
 Nokken,1
 Nolan,1
@@ -2772,26 +3163,32 @@ Noodle,1
 Noodles,1
 Nook,1
 Noose,1
+North,1
 Northman,1
 Northwind,1
 Nosecone,1
 Nosedive,1
 Nosey,1
+Nostradamus,1
 Notebook,1
 Nova,1
+Nox,1
 Nozzle,1
 Nugget,1
+Nuggets,1
 Nuke,1
 Null,1
 Numb,1
 Numbers,1
 Nunchaku,1
-Nunchuk,1
+Nurse,1
 Nursemaid,1
+Nutmeg,1
 Nuts,1
 Nutty,1
 Nymph,1
 Nyx,1
+Oaf,1
 Oak,1
 Oar,1
 Oatmeal,1
@@ -2803,8 +3200,10 @@ Ocean,1
 Oceanside,1
 Ocelot,1
 Octane,1
+Octo,1
 Octopus,1
 Oddball,1
+Odenta,1
 Odin,1
 Odinson,1
 Odysseus,1
@@ -2814,7 +3213,9 @@ Ogre,1
 Oil Slick,1
 Oiler,1
 Ol’ Blue,1
+Olaf,1
 Old Man,1
+Old Sock,1
 Old Spice,1
 Olive,1
 Olympia,1
@@ -2825,9 +3226,13 @@ Omen,1
 Omni,1
 Oni,1
 Onikuma,1
+Onimaru,1
+Onion,1
 Onyx,1
 Opal,1
 Opaque,1
+Opera,1
+Ophelia,1
 Optic,1
 Optimal,1
 Opulence,1
@@ -2841,17 +3246,22 @@ Order,1
 Organ,1
 Origami,1
 Origin,1
+Original,1
 Oriole,1
 Orion,1
 Ornate,1
+Orphan,1
+Orphanage,1
 Orpheus,1
 Orthrus,1
 Oscar,1
 Osiris,1
 Osprey,1
 Ostrich,1
+Otegine,1
 Otter,1
 Otterhound,1
+Ouchie,1
 Ouroboros,1
 Outback,1
 Outcast,1
@@ -2871,6 +3281,7 @@ Overcast,1
 Overcharge,1
 Overclock,1
 Overdrive,1
+Overgrowth,1
 Overhaul,1
 Overhead,1
 Overheat,1
@@ -2879,6 +3290,7 @@ Overload,1
 Overlord,1
 Overpass,1
 Overrun,1
+Overture,1
 Overwatch,1
 Owl,1
 Owlman,1
@@ -2896,10 +3308,12 @@ Padlock,1
 Pagan,1
 Paingod,1
 Paint,1
+Paint Job,1
 Paintball,1
 Painter,1
 Paisley,1
 Paladin,1
+Palendrome,1
 Palerider,1
 Palette,1
 Palisade,1
@@ -2911,28 +3325,38 @@ Panabas,1
 Panama,1
 Pancake,1
 Panda,1
+Pandemonium,1
 Pandora,1
+Pangea,1
 Panic,1
 Panther,1
 Panzer,1
+Papa,1
 Paper Tiger,1
+Papercut,1
+Papyrus,1
 Parabola,1
 Paradise,1
 Paradox,1
+Parasite,1
 Parrot,1
 Parry,1
 Parsec,1
+Parsnip,1
 Particle,1
 Partisan,1
+Partner,1
 Passenger,1
 Passion,1
 Passkey,1
 Password,1
+Pastel,1
 Patch,1
 Patch-Eye,1
 Patches,1
 Patchwork,1
 Pathfinder,1
+Patriot,1
 Patrol,1
 Patton,1
 Pavement,1
@@ -2940,6 +3364,7 @@ Payback,1
 Payday,1
 Payload,1
 Payroll,1
+Pea,1
 Peace,1
 Peacebreaker,1
 Peach,1
@@ -2958,7 +3383,9 @@ Pelican,1
 Penghou,1
 Penguin,1
 Penny,1
+Pennywise,1
 Pepper,1
+Peppermint,1
 Perfume,1
 Pericles,1
 Periwinkle,1
@@ -2966,7 +3393,10 @@ Permafrost,1
 Persephone,1
 Perseus,1
 Peryton,1
+Pestilence,1
 Petal,1
+Petals,1
+Pew-Pew,1
 Phalanx,1
 Phantom,1
 Pharaoh,1
@@ -2978,26 +3408,37 @@ Photon,1
 Piano,1
 Picker,1
 Pickle,1
+Pickles,1
 Pickup,1
 Picnic,1
 Pidge,1
 Piehole,1
 Pierce,1
 Pigeon,1
+Piglet,1
 Pigpen,1
 Pike,1
+Pile Driver,1
 Pilgrim,1
 Pillager,1
 Pillbug,1
 Pilot,1
+Pimple,1
 Pinball,1
 Pincer,1
+Pinchy,1
+Pincushion,1
 Pine,1
+Pine Fresh,1
+Pineapple,1
 Pinecone,1
 Ping Pong,1
+Pink Eye,1
+Pinkey,1
 Pinkie,1
 Pinky,1
 Pinnacle,1
+Pinocchio,1
 Pinpoint,1
 Pinto,1
 Pinwheel,1
@@ -3048,10 +3489,13 @@ Pocus,1
 Pod,1
 Poem,1
 Pogo,1
+Pogo Stick,1
+Poindexter,1
 Point Blank,1
 Pointer,1
 Pointman,1
 Poison,1
+Poison Ivy,1
 Poker,1
 Polar,1
 Polar Bear,1
@@ -3059,11 +3503,14 @@ Polaris,1
 Polecat,1
 Polished,1
 Pollen,1
+Polly,1
 Polt,1
 Poltergeist,1
 Pommel,1
+Poncho,1
 Pontoon,1
 Pony,1
+Pooch,1
 Pooka,1
 Pop,1
 Popcorn,1
@@ -3075,8 +3522,12 @@ Pops,1
 Popshot,1
 Porcelain,1
 Porcupine,1
+Pork Chop,1
+Porkers,1
+Porky,1
 Porthos,1
 Poseidon,1
+Possibilities,1
 Possum,1
 Poster,1
 Postie,1
@@ -3086,7 +3537,9 @@ Potion,1
 Potluck,1
 Potshot,1
 Pounce,1
+Poundcake,1
 Powderkeg,1
+Powderpuff,1
 Powergrid,1
 Powerhawk,1
 Powerline,1
@@ -3095,12 +3548,19 @@ Prancer,1
 Prankster,1
 Pratfall,1
 Preacher,1
+Precious,1
 Predator,1
 Premier,1
+Premonition,1
+President,1
 Prestige,1
+Presto,1
 Pretzel,1
 Prickleback,1
+Prickly,1
+Pride,1
 Priest,1
+Prima Donna,1
 Prime,1
 Primer,1
 Primetime,1
@@ -3115,8 +3575,11 @@ Probe,1
 Prodigy,1
 Professor,1
 Promenade,1
+Prometheus,1
 Pronto,1
+Propane,1
 Prophecy,1
+Prophet,1
 Protector,1
 Protocol,1
 Proton,1
@@ -3128,13 +3591,20 @@ Psych Out,1
 Psyche,1
 Psychic,1
 Psycho,1
+Psycho Doll,1
+Pterodactyl,1
+Puck,1
 Pudding,1
 Puddle Jumper,1
 Puddles,1
+Pudge,1
+Puff,1
+Puffball,1
 Puffbird,1
 Puffin,1
 Puffy,1
 Pugilist,1
+Pull My Finger,1
 Pulley,1
 Pulsar,1
 Pulse,1
@@ -3142,12 +3612,15 @@ Pulseblade,1
 Puma,1
 Pumpkin,1
 Punchcard,1
+Punches,1
 Punchy,1
 Punisher,1
 Punishment,1
 Punk,1
 Puppet Master,1
+Puppetmaster,1
 Puppy,1
+Purdy,1
 Pursuer,1
 Putter,1
 Puzzle,1
@@ -3155,6 +3628,7 @@ Pylon,1
 Pyramid,1
 Pyre,1
 Pyro,1
+Pythagoras,1
 Python,1
 Qilin,1
 Quack,1
@@ -3164,6 +3638,7 @@ Quake,1
 Quantum,1
 Quark,1
 Quarrel,1
+Quarry,1
 Quarterback,1
 Quarterdeck,1
 Quartz,1
@@ -3185,20 +3660,28 @@ Quiver,1
 Rabbi,1
 Rabbit,1
 Rabble,1
+Rabies,1
 Raccoon,1
 Racer,1
 Racetrack,1
 Rack,1
 Racket,1
+Rad,1
 Radar,1
 Radburn,1
+Raddish,1
 Radiance,1
 Radiant,1
+Radio,1
 Radiowave,1
+Radish,1
 Raft,1
 Rafter,1
 Ragamuffin,1
+Ragdoll,1
+Rage,1
 Ragnar,1
+Ragnarok,1
 Ragnor,1
 Ragtime,1
 Ragtop,1
@@ -3216,6 +3699,7 @@ Ramjet,1
 Rampage,1
 Rampart,1
 Ramps,1
+Ramses,1
 Rancher,1
 Range-Bull,1
 Ranger,1
@@ -3224,10 +3708,12 @@ Ranseur,1
 Rapier,1
 Raptor,1
 Rapture,1
+Rapunzel,1
 Rascal,1
 Raspberry,1
 Rat,1
 Rat Party,1
+Ratbag,1
 Ratchet,1
 Rattler,1
 Rattlesnake,1
@@ -3239,16 +3725,22 @@ Raveneye,1
 Ravenstar,1
 Ravine,1
 Rawhide,1
+Rawr,1
+Ray,1
 Raygun,1
 Rayshine,1
 Razor,1
 Razorback,1
 Razorcat,1
 Razorline,1
+Razzle Dazzle,1
 Reach,1
 Readout,1
 Ready,1
+Real Talk,1
 Reaper,1
+Rear View,1
+Reason,1
 Rebel,1
 Reboot,1
 Rebound,1
@@ -3263,6 +3755,7 @@ Red,1
 Red Alert,1
 Red Comet,1
 Red Flag,1
+Red Handed,1
 Red Star,1
 Red Velvet,1
 Red Zone,1
@@ -3286,7 +3779,9 @@ Reggae,1
 Regulator,1
 Regulus,1
 Reheat,1
+Reign,1
 Rein,1
+Reindeer,1
 Relay,1
 Relentless,1
 Reliant,1
@@ -3325,6 +3820,7 @@ Rhea,1
 Rhino,1
 Rhyme,1
 Rib-Eye,1
+Ribbon,1
 Riches,1
 Richter,1
 Rico,1
@@ -3368,8 +3864,10 @@ Roadkill,1
 Roadrash,1
 Roadrunner,1
 Roast,1
+Roboto,1
 Roc,1
 Rock,1
+Rock Candy,1
 Rock n Roll,1
 Rocket,1
 Rockfall,1
@@ -3380,9 +3878,13 @@ Rocky,1
 Rodeo,1
 Rogue,1
 Roguewave,1
+Roid Rage,1
+Roids,1
+Roland,1
 Rolex,1
 Rollbar,1
 Roller,1
+Rollout,1
 Roman,1
 Romeo,1
 Rommel,1
@@ -3397,13 +3899,17 @@ Root,1
 Root Beer,1
 Rose,1
 Rosebud,1
+Rosemary,1
+Rosewater,1
 Rosewood,1
+Rot,1
 Rotgut,1
 Rotor,1
 Rottweiler,1
 Roughneck,1
 Roughrider,1
 Roulette,1
+Round Up,1
 Rounder,1
 Roundhouse,1
 Roundup,1
@@ -3412,6 +3918,7 @@ Rover,1
 Rowboat,1
 Royal,1
 Royale,1
+Royalties,1
 Rubber,1
 Rubber Duck,1
 Rubberband,1
@@ -3427,9 +3934,12 @@ Rugby,1
 Ruin,1
 Rum Runner,1
 Rumble,1
+Rumble Tumble,1
+Rumbler,1
 Run Around,1
 Rune,1
 Runesmith,1
+Runs With Scissors,1
 Runt,1
 Runway,1
 Rusalka,1
@@ -3443,6 +3953,8 @@ Rusty Joe,1
 Rusty Nail,1
 Ruthless,1
 Rye,1
+Ryobu,1
+S'more,1
 Saber,1
 Sabertooth,1
 Sable,1
@@ -3455,14 +3967,18 @@ Sack,1
 Safeguard,1
 Safety,1
 Sage,1
+Saggy,1
 Sahara,1
 Sailor,1
 Saint,1
 Sake,1
 Salad,1
+Salamander,1
 Salesman,1
+Salmon,1
 Salsa,1
 Salt,1
+Salt Shaker,1
 Salt Water,1
 Saltfang,1
 Salty Dog,1
@@ -3482,6 +3998,7 @@ Sandhog,1
 Sandman,1
 Sandstorm,1
 Sandwich,1
+Sandy,1
 Sapper,1
 Sapphire,1
 Saros,1
@@ -3502,13 +4019,17 @@ Savvy,1
 Sawblade,1
 Sawbuck,1
 Saxon,1
+Scab,1
+Scales,1
 Scallywag,1
 Scalpel,1
+Scamper,1
 Scandal,1
 Scanner,1
 Scar,1
 Scarab,1
 Scarecrow,1
+Scarf,1
 Scarface,1
 Scarlet,1
 Scars,1
@@ -3520,6 +4041,7 @@ Schooner,1
 Scientist,1
 Scimitar,1
 Scissor,1
+Scissors,1
 Scofflaw,1
 Scone,1
 Scoop,1
@@ -3528,12 +4050,14 @@ Scope,1
 Scorch,1
 Score,1
 Scorn,1
+Scorpio,1
 Scorpion,1
 Scorpius,1
 Scotch,1
 Scoundrel,1
 Scout,1
 Scramble,1
+Scrambled Eggs,1
 Scrap,1
 Scrap Iron,1
 Scrapheap,1
@@ -3560,14 +4084,20 @@ Scythe,1
 Sea Dragon,1
 Sea Lord,1
 Sea Witch,1
+Seabed,1
 Seabird,1
+Seadog,1
 Seafoam,1
 Seagull,1
 Seahorse,1
 Sealion,1
 Searchlight,1
 Seaspray,1
+Seatbelt,1
+Seaweed,1
+Secrets,1
 Secutor,1
+Seed,1
 Seeker,1
 Seelie,1
 Seer,1
@@ -3584,7 +4114,9 @@ Sepia,1
 Seraph,1
 Serenade,1
 Serenity,1
+Sergeant,1
 Serpent,1
+Serpentine,1
 Servo,1
 Set,1
 Set Up,1
@@ -3613,6 +4145,7 @@ Shard,1
 Shark,1
 Sharkeye,1
 Sharp,1
+Sharp Tooth,1
 Sharpshooter,1
 Sharpshot,1
 Shatter,1
@@ -3623,6 +4156,7 @@ Sheet Metal,1
 Shell,1
 Shell Shock,1
 Shellcode,1
+Shellfish,1
 Shelter,1
 Shepherd,1
 Sherbet,1
@@ -3666,7 +4200,10 @@ Showtime,1
 Shrapnel,1
 Shredder,1
 Shrike,1
+Shrimp,1
+Shroom,1
 Shroud,1
+Shuriken,1
 Shut-In,1
 Shutter,1
 Shuttle,1
@@ -3697,6 +4234,7 @@ Silencer,1
 Silent,1
 Silhouette,1
 Silk,1
+Silky,1
 Silver,1
 Silver Eagle,1
 Silverback,1
@@ -3716,19 +4254,24 @@ Skater,1
 Skedaddle,1
 Skeet,1
 Sketch,1
+Skewer,1
 Skid,1
 Skidmark,1
 Skidoo,1
 Skids,1
 Skiff,1
 Skinny,1
+Skipper,1
 Skippy,1
+Skittles,1
 Skull,1
 Skullcap,1
 Skulls,1
+Skully,1
 Skunk,1
 Sky,1
 Skydancer,1
+Skye,1
 Skyfall,1
 Skyhawk,1
 Skylark,1
@@ -3736,6 +4279,7 @@ Skyline,1
 Skyscraper,1
 Skyward,1
 Slab,1
+Slab Bulkhead,1
 Slacker,1
 Slag,1
 Slam,1
@@ -3749,13 +4293,17 @@ Slate,1
 Slaughter,1
 Slaw,1
 Slay,1
+Slayer,1
 Sledge,1
 Sledgehammer,1
 Sleek,1
 Sleeper,1
 Sleepy,1
+Sleepyhead,1
 Sleet,1
 Sleipnir,1
+Sleuth,1
+Slicer,1
 Slick,1
 Slick Rick,1
 Slider,1
@@ -3763,6 +4311,7 @@ Sliderule,1
 Slim,1
 Slime,1
 Slingshot,1
+Slinky,1
 Slip,1
 Slipstick,1
 Slipstream,1
@@ -3774,10 +4323,13 @@ Sludge,1
 Slug,1
 Slugger,1
 Sluggo,1
+Slurpee,1
 Slush,1
+Slushy,1
 Sly,1
 Smallfry,1
 Smash,1
+Smell This,1
 Smiley,1
 Smirk,1
 Smog,1
@@ -3788,8 +4340,11 @@ Smokes,1
 Smokescreen,1
 Smokestack,1
 Smolder,1
+Smooches,1
+Smooth Jazz,1
 Smudge,1
 Smuggler,1
+Snaggle,1
 Snail,1
 Snake,1
 Snake Eyes,1
@@ -3814,7 +4369,9 @@ Snitch,1
 Snocone,1
 Snoop,1
 Snort,1
+Snot,1
 Snow,1
+Snow White,1
 Snowball,1
 Snowbank,1
 Snowbird,1
@@ -3829,6 +4386,7 @@ Snowman,1
 Snowstorm,1
 Snowwolf,1
 Sobek,1
+Social Disease,1
 Socket,1
 Socks,1
 Socrates,1
@@ -3839,8 +4397,11 @@ Softpoint,1
 Soggy,1
 Soggy Dog,1
 Solar,1
+Solar Panel,1
 Solarflare,1
+Soldier,1
 Solitaire,1
+Solo,1
 Solomon,1
 Solstice,1
 Sombrero,1
@@ -3848,32 +4409,39 @@ Sonar,1
 Sonata,1
 Songbird,1
 Sonic,1
+Sonic Boom,1
 Soot,1
 Sorcerer,1
 Sorrow,1
 Soul,1
+Soulfire,1
 Sound,1
 Sounder,1
 Sourbug,1
 Sourdough,1
 Sourpuss,1
+South,1
 Sovereign,1
 Spacer,1
+Spacey,1
 Spade,1
 Spaghetti,1
 Spam,1
 Spaniel,1
 Spanner,1
 Spar,1
+Spare Diaper,1
 Spare Parts,1
 Spark,1
 Sparkjaw,1
 Sparkle,1
+Sparkler,1
 Sparkles,1
 Sparkplug,1
 Sparky,1
 Sparrow,1
 Sparrowhawk,1
+Sparta,1
 Spartacus,1
 Spartan,1
 Spatha,1
@@ -3885,6 +4453,7 @@ Spectra,1
 Spectre,1
 Spectrum,1
 Speedbird,1
+Speedster,1
 Speedy,1
 Spender,1
 Spetum,1
@@ -3915,6 +4484,7 @@ Spooky,1
 Spoon,1
 Spork,1
 Sport,1
+Spot,1
 Spotter,1
 Sprawl,1
 Spraycan,1
@@ -3923,16 +4493,19 @@ Sprinkles,1
 Sprint,1
 Sprite,1
 Sprocket,1
+Sprout,1
 Spruce,1
 Spud,1
 Spud Muffin,1
 Spur,1
 Spyglass,1
+Squad,1
 Squadron,1
 Squall,1
 Square,1
 Squatter,1
 Squawk,1
+Squeaks,1
 Squib,1
 Squid,1
 Squirrel,1
@@ -3946,6 +4519,7 @@ Stalk,1
 Stalker,1
 Stallion,1
 Stalwart,1
+Stampede,1
 Stance,1
 Stand-Up,1
 Stanza,1
@@ -3956,6 +4530,7 @@ Starboard,1
 Starbreaker,1
 Starbuck,1
 Starburst,1
+Starchild,1
 Stardust,1
 Starfall,1
 Starfire,1
@@ -3963,6 +4538,7 @@ Starfish,1
 Stargazer,1
 Starlight,1
 Starlit,1
+Starlord,1
 Starman,1
 Starpath,1
 Startup,1
@@ -3981,6 +4557,7 @@ Steeler,1
 Steeljaw,1
 Steeltoe,1
 Steelwolf,1
+Stella,1
 Stepchild,1
 Stereo,1
 Sterling,1
@@ -4011,18 +4588,23 @@ Strafe,1
 Stranger,1
 Strap,1
 Stratosphere,1
+Stratus,1
 Stray,1
 Streak,1
+Streaker,1
 Stream,1
 Street Rat,1
 Streetlamp,1
 Streetwise,1
 Strength,1
+Stretch,1
 Stretcher,1
+Strider,1
 Strike,1
 Striker,1
 Strip,1
 Stripe,1
+Stripes,1
 Strix,1
 Stronghold,1
 Strudel,1
@@ -4032,17 +4614,23 @@ Stumpy,1
 Stungun,1
 Sturm,1
 Styx,1
+Sub Woofer,1
 Sublime,1
+Submarine,1
 Submerge,1
 Subnet,1
 Subroutine,1
 Subway,1
+Sucker,1
 Sugar,1
 Sugar Rush,1
+Sugari no Ontachi,1
 Sulfur,1
 Sulphur,1
+Summer,1
 Summit,1
 Summoner,1
+Sumo,1
 Sunbeam,1
 Sundae,1
 Sundance,1
@@ -4053,6 +4641,7 @@ Sundown,1
 Sunfish,1
 Sunflare,1
 Sunflower,1
+Sunny,1
 Sunrise,1
 Sunset,1
 Sunshine,1
@@ -4068,8 +4657,12 @@ Surge,1
 Surgical,1
 Surprise,1
 Survivor,1
+Sushi,1
+Swag,1
 Swagger,1
 Swamp,1
+Swamp Thing,1
+Swampy,1
 Swan,1
 Swan Song,1
 Swanky,1
@@ -4083,6 +4676,7 @@ Swerve,1
 Swift,1
 Swindle,1
 Swindler,1
+Swine Flu,1
 Swing,1
 Switch,1
 Switchback,1
@@ -4098,12 +4692,16 @@ Synergy,1
 Syrup,1
 Sysop,1
 T-Bone,1
+T-Wrecks,1
+Tablet,1
 Tabloid,1
 Taboo,1
+Taco Tuesday,1
 Taffy,1
 Taiaha,1
 Tailgate,1
 Tailpipe,1
+Tails,1
 Tailspin,1
 Taipan,1
 Takoba,1
@@ -4114,6 +4712,7 @@ Tally,1
 Talon,1
 Talonfire,1
 Talonstrike,1
+Tangle,1
 Tango,1
 Taniwha,1
 Tank,1
@@ -4121,6 +4720,7 @@ Tankbuster,1
 Tanker,1
 Tantrum,1
 Tanuki,1
+Tapir,1
 Tapper,1
 Taproom,1
 Tarantula,1
@@ -4128,9 +4728,11 @@ Tarbox,1
 Target,1
 Tarise,1
 Tarmac,1
+Tarot,1
 Tartan,1
+Tartar Sauce,1
 Tarzan,1
-Taser,1
+Tazer,1
 Taskmaster,1
 Tasty,1
 Tater,1
@@ -4142,6 +4744,9 @@ Teal,1
 Tech,1
 Techhound,1
 Techno,1
+Teddy Bear,1
+Teddy,1
+Teeth,1
 Teflon,1
 Telescope,1
 Telltale,1
@@ -4151,12 +4756,16 @@ Tempo,1
 Tempus,1
 Ten Pin,1
 Tengu,1
+Tentacles,1
 Terminal,1
 Termite,1
+Terra,1
+Terracotta,1
 Terrier,1
 Terrorbird,1
 Tesla,1
 Tesseract,1
+Tetanus,1
 Tetrad,1
 Texas,1
 Thalassa,1
@@ -4164,18 +4773,22 @@ Thane,1
 Thatcher,1
 Thaumaturge,1
 Thaw,1
+The Bomb,1
 The Count,1
 Theory,1
 Theropod,1
 Theseus,1
 Thief,1
 Thinker,1
+Third Degree,1
 Thirteen,1
 Thistle,1
 Thor,1
 Thorax,1
 Thorn,1
 Thornback,1
+Thorns,1
+Thorny,1
 Thoth,1
 Thought,1
 Thracian,1
@@ -4187,9 +4800,12 @@ Thresher,1
 Throttle,1
 Thrust,1
 Thud,1
+Thug,1
 Thumb,1
+Thumbtack,1
 Thumper,1
 Thunder,1
+Thunder Lizard,1
 Thunderbird,1
 Thunderbolt,1
 Thunderclap,1
@@ -4207,6 +4823,7 @@ Tidepool,1
 Tiger,1
 Tigerclaw,1
 Tigertail,1
+Tigger,1
 Tikbalang,1
 Timber,1
 Timberwolf,1
@@ -4220,13 +4837,18 @@ Tinker,1
 Tinkerbell,1
 Tiny,1
 Tip Top,1
+Tiramisu,1
 Tire Fire,1
 Tissue,1
 Titan,1
 Titania,1
+Titanic,1
 Titanium,1
+Tizona,1
+TNT,1
 Toad,1
 Toad-fox,1
+Toadstool,1
 Toast,1
 Toaster,1
 Toasty,1
@@ -4236,16 +4858,23 @@ Toga,1
 Toggle,1
 Tomahawk,1
 Tombstone,1
+Tonbokiri,1
 Tonic,1
 Tool,1
 Toolbox,1
+Tooth Fairy,1
+Toothless,1
+Toothpaste,1
 Toothsome,1
+Toothy,1
 Top Dog,1
+Top Gun,1
 Topaz,1
 Topshot,1
 Topspin,1
 Torch,1
 Torchlight,1
+Torment,1
 Tornado,1
 Toro,1
 Torpedo,1
@@ -4268,7 +4897,9 @@ Trailblaze,1
 Trailblazer,1
 Train,1
 Traitor,1
+Trample,1
 Trampoline,1
+Trance,1
 Tranquility,1
 Transistor,1
 Transit,1
@@ -4284,11 +4915,13 @@ Tread,1
 Treadmark,1
 Treble,1
 Trebuchet,1
+Tree,1
 Treehugger,1
 Tremor,1
 Trench,1
 Trencher,1
 Triceratops,1
+Tricks,1
 Trickshot,1
 Tricky,1
 Trident,1
@@ -4304,6 +4937,7 @@ Tripod,1
 Tripwire,1
 Triton,1
 Triumph,1
+Trixie,1
 Trojan,1
 Troll,1
 Trolley,1
@@ -4313,25 +4947,30 @@ Tropical,1
 Trouble,1
 Troubleshooter,1
 Trout,1
+Troy,1
 Truce,1
 Truck,1
 Trucker,1
 Truffle,1
 Trumpet,1
 Truncheon,1
+Trunks,1
 Truth,1
 Tsuchigumo,1
 Tsunami,1
 Tuba,1
+Tubbs,1
 Tugboat,1
 Tulip,1
 Tulpa,1
 Tumble,1
 Tumble Weed,1
 Tumbleweed,1
+Tumor,1
 Tuna,1
 Tundra,1
 Tunnel Rat,1
+Tunnels,1
 Tupilaq,1
 Turbine,1
 Turbo,1
@@ -4342,18 +4981,25 @@ Turncoat,1
 Turnip,1
 Turtle,1
 Tusk,1
+Tusks,1
 Tutankhamun,1
+Tuxedo,1
 Twilight,1
 Twinkle,1
+Twinkletoes,1
 Twirl,1
 Twister,1
 Twitch,1
+Two Face,1
 Two Times,1
 Two-Dog,1
 Two-Strike,1
 Typhon,1
 Typhoon,1
 Tyrant,1
+Tyrfing,1
+UFO,1
+Ugly Duckling,1
 Ullr,1
 Ultimatum,1
 Umber,1
@@ -4365,12 +5011,14 @@ Uncle,1
 Underboss,1
 Underground,1
 Underhand,1
+Underminer,1
 Underpass,1
 Undertaker,1
 Undertone,1
 Undertow,1
 Undine,1
 Unforged,1
+Unga Bunga,1
 Unicorn,1
 Unicycle,1
 Union,1
@@ -4381,11 +5029,16 @@ Unseen,1
 Updraft,1
 Upgrade,1
 Uptown,1
+Uranium,1
 Urbanite,1
+Urchin,1
 Ursa,1
+Ursula,1
+Used Towel,1
 Vacuum,1
 Vagabond,1
 Vagrant,1
+Valentine,1
 Valet,1
 Valhalla,1
 Valkyrie,1
@@ -4401,6 +5054,7 @@ Vanish,1
 Vapor,1
 Vapour,1
 Vaquero,1
+Variant,1
 Varnish,1
 Vault,1
 Vector,1
@@ -4412,12 +5066,14 @@ Velvet,1
 Vengeance,1
 Venom,1
 Venture,1
+Venus,1
 Vermilion,1
 Vermin,1
 Verse,1
 Vespa,1
 Vesper,1
 Vespid,1
+Vesuvius,1
 Vex,1
 Vice,1
 Victim,1
@@ -4428,6 +5084,7 @@ Vigil,1
 Vigilant,1
 Viking,1
 Vine,1
+Viola,1
 Violet,1
 Viper,1
 Virtual,1
@@ -4451,6 +5108,7 @@ Vulpes,1
 Vulpine,1
 Vulture,1
 Waddle,1
+Waddles,1
 Waffle,1
 Wagon,1
 Waihaka,1
@@ -4459,16 +5117,20 @@ Wakes,1
 Waldo,1
 Walker,1
 Wall,1
+Wall Decor,1
 Wallaby,1
 Wallflower,1
 Wallride,1
+Walnut,1
 Walnuts,1
 Walrus,1
 War,1
+War Rabbit,1
 Warbird,1
 Warden,1
 Warehouse,1
 Warhammer,1
+Warhead,1
 Warhorse,1
 Warlock,1
 Warlord,1
@@ -4477,6 +5139,7 @@ Warpath,1
 Warren,1
 Warrior,1
 Warship,1
+Wasabi,1
 Wash,1
 Wasp,1
 Wasted,1
@@ -4484,6 +5147,7 @@ Wasteland,1
 Wastelander,1
 Watchdog,1
 Watchtower,1
+Water Balloon,1
 Waterfall,1
 Watermelon,1
 Watson,1
@@ -4495,17 +5159,23 @@ Waxman,1
 Waypoint,1
 Weapon,1
 Weasel,1
+Weatherman,1
 Weaver,1
+Webby,1
 Webcap,1
+Wedding Day,1
 Wedge,1
 Weed,1
 Weevil,1
 Weld,1
 Welder,1
 Werewolf,1
+West,1
 Wetsuit,1
+Whack-a-Mole,1
 Whale,1
 Wharf,1
+What?,1
 Wheat,1
 Wheel,1
 Wheelman,1
@@ -4530,11 +5200,13 @@ Whitecap,1
 Whitewash,1
 Whiz Kid,1
 Who,1
+Whomp Whomp,1
 Wicked,1
 Wideload,1
 Widow,1
 Widowstrike,1
 Wiggle,1
+Wiggles,1
 Wiggly,1
 Wight,1
 Wild,1
@@ -4546,6 +5218,7 @@ Willow,1
 Willowisp,1
 Winch,1
 Windchill,1
+Windchime,1
 Windclaw,1
 Windfall,1
 Windjammer,1
@@ -4558,13 +5231,16 @@ Wineglass,1
 Winger,1
 Wingman,1
 Wingnut,1
+Wings,1
 Wingspan,1
 Wink,1
 Winter,1
 Wise Guy,1
 Wiseman,1
+Wish Maker,1
 Wisp,1
 Witch,1
+Witch Doctor,1
 Witness,1
 Wizard,1
 Wobbegong,1
@@ -4584,6 +5260,7 @@ Wooley,1
 Workhorse,1
 Worldwide,1
 Worm,1
+Wormwood,1
 Worry,1
 Worrywart,1
 Wraith,1
@@ -4597,6 +5274,7 @@ Wrecker,1
 Wren,1
 Wrench,1
 Wrestler,1
+Wrinkles,1
 Wrong Way,1
 Wushu,1
 Wyrm,1
@@ -4604,7 +5282,9 @@ Wyvern,1
 X-Ray,1
 Xanadu,1
 Xebec,1
+Xena,1
 Xerxes,1
+Xuande,1
 Yak,1
 Yamato,1
 Yankee,1
@@ -4613,16 +5293,22 @@ Yardarm,1
 Yearn,1
 Yellowjacket,1
 Yeti,1
+Yide,1
 Ymir,1
 Yogi,1
 Yogurt,1
+Yoke,1
+Yoshi,1
 Young Gun,1
 Yowie,1
+Yuanrang,1
 Yuki-Onna,1
 Yukon,1
+Yunchang,1
 Zanzibar,1
 Zap,1
 Zapper,1
+Zappy,1
 Zealot,1
 Zebra,1
 Zebrafinch,1
@@ -4636,14 +5322,22 @@ Zeppelin,1
 Zero,1
 ZeroDay,1
 Zeus,1
+Zhongda,1
+Zhongmou,1
+Ziggy,1
 Zigzag,1
+Zijing,1
+Ziming,1
 Zinger,1
 Zipper,1
+Zippo,1
 Zippy,1
 Zircon,1
 Zodiac,1
 Zombie,1
 Zoom,1
+Zoomies,1
 Zorilla,1
 Zorro,1
+Zulfiqar,1
 Zulu,1

--- a/megamek/data/names/callsigns.csv
+++ b/megamek/data/names/callsigns.csv
@@ -2216,7 +2216,7 @@ Honor,1
 Honor Guard,1
 Hooch,1
 Hood,1
-Hoodlem,1
+Hoodlum,1
 Hook,1
 Hooligan,1
 Hoop Snake,1


### PR DESCRIPTION
- Expanded the list of callsigns in `callsigns.csv` with 694 new entries.
- Corrected a typo in a handful of callsigns (e.g. `Barracade` to `Barricade`).
- Corrected formatting for `Alpha Strike`.

We're now at 5,342 callsigns and I think, at this point, we probably don't need any more :D

### Credit
Credit for many of the new callsigns goes to community member `BlueThing00`.