### PR TITLE
Removed deprecated logger method.

### DIFF
--- a/megamek/src/megamek/logging/MMLogger.java
+++ b/megamek/src/megamek/logging/MMLogger.java
@@ -20,6 +20,7 @@
 package megamek.logging;
 
 import io.sentry.Sentry;
+import javax.swing.JOptionPane;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,37 +28,29 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
 
-import javax.swing.*;
-import java.util.Collections;
-
 /**
  * <p>
- * Utility class to handle logging functions as well as reporting exceptions to
- * Sentry. To deal with general recommendations of confirming log level before
- * logging, additional checks are added to ensure we're only ever logging data
- * based upon the currently active log level.
+ * Utility class to handle logging functions as well as reporting exceptions to Sentry. To deal with general
+ * recommendations of confirming log level before logging, additional checks are added to ensure we're only ever logging
+ * data based upon the currently active log level.
  * </p>
  * <h2>How to use:</h2>
  * <p>
- * To utilize this class properly, it must be initialized within each class that
- * will use it. For example for use with the {@code megamek.MegaMek.class}.
+ * To utilize this class properly, it must be initialized within each class that will use it. For example for use with
+ * the {@code megamek.MegaMek.class}.
  * </p>
  *
  * <pre>{@code
  * private static final MMLogger logger = MMLogger.create(MegaMek.class);
  * }</pre>
  * <p>
- * And then for use, use {@code logger.info(message)} and pass a string to it.
- * Currently
- * supported levels include trace, info, warn, debug, error, and fatal. Warn,
- * Error and Fatal
- * can take any Throwable for sending to Sentry and has an overload for a title
- * to allow for displaying of a dialog box.
+ * And then for use, use {@code logger.info(message)} and pass a string to it. Currently supported levels include trace,
+ * info, warn, debug, error, and fatal. Warn, Error and Fatal can take any Throwable for sending to Sentry and has an
+ * overload for a title to allow for displaying of a dialog box.
  * </p>
  * <p>
- * This class also implements both the parametric pattern and the string format
- * for the functions that are overriden and added here. This means that you can
- * use the following formats for the messages in some cases:
+ * This class also implements both the parametric pattern and the string format for the functions that are overriden and
+ * added here. This means that you can use the following formats for the messages in some cases:
  * </p>
  *
  * <pre>{@code
@@ -65,13 +58,12 @@ import java.util.Collections;
  * logger.info("number: %d string: %s", 42, "Hello");
  * }</pre>
  * <p>
- * Due to how the logger works, the first format using curly braces is
- * preferred, but the second one
- * is grandfathered exclusively for logs already existing, and it is not
- * recommended for any new log.
+ * Due to how the logger works, the first format using curly braces is preferred, but the second one is grandfathered
+ * exclusively for logs already existing, and it is not recommended for any new log.
  * </p>
  */
 public class MMLogger extends ExtendedLoggerWrapper {
+
     private final ExtendedLoggerWrapper exLoggerWrapper;
 
     private static final String FQCN = MMLogger.class.getName();
@@ -95,11 +87,10 @@ public class MMLogger extends ExtendedLoggerWrapper {
     }
 
     /**
-     * Returns a custom Logger using the fully qualified name of the Class as
-     * the Logger name.
+     * Returns a custom Logger using the fully qualified name of the Class as the Logger name.
      *
-     * @param loggerName The Class whose name should be used as the Logger name.
-     *                   If null it will default to the calling class.
+     * @param loggerName The Class whose name should be used as the Logger name. If null it will default to the calling
+     * class.
      * @return The custom Logger.
      */
     public static MMLogger create(final Class<?> loggerName) {
@@ -111,7 +102,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Info Level Logging.
      *
      * @param message Message to be sent to the log file.
-     * @param args    Variable list of arguments for the message
+     * @param args Variable list of arguments for the message
      */
     @Override
     public void info(String message, Object... args) {
@@ -123,7 +114,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Warning Level Logging
      *
      * @param message Message to be logged.
-     * @param args    Variable list of arguments for the message
+     * @param args Variable list of arguments for the message
      */
     @Override
     public void warn(String message, Object... args) {
@@ -135,8 +126,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Warning Level Logging
      *
      * @param exception Exception to be logged.
-     * @param message   Message to be logged.
-     * @param args      Variable list of arguments for the message
+     * @param message Message to be logged.
+     * @param args Variable list of arguments for the message
      */
     public void warn(Throwable exception, String message, Object... args) {
         Sentry.captureException(exception);
@@ -148,7 +139,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Debug Level Logging
      *
      * @param message Message to be logged.
-     * @param args    Variable list of arguments for the message
+     * @param args Variable list of arguments for the message
      */
     @Override
     public void debug(String message, Object... args) {
@@ -160,8 +151,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Debug Level Logging
      *
      * @param exception Exception to be logged.
-     * @param message   Message to be logged.
-     * @param args      Variable list of arguments for the message
+     * @param message Message to be logged.
+     * @param args Variable list of arguments for the message
      */
     public void debug(Throwable exception, String message, Object... args) {
         Sentry.captureException(exception);
@@ -173,7 +164,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Error Level Logging w/ Exception
      *
      * @param exception Exception to be logged.
-     * @param message   Additional message.
+     * @param message Additional message.
      */
     public void error(Throwable exception, String message) {
         Sentry.captureException(exception);
@@ -184,8 +175,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Error Level Logging w/ Exception
      *
      * @param exception Exception to be logged.
-     * @param message   Additional message to be logged.
-     * @param args      Variable list of arguments for the message
+     * @param message Additional message to be logged.
+     * @param args Variable list of arguments for the message
      */
     public void error(Throwable exception, String message, Object... args) {
         message = parametrizedStringIfEnabled(Level.ERROR, message, args);
@@ -194,10 +185,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     }
 
     /**
-     * Error Level Logging w/ Exception
-     * This one was made to make it easier to replace the Log4J Calls
+     * Error Level Logging w/ Exception This one was made to make it easier to replace the Log4J Calls
      *
-     * @param message   Message to be logged.
+     * @param message Message to be logged.
      * @param exception Exception to be logged.
      */
     public void error(String message, Throwable exception) {
@@ -216,29 +206,12 @@ public class MMLogger extends ExtendedLoggerWrapper {
     }
 
     /**
-     * Error Level Logging w/ Exception w/ Dialog.
-     *
-     * @deprecated (since 21-feb-2025) Use
-     *             {@link #errorDialog(Throwable, String, String, Object...)}
-     *             instead.
-     * @param exception Exception to be logged.
-     * @param message   Message to write to the log file AND be displayed in the
-     *                  error pane.
-     * @param title     Title of the error message box.
-     */
-    @Deprecated(since = "0.50.04", forRemoval = true)
-    public void error(Throwable exception, String message, String title) {
-        errorDialog(exception, message, title, Collections.emptyList());
-    }
-
-    /**
      * Formatted Error Level Logging w/ Exception w/ Dialog.
      *
      * @param exception Exception to be logged.
-     * @param message   Message to write to the log file AND be displayed in the
-     *                  error pane.
-     * @param title     Title of the error message box.
-     * @param args      Variable list of arguments for the message.
+     * @param message Message to write to the log file AND be displayed in the error pane.
+     * @param title Title of the error message box.
+     * @param args Variable list of arguments for the message.
      */
     public void errorDialog(Throwable exception, String message, String title, Object... args) {
         Sentry.captureException(exception);
@@ -250,10 +223,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Formatted Error Level Logging w/o Exception w/ Dialog.
      *
-     * @param message Message to write to the log file AND be displayed in the
-     *                error pane.
-     * @param title   Title of the error message box.
-     * @param args    Variable list of arguments for the message
+     * @param message Message to write to the log file AND be displayed in the error pane.
+     * @param title Title of the error message box.
+     * @param args Variable list of arguments for the message
      */
     public void errorDialog(String title, String message, Object... args) {
         message = parametrizedStringAnyway(message, args);
@@ -264,10 +236,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Formatted Error Level Logging w/o Exception w/ Dialog.
      *
-     * @param message Message to write to the log file AND be displayed in the
-     *                error pane.
-     * @param title   Title of the error message box.
-     * @param args    Variable list of arguments for the message
+     * @param message Message to write to the log file AND be displayed in the error pane.
+     * @param title Title of the error message box.
+     * @param args Variable list of arguments for the message
      */
     private void popupErrorDialog(String title, String message, Object... args) {
         message = parametrizedStringAnyway(message, args);
@@ -281,9 +252,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Error Level Logging w/o Exception w/ Dialog.
      *
-     * @param message Message to write to the log file AND be displayed in the
-     *                error pane.
-     * @param title   Title of the error message box.
+     * @param message Message to write to the log file AND be displayed in the error pane.
+     * @param title Title of the error message box.
      */
     public void error(String message, String title) {
         error(message);
@@ -298,7 +268,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Fatal Level Logging w/ Exception.
      *
      * @param exception Exception that was triggered. Probably uncaught.
-     * @param message   Message to report to the log file.
+     * @param message Message to report to the log file.
      */
     public void fatal(Throwable exception, String message) {
         Sentry.captureException(exception);
@@ -308,11 +278,10 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Fatal Level Logging w/ Exception w/ Dialog
      *
-     * @deprecated (since 21-feb-2025) Use
-     *             {@link #fatalDialog(Throwable, String, String)} instead.
      * @param exception Exception that was triggered. Probably uncaught.
-     * @param message   Message to report to the log file.
-     * @param title     Title of the error message box.
+     * @param message Message to report to the log file.
+     * @param title Title of the error message box.
+     * @deprecated (since 21 - feb - 2025) Use {@link #fatalDialog(Throwable, String, String)} instead.
      */
     @Deprecated(since = "0.50.04", forRemoval = true)
     public void fatal(Throwable exception, String message, String title) {
@@ -323,8 +292,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Fatal Level Logging w/ Exception w/ Dialog
      *
      * @param exception Exception that was triggered. Probably uncaught.
-     * @param message   Message to report to the log file.
-     * @param title     Title of the error message box.
+     * @param message Message to report to the log file.
+     * @param title Title of the error message box.
      */
     public void fatalDialog(Throwable exception, String message, String title) {
         fatal(exception, message);
@@ -334,10 +303,9 @@ public class MMLogger extends ExtendedLoggerWrapper {
     /**
      * Fatal Level Logging w/o Exception w/ Dialog
      *
-     * @deprecated (since 21-feb-2025) Use {@link #fatalDialog(String, String)}
-     *             instead.
      * @param message Message to report to the log file.
-     * @param title   Title of the error message box.
+     * @param title Title of the error message box.
+     * @deprecated (since 21 - feb - 2025) Use {@link #fatalDialog(String, String)} instead.
      */
     @Deprecated(since = "0.50.04", forRemoval = true)
     public void fatal(String message, String title) {
@@ -348,7 +316,7 @@ public class MMLogger extends ExtendedLoggerWrapper {
      * Fatal Level Logging w/o Exception w/ Dialog
      *
      * @param message Message to report to the log file.
-     * @param title   Title of the error message box.
+     * @param title Title of the error message box.
      */
     public void fatalDialog(String message, String title) {
         fatal(message);
@@ -356,9 +324,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
     }
 
     /**
-     * Takes the passed in Level and checks if the current log level is more
-     * specific than provided. This is a helper method around the default logger's
-     * method.
+     * Takes the passed in Level and checks if the current log level is more specific than provided. This is a helper
+     * method around the default logger's method.
      *
      * @param checkedLevel Passed in Level to compare to.
      * @return True if the current log level is more specific than the passed in
@@ -368,9 +335,8 @@ public class MMLogger extends ExtendedLoggerWrapper {
     }
 
     /**
-     * Takes the passed in Level and checks if the current log level is less
-     * specific than provided. This is a helper method around the default logger's
-     * method.
+     * Takes the passed in Level and checks if the current log level is less specific than provided. This is a helper
+     * method around the default logger's method.
      *
      * @param checkedLevel Passed in Level to compare to.
      * @return True if the current log level is less specific than the passed in

--- a/megamek/unittests/megamek/logging/MMLoggerTest.java
+++ b/megamek/unittests/megamek/logging/MMLoggerTest.java
@@ -15,24 +15,28 @@
 
 package megamek.logging;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.nullable;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.awt.GraphicsEnvironment;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.mockito.ArgumentCaptor;
 import org.mockito.MockitoAnnotations;
 
-import java.awt.*;
-import java.awt.event.KeyEvent;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
-
 public class MMLoggerTest {
+
     private final static MMLogger logger = MMLogger.create(MMLoggerTest.class);
 
     private CustomLogger mockLogger;
@@ -161,7 +165,7 @@ public class MMLoggerTest {
             return;
         }
         automaticallyDismissDialog();
-        testMMLogger.fatal("Fatal with dialog with exception", "Fatal dialog title");
+        testMMLogger.fatalDialog("Fatal with dialog with exception", "Fatal dialog title");
         verifyLog(Level.FATAL, "Fatal with dialog with exception");
     }
 
@@ -181,20 +185,22 @@ public class MMLoggerTest {
         }
         automaticallyDismissDialog();
         Exception e = new Exception("Test exception");
-        testMMLogger.fatal(e, "Fatal without dialog with exception" , "Fatal dialog title");
+        testMMLogger.fatalDialog(e, "Fatal without dialog with exception", "Fatal dialog title");
         verifyLog(Level.FATAL, "Fatal without dialog with exception", e);
     }
 
     private void verifyLog(Level level, String message) {
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
-        verify(mockLogger).logMessage(anyString(), eq(level), nullable(Marker.class), messageCaptor.capture(), nullable(Throwable.class));
+        verify(mockLogger).logMessage(anyString(), eq(level), nullable(Marker.class), messageCaptor.capture(),
+              nullable(Throwable.class));
         assertEquals(message, messageCaptor.getValue().getFormattedMessage());
     }
 
     private void verifyLog(Level level, String message, Throwable e) {
         ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
         ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);
-        verify(mockLogger).logMessage(anyString(), eq(level), nullable(Marker.class), messageCaptor.capture(), throwableCaptor.capture());
+        verify(mockLogger).logMessage(anyString(), eq(level), nullable(Marker.class), messageCaptor.capture(),
+              throwableCaptor.capture());
         assertEquals(message, messageCaptor.getValue().getFormattedMessage());
         assertEquals(e, throwableCaptor.getValue());
     }
@@ -220,12 +226,14 @@ public class MMLoggerTest {
 
     // Custom logger implementation for testing
     private static class CustomLogger extends AbstractLogger {
+
         protected CustomLogger(String name) {
             super(name, null);
         }
 
         @Override
-        public void logMessage(String fqcn, Level level, org.apache.logging.log4j.Marker marker, String message, Throwable t) {
+        public void logMessage(String fqcn, Level level, org.apache.logging.log4j.Marker marker, String message,
+              Throwable t) {
             // Custom implementation for logging messages
         }
 
@@ -240,7 +248,8 @@ public class MMLoggerTest {
         }
 
         @Override
-        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, String message, Object... params) {
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, String message,
+              Object... params) {
             return true;
         }
 
@@ -260,37 +269,44 @@ public class MMLoggerTest {
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+              Object p3) {
             return true;
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+              Object p4) {
             return true;
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+              Object p4, Object p5) {
             return true;
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+              Object p4, Object p5, Object p6) {
             return true;
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+              Object p4, Object p5, Object p6, Object p7) {
             return true;
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+              Object p4, Object p5, Object p6, Object p7, Object p8) {
             return true;
         }
 
         @Override
-        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9) {
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+              Object p4, Object p5, Object p6, Object p7, Object p8, Object p9) {
             return true;
         }
 
@@ -305,7 +321,8 @@ public class MMLoggerTest {
         }
 
         @Override
-        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker, org.apache.logging.log4j.message.Message message, Throwable t) {
+        public boolean isEnabled(Level level, org.apache.logging.log4j.Marker marker,
+              org.apache.logging.log4j.message.Message message, Throwable t) {
             return true;
         }
 


### PR DESCRIPTION
While updating MekHQ deprecation methods, ran into issues where logger.error was opening the dialog instead of logging the error.