### PR TITLE
Fixes for Unit Selector and Game Options dialogs not refreshing

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
@@ -180,6 +180,7 @@ public abstract class AbstractButtonDialog extends AbstractDialog {
      * @return the result of showing the dialog
      */
     public DialogResult showDialog() {
+        getFrame().pack();
         setVisible(true);
         return getResult();
     }

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -782,6 +782,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
         validate();
         repaint();
+        frame.pack();
         super.setVisible(visible);
     }
 


### PR DESCRIPTION
Two quick fixes for minor graphical glitches that have been annoying me throughout 0.50.04 development:

1. The Unit Selector dialog, specifically the Tech Level Groups listbox, doesn't cleanly update when the allowed tech level is modified in Game Options.  Either newly-available options won't display until the dialog is resized, or no-long-available groups remain on display but are not cleaned up.

2. The Game Options dialog itself will show the wrong tab's info when re-opened after adjusting settings on tabs other than the first.  Then, when clicked, the first tab's contents will be displayed on top of an echo of the previously-opened tab, causing an ugly mish-mash.

Testing:
- Ran several tests opening and closing these dialogs, both with and without the fix.