### PR TITLE
Revert addition of pack() calls to various corrupted dialogs due to adverse side effects

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
+++ b/megamek/src/megamek/client/ui/baseComponents/AbstractButtonDialog.java
@@ -180,7 +180,6 @@ public abstract class AbstractButtonDialog extends AbstractDialog {
      * @return the result of showing the dialog
      */
     public DialogResult showDialog() {
-        pack();
         setVisible(true);
         return getResult();
     }

--- a/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/GameOptionsDialog.java
@@ -232,7 +232,6 @@ public class GameOptionsDialog extends AbstractButtonDialog implements ActionLis
         toggleOptions();
         addSearchPanel();
         validate();
-        pack();
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/swing/dialog/AbstractUnitSelectorDialog.java
@@ -782,7 +782,6 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
 
         validate();
         repaint();
-        pack();
         super.setVisible(visible);
     }
 


### PR DESCRIPTION
Other users reported negative impacts on UX so reverting the `pack()` calls in favor of writing an issue for somebody else to deal with.

Testing:
- confirmed dialog behavior is back to not updating correctly, but keeps its user-defined size.