### PR TITLE
#6732: In AS PV calculation for large craft, use various mods

### DIFF
--- a/megamek/src/megamek/common/alphaStrike/ASArcs.java
+++ b/megamek/src/megamek/common/alphaStrike/ASArcs.java
@@ -23,15 +23,11 @@ public enum ASArcs {
 
     @Override
     public String toString() {
-        switch (this) {
-            case LEFT:
-                return "Left Arc";
-            case RIGHT:
-                return "Right Arc";
-            case REAR:
-                return "Rear Arc";
-            default:
-                return "Front Arc";
-        }
+        return switch (this) {
+            case LEFT -> "Left Arc";
+            case RIGHT -> "Right Arc";
+            case REAR -> "Rear Arc";
+            default -> "Front Arc";
+        };
     }
 }

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASPointValueConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASPointValueConverter.java
@@ -64,6 +64,7 @@ public class ASPointValueConverter {
         processSize();
         processOffensiveSUAMods();
         processOffensiveBlanketMod();
+        processUnitTypeDamageDivisors();
 
         // Defensive Value
         report.addEmptyLine();
@@ -278,6 +279,10 @@ public class ASPointValueConverter {
                 formatForReport(offensiveValue) + " x " + formatForReport(blanketMod) + modifiers,
                 "= " + formatForReport(offensiveValue * blanketMod));
         offensiveValue *= blanketMod;
+    }
+
+    protected void processUnitTypeDamageDivisors() {
+        // only on large craft, the offensive value is divided based on unit type
     }
 
     protected void processDefensiveSUAMods() {


### PR DESCRIPTION
https://bg.battletech.com/forums/index.php?topic=84862.msg2007447#msg2007447 clarifies that large craft do use some of the PV mods that are labeled "(Ground Units)" in ASC
Most notably this now includes artillery in arcs in the PV. As usual, the values MM calculates only vaguely align with those of the official large craft AS cards from E-CAT35AS001 & E-CAT35AS002

fixes #6732