### PR TITLE
Fix #6740: outer window resizing issue

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
@@ -180,7 +180,7 @@ public abstract class AbstractButtonDialog extends AbstractDialog {
      * @return the result of showing the dialog
      */
     public DialogResult showDialog() {
-        getFrame().pack();
+        pack();
         setVisible(true);
         return getResult();
     }

--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -232,6 +232,7 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
         toggleOptions();
         addSearchPanel();
         validate();
+        pack();
     }
 
     /**


### PR DESCRIPTION
It turns out that for most dialogs, getFrame() returns the containing window and what we want is to call `pack()` on just the dialog itself.
We also want to call `pack()` on the Game Options dialog after refreshing its contents, as they are dynamically generated.

Testing:
- Ran several repros based on bug.
- Ran all 3 projects' unit tests.

Close #6740 