### PR TITLE
AS conversion 

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/conversion/ASConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASConverter.java
@@ -181,8 +181,8 @@ public final class ASConverter {
             element.getSpecialAbilities().setSUA(BattleForceSUA.AERODYNESC);
         }
         ASPointValueConverter pvConverter = ASPointValueConverter.getPointValueConverter(element, conversionReport);
-        element.setPointValue(pvConverter.getSkillAdjustedPointValue());
         element.setBasePointValue(pvConverter.getBasePointValue());
+        element.setPointValue(pvConverter.getSkillAdjustedPointValue(element.getBasePointValue()));
         element.setConversionReport(conversionReport);
         return element;
     }
@@ -296,7 +296,8 @@ public final class ASConverter {
         element.setTMM(ASMovementConverter.convertTMM(conversionData));
         element.setThreshold(ASArmStrConverter.convertThreshold(conversionData));
         ASPointValueConverter pvConverter = ASPointValueConverter.getPointValueConverter(element, report);
-        element.setPointValue(pvConverter.getSkillAdjustedPointValue());
+        element.setBasePointValue(pvConverter.getBasePointValue());
+        element.setPointValue(pvConverter.getSkillAdjustedPointValue(element.getBasePointValue()));
     }
 
     /**

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASPointValueConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASPointValueConverter.java
@@ -131,27 +131,29 @@ public class ASPointValueConverter {
         }
     }
 
-    int getSkillAdjustedPointValue() {
-        int basePointValue = getBasePointValue();
+    int getSkillAdjustedPointValue(int basePointValue) {
         if (element.getSkill() == 4) {
             return basePointValue;
         }
 
         int multiplier = 1;
         int newPointValue = basePointValue;
+        String calculation = "";
         if (element.getSkill() > 4) {
             if (basePointValue > 14) {
                 multiplier += (basePointValue - 5) / 10;
             }
-            newPointValue = basePointValue - (element.getSkill() - 4) * multiplier;
+            newPointValue -= (element.getSkill() - 4) * multiplier;
+            calculation = "- (%d - 4) x (1 + %d)".formatted(element.getSkill(), multiplier - 1);
         } else if (element.getSkill() < 4) {
             if (basePointValue > 7) {
                 multiplier += (basePointValue - 3) / 5;
             }
-            newPointValue = basePointValue + (4 - element.getSkill()) * multiplier;
+            newPointValue += (4 - element.getSkill()) * multiplier;
+            calculation = "+ (4 - %d) x (1 + %d)".formatted(element.getSkill(), multiplier - 1);
         }
         newPointValue = Math.max(newPointValue, 1);
-        report.addLine("Skill-adjusted Point Value", "", "" + newPointValue);
+        report.addLine("Skill-adjusted Point Value", calculation, "" + newPointValue);
         return newPointValue;
     }
 


### PR DESCRIPTION
This fixes the AS conversion report containing the point value calculation twice. To do this, the method getSkillAdjustedPointValue() now requires passing in the base point value so it doesnt have to get calculated twice (and add the report twice).

Also adds a bit of detail for the PV skill adjustment to the report.