### PR TITLE
Fix 6403: Avoid mp null Exception, add warning logging

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -540,7 +540,7 @@ public abstract class BotClient extends Client {
                 try {
                     Thread.sleep(Compute.randomInt(1000) + 500);
                 } catch (InterruptedException e) {
-                    logger.error(e, "calculateMyTune");
+                    logger.error(e, "calculateMyTurn");
                 }
             }
         }
@@ -557,19 +557,31 @@ public abstract class BotClient extends Client {
         try {
             if (game.getPhase().isMovement()) {
                 MovePath mp;
-                if (game.getTurn() instanceof SpecificEntityTurn) {
-                    SpecificEntityTurn turn = (SpecificEntityTurn) game.getTurn();
-                    Entity mustMove = game.getEntity(turn.getEntityNum());
+                int moverId = -1;
+                if (game.getTurn() instanceof SpecificEntityTurn turn) {
+                    moverId = turn.getEntityNum();
+                    Entity mustMove = game.getEntity(moverId);
                     mp = continueMovementFor(mustMove);
                 } else {
                     if (config.isForcedIndividual()) {
                         Entity mustMove = getRandomUnmovedEntity();
+                        moverId = mustMove.getId();
                         mp = continueMovementFor(mustMove);
                     } else {
                         mp = calculateMoveTurn();
                     }
                 }
-                moveEntity(mp.getEntity().getId(), mp);
+                // MP can be null due to various factors in pathing.  Avoid derailing the bot if so.
+                if (mp != null) {
+                    moveEntity(mp.getEntity().getId(), mp);
+                } else {
+                    // This attempt to calculate the turn failed, but we don't want to log
+                    // an exception here.
+                    logger.warn(
+                          "Null move path; entity was " + ((moverId != -1) ? "ID " + moverId : "Unknown")
+                    );
+                    return false;
+                }
             } else if (game.getPhase().isFiring()) {
                 calculateFiringTurn();
             } else if (game.getPhase().isPhysical()) {

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -565,7 +565,7 @@ public abstract class BotClient extends Client {
                 } else {
                     if (config.isForcedIndividual()) {
                         Entity mustMove = getRandomUnmovedEntity();
-                        moverId = mustMove.getId();
+                        moverId = (mustMove != null) ? mustMove.getId() : -1;
                         mp = continueMovementFor(mustMove);
                     } else {
                         mp = calculateMoveTurn();


### PR DESCRIPTION
This PR will prevent the specific NPE from #6403, increase logged info for missing MovePath turns, and downgrade the error to a warning.

Testing:
- Ran all 3 projects' unit tests
- Ran large ASF vs ASF battles to confirm NPE not logged (generally saw one or two instances)

Close #6403 