### PR TITLE
Remove reference to frame, which was extraneous, but keep pack(), which cleans up dialog display

### DIFF
--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -782,7 +782,7 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
         validate();
         repaint();
-        frame.pack();
+        pack();
         super.setVisible(visible);
     }
 


### PR DESCRIPTION
The `frame.pack()` call worked fine for MegaMek which creates a new frame for its Unit Selector and runs it in a separate process.
But calling `frame.pack()` causes the MekHQ main UI to resize, which is undesireable.
Also, it turns out that `pack()` within the AbstractUnitSelectorDialog context is sufficient to clean up the Tech Group ListBox contents.

Testing:
- Made the change, tested both UIs.