### PR TITLE
Cache results from text normalization

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -679,9 +679,9 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
     protected boolean matchesTextFilter(MekSummary unit) {
         if (!textFilter.getText().isBlank()) {
-            String text = Internationalization.normalizeTextToASCII(textFilter.getText()).toLowerCase();
+            String text = Internationalization.normalizeTextToASCII(textFilter.getText(), false).toLowerCase();
             String[] tokens = text.split(" ");
-            String searchText = Internationalization.normalizeTextToASCII(unit.getName() + "###" + unit.getModel()).toLowerCase();
+            String searchText = Internationalization.normalizeTextToASCII(unit.getName() + "###" + unit.getModel(), true).toLowerCase();
             for (String token : tokens) {
                 if (!searchText.contains(token)) {
                     return false;

--- a/megamek/src/megamek/common/internationalization/Internationalization.java
+++ b/megamek/src/megamek/common/internationalization/Internationalization.java
@@ -14,8 +14,6 @@
 package megamek.common.internationalization;
 
 import com.ibm.icu.text.Transliterator;
-import megamek.MegaMek;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -25,6 +23,7 @@ import java.util.Locale;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
+import megamek.MegaMek;
 
 /**
  * Class to handle internationalization (you will find online material on that looking for i18n)
@@ -115,6 +114,8 @@ public class Internationalization {
     // The Any-Latin transliteration will attempt phonetic transliteration based on the most likely pronunciation for the given characters,
     private static final Transliterator normalizer = Transliterator.getInstance("Latin-ASCII");
 
+    private static final ConcurrentHashMap<String,String> normalizationCache = new ConcurrentHashMap<>();
+
     /**
      * Takes a string of Unicode text and attempts to convert it to an ASCII representation of that string.
      * Characters such as ø and ö will be converted to o.
@@ -123,6 +124,6 @@ public class Internationalization {
      *  The returned string is <i>not</i> guaranteed to be only ASCII. Normalization will fail if there's no direct mapping from a character to its ASCII equivalent.
      */
     public static String normalizeTextToASCII(String text) {
-        return normalizer.transliterate(text);
+        return normalizationCache.computeIfAbsent(text, normalizer::transliterate);
     }
 }

--- a/megamek/src/megamek/common/internationalization/Internationalization.java
+++ b/megamek/src/megamek/common/internationalization/Internationalization.java
@@ -120,10 +120,15 @@ public class Internationalization {
      * Takes a string of Unicode text and attempts to convert it to an ASCII representation of that string.
      * Characters such as ø and ö will be converted to o.
      * @param text A String, such as <i>Gún</i> or <i>Götterdämmerung</i>
+     * @param cache Set to try to cache the result. The memoization cache can grow indefinitely,
+     *              so care should be taken to not fill the cache with strings that might never be referenced again.
+     *              For example, strings typed by the user shouldn't be cached, but unit names should be.
      * @return The normalized String, such as <i>Gun</i> or <i>Gotterdammerung</i>.<br/>
      *  The returned string is <i>not</i> guaranteed to be only ASCII. Normalization will fail if there's no direct mapping from a character to its ASCII equivalent.
      */
-    public static String normalizeTextToASCII(String text) {
-        return normalizationCache.computeIfAbsent(text, normalizer::transliterate);
+    public static String normalizeTextToASCII(String text, boolean cache) {
+        return cache
+              ? normalizationCache.computeIfAbsent(text, normalizer::transliterate)
+              : normalizer.transliterate(text);
     }
 }


### PR DESCRIPTION
Normalizing text to ASCII is slow. This caches the results so it's only slow the first time the unit search dialog is opened. 