### PR TITLE
Fix 6716: Prevent selecting the incorrect ammo index when switching between ammo-fed weapons

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -2099,10 +2099,13 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
 
                     vAmmo.add(ammo);
                     m_chAmmo.addItem(formatAmmo(ammo));
-                    if (currentAmmoSelectionIndex != -1) {
-                        newSelectedIndex = currentAmmoSelectionIndex;
-                    } else if ((mounted.getLinked() != null) && mounted.getLinked().equals(ammo)) {
+                    if ((mounted.getLinked() != null) && mounted.getLinked().equals(ammo)) {
                         newSelectedIndex = i;
+                        // Prevent later overriding.
+                        currentAmmoSelectionIndex = -1;
+                    } else if (currentAmmoSelectionIndex != -1) {
+                        // This should be the fallback
+                        newSelectedIndex = currentAmmoSelectionIndex;
                     }
                     i++;
                 }


### PR DESCRIPTION
Update the ammo combobox update code to reset it to the index of the currently-linked ammo if known, the last selected index if not, and the "unselected" index as a last resort.

Testing:
- Used OP's repro save to confirm correct behaviour in the reported use case.
- Ran all 3 projects' unit tests

Close #6716 