### PR TITLE
Formatting, remove armored component weight from aero weight calc (MML#1173)

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAero.java
+++ b/megamek/src/megamek/common/verifier/TestAero.java
@@ -995,8 +995,6 @@ public class TestAero extends TestEntity {
         weight += getWeightPowerAmp();
 
         weight += getWeightCarryingSpace();
-
-        weight += getArmoredComponentWeight();
         return weight;
     }
 

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1933,8 +1933,12 @@ public abstract class TestEntity implements TestEntityOption {
                 + getEntity().getYear() + ")\n";
     }
 
+    /**
+     * @return The total additional weight due to critical slot armoring. Does not include the weight of the equipment
+     * itself.
+     */
     public double getArmoredComponentWeight() {
-        return 0.0;
+        return 0;
     }
 
     public static boolean usesKgStandard(Entity entity) {

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -786,21 +786,16 @@ public class TestMek extends TestEntity {
         return "Mek: " + mek.getDisplayName();
     }
 
-    /**
-     * calculates the total weight of all armored components.
-     */
     @Override
     public double getArmoredComponentWeight() {
         double weight = 0.0;
         double cockpitWeight = 0.0;
-        for (int location = Mek.LOC_HEAD; location < mek.locations(); location++) {
+        for (int location = 0; location < mek.locations(); location++) {
             for (int slot = 0; slot < mek.getNumberOfCriticals(location); slot++) {
                 CriticalSlot cs = mek.getCritical(location, slot);
                 if ((cs != null) && cs.isArmored()) {
-                    // Armored cockpit (including command console) adds 1 ton, regardless of number
-                    // of slots
-                    if ((cs.getType() == CriticalSlot.TYPE_SYSTEM)
-                            && (cs.getIndex() == Mek.SYSTEM_COCKPIT)) {
+                    // Armored cockpit (including command console) adds 1 ton, regardless of number of slots
+                    if ((cs.getType() == CriticalSlot.TYPE_SYSTEM) && (cs.getIndex() == Mek.SYSTEM_COCKPIT)) {
                         cockpitWeight = 1.0;
                     } else {
                         weight += 0.5;


### PR DESCRIPTION
comes together with Megamek/megameklab#1773 but they're not dependent. This is a bit of formatting and it removes the armored component weight from aero weight calculation as only BM/IM can have armored components and only TestMek will ever return anything other than 0.